### PR TITLE
Log message on attempted parallel blockchain download; javadoc edit.

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/AbstractBlockChain.java
+++ b/core/src/main/java/com/google/bitcoin/core/AbstractBlockChain.java
@@ -927,10 +927,11 @@ public abstract class AbstractBlockChain {
     /**
      * An orphan block is one that does not connect to the chain anywhere (ie we can't find its parent, therefore
      * it's an orphan). Typically this occurs when we are downloading the chain and didn't reach the head yet, and/or
-     * if a block is solved whilst we are downloading. It's possible that we see a small amount of orphan blocks which
-     * chain together, this method tries walking backwards through the known orphan blocks to find the bottom-most.
+     * if a block is solved whilst we are downloading. It's possible that we see a small sequence of orphan blocks that
+     * chain together; this method tries walking backwards through that chain of known orphan blocks to find the earliest.
      *
-     * @return from or one of froms parents, or null if "from" does not identify an orphan block
+     * @return <code>from</code> or one of <code>from</code>'s ancestors, or <code>null</code> if
+     *         <code>from</code> does not identify an orphan block
      */
     @Nullable
     public Block getOrphanRoot(Sha256Hash from) {

--- a/core/src/main/java/com/google/bitcoin/core/Peer.java
+++ b/core/src/main/java/com/google/bitcoin/core/Peer.java
@@ -1234,7 +1234,8 @@ public class Peer extends PeerSocketHandler {
         Sha256Hash chainHeadHash = chainHead.getHeader().getHash();
         // Did we already make this request? If so, don't do it again.
         if (Objects.equal(lastGetBlocksBegin, chainHeadHash) && Objects.equal(lastGetBlocksEnd, toHash)) {
-            log.info("blockChainDownloadLocked({}): ignoring duplicated request", toHash.toString());
+            StackTraceElement[] s = Thread.currentThread().getStackTrace();
+            log.info("{}.{}({}): ignoring duplicated request", s[2].getMethodName(), s[1].getMethodName(), toHash.toString());
             return;
         }
         log.debug("{}: blockChainDownloadLocked({}) current head = {}",


### PR DESCRIPTION
Changes I made on my repo while diagnosing a problem.  The log message written during an attempted parallel download indicates it's the `blockChainDownloadLocked()` method writing the log message, but not which method invoked `blockChainDownloadLocked()`.  I changed that.

Also I had difficulty understanding the javadoc description of `AbstractBlockChain.getOrphanRoot()`.  I made some slight modification to that text and its formatting.
