### PR TITLE
wallet: make FeeCalculation public

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/Wallet.java
+++ b/core/src/main/java/com/google/bitcoin/core/Wallet.java
@@ -3591,7 +3591,7 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
     //
     // Fee calculation code.
 
-    private class FeeCalculation {
+    public class FeeCalculation {
         private CoinSelection bestCoinSelection;
         private TransactionOutput bestChangeOutput;
 


### PR DESCRIPTION
This allows the developer to create an instance of `FeeCalculator` to calculate the fee it would cost to send a transaction.

**Use case**
We want to be able to show our users the fee before they make their transaction. This helps them understand why more money was taken than they asked to send.

This is probably not the most elegant way to solve it and I'm happy to suggestions on how this could be done in the best way. I fell that this is a fairly basic function that should be provided by the library.
