### PR TITLE
Make Transaction comparators compatible with equals

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/Transaction.java
+++ b/core/src/main/java/com/google/bitcoin/core/Transaction.java
@@ -63,7 +63,7 @@ public class Transaction extends ChildMessage implements Serializable {
             final long time2 = tx2.getUpdateTime().getTime();
             final int updateTimeComparison = -(Longs.compare(time1, time2));
             //If time1==time2, compare by tx hash to make comparator consistent with equals
-            return updateTimeComparison!=0 ? updateTimeComparison : tx1.getHash().compareTo(tx2.getHash());
+            return updateTimeComparison != 0 ? updateTimeComparison : tx1.getHash().compareTo(tx2.getHash());
         }
     };
     /** A comparator that can be used to sort transactions by their chain height. */
@@ -74,7 +74,7 @@ public class Transaction extends ChildMessage implements Serializable {
             final int height2 = tx2.getConfidence().getAppearedAtChainHeight();
             final int heightComparison = -(Ints.compare(height1, height2));
             //If height1==height2, compare by tx hash to make comparator consistent with equals
-            return heightComparison!=0 ? heightComparison : tx1.getHash().compareTo(tx2.getHash());            
+            return heightComparison != 0 ? heightComparison : tx1.getHash().compareTo(tx2.getHash());            
         }
     };
     private static final Logger log = LoggerFactory.getLogger(Transaction.class);


### PR DESCRIPTION
Before this commit, if you call wallet.toString() in a wallet with several unspent transactions included in the same block, you only get listed one of them. That is because the comparator was not compatible with equals() so the TreeSet iterator returned just 1 of them.
