### PR TITLE
Improved consistency and formal correctness of existing equals methods

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/Block.java
+++ b/core/src/main/java/com/google/bitcoin/core/Block.java
@@ -805,8 +805,8 @@ public class Block extends Message {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Block))
-            return false;
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         Block other = (Block) o;
         return getHash().equals(other.getHash());
     }

--- a/core/src/main/java/com/google/bitcoin/core/BloomFilter.java
+++ b/core/src/main/java/com/google/bitcoin/core/BloomFilter.java
@@ -266,11 +266,13 @@ public class BloomFilter extends Message {
     }
     
     @Override
-    public boolean equals(Object other) {
-        return other instanceof BloomFilter &&
-                ((BloomFilter) other).hashFuncs == this.hashFuncs &&
-                ((BloomFilter) other).nTweak == this.nTweak &&
-                Arrays.equals(((BloomFilter) other).data, this.data);
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BloomFilter other = (BloomFilter) o;
+        return hashFuncs == other.hashFuncs &&
+               nTweak == other.nTweak &&
+               Arrays.equals(data, other.data);
     }
 
     @Override

--- a/core/src/main/java/com/google/bitcoin/core/DumpedPrivateKey.java
+++ b/core/src/main/java/com/google/bitcoin/core/DumpedPrivateKey.java
@@ -79,19 +79,13 @@ public class DumpedPrivateKey extends VersionedChecksummedBytes {
     }
 
     @Override
-    public boolean equals(Object other) {
-        // This odd construction is to avoid anti-symmetry of equality: where a.equals(b) != b.equals(a).
-        boolean result = false;
-        if (other instanceof VersionedChecksummedBytes) {
-            result = Arrays.equals(bytes, ((VersionedChecksummedBytes)other).bytes);
-        }
-        if (other instanceof DumpedPrivateKey) {
-            DumpedPrivateKey o = (DumpedPrivateKey) other;
-            result = Arrays.equals(bytes, o.bytes) &&
-                     version == o.version &&
-                     compressed == o.compressed;
-        }
-        return result;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DumpedPrivateKey other = (DumpedPrivateKey) o;
+        return Arrays.equals(bytes, other.bytes) &&
+               version == other.version &&
+               compressed == other.compressed;
     }
 
     @Override

--- a/core/src/main/java/com/google/bitcoin/core/ECKey.java
+++ b/core/src/main/java/com/google/bitcoin/core/ECKey.java
@@ -402,13 +402,9 @@ public class ECKey implements Serializable {
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-
-            ECDSASignature signature = (ECDSASignature) o;
-
-            if (!r.equals(signature.r)) return false;
-            if (!s.equals(signature.s)) return false;
-
-            return true;
+            ECDSASignature other = (ECDSASignature) o;
+            return r.equals(other.r) &&
+                   s.equals(other.s);
         }
 
         @Override
@@ -828,10 +824,8 @@ public class ECKey implements Serializable {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
-        ECKey ecKey = (ECKey) o;
-
-        return Arrays.equals(pub, ecKey.pub);
+        ECKey other = (ECKey) o;
+        return Arrays.equals(pub, other.pub);
     }
 
     @Override

--- a/core/src/main/java/com/google/bitcoin/core/GetBlocksMessage.java
+++ b/core/src/main/java/com/google/bitcoin/core/GetBlocksMessage.java
@@ -99,11 +99,13 @@ public class GetBlocksMessage extends Message {
 
     @Override
     public boolean equals(Object o) {
-        if (o == null || o.getClass() != getClass()) return false;
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         GetBlocksMessage other = (GetBlocksMessage) o;
-        return (other.version == version &&
-                locator.size() == other.locator.size() && locator.containsAll(other.locator) &&
-                stopHash.equals(other.stopHash));
+        return version == other.version &&
+               locator.size() == other.locator.size() &&
+               locator.containsAll(other.locator) &&
+               stopHash.equals(other.stopHash);
     }
 
     @Override

--- a/core/src/main/java/com/google/bitcoin/core/GetHeadersMessage.java
+++ b/core/src/main/java/com/google/bitcoin/core/GetHeadersMessage.java
@@ -50,11 +50,13 @@ public class GetHeadersMessage extends GetBlocksMessage {
      */
     @Override
     public boolean equals(Object o) {
-        if (o == null || o.getClass() != getClass()) return false;
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         GetHeadersMessage other = (GetHeadersMessage) o;
-        return (other.version == version &&
-                locator.size() == other.locator.size() && locator.containsAll(other.locator) &&
-                stopHash.equals(other.stopHash));
+        return version == other.version &&
+               locator.size() == other.locator.size() &&
+               locator.containsAll(other.locator) &&
+               stopHash.equals(other.stopHash);
     }
 
     @Override

--- a/core/src/main/java/com/google/bitcoin/core/InventoryItem.java
+++ b/core/src/main/java/com/google/bitcoin/core/InventoryItem.java
@@ -43,13 +43,17 @@ public class InventoryItem {
         return type.toString() + ": " + hash;
     }
 
-    public int hashCode() {
-        return hash.hashCode() + type.ordinal();
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        InventoryItem other = (InventoryItem) o;
+        return type == other.type &&
+               hash.equals(other.hash);
     }
 
-    public boolean equals(Object o) {
-        return o instanceof InventoryItem &&
-                ((InventoryItem)o).type == this.type &&
-                ((InventoryItem)o).hash.equals(this.hash);
+    @Override
+    public int hashCode() {
+        return hash.hashCode() + type.ordinal();
     }
 }

--- a/core/src/main/java/com/google/bitcoin/core/ListMessage.java
+++ b/core/src/main/java/com/google/bitcoin/core/ListMessage.java
@@ -34,7 +34,6 @@ public abstract class ListMessage extends Message {
 
     public static final long MAX_INVENTORY_ITEMS = 50000;
 
-
     public ListMessage(NetworkParameters params, byte[] bytes) throws ProtocolException {
         super(params, bytes, 0);
     }
@@ -43,7 +42,6 @@ public abstract class ListMessage extends Message {
             throws ProtocolException {
         super(params, msg, 0, parseLazy, parseRetain, length);
     }
-
 
     public ListMessage(NetworkParameters params) {
         super(params);
@@ -124,7 +122,14 @@ public abstract class ListMessage extends Message {
 
     @Override
     public boolean equals(Object o) {
-        return o.getClass() == this.getClass() &&
-                ((ListMessage)o).items.equals(this.items);
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ListMessage other = (ListMessage) o;
+        return items.equals(other.items);
+    }
+
+    @Override
+    public int hashCode() {
+        return items.hashCode();
     }
 }

--- a/core/src/main/java/com/google/bitcoin/core/NetworkParameters.java
+++ b/core/src/main/java/com/google/bitcoin/core/NetworkParameters.java
@@ -181,10 +181,11 @@ public abstract class NetworkParameters implements Serializable {
     public abstract String getPaymentProtocolId();
 
     @Override
-    public boolean equals(Object other) {
-        if (!(other instanceof NetworkParameters)) return false;
-        NetworkParameters o = (NetworkParameters) other;
-        return o.getId().equals(getId());
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        NetworkParameters other = (NetworkParameters) o;
+        return getId().equals(other.getId());
     }
 
     @Override

--- a/core/src/main/java/com/google/bitcoin/core/PeerAddress.java
+++ b/core/src/main/java/com/google/bitcoin/core/PeerAddress.java
@@ -246,13 +246,14 @@ public class PeerAddress extends ChildMessage {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof PeerAddress)) return false;
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         PeerAddress other = (PeerAddress) o;
         return other.addr.equals(addr) &&
                 other.port == port &&
                 other.services.equals(services) &&
                 other.time == time;
-        //FIXME including services and time could cause same peer to be added multiple times in collections
+        //TODO: including services and time could cause same peer to be added multiple times in collections
     }
 
     @Override

--- a/core/src/main/java/com/google/bitcoin/core/RejectMessage.java
+++ b/core/src/main/java/com/google/bitcoin/core/RejectMessage.java
@@ -151,11 +151,13 @@ public class RejectMessage extends Message {
 
     @Override
     public boolean equals(Object o) {
-        return o instanceof RejectMessage &&
-                ((RejectMessage) o).message.equals(message) &&
-                ((RejectMessage) o).code.equals(code) &&
-                ((RejectMessage) o).reason.equals(reason) &&
-                ((RejectMessage) o).messageHash.equals(messageHash);
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RejectMessage other = (RejectMessage) o;
+        return message.equals(other.message) &&
+               code.equals(other.code) &&
+               reason.equals(other.reason) &&
+               messageHash.equals(other.messageHash);
     }
 
     @Override

--- a/core/src/main/java/com/google/bitcoin/core/Sha256Hash.java
+++ b/core/src/main/java/com/google/bitcoin/core/Sha256Hash.java
@@ -88,13 +88,12 @@ public class Sha256Hash implements Serializable, Comparable {
         }
     }
 
-    /**
-     * Returns true if the hashes are equal.
-     */
     @Override
-    public boolean equals(Object other) {
-        if (!(other instanceof Sha256Hash)) return false;
-        return Arrays.equals(bytes, ((Sha256Hash) other).bytes);
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Sha256Hash other = (Sha256Hash) o;
+        return Arrays.equals(bytes, other.bytes);
     }
 
     /**

--- a/core/src/main/java/com/google/bitcoin/core/StoredBlock.java
+++ b/core/src/main/java/com/google/bitcoin/core/StoredBlock.java
@@ -82,10 +82,13 @@ public class StoredBlock implements Serializable {
     }
 
     @Override
-    public boolean equals(Object other) {
-        if (!(other instanceof StoredBlock)) return false;
-        StoredBlock o = (StoredBlock) other;
-        return o.header.equals(header) && o.chainWork.equals(chainWork) && o.height == height;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        StoredBlock other = (StoredBlock) o;
+        return header.equals(other.header) &&
+               chainWork.equals(other.chainWork) &&
+               height == other.height;
     }
 
     @Override
@@ -93,7 +96,6 @@ public class StoredBlock implements Serializable {
         // A better hashCode is possible, but this works for now.
         return header.hashCode() ^ chainWork.hashCode() ^ height;
     }
-
 
     /**
      * Creates a new StoredBlock, calculating the additional fields by adding to the values in this block.

--- a/core/src/main/java/com/google/bitcoin/core/StoredTransactionOutput.java
+++ b/core/src/main/java/com/google/bitcoin/core/StoredTransactionOutput.java
@@ -142,14 +142,18 @@ public class StoredTransactionOutput implements Serializable {
         return String.format("Stored TxOut of %s (%s:%d)", Utils.bitcoinValueToFriendlyString(value), hash.toString(), index);
     }
 
+    @Override
     public int hashCode() {
         return hash.hashCode() + (int)index;
     }
 
+    @Override
     public boolean equals(Object o) {
-        if (!(o instanceof StoredTransactionOutput)) return false;
-        return ((StoredTransactionOutput) o).getIndex() == this.getIndex() &&
-                ((StoredTransactionOutput) o).getHash().equals(this.getHash());
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        StoredTransactionOutput other = (StoredTransactionOutput) o;
+        return getHash().equals(other.getHash()) &&
+               getIndex() == other.getIndex();
     }
 
     public void serializeToStream(OutputStream bos) throws IOException {

--- a/core/src/main/java/com/google/bitcoin/core/StoredUndoableBlock.java
+++ b/core/src/main/java/com/google/bitcoin/core/StoredUndoableBlock.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 /**
  * Contains minimal data neccessary to disconnect/connect the transactions
- * in the stored block at will.  Can either store the full set of
+ * in the stored block at will. Can either store the full set of
  * transactions (if the inputs for the block have not been tested to work)
  * or the set of transaction outputs created/destroyed when the block is
  * connected.
@@ -70,14 +70,18 @@ public class StoredUndoableBlock implements Serializable {
     public Sha256Hash getHash() {
         return blockHash;
     }
-    
+
+    @Override
     public int hashCode() {
         return blockHash.hashCode();
     }
-    
+
+    @Override
     public boolean equals(Object o) {
-        if (!(o instanceof StoredUndoableBlock)) return false;
-        return ((StoredUndoableBlock)o).getHash().equals(this.getHash());
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        StoredUndoableBlock other = (StoredUndoableBlock) o;
+        return getHash().equals(other.getHash());
     }
 
     @Override

--- a/core/src/main/java/com/google/bitcoin/core/Transaction.java
+++ b/core/src/main/java/com/google/bitcoin/core/Transaction.java
@@ -1176,11 +1176,11 @@ public class Transaction extends ChildMessage implements Serializable {
     }
 
     @Override
-    public boolean equals(Object other) {
-        if (!(other instanceof Transaction)) return false;
-        Transaction t = (Transaction) other;
-
-        return t.getHash().equals(getHash());
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Transaction other = (Transaction) o;
+        return getHash().equals(other.getHash());
     }
 
     @Override

--- a/core/src/main/java/com/google/bitcoin/core/TransactionInput.java
+++ b/core/src/main/java/com/google/bitcoin/core/TransactionInput.java
@@ -89,7 +89,6 @@ public class TransactionInput extends ChildMessage implements Serializable {
         scriptBytes = EMPTY_ARRAY;
         sequence = NO_SEQUENCE;
         this.parentTransaction = parentTransaction;
-
         length = 41;
     }
 

--- a/core/src/main/java/com/google/bitcoin/core/TransactionOutPoint.java
+++ b/core/src/main/java/com/google/bitcoin/core/TransactionOutPoint.java
@@ -190,10 +190,12 @@ public class TransactionOutPoint extends ChildMessage implements Serializable {
     }
 
     @Override
-    public boolean equals(Object other) {
-        if (!(other instanceof TransactionOutPoint)) return false;
-        TransactionOutPoint o = (TransactionOutPoint) other;
-        return o.getIndex() == getIndex() && o.getHash().equals(getHash());
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TransactionOutPoint other = (TransactionOutPoint) o;
+        return getIndex() == other.getIndex() &&
+               getHash().equals(other.getHash());
     }
 
     @Override

--- a/core/src/main/java/com/google/bitcoin/core/TransactionOutput.java
+++ b/core/src/main/java/com/google/bitcoin/core/TransactionOutput.java
@@ -352,11 +352,11 @@ public class TransactionOutput extends ChildMessage implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        TransactionOutput output = (TransactionOutput) o;
+        TransactionOutput other = (TransactionOutput) o;
 
-        if (!Arrays.equals(scriptBytes, output.scriptBytes)) return false;
-        if (value != null ? !value.equals(output.value) : output.value != null) return false;
-        if (parentTransaction != null && parentTransaction != output.parentTransaction) return false;
+        if (!Arrays.equals(scriptBytes, other.scriptBytes)) return false;
+        if (value != null ? !value.equals(other.value) : other.value != null) return false;
+        if (parentTransaction != null && parentTransaction != other.parentTransaction) return false;
 
         return true;
     }

--- a/core/src/main/java/com/google/bitcoin/core/VersionMessage.java
+++ b/core/src/main/java/com/google/bitcoin/core/VersionMessage.java
@@ -201,7 +201,8 @@ public class VersionMessage extends Message {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof VersionMessage)) return false;
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         VersionMessage other = (VersionMessage) o;
         return other.bestHeight == bestHeight &&
                 other.clientVersion == clientVersion &&
@@ -211,6 +212,12 @@ public class VersionMessage extends Message {
                 other.myAddr.equals(myAddr) &&
                 other.theirAddr.equals(theirAddr) &&
                 other.relayTxesBeforeFilter == relayTxesBeforeFilter;
+    }
+
+    @Override
+    public int hashCode() {
+        return (int) bestHeight ^ clientVersion ^ (int) localServices ^ (int) time ^ subVer.hashCode() ^ myAddr.hashCode()
+            ^ theirAddr.hashCode() * (relayTxesBeforeFilter ? 1 : 2);
     }
 
     /**
@@ -227,12 +234,6 @@ public class VersionMessage extends Message {
     @Override
     void setChecksum(byte[] checksum) {
         throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int hashCode() {
-        return (int) bestHeight ^ clientVersion ^ (int) localServices ^ (int) time ^ subVer.hashCode() ^ myAddr.hashCode()
-                ^ theirAddr.hashCode() * (relayTxesBeforeFilter ? 1 : 2);
     }
 
     public String toString() {

--- a/core/src/main/java/com/google/bitcoin/core/VersionedChecksummedBytes.java
+++ b/core/src/main/java/com/google/bitcoin/core/VersionedChecksummedBytes.java
@@ -58,6 +58,7 @@ public class VersionedChecksummedBytes {
         return Base58.encode(addressBytes);
     }
 
+    // TODO: shouldn't hashCode be also based on the version?
     @Override
     public int hashCode() {
         return Arrays.hashCode(bytes);
@@ -65,9 +66,10 @@ public class VersionedChecksummedBytes {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof VersionedChecksummedBytes)) return false;
-        VersionedChecksummedBytes vcb = (VersionedChecksummedBytes) o;
-        return Arrays.equals(vcb.bytes, bytes);
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        VersionedChecksummedBytes other = (VersionedChecksummedBytes) o;
+        return Arrays.equals(bytes, other.bytes);
     }
 
     /**

--- a/core/src/main/java/com/google/bitcoin/crypto/ChildNumber.java
+++ b/core/src/main/java/com/google/bitcoin/crypto/ChildNumber.java
@@ -64,7 +64,10 @@ public class ChildNumber {
 
     @Override
     public boolean equals(Object o) {
-        return this == o || !(o == null || getClass() != o.getClass()) && i == ((ChildNumber) o).i;
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ChildNumber other = (ChildNumber) o;
+        return i == other.i;
     }
 
     @Override

--- a/core/src/main/java/com/google/bitcoin/crypto/EncryptedPrivateKey.java
+++ b/core/src/main/java/com/google/bitcoin/crypto/EncryptedPrivateKey.java
@@ -15,6 +15,8 @@
  */
 package com.google.bitcoin.crypto;
 
+import com.google.common.base.Objects;
+
 import java.util.Arrays;
 
 /**
@@ -99,17 +101,12 @@ public class EncryptedPrivateKey {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        final EncryptedPrivateKey other = (EncryptedPrivateKey) obj;
-
-        return com.google.common.base.Objects.equal(this.initialisationVector, other.initialisationVector)
-                && com.google.common.base.Objects.equal(this.encryptedPrivateBytes, other.encryptedPrivateBytes);
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        EncryptedPrivateKey other = (EncryptedPrivateKey) o;
+        return Objects.equal(initialisationVector, other.initialisationVector) &&
+               Objects.equal(encryptedPrivateBytes, other.encryptedPrivateBytes);
     }
 
     @Override

--- a/core/src/main/java/com/google/bitcoin/crypto/KeyCrypterScrypt.java
+++ b/core/src/main/java/com/google/bitcoin/crypto/KeyCrypterScrypt.java
@@ -16,6 +16,7 @@
  */
 package com.google.bitcoin.crypto;
 
+import com.google.common.base.Objects;
 import com.google.protobuf.ByteString;
 import com.lambdaworks.crypto.SCrypt;
 import org.bitcoinj.wallet.Protos;
@@ -255,15 +256,10 @@ public class KeyCrypterScrypt implements KeyCrypter, Serializable {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        final KeyCrypterScrypt other = (KeyCrypterScrypt) obj;
-
-        return com.google.common.base.Objects.equal(this.scryptParameters, other.scryptParameters);
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        KeyCrypterScrypt other = (KeyCrypterScrypt) o;
+        return Objects.equal(scryptParameters, other.scryptParameters);
     }
 }

--- a/core/src/main/java/com/google/bitcoin/script/Script.java
+++ b/core/src/main/java/com/google/bitcoin/script/Script.java
@@ -1279,11 +1279,11 @@ public class Script {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (!(obj instanceof Script))
-            return false;
-        Script s = (Script)obj;
-        return Arrays.equals(getQuickProgram(), s.getQuickProgram());
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Script other = (Script) o;
+        return Arrays.equals(getQuickProgram(), other.getQuickProgram());
     }
 
     @Override

--- a/core/src/main/java/com/google/bitcoin/script/ScriptChunk.java
+++ b/core/src/main/java/com/google/bitcoin/script/ScriptChunk.java
@@ -102,11 +102,11 @@ public class ScriptChunk {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        ScriptChunk chunk = (ScriptChunk) o;
+        ScriptChunk other = (ScriptChunk) o;
 
-        if (opcode != chunk.opcode) return false;
-        if (startLocationInProgram != chunk.startLocationInProgram) return false;
-        if (!Arrays.equals(data, chunk.data)) return false;
+        if (opcode != other.opcode) return false;
+        if (startLocationInProgram != other.startLocationInProgram) return false;
+        if (!Arrays.equals(data, other.data)) return false;
 
         return true;
     }

--- a/core/src/main/java/com/google/bitcoin/store/MemoryFullPrunedBlockStore.java
+++ b/core/src/main/java/com/google/bitcoin/store/MemoryFullPrunedBlockStore.java
@@ -60,7 +60,8 @@ class StoredTransactionOutPoint implements Serializable {
     long getIndex() {
         return index;
     }
-    
+
+    @Override
     public int hashCode() {
         return this.hash.hashCode() + (int)index;
     }
@@ -68,11 +69,14 @@ class StoredTransactionOutPoint implements Serializable {
     public String toString() {
         return "Stored transaction out point: " + hash.toString() + ":" + index;
     }
-    
+
+    @Override
     public boolean equals(Object o) {
-        if (!(o instanceof StoredTransactionOutPoint)) return false;
-        return ((StoredTransactionOutPoint)o).getIndex() == this.index &&
-                Objects.equal(this.getHash(), ((StoredTransactionOutPoint)o).getHash());
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        StoredTransactionOutPoint other = (StoredTransactionOutPoint) o;
+        return getIndex() == other.getIndex() &&
+               Objects.equal(getHash(), other.getHash());
     }
 }
 


### PR DESCRIPTION
In most cases these changes probably won't have any observable effect. However, the patch aims to establish a better practice and consistency in the tricky subject of objects equality.

Improved consistency and formal correctness of all existing .equals methods to meet IntelliJ's convention.
- added null handling so equals methods return false for null argument
- replaced instanceof with getClass to force strict type equality
- added @Override for equals and hashCode where missing
- minor refactorings in equals methods to simplify and improve consistency
- added missing hashCode for ListMessage based on equals definition

Things that HAVE NOT changed:
- set of attributes used for equality checking
- hashCode calculation (except for added hashCode in ListMessage)
- correlation between equals and hashCode
- no new equals methods added
