### PR TITLE
Rename addFollowingAccounts → addFollowingAccountKeys

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/Wallet.java
+++ b/core/src/main/java/com/google/bitcoin/core/Wallet.java
@@ -559,10 +559,10 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
      * to get P2SH addresses to receive coins to.
      * This method should be called only once before key rotation, otherwise it will throw an IllegalStateException.
      */
-    public void addFollowingAccounts(List<DeterministicKey> followingAccountKeys) {
+    public void addFollowingAccountKeys(List<DeterministicKey> followingAccountKeys) {
         lock.lock();
         try {
-            keychain.addFollowingAccounts(followingAccountKeys);
+            keychain.addFollowingAccountKeys(followingAccountKeys);
         } finally {
             lock.unlock();
         }

--- a/core/src/main/java/com/google/bitcoin/wallet/KeyChainGroup.java
+++ b/core/src/main/java/com/google/bitcoin/wallet/KeyChainGroup.java
@@ -107,7 +107,7 @@ public class KeyChainGroup {
     public KeyChainGroup(NetworkParameters params, DeterministicSeed seed, List<DeterministicKey> followingAccountKeys) {
         this(params, seed);
 
-        addFollowingAccounts(followingAccountKeys);
+        addFollowingAccountKeys(followingAccountKeys);
     }
 
     /**
@@ -116,7 +116,7 @@ public class KeyChainGroup {
      * This method will throw an IllegalStateException, if active keychain is already married or already has leaf keys
      * issued. In future this behaviour may be replaced with key rotation
      */
-    public void addFollowingAccounts(List<DeterministicKey> followingAccountKeys) {
+    public void addFollowingAccountKeys(List<DeterministicKey> followingAccountKeys) {
         checkState(!isMarried(), "KeyChainGroup is married already");
         checkState(getActiveKeyChain().numLeafKeysIssued() == 0, "Active keychain already has keys in use");
         DeterministicKey accountKey = getActiveKeyChain().getWatchingKey();

--- a/core/src/test/java/com/google/bitcoin/wallet/KeyChainGroupTest.java
+++ b/core/src/test/java/com/google/bitcoin/wallet/KeyChainGroupTest.java
@@ -407,21 +407,21 @@ public class KeyChainGroupTest {
     @Test
     public void addFollowingAccounts() throws Exception {
         assertFalse(group.isMarried());
-        group.addFollowingAccounts(ImmutableList.of(watchingAccountKey));
+        group.addFollowingAccountKeys(ImmutableList.of(watchingAccountKey));
         assertTrue(group.isMarried());
     }
 
     @Test (expected = IllegalStateException.class)
     public void addFollowingAccountsTwiceShouldFail() {
         ImmutableList<DeterministicKey> followingKeys = ImmutableList.of(watchingAccountKey);
-        group.addFollowingAccounts(followingKeys);
-        group.addFollowingAccounts(followingKeys);
+        group.addFollowingAccountKeys(followingKeys);
+        group.addFollowingAccountKeys(followingKeys);
     }
 
     @Test (expected = IllegalStateException.class)
     public void addFollowingAccountsForUsedKeychainShouldFail() {
         group.freshAddress(KeyChain.KeyPurpose.RECEIVE_FUNDS);
-        group.addFollowingAccounts(ImmutableList.of(watchingAccountKey));
+        group.addFollowingAccountKeys(ImmutableList.of(watchingAccountKey));
     }
 
     @Test


### PR DESCRIPTION
As `addFollowingAccounts` is confusing I propose to rename it to `addFollowingAccountKeys`
