### PR TITLE
Dead transaction does not contain confidence depth and should not fail when sorting

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/Wallet.java
+++ b/core/src/main/java/com/google/bitcoin/core/Wallet.java
@@ -2817,7 +2817,7 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
                 }
                 if (dead.size() > 0) {
                     builder.append("\n>>> DEAD:\n");
-                    toStringHelper(builder, dead, chain, Transaction.SORT_TX_BY_HEIGHT);
+                    toStringHelper(builder, dead, chain, Transaction.SORT_TX_BY_UPDATE_TIME);
                 }
             }
             if (includeExtensions && extensions.size() > 0) {


### PR DESCRIPTION
Now Comparator `Transaction.SORT_TX_BY_HEIGHT` fails for DEAD transactions, because of `TransactionConfidence.getAppearedAtChainHeight()` validation
