### PR TITLE
Fixed type references in javadoc to avoid IntelliJ error reports on rebuild

### DIFF
--- a/core/src/main/java/com/google/bitcoin/crypto/ChildNumber.java
+++ b/core/src/main/java/com/google/bitcoin/crypto/ChildNumber.java
@@ -18,7 +18,7 @@ package com.google.bitcoin.crypto;
 
 /**
  * <p>This is just a wrapper for the i (child number) as per BIP 32 with a boolean getter for the first bit and a getter
- * for the actual 0-based child number. A {@link List} of these forms a <i>path</i> through a
+ * for the actual 0-based child number. A {@link java.util.List} of these forms a <i>path</i> through a
  * {@link DeterministicHierarchy}. This class is immutable.
  */
 public class ChildNumber {

--- a/core/src/main/java/com/google/bitcoin/crypto/EncryptedPrivateKey.java
+++ b/core/src/main/java/com/google/bitcoin/crypto/EncryptedPrivateKey.java
@@ -41,7 +41,7 @@ public class EncryptedPrivateKey {
     }
 
     /**
-     * @param iv
+     * @param initialisationVector
      * @param encryptedPrivateKeys
      */
     public EncryptedPrivateKey(byte[] initialisationVector, byte[] encryptedPrivateKeys) {

--- a/core/src/main/java/com/google/bitcoin/store/MemoryFullPrunedBlockStore.java
+++ b/core/src/main/java/com/google/bitcoin/store/MemoryFullPrunedBlockStore.java
@@ -164,8 +164,8 @@ class TransactionalHashMap<KeyType, ValueType> {
 /**
  * A Map with multiple key types that is DB per-thread-transaction-aware.
  * However, this class is not thread-safe.
- * @param UniqueKeyType is a key that must be unique per object
- * @param MultiKeyType is a key that can have multiple values
+ * @param <UniqueKeyType> is a key that must be unique per object
+ * @param <MultiKeyType> is a key that can have multiple values
  */
 class TransactionalMultiKeyHashMap<UniqueKeyType, MultiKeyType, ValueType> {
     TransactionalHashMap<UniqueKeyType, ValueType> mapValues;


### PR DESCRIPTION
Minor JavaDoc changes safe to merge.
