### PR TITLE
PeerGroup. startBlockChainDownload() - listener bugfix

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/PeerGroup.java
+++ b/core/src/main/java/com/google/bitcoin/core/PeerGroup.java
@@ -1004,6 +1004,8 @@ public class PeerGroup extends AbstractExecutionThreadService implements Transac
         try {
             if (downloadPeer != null && this.downloadListener != null)
                 downloadPeer.removeEventListener(this.downloadListener);
+            if (downloadPeer != null && listener != null)
+                downloadPeer.addEventListener(listener);
             this.downloadListener = listener;
             // TODO: be more nuanced about which peer to download from.  We can also try
             // downloading from multiple peers and handle the case when a new peer comes along


### PR DESCRIPTION
There was this bug: If downloadPeer != null, the old downloadListener is removed as a listener, but the new listener is not added to downloadPeer. downloadPeer ends up with no downloadListener. Please not  setDownloadPeer() does not fix this situation because it only sets the the downloadListener if downloadPeer has chaned.
