### PR TITLE
Adjust MIN_NONDUST_OUTPUT down to 546 only for risk analysis.

### DIFF
--- a/core/src/main/java/com/google/bitcoin/wallet/DefaultRiskAnalysis.java
+++ b/core/src/main/java/com/google/bitcoin/wallet/DefaultRiskAnalysis.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.math.BigInteger;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -38,6 +39,13 @@ import static com.google.common.base.Preconditions.checkState;
  */
 public class DefaultRiskAnalysis implements RiskAnalysis {
     private static final Logger log = LoggerFactory.getLogger(DefaultRiskAnalysis.class);
+
+    /**
+     * Any standard output smaller than this value (in satoshis) will be considered risky, as it's most likely be
+     * rejected by the network. Currently it's 546 satoshis. This is different from {@link Transaction#MIN_NONDUST_OUTPUT}
+     * because of an upcoming fee change in Bitcoin Core 0.9.
+     */
+    public static final BigInteger MIN_ANALYSIS_NONDUST_OUTPUT = BigInteger.valueOf(546);
 
     protected final Transaction tx;
     protected final List<Transaction> dependencies;
@@ -115,7 +123,7 @@ public class DefaultRiskAnalysis implements RiskAnalysis {
         final List<TransactionOutput> outputs = tx.getOutputs();
         for (int i = 0; i < outputs.size(); i++) {
             TransactionOutput output = outputs.get(i);
-            if (output.getMinNonDustValue().compareTo(output.getValue()) > 0) {
+            if (MIN_ANALYSIS_NONDUST_OUTPUT.compareTo(output.getValue()) > 0) {
                 log.warn("TX considered non-standard due to output {} being dusty", i);
                 return RuleViolation.DUST;
             }

--- a/core/src/test/java/com/google/bitcoin/wallet/DefaultRiskAnalysisTest.java
+++ b/core/src/test/java/com/google/bitcoin/wallet/DefaultRiskAnalysisTest.java
@@ -138,7 +138,7 @@ public class DefaultRiskAnalysisTest {
 
         Transaction edgeCaseTx = new Transaction(params);
         edgeCaseTx.addInput(params.getGenesisBlock().getTransactions().get(0).getOutput(0));
-        edgeCaseTx.addOutput(dustTx.getOutput(0).getMinNonDustValue(), key1); // Dust threshold
+        edgeCaseTx.addOutput(DefaultRiskAnalysis.MIN_ANALYSIS_NONDUST_OUTPUT, key1); // Dust threshold
         assertEquals(RiskAnalysis.Result.OK, DefaultRiskAnalysis.FACTORY.create(wallet, edgeCaseTx, NO_DEPS).analyze());
     }
 }


### PR DESCRIPTION
This is required because we start seeing more and more transactions using the new fee rules introduced with Bitcoin Core 0.9.
