### PR TITLE
A few small fixes/additions to the postgres block store

### DIFF
--- a/core/src/main/java/com/google/bitcoin/store/PostgresFullPrunedBlockStore.java
+++ b/core/src/main/java/com/google/bitcoin/store/PostgresFullPrunedBlockStore.java
@@ -113,16 +113,20 @@ public class PostgresFullPrunedBlockStore implements FullPrunedBlockStore {
     }
 
     /**
-     * Creates a new PostgresFullPrunedBlockStore.
+     * <p>Create a new PostgresFullPrunedBlockStore, storing the tables in the schema specified.  You may want to
+     * specify a schema to avoid name collisions, or just to keep the database better organized.  The schema is not
+     * required, and if one is not provided than the default schema for the username will be used.  See
+     * <a href="http://www.postgres.org/docs/9.3/static/ddl-schemas.html">the postgres schema docs</a> for more on
+     * schemas.</p>
      *
-     * @param params A copy of the NetworkParameters used
-     * @param fullStoreDepth The number of blocks of history stored in full (something like 1000 is pretty safe)
-     * @param hostname The hostname of the database to connect to
-     * @param dbName The database to connect to
-     * @param username The database username
-     * @param password The password to the database
-     * @param schemaName The name of the schema to put the tables in.  May be null if no schema is being used
-     * @throws BlockStoreException if the database fails to open for any reason
+     * @param params A copy of the NetworkParameters used.
+     * @param fullStoreDepth The number of blocks of history stored in full (something like 1000 is pretty safe).
+     * @param hostname The hostname of the database to connect to.
+     * @param dbName The database to connect to.
+     * @param username The database username.
+     * @param password The password to the database.
+     * @param schemaName The name of the schema to put the tables in.  May be null if no schema is being used.
+     * @throws BlockStoreException If the database fails to open for any reason.
      */
     public PostgresFullPrunedBlockStore(NetworkParameters params, int fullStoreDepth, String hostname, String dbName,
                                         String username, String password, @Nullable String schemaName) throws BlockStoreException {
@@ -130,16 +134,27 @@ public class PostgresFullPrunedBlockStore implements FullPrunedBlockStore {
     }
 
     /**
-     * Creates a new PostgresFullPrunedBlockStore.
+     * <p>Create a new PostgresFullPrunedBlockStore, using the full connection URL instead of a hostname and password,
+     * and optionally allowing a schema to be specified.</p>
+     *
+     * <p>The connection URL will be passed to the database driver, and should look like
+     * "jdbc:postrgresql://host[:port]/databasename".  You can use this to change the port, or specify additional
+     * parameters.  See <a href="http://jdbc.postgresql.org/documentation/head/connect.html#connection-parameters">
+     * the PostgreSQL JDBC documentation</a> for more on the connection URL.</p>
+     *
+     * <p>This constructor also accepts a schema name to use, which can be used to avoid name collisions, or to keep the
+     * database organized.  If no schema is provided the default schema for the username will be used.  See
+     * <a href="http://www.postgres.org/docs/9.3/static/ddl-schemas.html">the postgres schema docs</a> for more on
+     * schemas.</p>
      *
      *
-     * @param params A copy of the NetworkParameters used
+     * @param params A copy of the NetworkParameters used.
      * @param connectionURL The jdbc url to connect to the database.
-     * @param fullStoreDepth The number of blocks of history stored in full (something like 1000 is pretty safe)
-     * @param username The database username
-     * @param password The password to the database
-     * @param schemaName The name of the schema to put the tables in.  May be null if no schema is being used
-     * @throws BlockStoreException if the database fails to open for any reason
+     * @param fullStoreDepth The number of blocks of history stored in full (something like 1000 is pretty safe).
+     * @param username The database username.
+     * @param password The password to the database.
+     * @param schemaName The name of the schema to put the tables in.  May be null if no schema is being used.
+     * @throws BlockStoreException If the database fails to open for any reason.
      */
     public PostgresFullPrunedBlockStore(NetworkParameters params, String connectionURL, int fullStoreDepth,
                                         String username, String password, @Nullable String schemaName) throws BlockStoreException {
@@ -188,7 +203,7 @@ public class PostgresFullPrunedBlockStore implements FullPrunedBlockStore {
 
             Connection connection = conn.get();
             // set the schema if one is needed
-            if( schemaName != null ) {
+            if(schemaName != null) {
                 Statement s = connection.createStatement();
                 s.execute("CREATE SCHEMA IF NOT EXISTS " + schemaName + ";");
                 s.execute("set search_path to '" + schemaName +"';");

--- a/core/src/test/java/com/google/bitcoin/core/PostgresFullPrunedBlockChainTest.java
+++ b/core/src/test/java/com/google/bitcoin/core/PostgresFullPrunedBlockChainTest.java
@@ -25,10 +25,12 @@ public class PostgresFullPrunedBlockChainTest extends AbstractFullPrunedBlockCha
     @Override
     public FullPrunedBlockStore createStore(NetworkParameters params, int blockCount)
             throws BlockStoreException {
-        if( useSchema )
+        if(useSchema) {
             return new PostgresFullPrunedBlockStore(params, blockCount, DB_HOSTNAME, DB_NAME, DB_USERNAME, DB_PASSWORD, DB_SCHEMA);
-        else
+        }
+        else {
             return new PostgresFullPrunedBlockStore(params, blockCount, DB_HOSTNAME, DB_NAME, DB_USERNAME, DB_PASSWORD);
+        }
     }
 
     @Override
@@ -36,10 +38,6 @@ public class PostgresFullPrunedBlockChainTest extends AbstractFullPrunedBlockCha
         ((PostgresFullPrunedBlockStore)store).resetStore();
     }
 
-    /**
-     * Run a test with a custom schema name to make sure
-     * everything works when we set a schema.
-     */
     @Test
     public void testFirst100kBlocksWithCustomSchema() throws Exception {
         boolean oldSchema = useSchema;


### PR DESCRIPTION
This pull request adds some functionality to the postgres block store that I thought others would find useful:
1. Adds a constructor so you can pass in the jdbc url instead of only the hostname and database name.  
2. Adds the ability to use a schema to store the tables in - by default they were being stored in the 'public' schema, but users may want to put it in other schemas.
3. Fixes an exception in close() when it was attempting to rollback a connection where autocommit was true.

Also adds a test to the PostgresFullPrunedBlockChainTest to make sure it works with a schema name set.  
