### PR TITLE
Use BigInteger.signum() rather than .compareTo(ZERO)

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/Block.java
+++ b/core/src/main/java/com/google/bitcoin/core/Block.java
@@ -627,7 +627,7 @@ public class Block extends Message {
     public BigInteger getDifficultyTargetAsInteger() throws VerificationException {
         maybeParseHeader();
         BigInteger target = Utils.decodeCompactBits(difficultyTarget);
-        if (target.compareTo(BigInteger.ZERO) <= 0 || target.compareTo(params.proofOfWorkLimit) > 0)
+        if (target.signum() <= 0 || target.compareTo(params.proofOfWorkLimit) > 0)
             throw new VerificationException("Difficulty target is bad: " + target.toString());
         return target;
     }

--- a/core/src/main/java/com/google/bitcoin/core/ECKey.java
+++ b/core/src/main/java/com/google/bitcoin/core/ECKey.java
@@ -707,8 +707,8 @@ public class ECKey implements Serializable {
     @Nullable
     public static ECKey recoverFromSignature(int recId, ECDSASignature sig, Sha256Hash message, boolean compressed) {
         Preconditions.checkArgument(recId >= 0, "recId must be positive");
-        Preconditions.checkArgument(sig.r.compareTo(BigInteger.ZERO) >= 0, "r must be positive");
-        Preconditions.checkArgument(sig.s.compareTo(BigInteger.ZERO) >= 0, "s must be positive");
+        Preconditions.checkArgument(sig.r.signum() >= 0, "r must be positive");
+        Preconditions.checkArgument(sig.s.signum() >= 0, "s must be positive");
         Preconditions.checkNotNull(message);
         // 1.0 For j from 0 to h   (h == recId here and the loop is outside this function)
         //   1.1 Let x = r + jn

--- a/core/src/main/java/com/google/bitcoin/core/FullPrunedBlockChain.java
+++ b/core/src/main/java/com/google/bitcoin/core/FullPrunedBlockChain.java
@@ -224,7 +224,7 @@ public class FullPrunedBlockChain extends AbstractBlockChain {
                 }
                 // All values were already checked for being non-negative (as it is verified in Transaction.verify())
                 // but we check again here just for defence in depth. Transactions with zero output value are OK.
-                if (valueOut.compareTo(BigInteger.ZERO) < 0 || valueOut.compareTo(params.MAX_MONEY) > 0)
+                if (valueOut.signum() < 0 || valueOut.compareTo(params.MAX_MONEY) > 0)
                     throw new VerificationException("Transaction output value out of rage");
                 if (isCoinBase) {
                     coinbaseValue = valueOut;
@@ -346,7 +346,7 @@ public class FullPrunedBlockChain extends AbstractBlockChain {
                     }
                     // All values were already checked for being non-negative (as it is verified in Transaction.verify())
                     // but we check again here just for defence in depth. Transactions with zero output value are OK.
-                    if (valueOut.compareTo(BigInteger.ZERO) < 0 || valueOut.compareTo(params.MAX_MONEY) > 0)
+                    if (valueOut.signum() < 0 || valueOut.compareTo(params.MAX_MONEY) > 0)
                         throw new VerificationException("Transaction output value out of rage");
                     if (isCoinBase) {
                         coinbaseValue = valueOut;

--- a/core/src/main/java/com/google/bitcoin/core/Transaction.java
+++ b/core/src/main/java/com/google/bitcoin/core/Transaction.java
@@ -1184,7 +1184,7 @@ public class Transaction extends ChildMessage implements Serializable {
 
         BigInteger valueOut = BigInteger.ZERO;
         for (TransactionOutput output : outputs) {
-            if (output.getValue().compareTo(BigInteger.ZERO) < 0)
+            if (output.getValue().signum() < 0)
                 throw new VerificationException("Transaction output negative");
             valueOut = valueOut.add(output.getValue());
         }

--- a/core/src/main/java/com/google/bitcoin/core/TransactionOutput.java
+++ b/core/src/main/java/com/google/bitcoin/core/TransactionOutput.java
@@ -109,7 +109,7 @@ public class TransactionOutput extends ChildMessage implements Serializable {
         super(params);
         // Negative values obviously make no sense, except for -1 which is used as a sentinel value when calculating
         // SIGHASH_SINGLE signatures, so unfortunately we have to allow that here.
-        checkArgument(value.compareTo(BigInteger.ZERO) >= 0 || value.equals(Utils.NEGATIVE_ONE), "Negative values not allowed");
+        checkArgument(value.signum() >= 0 || value.equals(Utils.NEGATIVE_ONE), "Negative values not allowed");
         checkArgument(value.compareTo(NetworkParameters.MAX_MONEY) < 0, "Values larger than MAX_MONEY not allowed");
         this.value = value;
         this.scriptBytes = scriptBytes;

--- a/core/src/main/java/com/google/bitcoin/core/Utils.java
+++ b/core/src/main/java/com/google/bitcoin/core/Utils.java
@@ -120,7 +120,7 @@ public class Utils {
      */
     public static BigInteger toNanoCoins(String coins) {
         BigInteger bigint = new BigDecimal(coins).movePointRight(8).toBigIntegerExact();
-        if (bigint.compareTo(BigInteger.ZERO) < 0)
+        if (bigint.signum() < 0)
             throw new ArithmeticException("Negative coins specified");
         if (bigint.compareTo(NetworkParameters.MAX_MONEY) > 0)
             throw new ArithmeticException("Amount larger than the total quantity of Bitcoins possible specified.");
@@ -331,7 +331,7 @@ public class Utils {
      */
     public static String bitcoinValueToFriendlyString(BigInteger value) {
         // TODO: This API is crap. This method should go away when we encapsulate money values.
-        boolean negative = value.compareTo(BigInteger.ZERO) < 0;
+        boolean negative = value.signum() < 0;
         if (negative)
             value = value.negate();
         BigDecimal bd = new BigDecimal(value, 8);
@@ -404,7 +404,7 @@ public class Utils {
             else
                 return new byte[] {0x00, 0x00, 0x00, 0x00};
         }
-        boolean isNegative = value.compareTo(BigInteger.ZERO) < 0;
+        boolean isNegative = value.signum() < 0;
         if (isNegative)
             value = value.negate();
         byte[] array = value.toByteArray();

--- a/core/src/main/java/com/google/bitcoin/protocols/channels/PaymentChannelClientState.java
+++ b/core/src/main/java/com/google/bitcoin/protocols/channels/PaymentChannelClientState.java
@@ -157,7 +157,7 @@ public class PaymentChannelClientState {
      */
     public PaymentChannelClientState(Wallet wallet, ECKey myKey, ECKey serverMultisigKey,
                                      BigInteger value, long expiryTimeInSeconds) throws VerificationException {
-        checkArgument(value.compareTo(BigInteger.ZERO) > 0);
+        checkArgument(value.signum() > 0);
         this.wallet = checkNotNull(wallet);
         initWalletListeners();
         this.serverMultisigKey = checkNotNull(serverMultisigKey);
@@ -396,15 +396,15 @@ public class PaymentChannelClientState {
         checkState(state == State.READY);
         checkNotExpired();
         checkNotNull(size);  // Validity of size will be checked by makeUnsignedChannelContract.
-        if (size.compareTo(BigInteger.ZERO) < 0)
+        if (size.signum() < 0)
             throw new ValueOutOfRangeException("Tried to decrement payment");
         BigInteger newValueToMe = valueToMe.subtract(size);
-        if (newValueToMe.compareTo(Transaction.MIN_NONDUST_OUTPUT) < 0 && newValueToMe.compareTo(BigInteger.ZERO) > 0) {
+        if (newValueToMe.compareTo(Transaction.MIN_NONDUST_OUTPUT) < 0 && newValueToMe.signum() > 0) {
             log.info("New value being sent back as change was smaller than minimum nondust output, sending all");
             size = valueToMe;
             newValueToMe = BigInteger.ZERO;
         }
-        if (newValueToMe.compareTo(BigInteger.ZERO) < 0)
+        if (newValueToMe.signum() < 0)
             throw new ValueOutOfRangeException("Channel has too little money to pay " + size + " satoshis");
         Transaction tx = makeUnsignedChannelContract(newValueToMe);
         log.info("Signing new payment tx {}", tx);

--- a/core/src/main/java/com/google/bitcoin/protocols/channels/PaymentChannelServer.java
+++ b/core/src/main/java/com/google/bitcoin/protocols/channels/PaymentChannelServer.java
@@ -315,7 +315,7 @@ public class PaymentChannelServer {
         boolean stillUsable = state.incrementPayment(refundSize, msg.getSignature().toByteArray());
         BigInteger bestPaymentChange = state.getBestValueToMe().subtract(lastBestPayment);
 
-        if (bestPaymentChange.compareTo(BigInteger.ZERO) > 0)
+        if (bestPaymentChange.signum() > 0)
             conn.paymentIncrease(bestPaymentChange, state.getBestValueToMe());
 
         if (sendAck) {

--- a/core/src/main/java/com/google/bitcoin/protocols/channels/PaymentChannelServerState.java
+++ b/core/src/main/java/com/google/bitcoin/protocols/channels/PaymentChannelServerState.java
@@ -227,7 +227,7 @@ public class PaymentChannelServerState {
                 throw new VerificationException("Multisig contract's first output was not a standard 2-of-2 multisig to client and server in that order.");
 
             this.totalValue = multisigContract.getOutput(0).getValue();
-            if (this.totalValue.compareTo(BigInteger.ZERO) <= 0)
+            if (this.totalValue.signum() <= 0)
                 throw new VerificationException("Not accepting an attempt to open a contract with zero value.");
         } catch (VerificationException e) {
             // We couldn't parse the multisig transaction or its output.
@@ -294,7 +294,7 @@ public class PaymentChannelServerState {
         if (refundSize.compareTo(clientOutput.getMinNonDustValue()) < 0 && !fullyUsedUp)
             throw new ValueOutOfRangeException("Attempt to refund negative value or value too small to be accepted by the network");
         BigInteger newValueToMe = totalValue.subtract(refundSize);
-        if (newValueToMe.compareTo(BigInteger.ZERO) < 0)
+        if (newValueToMe.signum() < 0)
             throw new ValueOutOfRangeException("Attempt to refund more than the contract allows.");
         if (newValueToMe.compareTo(bestValueToMe) < 0)
             throw new ValueOutOfRangeException("Attempt to roll back payment on the channel.");

--- a/core/src/main/java/com/google/bitcoin/protocols/channels/StoredPaymentChannelClientStates.java
+++ b/core/src/main/java/com/google/bitcoin/protocols/channels/StoredPaymentChannelClientStates.java
@@ -220,8 +220,8 @@ public class StoredPaymentChannelClientStates implements WalletExtension {
             ClientState.StoredClientPaymentChannels.Builder builder = ClientState.StoredClientPaymentChannels.newBuilder();
             for (StoredClientChannel channel : mapChannels.values()) {
                 // First a few asserts to make sure things won't break
-                checkState(channel.valueToMe.compareTo(BigInteger.ZERO) >= 0 && channel.valueToMe.compareTo(NetworkParameters.MAX_MONEY) < 0);
-                checkState(channel.refundFees.compareTo(BigInteger.ZERO) >= 0 && channel.refundFees.compareTo(NetworkParameters.MAX_MONEY) < 0);
+                checkState(channel.valueToMe.signum() >= 0 && channel.valueToMe.compareTo(NetworkParameters.MAX_MONEY) < 0);
+                checkState(channel.refundFees.signum() >= 0 && channel.refundFees.compareTo(NetworkParameters.MAX_MONEY) < 0);
                 checkNotNull(channel.myKey.getPrivKeyBytes());
                 checkState(channel.refund.getConfidence().getSource() == TransactionConfidence.Source.SELF);
                 final ClientState.StoredClientPaymentChannel.Builder value = ClientState.StoredClientPaymentChannel.newBuilder()

--- a/core/src/main/java/com/google/bitcoin/protocols/channels/StoredPaymentChannelServerStates.java
+++ b/core/src/main/java/com/google/bitcoin/protocols/channels/StoredPaymentChannelServerStates.java
@@ -150,7 +150,7 @@ public class StoredPaymentChannelServerStates implements WalletExtension {
             ServerState.StoredServerPaymentChannels.Builder builder = ServerState.StoredServerPaymentChannels.newBuilder();
             for (StoredServerChannel channel : mapChannels.values()) {
                 // First a few asserts to make sure things won't break
-                checkState(channel.bestValueToMe.compareTo(BigInteger.ZERO) >= 0 && channel.bestValueToMe.compareTo(NetworkParameters.MAX_MONEY) < 0);
+                checkState(channel.bestValueToMe.signum() >= 0 && channel.bestValueToMe.compareTo(NetworkParameters.MAX_MONEY) < 0);
                 checkState(channel.refundTransactionUnlockTimeSecs > 0);
                 checkNotNull(channel.myKey.getPrivKeyBytes());
                 ServerState.StoredServerPaymentChannel.Builder channelBuilder = ServerState.StoredServerPaymentChannel.newBuilder()

--- a/core/src/main/java/com/google/bitcoin/script/Script.java
+++ b/core/src/main/java/com/google/bitcoin/script/Script.java
@@ -883,7 +883,7 @@ public class Script {
                         numericOPnum = numericOPnum.negate();
                         break;
                     case OP_ABS:
-                        if (numericOPnum.compareTo(BigInteger.ZERO) < 0)
+                        if (numericOPnum.signum() < 0)
                             numericOPnum = numericOPnum.negate();
                         break;
                     case OP_NOT:

--- a/core/src/main/java/com/google/bitcoin/uri/BitcoinURI.java
+++ b/core/src/main/java/com/google/bitcoin/uri/BitcoinURI.java
@@ -326,7 +326,7 @@ public class BitcoinURI {
     public static String convertToBitcoinURI(String address, @Nullable BigInteger amount, @Nullable String label,
                                              @Nullable String message) {
         checkNotNull(address);
-        if (amount != null && amount.compareTo(BigInteger.ZERO) < 0) {
+        if (amount != null && amount.signum() < 0) {
             throw new IllegalArgumentException("Amount must be positive");
         }
         

--- a/core/src/test/java/com/google/bitcoin/core/BlockChainTest.java
+++ b/core/src/test/java/com/google/bitcoin/core/BlockChainTest.java
@@ -127,7 +127,7 @@ public class BlockChainTest {
                                        wallet.getKeys().get(0).toAddress(unitTestParams));
         Block b1 = createFakeBlock(blockStore, tx1).block;
         chain.add(b1);
-        assertTrue(wallet.getBalance().compareTo(BigInteger.ZERO) > 0);
+        assertTrue(wallet.getBalance().signum() > 0);
     }
 
     @Test

--- a/core/src/test/java/com/google/bitcoin/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/com/google/bitcoin/store/WalletProtobufSerializerTest.java
@@ -181,11 +181,11 @@ public class WalletProtobufSerializerTest {
         // Start by building two blocks on top of the genesis block.
         Block b1 = params.getGenesisBlock().createNextBlock(myAddress);
         BigInteger work1 = b1.getWork();
-        assertTrue(work1.compareTo(BigInteger.ZERO) > 0);
+        assertTrue(work1.signum() > 0);
 
         Block b2 = b1.createNextBlock(myAddress);
         BigInteger work2 = b2.getWork();
-        assertTrue(work2.compareTo(BigInteger.ZERO) > 0);
+        assertTrue(work2.signum() > 0);
 
         assertTrue(chain.add(b1));
         assertTrue(chain.add(b2));


### PR DESCRIPTION
Replace usage of BigInteger.compareTo(BigInteger.ZERO) with BigInteger.signum() as it's easier to read and more performant. Passes all unit tests.
