### PR TITLE
Declare Orchid dependency as optional.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -284,6 +284,7 @@
             <groupId>com.subgraph</groupId>
             <artifactId>orchid</artifactId>
             <version>1.0-SNAPSHOT</version>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -90,5 +90,10 @@
       <artifactId>h2</artifactId>
       <version>1.3.167</version>
     </dependency>
+    <dependency>
+      <groupId>com.subgraph</groupId>
+      <artifactId>orchid</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
We should not force it on users.
