### PR TITLE
Fix autosave in WalletTool on Windows

### DIFF
--- a/tools/src/main/java/com/google/bitcoin/tools/WalletTool.java
+++ b/tools/src/main/java/com/google/bitcoin/tools/WalletTool.java
@@ -53,10 +53,7 @@ import org.spongycastle.crypto.params.KeyParameter;
 import org.spongycastle.util.encoders.Hex;
 
 import javax.annotation.Nullable;
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
+import java.io.*;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -301,11 +298,13 @@ public class WalletTool {
             }
         }
 
+        InputStream walletInputStream = null;
         try {
             WalletProtobufSerializer loader = new WalletProtobufSerializer();
             if (options.has("ignore-mandatory-extensions"))
                 loader.setRequireMandatoryExtensions(false);
-            wallet = loader.readWallet(new BufferedInputStream(new FileInputStream(walletFile)));
+            walletInputStream = new BufferedInputStream(new FileInputStream(walletFile));
+            wallet = loader.readWallet(walletInputStream);
             if (!wallet.getParams().equals(params)) {
                 System.err.println("Wallet does not match requested network parameters: " +
                         wallet.getParams().getId() + " vs " + params.getId());
@@ -315,6 +314,10 @@ public class WalletTool {
             System.err.println("Failed to load wallet '" + walletFile + "': " + e.getMessage());
             e.printStackTrace();
             return;
+        } finally {
+            if (walletInputStream != null) {
+                walletInputStream.close();
+            }
         }
 
         // What should we do?


### PR DESCRIPTION
`Wallet.saveToFile` failed to remove original wallet file because WalletTool
left open input stream. This error happened on Windows-specific code path

Stacktrace:

```
Failed to save wallet! Old wallet should be left untouched.
java.io.IOException: Failed to delete canonical wallet file for
replacement with autosave
        at com.google.bitcoin.core.Wallet.saveToFile(Wallet.java:834)
            at
        com.google.bitcoin.core.Wallet.saveToFile(Wallet.java:863)
                at
            com.google.bitcoin.tools.WalletTool.saveWallet(WalletTool.java:851)
                    at
                com.google.bitcoin.tools.WalletTool.main(WalletTool.java:362)
```
