### PR TITLE
Fix failing deserialization of wallet with an empty HD chain

### DIFF
--- a/core/src/main/java/com/google/bitcoin/wallet/KeyChainGroup.java
+++ b/core/src/main/java/com/google/bitcoin/wallet/KeyChainGroup.java
@@ -468,19 +468,25 @@ public class KeyChainGroup {
 
     private static EnumMap<KeyChain.KeyPurpose, DeterministicKey> createCurrentKeysMap(List<DeterministicKeyChain> chains) {
         DeterministicKeyChain activeChain = chains.get(chains.size() - 1);
-        DeterministicKey currentExternalKey = activeChain.getKeyByPath(
-                ImmutableList.of(ChildNumber.ZERO_HARDENED, ChildNumber.ZERO, new ChildNumber(activeChain.getIssuedExternalKeys() - 1))
-        );
-        DeterministicKey currentInternalKey = activeChain.getKeyByPath(
-                ImmutableList.of(ChildNumber.ZERO_HARDENED, new ChildNumber(1), new ChildNumber(activeChain.getIssuedInternalKeys() - 1))
-        );
 
         EnumMap<KeyChain.KeyPurpose, DeterministicKey> currentKeys = new EnumMap<KeyChain.KeyPurpose, DeterministicKey>(KeyChain.KeyPurpose.class);
+
         // assuming that only RECEIVE and CHANGE keys are being used at the moment, we will treat latest issued external key
         // as current RECEIVE key and latest issued internal key as CHANGE key. This should be changed as soon as other
         // kinds of KeyPurpose are introduced.
-        currentKeys.put(KeyChain.KeyPurpose.RECEIVE_FUNDS, currentExternalKey);
-        currentKeys.put(KeyChain.KeyPurpose.CHANGE, currentInternalKey);
+        if (activeChain.getIssuedExternalKeys() > 0) {
+            DeterministicKey currentExternalKey = activeChain.getKeyByPath(
+                    ImmutableList.of(ChildNumber.ZERO_HARDENED, ChildNumber.ZERO, new ChildNumber(activeChain.getIssuedExternalKeys() - 1))
+            );
+            currentKeys.put(KeyChain.KeyPurpose.RECEIVE_FUNDS, currentExternalKey);
+        }
+
+        if (activeChain.getIssuedInternalKeys() > 0) {
+            DeterministicKey currentInternalKey = activeChain.getKeyByPath(
+                    ImmutableList.of(ChildNumber.ZERO_HARDENED, new ChildNumber(1), new ChildNumber(activeChain.getIssuedInternalKeys() - 1))
+            );
+            currentKeys.put(KeyChain.KeyPurpose.CHANGE, currentInternalKey);
+        }
         return currentKeys;
     }
 

--- a/core/src/test/java/com/google/bitcoin/wallet/KeyChainGroupTest.java
+++ b/core/src/test/java/com/google/bitcoin/wallet/KeyChainGroupTest.java
@@ -284,6 +284,7 @@ public class KeyChainGroupTest {
     @Test
     public void serialization() throws Exception {
         assertEquals(INITIAL_KEYS + 1 /* for the seed */, group.serializeToProtobuf().size());
+        group = KeyChainGroup.fromProtobufUnencrypted(group.serializeToProtobuf());
         group.freshKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         DeterministicKey key1 = group.freshKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         DeterministicKey key2 = group.freshKey(KeyChain.KeyPurpose.CHANGE);


### PR DESCRIPTION
This addresses Kalpesh's issue: https://github.com/bitcoinj/bitcoinj/pull/93#issuecomment-45765995

Error occurred when deserializing wallet if either internal or external zero account key chain of this wallet has no keys issued.
