### PR TITLE
HD Wallets: let you specify the creation time for a WatchingKey

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/Wallet.java
+++ b/core/src/main/java/com/google/bitcoin/core/Wallet.java
@@ -200,6 +200,10 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
         return new Wallet(params, new KeyChainGroup(seed));
     }
 
+    public static Wallet fromWatchingKey(NetworkParameters params, DeterministicKey watchKey, long creationTimeSeconds) {
+        return new Wallet(params, new KeyChainGroup(watchKey, creationTimeSeconds));
+    }
+
     public static Wallet fromWatchingKey(NetworkParameters params, DeterministicKey watchKey) {
         return new Wallet(params, new KeyChainGroup(watchKey));
     }

--- a/core/src/main/java/com/google/bitcoin/wallet/KeyChainGroup.java
+++ b/core/src/main/java/com/google/bitcoin/wallet/KeyChainGroup.java
@@ -76,6 +76,10 @@ public class KeyChainGroup {
         this(null, ImmutableList.of(new DeterministicKeyChain(watchKey)), null);
     }
 
+    public KeyChainGroup(DeterministicKey watchKey, long creationTimeSeconds) {
+        this(null, ImmutableList.of(new DeterministicKeyChain(watchKey, creationTimeSeconds)), null);
+    }
+
     // Used for deserialization.
     private KeyChainGroup(@Nullable BasicKeyChain basicKeyChain, List<DeterministicKeyChain> chains, @Nullable KeyCrypter crypter) {
         this.basic = basicKeyChain == null ? new BasicKeyChain() : basicKeyChain;


### PR DESCRIPTION
If the creation time for a WatchingKey is known, it should be taken into
account and stored.
