### PR TITLE
Allow fallback URLs for BIP72 payment request fetching. Adds unit tests.

### DIFF
--- a/core/src/main/java/com/google/bitcoin/uri/BitcoinURI.java
+++ b/core/src/main/java/com/google/bitcoin/uri/BitcoinURI.java
@@ -32,7 +32,10 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -291,7 +294,25 @@ public class BitcoinURI {
     public String getPaymentRequestUrl() {
         return (String) parameterMap.get(FIELD_PAYMENT_REQUEST_URL);
     }
-    
+
+    /**
+     * Returns the URLs where a payment request (as specified in BIP 70) may be fetched. The first URL is the main URL,
+     * all subsequent URLs are fallbacks.
+     */
+    public List<String> getPaymentRequestUrls() {
+        ArrayList<String> urls = new ArrayList<String>();
+        while (true) {
+            int i = urls.size();
+            String paramName = FIELD_PAYMENT_REQUEST_URL + (i > 0 ? Integer.toString(i) : "");
+            String url = (String) parameterMap.get(paramName);
+            if (url == null)
+                break;
+            urls.add(url);
+        }
+        Collections.reverse(urls);
+        return urls;
+    }
+
     /**
      * @param name The name of the parameter
      * @return The parameter value, or null if not present

--- a/core/src/test/java/com/google/bitcoin/uri/BitcoinURITest.java
+++ b/core/src/test/java/com/google/bitcoin/uri/BitcoinURITest.java
@@ -21,6 +21,7 @@ package com.google.bitcoin.uri;
 import com.google.bitcoin.core.Address;
 import com.google.bitcoin.params.MainNetParams;
 import com.google.bitcoin.params.TestNet3Params;
+import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 
 import java.io.UnsupportedEncodingException;
@@ -388,6 +389,24 @@ public class BitcoinURITest {
         // Non-backwards compatible form ...
         BitcoinURI uri = new BitcoinURI(TestNet3Params.get(), "bitcoin:?r=https%3A%2F%2Fbitcoincore.org%2F%7Egavin%2Ff.php%3Fh%3Db0f02e7cea67f168e25ec9b9f9d584f9");
         assertEquals("https://bitcoincore.org/~gavin/f.php?h=b0f02e7cea67f168e25ec9b9f9d584f9", uri.getPaymentRequestUrl());
+        assertEquals(ImmutableList.of("https://bitcoincore.org/~gavin/f.php?h=b0f02e7cea67f168e25ec9b9f9d584f9"),
+                uri.getPaymentRequestUrls());
         assertNull(uri.getAddress());
+    }
+
+    @Test
+    public void testMultiplePaymentProtocolReq() throws Exception {
+        BitcoinURI uri = new BitcoinURI(MainNetParams.get(),
+                "bitcoin:?r=https%3A%2F%2Fbitcoincore.org%2F%7Egavin&r1=bt:112233445566");
+        assertEquals(ImmutableList.of("bt:112233445566", "https://bitcoincore.org/~gavin"), uri.getPaymentRequestUrls());
+        assertEquals("https://bitcoincore.org/~gavin", uri.getPaymentRequestUrl());
+    }
+
+    @Test
+    public void testNoPaymentProtocolReq() throws Exception {
+        BitcoinURI uri = new BitcoinURI(MainNetParams.get(), "bitcoin:" + MAINNET_GOOD_ADDRESS);
+        assertNull(uri.getPaymentRequestUrl());
+        assertEquals(ImmutableList.of(), uri.getPaymentRequestUrls());
+        assertNotNull(uri.getAddress());
     }
 }


### PR DESCRIPTION
As agreed on the bitcoin-dev mailing list on 2014-07-01 and 2014-07-02.
