### PR TITLE
Renamed proofOfWorkLimit to maxTarget along with get/set and minor refactorings

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/Block.java
+++ b/core/src/main/java/com/google/bitcoin/core/Block.java
@@ -627,7 +627,7 @@ public class Block extends Message {
     public BigInteger getDifficultyTargetAsInteger() throws VerificationException {
         maybeParseHeader();
         BigInteger target = Utils.decodeCompactBits(difficultyTarget);
-        if (target.signum() <= 0 || target.compareTo(params.proofOfWorkLimit) > 0)
+        if (target.signum() <= 0 || target.compareTo(params.maxTarget) > 0)
             throw new VerificationException("Difficulty target is bad: " + target.toString());
         return target;
     }

--- a/core/src/main/java/com/google/bitcoin/core/NetworkParameters.java
+++ b/core/src/main/java/com/google/bitcoin/core/NetworkParameters.java
@@ -65,7 +65,7 @@ public abstract class NetworkParameters implements Serializable {
     // TODO: Seed nodes should be here as well.
 
     protected Block genesisBlock;
-    protected BigInteger proofOfWorkLimit;
+    protected BigInteger maxTarget;
     protected int port;
     protected long packetMagic;
     protected int addressHeader;
@@ -323,9 +323,9 @@ public abstract class NetworkParameters implements Serializable {
         return interval;
     }
 
-    /** What the easiest allowable proof of work should be. */
-    public BigInteger getProofOfWorkLimit() {
-        return proofOfWorkLimit;
+    /** Maximum target represents the easiest allowable proof of work. */
+    public BigInteger getMaxTarget() {
+        return maxTarget;
     }
 
     /**

--- a/core/src/main/java/com/google/bitcoin/params/MainNetParams.java
+++ b/core/src/main/java/com/google/bitcoin/params/MainNetParams.java
@@ -30,7 +30,7 @@ public class MainNetParams extends NetworkParameters {
         super();
         interval = INTERVAL;
         targetTimespan = TARGET_TIMESPAN;
-        proofOfWorkLimit = Utils.decodeCompactBits(0x1d00ffffL);
+        maxTarget = Utils.decodeCompactBits(0x1d00ffffL);
         dumpedPrivateKeyHeader = 128;
         addressHeader = 0;
         p2shHeader = 5;

--- a/core/src/main/java/com/google/bitcoin/params/RegTestParams.java
+++ b/core/src/main/java/com/google/bitcoin/params/RegTestParams.java
@@ -26,12 +26,12 @@ import static com.google.common.base.Preconditions.checkState;
  * Network parameters for the regression test mode of bitcoind in which all blocks are trivially solvable.
  */
 public class RegTestParams extends TestNet2Params {
-    private static final BigInteger PROOF_OF_WORK_LIMIT = new BigInteger("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16);
+    private static final BigInteger MAX_TARGET = new BigInteger("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16);
 
     public RegTestParams() {
         super();
         interval = 10000;
-        proofOfWorkLimit = PROOF_OF_WORK_LIMIT;
+        maxTarget = MAX_TARGET;
         subsidyDecreaseBlockCount = 150;
         port = 18444;
     }

--- a/core/src/main/java/com/google/bitcoin/params/TestNet2Params.java
+++ b/core/src/main/java/com/google/bitcoin/params/TestNet2Params.java
@@ -36,7 +36,7 @@ public class TestNet2Params extends NetworkParameters {
         acceptableAddressCodes = new int[] { addressHeader, p2shHeader };
         interval = INTERVAL;
         targetTimespan = TARGET_TIMESPAN;
-        proofOfWorkLimit = Utils.decodeCompactBits(0x1d0fffffL);
+        maxTarget = Utils.decodeCompactBits(0x1d0fffffL);
         dumpedPrivateKeyHeader = 239;
         genesisBlock.setTime(1296688602L);
         genesisBlock.setDifficultyTarget(0x1d07fff8L);

--- a/core/src/main/java/com/google/bitcoin/params/TestNet3Params.java
+++ b/core/src/main/java/com/google/bitcoin/params/TestNet3Params.java
@@ -34,7 +34,7 @@ public class TestNet3Params extends NetworkParameters {
         packetMagic = 0x0b110907;
         interval = INTERVAL;
         targetTimespan = TARGET_TIMESPAN;
-        proofOfWorkLimit = Utils.decodeCompactBits(0x1d00ffffL);
+        maxTarget = Utils.decodeCompactBits(0x1d00ffffL);
         port = 18333;
         addressHeader = 111;
         p2shHeader = 196;

--- a/core/src/main/java/com/google/bitcoin/params/UnitTestParams.java
+++ b/core/src/main/java/com/google/bitcoin/params/UnitTestParams.java
@@ -33,7 +33,7 @@ public class UnitTestParams extends NetworkParameters {
         addressHeader = 111;
         p2shHeader = 196;
         acceptableAddressCodes = new int[] { addressHeader, p2shHeader };
-        proofOfWorkLimit = new BigInteger("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16);
+        maxTarget = new BigInteger("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16);
         genesisBlock.setTime(System.currentTimeMillis() / 1000);
         genesisBlock.setDifficultyTarget(Block.EASIEST_DIFFICULTY_TARGET);
         genesisBlock.solve();

--- a/core/src/test/java/com/google/bitcoin/core/BlockChainTest.java
+++ b/core/src/test/java/com/google/bitcoin/core/BlockChainTest.java
@@ -51,8 +51,8 @@ public class BlockChainTest {
     private Transaction coinbaseTransaction;
 
     private static class TweakableTestNet2Params extends TestNet2Params {
-        public void setProofOfWorkLimit(BigInteger limit) {
-            proofOfWorkLimit = limit;
+        public void setMaxTarget(BigInteger limit) {
+            maxTarget = limit;
         }
     }
     private static final TweakableTestNet2Params testNet = new TweakableTestNet2Params();
@@ -228,9 +228,8 @@ public class BlockChainTest {
         }
 
         // Accept any level of difficulty now.
-        BigInteger oldVal = testNet.getProofOfWorkLimit();
-        testNet.setProofOfWorkLimit(new BigInteger
-                ("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16));
+        BigInteger oldVal = testNet.getMaxTarget();
+        testNet.setMaxTarget(new BigInteger("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16));
         try {
             testNetChain.add(bad);
             // We should not get here as the difficulty target should not be changing at this point.
@@ -238,7 +237,7 @@ public class BlockChainTest {
         } catch (VerificationException e) {
             assertTrue(e.getMessage(), e.getCause().getMessage().contains("Unexpected change in difficulty"));
         }
-        testNet.setProofOfWorkLimit(oldVal);
+        testNet.setMaxTarget(oldVal);
 
         // TODO: Test difficulty change is not out of range when a transition period becomes valid.
     }


### PR DESCRIPTION
What changed:
- The proofOfWorkLimit renamed to maxTarget to get it more in line with commonly used terminology (wiki, etc.).
- Some misleading local variables renamed from 'difficulty' to 'target'.

Note to the reviewer:
- These refactorings were fully automated and thus should be safe to merge.
- Breaks public API a bit but almost no one uses the getter being renamed here. Bitcoin Wallet does not, Mycelium does not, and Multibit only once in the tests.
- Tests passs.
- Feel free to discard if the change is not worth it.
