### PR TITLE
Fix race of mock clock with current time if tests are all run sequentially.

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/Utils.java
+++ b/core/src/main/java/com/google/bitcoin/core/Utils.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2011 Google Inc.
+ * Copyright 2014 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -460,13 +461,20 @@ public class Utils {
      */
     public static Date rollMockClockMillis(long millis) {
         if (mockTime == null)
-            mockTime = new Date();
+            throw new IllegalStateException("You need to use setMockClock() first.");
         mockTime = new Date(mockTime.getTime() + millis);
         return mockTime;
     }
 
     /**
-     * Sets the mock clock to the given time (in seconds)
+     * Sets the mock clock to the current time.
+     */
+    public static void setMockClock() {
+        mockTime = new Date();
+    }
+
+    /**
+     * Sets the mock clock to the given time (in seconds).
      */
     public static void setMockClock(long mockClock) {
         mockTime = new Date(mockClock * 1000);

--- a/core/src/test/java/com/google/bitcoin/core/ChainSplitTest.java
+++ b/core/src/test/java/com/google/bitcoin/core/ChainSplitTest.java
@@ -52,6 +52,7 @@ public class ChainSplitTest {
     @Before
     public void setUp() throws Exception {
         BriefLogFormatter.init();
+        Utils.setMockClock(); // Use mock clock
         Wallet.SendRequest.DEFAULT_FEE_PER_KB = BigInteger.ZERO;
         unitTestParams = UnitTestParams.get();
         wallet = new Wallet(unitTestParams);

--- a/core/src/test/java/com/google/bitcoin/core/TransactionBroadcastTest.java
+++ b/core/src/test/java/com/google/bitcoin/core/TransactionBroadcastTest.java
@@ -52,6 +52,7 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
     @Override
     @Before
     public void setUp() throws Exception {
+        Utils.setMockClock(); // Use mock clock
         super.setUp(new MemoryBlockStore(UnitTestParams.get()));
         peerGroup.addWallet(wallet);
         // Fix the random permutation that TransactionBroadcast uses to shuffle the peers.

--- a/core/src/test/java/com/google/bitcoin/protocols/channels/ChannelConnectionTest.java
+++ b/core/src/test/java/com/google/bitcoin/protocols/channels/ChannelConnectionTest.java
@@ -63,6 +63,7 @@ public class ChannelConnectionTest extends TestWithWallet {
     @Before
     public void setUp() throws Exception {
         super.setUp();
+        Utils.setMockClock(); // Use mock clock
         sendMoneyToWallet(Utils.COIN, AbstractBlockChain.NewBlockType.BEST_CHAIN);
         sendMoneyToWallet(Utils.COIN, AbstractBlockChain.NewBlockType.BEST_CHAIN);
         wallet.addExtension(new StoredPaymentChannelClientStates(wallet, failBroadcaster));

--- a/core/src/test/java/com/google/bitcoin/protocols/channels/PaymentChannelStateTest.java
+++ b/core/src/test/java/com/google/bitcoin/protocols/channels/PaymentChannelStateTest.java
@@ -114,7 +114,7 @@ public class PaymentChannelStateTest extends TestWithWallet {
     public void basic() throws Exception {
         // Check it all works when things are normal (no attacks, no problems).
 
-        Utils.rollMockClock(0); // Use mock clock
+        Utils.setMockClock(); // Use mock clock
         final long EXPIRE_TIME = Utils.currentTimeMillis()/1000 + 60*60*24;
 
         serverState = new PaymentChannelServerState(mockBroadcaster, serverWallet, serverKey, EXPIRE_TIME);
@@ -228,7 +228,7 @@ public class PaymentChannelStateTest extends TestWithWallet {
         StoredPaymentChannelClientStates stateStorage = new StoredPaymentChannelClientStates(wallet, mockBroadcaster);
         wallet.addOrUpdateExtension(stateStorage);
 
-        Utils.rollMockClock(0); // Use mock clock
+        Utils.setMockClock(); // Use mock clock
         final long EXPIRE_TIME = Utils.currentTimeMillis()/1000 + 60*60*24;
 
         serverState = new PaymentChannelServerState(mockBroadcaster, serverWallet, serverKey, EXPIRE_TIME);
@@ -330,7 +330,7 @@ public class PaymentChannelStateTest extends TestWithWallet {
 
         // We'll broadcast only one tx: multisig contract
 
-        Utils.rollMockClock(0); // Use mock clock
+        Utils.setMockClock(); // Use mock clock
         final long EXPIRE_TIME = Utils.currentTimeMillis()/1000 + 60*60*24;
 
         serverState = new PaymentChannelServerState(mockBroadcaster, serverWallet, serverKey, EXPIRE_TIME);
@@ -541,7 +541,7 @@ public class PaymentChannelStateTest extends TestWithWallet {
         chain.add(makeSolvedTestBlock(blockStore.getChainHead().getHeader(), createFakeTx(params, Utils.CENT, myAddress)));
         assertEquals(Utils.CENT, wallet.getBalance());
 
-        Utils.rollMockClock(0); // Use mock clock
+        Utils.setMockClock(); // Use mock clock
         final long EXPIRE_TIME = Utils.currentTimeMillis()/1000 + 60*60*24;
 
         serverState = new PaymentChannelServerState(mockBroadcaster, serverWallet, serverKey, EXPIRE_TIME);
@@ -644,7 +644,7 @@ public class PaymentChannelStateTest extends TestWithWallet {
     public void serverAddsFeeTest() throws Exception {
         // Test that the server properly adds the necessary fee at the end (or just drops the payment if its not worth it)
 
-        Utils.rollMockClock(0); // Use mock clock
+        Utils.setMockClock(); // Use mock clock
         final long EXPIRE_TIME = Utils.currentTimeMillis()/1000 + 60*60*24;
 
         serverState = new PaymentChannelServerState(mockBroadcaster, serverWallet, serverKey, EXPIRE_TIME);
@@ -730,7 +730,7 @@ public class PaymentChannelStateTest extends TestWithWallet {
         // Tests that if the client double-spends the multisig contract after it is sent, no more payments are accepted
 
         // Start with a copy of basic()....
-        Utils.rollMockClock(0); // Use mock clock
+        Utils.setMockClock(); // Use mock clock
         final long EXPIRE_TIME = Utils.currentTimeMillis()/1000 + 60*60*24;
 
         serverState = new PaymentChannelServerState(mockBroadcaster, serverWallet, serverKey, EXPIRE_TIME);

--- a/core/src/test/java/com/google/bitcoin/wallet/DefaultCoinSelectorTest.java
+++ b/core/src/test/java/com/google/bitcoin/wallet/DefaultCoinSelectorTest.java
@@ -39,6 +39,7 @@ public class DefaultCoinSelectorTest extends TestWithWallet {
     @Override
     public void setUp() throws Exception {
         super.setUp();
+        Utils.setMockClock(); // Use mock clock
     }
 
     @After


### PR DESCRIPTION
This commit requires you to use one of the setMockClock() variants before being able to roll it.
