### PR TITLE
added path to files on the Mac

### DIFF
--- a/core/src/main/java/com/google/bitcoin/utils/BlockFileLoader.java
+++ b/core/src/main/java/com/google/bitcoin/utils/BlockFileLoader.java
@@ -51,8 +51,11 @@ public class BlockFileLoader implements Iterable<Block>, Iterator<Block> {
      */
     public static List<File> getReferenceClientBlockFileList() {
         String defaultDataDir;
-        if (System.getProperty("os.name").toLowerCase().indexOf("win") >= 0) {
+        String OS = System.getProperty("os.name").toLowerCase();
+        if (OS.indexOf("win") >= 0) {
             defaultDataDir = System.getenv("APPDATA") + "\\.bitcoin\\blocks\\";
+        } else if (OS.indexOf("mac") >= 0 || (OS.indexOf("darwin") >= 0)) {
+            defaultDataDir = System.getProperty("user.home") + "/Library/Application Support/Bitcoin/blocks/";
         } else {
             defaultDataDir = System.getProperty("user.home") + "/.bitcoin/blocks/";
         }


### PR DESCRIPTION
BlockFileLoader wasn't working on OSX because it was missing the path to the location of the block files on OSX (~/Library/Application Support/Bitcoin/blocks). Added it.
