### PR TITLE
Make DumpedPrivateKey serializable.

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/VersionedChecksummedBytes.java
+++ b/core/src/main/java/com/google/bitcoin/core/VersionedChecksummedBytes.java
@@ -16,6 +16,7 @@
 
 package com.google.bitcoin.core;
 
+import java.io.Serializable;
 import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -28,8 +29,8 @@ import static com.google.common.base.Preconditions.checkArgument;
  * <p>and the result is then Base58 encoded. This format is used for addresses, and private keys exported using the
  * dumpprivkey command.</p>
  */
-public class VersionedChecksummedBytes {
-    protected int version;
+public class VersionedChecksummedBytes implements Serializable {
+    protected final int version;
     protected byte[] bytes;
 
     protected VersionedChecksummedBytes(String encoded) throws AddressFormatException {

--- a/core/src/test/java/com/google/bitcoin/core/DumpedPrivateKeyTest.java
+++ b/core/src/test/java/com/google/bitcoin/core/DumpedPrivateKeyTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014 Andreas Schildbach
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.bitcoin.core;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import org.junit.Test;
+
+import com.google.bitcoin.params.MainNetParams;
+
+public class DumpedPrivateKeyTest {
+    @Test
+    public void testJavaSerialization() throws Exception {
+
+        DumpedPrivateKey key = new DumpedPrivateKey(MainNetParams.get(), new ECKey().getPrivKeyBytes(), true);
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        new ObjectOutputStream(os).writeObject(key);
+        DumpedPrivateKey keyCopy = (DumpedPrivateKey) new ObjectInputStream(new ByteArrayInputStream(os.toByteArray()))
+                .readObject();
+        assertEquals(key, keyCopy);
+    }
+}


### PR DESCRIPTION
...so that it can be used to pass around keys between loosely coupled application components.
