### PR TITLE
use List interface instead of LinkedList implementation

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/Wallet.java
+++ b/core/src/main/java/com/google/bitcoin/core/Wallet.java
@@ -2276,7 +2276,7 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
      * {@link #addWatchedScripts(java.util.List)}.
      * @param excludeImmatureCoinbases Whether to ignore outputs that are unspendable due to being immature.
      */
-    public LinkedList<TransactionOutput> getWatchedOutputs(boolean excludeImmatureCoinbases) {
+    public List<TransactionOutput> getWatchedOutputs(boolean excludeImmatureCoinbases) {
         lock.lock();
         try {
             LinkedList<TransactionOutput> candidates = Lists.newLinkedList();
@@ -2723,7 +2723,7 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
         lock.lock();
         try {
             checkNotNull(selector);
-            LinkedList<TransactionOutput> candidates = getWatchedOutputs(true);
+            List<TransactionOutput> candidates = getWatchedOutputs(true);
             CoinSelection selection = selector.select(NetworkParameters.MAX_MONEY, candidates);
             return selection.valueGathered;
         } finally {

--- a/core/src/main/java/com/google/bitcoin/wallet/CoinSelector.java
+++ b/core/src/main/java/com/google/bitcoin/wallet/CoinSelector.java
@@ -3,7 +3,7 @@ package com.google.bitcoin.wallet;
 import com.google.bitcoin.core.Coin;
 import com.google.bitcoin.core.TransactionOutput;
 
-import java.util.LinkedList;
+import java.util.List;
 
 /**
  * A CoinSelector is responsible for picking some outputs to spend, from the list of all spendable outputs. It
@@ -17,5 +17,5 @@ public interface CoinSelector {
      * this call and can be edited freely. See the docs for CoinSelection to learn more, or look a the implementation
      * of {@link com.google.bitcoin.wallet.DefaultCoinSelector}.
      */
-    public CoinSelection select(Coin target, LinkedList<TransactionOutput> candidates);
+    public CoinSelection select(Coin target, List<TransactionOutput> candidates);
 }

--- a/core/src/main/java/com/google/bitcoin/wallet/DefaultCoinSelector.java
+++ b/core/src/main/java/com/google/bitcoin/wallet/DefaultCoinSelector.java
@@ -18,7 +18,7 @@ import java.util.*;
  */
 public class DefaultCoinSelector implements CoinSelector {
     @Override
-    public CoinSelection select(Coin biTarget, LinkedList<TransactionOutput> candidates) {
+    public CoinSelection select(Coin biTarget, List<TransactionOutput> candidates) {
         long target = biTarget.value;
         HashSet<TransactionOutput> selected = new HashSet<TransactionOutput>();
         // Sort the inputs by age*value so we get the highest "coindays" spent.

--- a/core/src/main/java/com/google/bitcoin/wallet/FilteringCoinSelector.java
+++ b/core/src/main/java/com/google/bitcoin/wallet/FilteringCoinSelector.java
@@ -21,7 +21,7 @@ import com.google.bitcoin.core.*;
 
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
+import java.util.List;
 
 /**
  * A filtering coin selector delegates to another coin selector, but won't select outputs spent by the given transactions.
@@ -41,7 +41,7 @@ public class FilteringCoinSelector implements CoinSelector {
     }
 
     @Override
-    public CoinSelection select(Coin target, LinkedList<TransactionOutput> candidates) {
+    public CoinSelection select(Coin target, List<TransactionOutput> candidates) {
         Iterator<TransactionOutput> iter = candidates.iterator();
         while (iter.hasNext()) {
             TransactionOutput output = iter.next();

--- a/core/src/main/java/com/google/bitcoin/wallet/KeyTimeCoinSelector.java
+++ b/core/src/main/java/com/google/bitcoin/wallet/KeyTimeCoinSelector.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.LinkedList;
+import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -47,7 +48,7 @@ public class KeyTimeCoinSelector implements CoinSelector {
     }
 
     @Override
-    public CoinSelection select(Coin target, LinkedList<TransactionOutput> candidates) {
+    public CoinSelection select(Coin target, List<TransactionOutput> candidates) {
         try {
             LinkedList<TransactionOutput> gathered = Lists.newLinkedList();
             Coin valueGathered = Coin.ZERO;


### PR DESCRIPTION
I am using the getWatchedOutputsMethod and when mocking the Wallet class I would prefer to have List Interface returned instead of the LinkedList Implementation
