### PR TITLE
Fix handling of defaults when parsing the payment message.

### DIFF
--- a/core/src/main/java/com/google/bitcoin/protocols/payments/PaymentSession.java
+++ b/core/src/main/java/com/google/bitcoin/protocols/payments/PaymentSession.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2013 Google Inc.
+ * Copyright 2014 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,6 +73,7 @@ import java.util.concurrent.Callable;
  * "processing" or that an error occurred.
  *
  * @author Kevin Greene
+ * @author Andreas Schildbach
  * @see <a href="https://github.com/bitcoin/bips/blob/master/bip-0070.mediawiki">BIP 0070</a>
  */
 public class PaymentSession {
@@ -246,7 +248,10 @@ public class PaymentSession {
      * Returns the memo included by the merchant in the payment request.
      */
     public String getMemo() {
-        return paymentDetails.getMemo();
+        if (paymentDetails.hasMemo())
+            return paymentDetails.getMemo();
+        else
+            return null;
     }
 
     /**
@@ -593,8 +598,6 @@ public class PaymentSession {
         try {
             if (request == null)
                 throw new PaymentRequestException("request cannot be null");
-            if (!request.hasPaymentDetailsVersion())
-                throw new PaymentRequestException.InvalidVersion("No version");
             if (request.getPaymentDetailsVersion() != 1)
                 throw new PaymentRequestException.InvalidVersion("Version 1 required. Received version " + request.getPaymentDetailsVersion());
             paymentRequest = request;

--- a/core/src/test/java/com/google/bitcoin/protocols/payments/PaymentSessionTest.java
+++ b/core/src/test/java/com/google/bitcoin/protocols/payments/PaymentSessionTest.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2013 Google Inc.
+ * Copyright 2014 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,6 +81,23 @@ public class PaymentSessionTest {
         TransactionOutput refundOutput = new TransactionOutput(params, null, nanoCoins, refundAddr);
         ByteString refundScript = ByteString.copyFrom(refundOutput.getScriptBytes());
         assertTrue(refundScript.equals(payment.getRefundTo(0).getScript()));
+    }
+
+    @Test
+    public void testDefaults() throws Exception {
+        Protos.Output.Builder outputBuilder = Protos.Output.newBuilder()
+                .setScript(ByteString.copyFrom(outputToMe.getScriptBytes()));
+        Protos.PaymentDetails paymentDetails = Protos.PaymentDetails.newBuilder()
+                .setTime(time)
+                .addOutputs(outputBuilder)
+                .build();
+        Protos.PaymentRequest paymentRequest = Protos.PaymentRequest.newBuilder()
+                .setSerializedPaymentDetails(paymentDetails.toByteString())
+                .build();
+        MockPaymentSession paymentSession = new MockPaymentSession(paymentRequest);
+        assertEquals(BigInteger.ZERO, paymentSession.getValue());
+        assertNull(paymentSession.getPaymentUrl());
+        assertNull(paymentSession.getMemo());
     }
 
     @Test


### PR DESCRIPTION
Bitpay is leaving out the payment details version which was handled incorrectly. Adds a testcase for the defaults.
