### PR TITLE
Upgrade to Guava 16.0.1.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -151,7 +151,7 @@
                                     <!-- classifier is "null" if not present -->
                                     <urns>
                                         <urn>com.google.code.findbugs:jsr305:1.3.9:jar:null:compile:40719ea6961c0cb6afaeb6a921eaa1f6afd4cfdf</urn>
-                                        <urn>com.google.guava:guava:13.0.1:jar:null:compile:0d6f22b1e60a2f1ef99e22c9f5fde270b2088365</urn>
+                                        <urn>com.google.guava:guava:16.0.1:jar:null:compile:5fa98cd1a63c99a44dd8d3b77e4762b066a5d0c5</urn>
                                         <urn>com.google.protobuf:protobuf-java:2.5.0:jar:null:compile:a10732c76bfacdbd633a7eb0f7968b1059a65dfa</urn>
                                         <urn>com.h2database:h2:1.3.167:jar:null:compile:d3867d586f087e53eb12fc65e5693d8ee9a5da17</urn>
                                         <urn>com.lambdaworks:scrypt:1.3.3:jar:null:compile:06d6813de41e177189e1722717979b4fb5454b1d</urn>
@@ -254,7 +254,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>13.0.1</version>
+            <version>16.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/core/src/main/java/com/google/bitcoin/core/PeerGroup.java
+++ b/core/src/main/java/com/google/bitcoin/core/PeerGroup.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2013 Google Inc.
+ * Copyright 2014 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 
 package com.google.bitcoin.core;
 
@@ -682,7 +682,8 @@ public class PeerGroup extends AbstractExecutionThreadService implements Transac
     protected void startUp() throws Exception {
         // This is run in a background thread by the Service implementation.
         vPingTimer = new Timer("Peer pinging thread", true);
-        channels.startAndWait();
+        channels.startAsync();
+        channels.awaitRunning();
         triggerConnections();
     }
 
@@ -691,7 +692,8 @@ public class PeerGroup extends AbstractExecutionThreadService implements Transac
         // This is run on a separate thread by the Service implementation.
         vPingTimer.cancel();
         // Blocking close of all sockets.
-        channels.stopAndWait();
+        channels.stopAsync();
+        channels.awaitTerminated();
         for (PeerDiscovery peerDiscovery : peerDiscoverers) {
             peerDiscovery.shutdown();
         }

--- a/core/src/main/java/com/google/bitcoin/net/NioClient.java
+++ b/core/src/main/java/com/google/bitcoin/net/NioClient.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2013 Google Inc.
+ * Copyright 2014 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +49,7 @@ public class NioClient implements MessageWriteTarget {
         @Override
         public void connectionClosed() {
             upstreamParser.connectionClosed();
-            manager.stop();
+            manager.stopAsync();
         }
 
         @Override
@@ -90,7 +91,8 @@ public class NioClient implements MessageWriteTarget {
      */
     public NioClient(final SocketAddress serverAddress, final StreamParser parser,
                      final int connectTimeoutMillis) throws IOException {
-        manager.startAndWait();
+        manager.startAsync();
+        manager.awaitRunning();
         handler = new Handler(parser, connectTimeoutMillis);
         manager.openConnection(serverAddress, handler);
     }

--- a/core/src/main/java/com/google/bitcoin/protocols/channels/PaymentChannelServerListener.java
+++ b/core/src/main/java/com/google/bitcoin/protocols/channels/PaymentChannelServerListener.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2013 Google Inc.
+ * Copyright 2014 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -142,7 +143,8 @@ public class PaymentChannelServerListener {
                 return new ServerHandler(new InetSocketAddress(inetAddress, port), timeoutSeconds).socketProtobufHandler;
             }
         }, new InetSocketAddress(port));
-        server.startAndWait();
+        server.startAsync();
+        server.awaitRunning();
     }
 
     /**
@@ -176,6 +178,7 @@ public class PaymentChannelServerListener {
      * wallet.</p>
      */
     public void close() {
-        server.stopAndWait();
+        server.stopAsync();
+        server.awaitTerminated();
     }
 }

--- a/core/src/test/java/com/google/bitcoin/core/BitcoindComparisonTool.java
+++ b/core/src/test/java/com/google/bitcoin/core/BitcoindComparisonTool.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2012 Matt Corallo.
+ * Copyright 2014 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -142,7 +143,7 @@ public class BitcoindComparisonTool {
         bitcoindChainHead = params.getGenesisBlock().getHash();
         
         // Connect to bitcoind and make sure it has no blocks
-        peers.start();
+        peers.startAsync();
         peers.setMaxConnections(1);
         peers.downloadBlockChain();
         

--- a/core/src/test/java/com/google/bitcoin/core/FilteredBlockAndPartialMerkleTreeTests.java
+++ b/core/src/test/java/com/google/bitcoin/core/FilteredBlockAndPartialMerkleTreeTests.java
@@ -1,3 +1,20 @@
+/**
+ * Copyright 2012 Matt Corallo
+ * Copyright 2014 Andreas Schildbach
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.bitcoin.core;
 
 import com.google.bitcoin.core.TransactionConfidence.ConfidenceType;
@@ -101,7 +118,8 @@ public class FilteredBlockAndPartialMerkleTreeTests extends TestWithPeerGroup {
         peerGroup.addWallet(wallet);
         blockChain.addWallet(wallet);
 
-        peerGroup.startAndWait();
+        peerGroup.startAsync();
+        peerGroup.awaitRunning();
 
         // Create a peer.
         InboundMessageQueuer p1 = connectPeer(1);
@@ -143,7 +161,7 @@ public class FilteredBlockAndPartialMerkleTreeTests extends TestWithPeerGroup {
 
         // Peer 1 goes away.
         closePeer(peerOf(p1));
-        peerGroup.stop();
+        peerGroup.stopAsync();
         super.tearDown();
     }
 }

--- a/core/src/test/java/com/google/bitcoin/core/TestWithNetworkConnections.java
+++ b/core/src/test/java/com/google/bitcoin/core/TestWithNetworkConnections.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2011 Google Inc.
+ * Copyright 2014 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,8 +90,10 @@ public class TestWithNetworkConnections {
         blockChain = new BlockChain(unitTestParams, wallet, blockStore);
 
         startPeerServers();
-        if (clientType == ClientType.NIO_CLIENT_MANAGER || clientType == ClientType.BLOCKING_CLIENT_MANAGER)
-            channels.startAndWait();
+        if (clientType == ClientType.NIO_CLIENT_MANAGER || clientType == ClientType.BLOCKING_CLIENT_MANAGER) {
+            channels.startAsync();
+            channels.awaitRunning();
+        }
 
         socketAddress = new InetSocketAddress("127.0.0.1", 1111);
     }
@@ -118,7 +121,8 @@ public class TestWithNetworkConnections {
                 };
             }
         }, new InetSocketAddress("127.0.0.1", 2000 + i));
-        peerServers[i].startAndWait();
+        peerServers[i].startAsync();
+        peerServers[i].awaitRunning();
     }
 
     public void tearDown() throws Exception {
@@ -132,7 +136,8 @@ public class TestWithNetworkConnections {
     }
 
     protected void stopPeerServer(int i) {
-        peerServers[i].stopAndWait();
+        peerServers[i].stopAsync();
+        peerServers[i].awaitTerminated();
     }
 
     protected InboundMessageQueuer connect(Peer peer, VersionMessage versionMessage) throws Exception {

--- a/core/src/test/java/com/google/bitcoin/core/TransactionBroadcastTest.java
+++ b/core/src/test/java/com/google/bitcoin/core/TransactionBroadcastTest.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2013 Google Inc.
+ * Copyright 2014 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,13 +59,15 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
         // Fix the random permutation that TransactionBroadcast uses to shuffle the peers.
         TransactionBroadcast.random = new Random(0);
         peerGroup.setMinBroadcastConnections(2);
-        peerGroup.startAndWait();
+        peerGroup.startAsync();
+        peerGroup.awaitRunning();
     }
 
     @After
     public void tearDown() throws Exception {
         super.tearDown();
-        peerGroup.stopAndWait();
+        peerGroup.stopAsync();
+        peerGroup.awaitTerminated();
     }
 
     @Test

--- a/core/src/test/java/com/google/bitcoin/net/NetworkAbstractionTests.java
+++ b/core/src/test/java/com/google/bitcoin/net/NetworkAbstractionTests.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2013 Google Inc.
+ * Copyright 2014 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,10 +54,10 @@ public class NetworkAbstractionTests {
         this.clientType = clientType;
         if (clientType == 0) {
             channels = new NioClientManager();
-            channels.start();
+            channels.startAsync();
         } else if (clientType == 1) {
             channels = new BlockingClientManager();
-            channels.start();
+            channels.startAsync();
         } else
             channels = null;
     }
@@ -117,7 +118,8 @@ public class NetworkAbstractionTests {
                 }, Protos.TwoWayChannelMessage.getDefaultInstance(), 1000, 0);
             }
         }, new InetSocketAddress("localhost", 4243));
-        server.startAndWait();
+        server.startAsync();
+        server.awaitRunning();
 
         ProtobufParser<Protos.TwoWayChannelMessage> clientHandler = new ProtobufParser<Protos.TwoWayChannelMessage>(
                 new ProtobufParser.Listener<Protos.TwoWayChannelMessage>() {
@@ -154,7 +156,8 @@ public class NetworkAbstractionTests {
         serverConnectionClosed.get();
         clientConnectionClosed.get();
 
-        server.stopAndWait();
+        server.stopAsync();
+        server.awaitTerminated();
         assertFalse(server.isRunning());
     }
 
@@ -199,7 +202,8 @@ public class NetworkAbstractionTests {
                 }, Protos.TwoWayChannelMessage.getDefaultInstance(), 1000, 10);
             }
         }, new InetSocketAddress("localhost", 4243));
-        server.startAndWait();
+        server.startAsync();
+        server.awaitRunning();
 
         openConnection(new InetSocketAddress("localhost", 4243), new ProtobufParser<Protos.TwoWayChannelMessage>(
                 new ProtobufParser.Listener<Protos.TwoWayChannelMessage>() {
@@ -254,7 +258,8 @@ public class NetworkAbstractionTests {
         clientConnection2Closed.get();
         serverConnection2Closed.get();
 
-        server.stopAndWait();
+        server.stopAsync();
+        server.awaitTerminated();
     }
 
     @Test
@@ -289,7 +294,8 @@ public class NetworkAbstractionTests {
                 }, Protos.TwoWayChannelMessage.getDefaultInstance(), 0x10000, 0);
             }
         }, new InetSocketAddress("localhost", 4243));
-        server.startAndWait();
+        server.startAsync();
+        server.awaitRunning();
 
         ProtobufParser<Protos.TwoWayChannelMessage> clientHandler = new ProtobufParser<Protos.TwoWayChannelMessage>(
                 new ProtobufParser.Listener<Protos.TwoWayChannelMessage>() {
@@ -397,7 +403,8 @@ public class NetworkAbstractionTests {
         serverConnectionClosed.get();
         clientConnectionClosed.get();
 
-        server.stopAndWait();
+        server.stopAsync();
+        server.awaitTerminated();
     }
 
     @Test
@@ -451,7 +458,8 @@ public class NetworkAbstractionTests {
                 }, Protos.TwoWayChannelMessage.getDefaultInstance(), 1000, 0);
             }
         }, new InetSocketAddress("localhost", 4243));
-        server.startAndWait();
+        server.startAsync();
+        server.awaitRunning();
 
         ProtobufParser<Protos.TwoWayChannelMessage> client1Handler = new ProtobufParser<Protos.TwoWayChannelMessage>(
                 new ProtobufParser.Listener<Protos.TwoWayChannelMessage>() {
@@ -538,16 +546,18 @@ public class NetworkAbstractionTests {
 
         // Try to create a race condition by triggering handlerThread closing and client3 closing at the same time
         // This often triggers ClosedByInterruptException in handleKey
-        server.stop();
+        server.stopAsync();
         server.selector.wakeup();
         client3.closeConnection();
         client3ConnectionClosed.get();
         serverConnectionClosed3.get();
 
-        server.stopAndWait();
+        server.stopAsync();
+        server.awaitTerminated();
         client2ConnectionClosed.get();
         serverConnectionClosed2.get();
 
-        server.stopAndWait();
+        server.stopAsync();
+        server.awaitTerminated();
     }
 }

--- a/examples/src/main/java/com/google/bitcoin/examples/ExamplePaymentChannelClient.java
+++ b/examples/src/main/java/com/google/bitcoin/examples/ExamplePaymentChannelClient.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2013 Google Inc.
+ * Copyright 2014 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,7 +74,8 @@ public class ExamplePaymentChannelClient {
                 wallet().addExtension(new StoredPaymentChannelClientStates(wallet(), peerGroup()));
             }
         };
-        appKit.startAndWait();
+        appKit.startAsync();
+        appKit.awaitRunning();
         // We now have active network connections and a fully synced wallet.
         // Add a new key which will be used for the multisig contract.
         appKit.wallet().addKey(myKey);
@@ -103,7 +105,8 @@ public class ExamplePaymentChannelClient {
         log.info("Waiting ...");
         Thread.sleep(60 * 60 * 1000);  // 1 hour.
         log.info("Stopping ...");
-        appKit.stopAndWait();
+        appKit.stopAsync();
+        appKit.awaitTerminated();
     }
 
     private void openAndSend(int timeoutSecs, InetSocketAddress server, String channelID) throws IOException, ValueOutOfRangeException, InterruptedException {

--- a/examples/src/main/java/com/google/bitcoin/examples/ExamplePaymentChannelServer.java
+++ b/examples/src/main/java/com/google/bitcoin/examples/ExamplePaymentChannelServer.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2013 Google Inc.
+ * Copyright 2014 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +58,8 @@ public class ExamplePaymentChannelServer implements PaymentChannelServerListener
                 wallet().addExtension(storedStates);
             }
         };
-        appKit.startAndWait();
+        appKit.startAsync();
+        appKit.awaitRunning();
 
         System.out.println(appKit.wallet());
 

--- a/examples/src/main/java/com/google/bitcoin/examples/FetchBlock.java
+++ b/examples/src/main/java/com/google/bitcoin/examples/FetchBlock.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2011 Google Inc.
+ * Copyright 2014 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +38,8 @@ public class FetchBlock {
         BlockStore blockStore = new MemoryBlockStore(params);
         BlockChain chain = new BlockChain(params, blockStore);
         PeerGroup peerGroup = new PeerGroup(params, chain);
-        peerGroup.startAndWait();
+        peerGroup.startAsync();
+        peerGroup.awaitRunning();
         PeerAddress addr = new PeerAddress(InetAddress.getLocalHost(), params.getPort());
         peerGroup.addAddress(addr);
         peerGroup.waitForPeers(1).get();
@@ -48,6 +50,6 @@ public class FetchBlock {
         System.out.println("Waiting for node to send us the requested block: " + blockHash);
         Block block = future.get();
         System.out.println(block);
-        peerGroup.stop();
+        peerGroup.stopAsync();
     }
 }

--- a/examples/src/main/java/com/google/bitcoin/examples/FetchTransactions.java
+++ b/examples/src/main/java/com/google/bitcoin/examples/FetchTransactions.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2012 Google Inc.
+ * Copyright 2014 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +39,8 @@ public class FetchTransactions {
         BlockStore blockStore = new MemoryBlockStore(params);
         BlockChain chain = new BlockChain(params, blockStore);
         PeerGroup peerGroup = new PeerGroup(params, chain);
-        peerGroup.startAndWait();
+        peerGroup.startAsync();
+        peerGroup.awaitRunning();
         peerGroup.addAddress(new PeerAddress(InetAddress.getLocalHost(), params.getPort()));
         peerGroup.waitForPeers(1).get();
         Peer peer = peerGroup.getConnectedPeers().get(0);
@@ -56,6 +58,7 @@ public class FetchTransactions {
         }
 
         System.out.println("Done.");
-        peerGroup.stopAndWait();
+        peerGroup.stopAsync();
+        peerGroup.awaitTerminated();
     }
 }

--- a/examples/src/main/java/com/google/bitcoin/examples/ForwardingService.java
+++ b/examples/src/main/java/com/google/bitcoin/examples/ForwardingService.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2013 Google Inc.
+ * Copyright 2014 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +75,8 @@ public class ForwardingService {
         }
 
         // Download the block chain and wait until it's done.
-        kit.startAndWait();
+        kit.startAsync();
+        kit.awaitRunning();
 
         // We want to know when we receive money.
         kit.wallet().addEventListener(new AbstractWalletEventListener() {

--- a/examples/src/main/java/com/google/bitcoin/examples/PeerMonitor.java
+++ b/examples/src/main/java/com/google/bitcoin/examples/PeerMonitor.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2012 Google Inc.
+ * Copyright 2014 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +58,7 @@ public class PeerMonitor {
     public PeerMonitor() {
         setupNetwork();
         setupGUI();
-        peerGroup.start();
+        peerGroup.startAsync();
     }
 
     private void setupNetwork() {
@@ -113,7 +114,8 @@ public class PeerMonitor {
             @Override
             public void windowClosing(WindowEvent windowEvent) {
                 System.out.println("Shutting down ...");
-                peerGroup.stopAndWait();
+                peerGroup.stopAsync();
+                peerGroup.awaitTerminated();
                 System.out.println("Shutdown complete.");
                 System.exit(0);
             }

--- a/examples/src/main/java/com/google/bitcoin/examples/PrivateKeys.java
+++ b/examples/src/main/java/com/google/bitcoin/examples/PrivateKeys.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2011 Google Inc.
+ * Copyright 2014 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,9 +62,9 @@ public class PrivateKeys {
 
             final PeerGroup peerGroup = new PeerGroup(params, chain);
             peerGroup.addAddress(new PeerAddress(InetAddress.getLocalHost()));
-            peerGroup.start();
+            peerGroup.startAsync();
             peerGroup.downloadBlockChain();
-            peerGroup.stop();
+            peerGroup.stopAsync();
 
             // And take them!
             System.out.println("Claiming " + Utils.bitcoinValueToFriendlyString(wallet.getBalance()) + " coins");

--- a/examples/src/main/java/com/google/bitcoin/examples/RefreshWallet.java
+++ b/examples/src/main/java/com/google/bitcoin/examples/RefreshWallet.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2011 Google Inc.
+ * Copyright 2014 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +42,7 @@ public class RefreshWallet {
 
         final PeerGroup peerGroup = new PeerGroup(params, chain);
         peerGroup.addAddress(new PeerAddress(InetAddress.getLocalHost()));
-        peerGroup.start();
+        peerGroup.startAsync();
 
         wallet.addEventListener(new AbstractWalletEventListener() {
             @Override
@@ -53,7 +54,7 @@ public class RefreshWallet {
 
         // Now download and process the block chain.
         peerGroup.downloadBlockChain();
-        peerGroup.stop();
+        peerGroup.stopAsync();
         wallet.saveToFile(file);
         System.out.println("\nDone!\n");
         System.out.println(wallet.toString());

--- a/tools/src/main/java/com/google/bitcoin/tools/BuildCheckpoints.java
+++ b/tools/src/main/java/com/google/bitcoin/tools/BuildCheckpoints.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2013 Google Inc.
+ * Copyright 2014 Andreas Schildbach
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.bitcoin.tools;
 
 import com.google.bitcoin.core.*;
@@ -58,7 +75,8 @@ public class BuildCheckpoints {
             }
         }, Threading.SAME_THREAD);
 
-        peerGroup.startAndWait();
+        peerGroup.startAsync();
+        peerGroup.awaitRunning();
         peerGroup.downloadBlockChain();
 
         checkState(checkpoints.size() > 0);
@@ -85,7 +103,8 @@ public class BuildCheckpoints {
         digestOutputStream.close();
         fileOutputStream.close();
 
-        peerGroup.stopAndWait();
+        peerGroup.stopAsync();
+        peerGroup.awaitTerminated();
         store.close();
 
         // Sanity check the created file.

--- a/tools/src/main/java/com/google/bitcoin/tools/WalletTool.java
+++ b/tools/src/main/java/com/google/bitcoin/tools/WalletTool.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2012 Google Inc.
+ * Copyright 2014 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -452,7 +453,8 @@ public class WalletTool {
             }
 
             setup();
-            peers.startAndWait();
+            peers.startAsync();
+            peers.awaitRunning();
             // Wait for peers to connect, the tx to be sent to one of them and for it to be propagated across the
             // network. Once propagation is complete and we heard the transaction back from all our peers, it will
             // be committed to the wallet.
@@ -557,7 +559,8 @@ public class WalletTool {
             ListenableFuture<PaymentSession.Ack> future = session.sendPayment(ImmutableList.of(req.tx), null, null);
             if (future == null) {
                 // No payment_url for submission so, broadcast and wait.
-                peers.startAndWait();
+                peers.startAsync();
+                peers.awaitRunning();
                 peers.broadcastTransaction(req.tx).get();
             } else {
                 PaymentSession.Ack ack = future.get();
@@ -651,7 +654,7 @@ public class WalletTool {
                 break;
 
         }
-        peers.start();
+        peers.startAsync();
         try {
             latch.await();
         } catch (InterruptedException e) {
@@ -713,7 +716,8 @@ public class WalletTool {
             setup();
             int startTransactions = wallet.getTransactions(true).size();
             DownloadListener listener = new DownloadListener();
-            peers.startAndWait();
+            peers.startAsync();
+            peers.awaitRunning();
             peers.startBlockChainDownload(listener);
             try {
                 listener.await();
@@ -734,7 +738,8 @@ public class WalletTool {
     private static void shutdown() {
         try {
             if (peers == null) return;  // setup() never called so nothing to do.
-            peers.stopAndWait();
+            peers.stopAsync();
+            peers.awaitTerminated();
             saveWallet(walletFile);
             store.close();
             wallet = null;

--- a/tools/src/main/java/com/google/bitcoin/tools/WatchMempool.java
+++ b/tools/src/main/java/com/google/bitcoin/tools/WatchMempool.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2013 Google Inc.
+ * Copyright 2014 Andreas Schildbach
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.bitcoin.tools;
 
 import com.google.bitcoin.core.*;
@@ -27,6 +44,6 @@ public class WatchMempool {
                 }
             }
         });
-        peerGroup.start();
+        peerGroup.startAsync();
     }
 }

--- a/wallettemplate/pom.xml
+++ b/wallettemplate/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>13.0</version>
+            <version>16.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.aquafx-project</groupId>

--- a/wallettemplate/src/main/java/wallettemplate/Main.java
+++ b/wallettemplate/src/main/java/wallettemplate/Main.java
@@ -92,8 +92,9 @@ public class Main extends Application {
         // or progress widget to keep the user engaged whilst we initialise, but we don't.
         bitcoin.setDownloadListener(controller.progressBarUpdater())
                .setBlockingStartup(false)
-               .setUserAgent(APP_NAME, "1.0")
-               .startAndWait();
+               .setUserAgent(APP_NAME, "1.0");
+        bitcoin.startAsync();
+        bitcoin.awaitRunning();
         // Don't make the user wait for confirmations for now, as the intention is they're sending it their own money!
         bitcoin.wallet().allowSpendingUnconfirmedTransactions();
         bitcoin.peerGroup().setMaxConnections(11);
@@ -162,7 +163,8 @@ public class Main extends Application {
 
     @Override
     public void stop() throws Exception {
-        bitcoin.stopAndWait();
+        bitcoin.stopAsync();
+        bitcoin.awaitTerminated();
         super.stop();
     }
 


### PR DESCRIPTION
Migrate all deprecated Service.start_() and Service.stop_() invocations.

Please someone have a second look at WalletAppKit.java (needed to get rid of a future) and the wallettemplate subproject (had to migrate blindly, no Java8 at hand).

Also adds the odd copyright header where it was missing.
