### PR TITLE
Renaming file to a nonexisting file on Windows

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/Wallet.java
+++ b/core/src/main/java/com/google/bitcoin/core/Wallet.java
@@ -328,7 +328,7 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
             if (Utils.isWindows()) {
                 // Work around an issue on Windows whereby you can't rename over existing files.
                 File canonical = destFile.getCanonicalFile();
-                if (!canonical.delete())
+                if (canonical.exists() && !canonical.delete())
                     throw new IOException("Failed to delete canonical wallet file for replacement with autosave");
                 if (temp.renameTo(canonical))
                     return;  // else fall through.


### PR DESCRIPTION
The method fails in case the file does not exists before renaming. canonical.delete() returns false in that case and the method throws an exception.
