### PR TITLE
DeterministicKeyChain: call maybeLookahead(), if lookahead or threshold changes

### DIFF
--- a/core/src/main/java/com/google/bitcoin/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/com/google/bitcoin/wallet/DeterministicKeyChain.java
@@ -739,7 +739,10 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
     public void setLookaheadSize(int lookaheadSize) {
         lock.lock();
         try {
+            int oldlookaheadSize = this.lookaheadSize;
             this.lookaheadSize = lookaheadSize;
+            if (oldlookaheadSize != lookaheadSize)
+                maybeLookAhead();
         } finally {
             lock.unlock();
         }
@@ -755,9 +758,12 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
     public void setLookaheadThreshold(int num) {
         lock.lock();
         try {
+            int oldthreshold = this.lookaheadThreshold;
             if (num >= lookaheadSize)
                 throw new IllegalArgumentException("Threshold larger or equal to the lookaheadSize");
             this.lookaheadThreshold = num;
+            if (oldthreshold != num)
+                maybeLookAhead();
         } finally {
             lock.unlock();
         }


### PR DESCRIPTION
The immediate key creation would allow UIs to precreate the lookahead keys
in a separate thread and report the progress to the UI.

E.g. Android AsyncTask:

wallet.setLookaheadThreshold(0);

for (int l = 1; l <= lookahead; l++) {
    wallet.setKeychainLookaheadSize(lookahead);
    publishProgress(l \* 100 / lookahead);
}
