### PR TITLE
signInputs: Throw exception on missing private Key

### DIFF
--- a/core/src/test/java/com/google/bitcoin/core/WalletTest.java
+++ b/core/src/test/java/com/google/bitcoin/core/WalletTest.java
@@ -2302,7 +2302,11 @@ public class WalletTest extends TestWithWallet {
 
         ECKey dest = new ECKey();
         Wallet.SendRequest req = Wallet.SendRequest.emptyWallet(dest.toAddress(params));
-        wallet.completeTx(req);
+        try {
+		wallet.completeTx(req);
+	} catch (ECKey.MissingPrivateKeyException e) {
+		//log.info("Ignoring ECKey.MissingPrivateKeyException");
+	}
         byte[] dummySig = TransactionSignature.dummy().encodeToBitcoin();
         // Selected inputs can be in any order.
         for (int i = 0; i < req.tx.getInputs().size(); i++) {


### PR DESCRIPTION
signInputs() throws a ECKey.MissingPrivateKeyException, if a dummy
signature was used, so that callers now can react on it.
Otherwise the caller cannot know, that the Transaction might need to be
signed by somebody else.
