### PR TITLE
Pluggable signers: simple local KeyBag signer

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/ECKey.java
+++ b/core/src/main/java/com/google/bitcoin/core/ECKey.java
@@ -974,6 +974,13 @@ public class ECKey implements EncryptableItem, Serializable {
     }
 
     /**
+     * Creates decrypted private key if needed.
+     */
+    public ECKey maybeDecrypt(@Nullable KeyParameter aesKey) throws KeyCrypterException {
+        return isEncrypted() && aesKey != null ? decrypt(aesKey) : this;
+    }
+
+    /**
      * <p>Check that it is possible to decrypt the key with the keyCrypter and that the original key is returned.</p>
      *
      * <p>Because it is a critical failure if the private keys cannot be decrypted successfully (resulting of loss of all

--- a/core/src/main/java/com/google/bitcoin/core/TransactionOutPoint.java
+++ b/core/src/main/java/com/google/bitcoin/core/TransactionOutPoint.java
@@ -127,7 +127,7 @@ public class TransactionOutPoint extends ChildMessage implements Serializable {
      * Returns the pubkey script from the connected output.
      * @throws java.lang.NullPointerException if there is no connected output.
      */
-    byte[] getConnectedPubKeyScript() {
+    public byte[] getConnectedPubKeyScript() {
         byte[] result = checkNotNull(getConnectedOutput()).getScriptBytes();
         checkState(result.length > 0);
         return result;

--- a/core/src/main/java/com/google/bitcoin/script/ScriptBuilder.java
+++ b/core/src/main/java/com/google/bitcoin/script/ScriptBuilder.java
@@ -161,7 +161,7 @@ public class ScriptBuilder {
         return createMultiSigInputScriptBytes(sigs, multisigProgramBytes);
     }
 
-    /** 
+    /**
      * Create a program that satisfies an OP_CHECKMULTISIG program, using pre-encoded signatures. 
      * Optionally, appends the script program bytes if spending a P2SH output.
      */

--- a/core/src/main/java/com/google/bitcoin/signers/LocalTransactionSigner.java
+++ b/core/src/main/java/com/google/bitcoin/signers/LocalTransactionSigner.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2014 Kosta Korenkov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.bitcoin.signers;
+
+import com.google.bitcoin.core.ECKey;
+import com.google.bitcoin.core.ScriptException;
+import com.google.bitcoin.core.Transaction;
+import com.google.bitcoin.core.TransactionInput;
+import com.google.bitcoin.crypto.TransactionSignature;
+import com.google.bitcoin.script.Script;
+import com.google.bitcoin.script.ScriptBuilder;
+import com.google.bitcoin.wallet.KeyBag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * <p>{@link TransactionSigner} implementation for signing inputs using keys from provided {@link com.google.bitcoin.wallet.KeyBag}.
+ * It always uses {@link com.google.bitcoin.core.Transaction.SigHash#ALL} signing mode.</p>
+ * <p>At the moment it works for pay-to-address and pay-to-pubkey outputs only and will throw {@link RuntimeException} for
+ * other script types</p>
+ */
+public class LocalTransactionSigner implements TransactionSigner {
+    private static final Logger log = LoggerFactory.getLogger(LocalTransactionSigner.class);
+
+    @Override
+    public boolean isReady() {
+        return true;
+    }
+
+    @Override
+    public byte[] serialize() {
+        return new byte[0];
+    }
+
+    @Override
+    public void deserialize(byte[] data) {
+    }
+
+    @Override
+    public boolean signInputs(Transaction tx, KeyBag keyBag) {
+        int numInputs = tx.getInputs().size();
+        for (int i = 0; i < numInputs; i++) {
+            TransactionInput txIn = tx.getInput(i);
+            if (txIn.getConnectedOutput() == null) {
+                log.warn("Missing connected output, assuming input {} is already signed.", i);
+                continue;
+            }
+
+            Script scriptPubKey = txIn.getConnectedOutput().getScriptPubKey();
+
+            // skip input if it spends not pay-to-address or pay-to-pubkey tx
+            // we're not returning false here as this signer theoretically could still sign
+            // some of the inputs (if someday it would be possible to have inputs mixed with multisig)
+            if (!scriptPubKey.isSentToAddress() && !scriptPubKey.isSentToRawPubKey())
+                continue;
+
+            try {
+                // We assume if its already signed, its hopefully got a SIGHASH type that will not invalidate when
+                // we sign missing pieces (to check this would require either assuming any signatures are signing
+                // standard output types or a way to get processed signatures out of script execution)
+                txIn.getScriptSig().correctlySpends(tx, i, txIn.getConnectedOutput().getScriptPubKey(), true);
+                log.warn("Input {} already correctly spends output, assuming SIGHASH type used will be safe and skipping signing.", i);
+                continue;
+            } catch (ScriptException e) {
+                // Expected.
+            }
+
+            ECKey key = txIn.getOutpoint().getConnectedKey(keyBag);
+            // This assert should never fire. If it does, it means the wallet is inconsistent.
+            checkNotNull(key, "Transaction exists in wallet that we cannot redeem: %s", txIn.getOutpoint().getHash());
+            byte[] connectedPubKeyScript = txIn.getOutpoint().getConnectedPubKeyScript();
+            TransactionSignature signature;
+            try {
+                signature = tx.calculateSignature(i, key, connectedPubKeyScript, Transaction.SigHash.ALL, false);
+            } catch (ECKey.KeyIsEncryptedException e) {
+                throw e;
+            } catch (ECKey.MissingPrivateKeyException e) {
+                // Create a dummy signature to ensure the transaction is of the correct size when we try to ensure
+                // the right fee-per-kb is attached. If the wallet doesn't have the privkey, the user is assumed to
+                // be doing something special and that they will replace the dummy signature with a real one later.
+                signature = TransactionSignature.dummy();
+                log.info("Used dummy signature for input {} due to failure during signing (most likely missing privkey)", i);
+            }
+            if (scriptPubKey.isSentToAddress()) {
+                txIn.setScriptSig(ScriptBuilder.createInputScript(signature, key));
+            } else if (scriptPubKey.isSentToRawPubKey()) {
+                txIn.setScriptSig(ScriptBuilder.createInputScript(signature));
+            }
+            // if input spends not pay-to-address or pay-to-pubkey tx
+            // we're not returning false here as this signer theoretically could still sign
+            // some of the inputs (if someday it would be possible to have inputs mixed with multisig)
+
+        }
+        return true;
+    }
+
+}

--- a/core/src/main/java/com/google/bitcoin/signers/TransactionSigner.java
+++ b/core/src/main/java/com/google/bitcoin/signers/TransactionSigner.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2014 Kosta Korenkov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.bitcoin.signers;
+
+import com.google.bitcoin.core.Transaction;
+import com.google.bitcoin.wallet.KeyBag;
+import org.spongycastle.crypto.params.KeyParameter;
+
+import javax.annotation.Nullable;
+
+/**
+ * <p>Implementations of this interface are intended to sign inputs of the given transaction. Given transaction may already
+ * be partially signed or somehow altered by other signers.</p>
+ * <p>To make use of the signer, you need to add it into the  wallet by
+ * calling {@link com.google.bitcoin.core.Wallet#addTransactionSigner(TransactionSigner)}. Signer will be serialized
+ * along with the wallet data. In order for wallet to recreate signer after deserialization, each signer
+ * should have no-args constructor</p>
+ */
+public interface TransactionSigner {
+
+    /**
+     * Returns true if this signer is ready to be used.
+     */
+    boolean isReady();
+
+    /**
+     * Returns byte array of data representing state of this signer. It's used to serialize/deserialize this signer
+     */
+    byte[] serialize();
+
+    /**
+     * Uses given byte array of data to reconstruct internal state of this signer
+     */
+    void deserialize(byte[] data);
+
+    /**
+     * Signs given transaction's inputs.
+     * Returns true if signer is compatible with given transaction (can do something meaningful with it).
+     * Otherwise this method returns false
+     */
+    boolean signInputs(Transaction tx, KeyBag keyBag);
+
+}

--- a/core/src/main/java/com/google/bitcoin/store/WalletProtobufSerializer.java
+++ b/core/src/main/java/com/google/bitcoin/store/WalletProtobufSerializer.java
@@ -22,6 +22,8 @@ import com.google.bitcoin.core.TransactionConfidence.ConfidenceType;
 import com.google.bitcoin.crypto.KeyCrypter;
 import com.google.bitcoin.crypto.KeyCrypterScrypt;
 import com.google.bitcoin.script.Script;
+import com.google.bitcoin.signers.LocalTransactionSigner;
+import com.google.bitcoin.signers.TransactionSigner;
 import com.google.bitcoin.wallet.KeyChainGroup;
 import com.google.bitcoin.wallet.WalletTransaction;
 import com.google.common.collect.Lists;
@@ -189,6 +191,16 @@ public class WalletProtobufSerializer {
         for (Map.Entry<String, ByteString> entry : wallet.getTags().entrySet()) {
             Protos.Tag.Builder tag = Protos.Tag.newBuilder().setTag(entry.getKey()).setData(entry.getValue());
             walletBuilder.addTags(tag);
+        }
+
+        for (TransactionSigner signer : wallet.getTransactionSigners()) {
+            // do not serialize LocalTransactionSigner as it's being added implicitly
+            if (signer instanceof LocalTransactionSigner)
+                continue;
+            Protos.TransactionSigner.Builder protoSigner = Protos.TransactionSigner.newBuilder();
+            protoSigner.setClassName(signer.getClass().getName());
+            protoSigner.setData(ByteString.copyFrom(signer.serialize()));
+            walletBuilder.addTransactionSigners(protoSigner);
         }
 
         // Populate the wallet version.
@@ -446,6 +458,18 @@ public class WalletProtobufSerializer {
 
         for (Protos.Tag tag : walletProto.getTagsList()) {
             wallet.setTag(tag.getTag(), tag.getData());
+        }
+
+        for (Protos.TransactionSigner signerProto : walletProto.getTransactionSignersList()) {
+            try {
+                Class signerClass = Class.forName(signerProto.getClassName());
+                TransactionSigner signer = (TransactionSigner)signerClass.newInstance();
+                signer.deserialize(signerProto.getData().toByteArray());
+                wallet.addTransactionSigner(signer);
+            } catch (Exception e) {
+                throw new UnreadableWalletException("Unable to deserialize TransactionSigner instance: " +
+                        signerProto.getClassName(), e);
+            }
         }
 
         if (walletProto.hasVersion()) {

--- a/core/src/main/java/com/google/bitcoin/testing/NopTransactionSigner.java
+++ b/core/src/main/java/com/google/bitcoin/testing/NopTransactionSigner.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2014 Kosta Korenkov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.bitcoin.testing;
+
+import com.google.bitcoin.core.Transaction;
+import com.google.bitcoin.signers.TransactionSigner;
+import com.google.bitcoin.wallet.KeyBag;
+
+public class NopTransactionSigner implements TransactionSigner {
+    private boolean isReady;
+
+    public NopTransactionSigner() {
+    }
+
+    public NopTransactionSigner(boolean ready) {
+        this.isReady = ready;
+    }
+
+    @Override
+    public boolean isReady() {
+        return isReady;
+    }
+
+    @Override
+    public byte[] serialize() {
+        return isReady ? new byte[]{1} : new byte[]{0};
+    }
+
+    @Override
+    public void deserialize(byte[] data) {
+        if (data.length > 0)
+            isReady = data[0] == 1;
+    }
+
+    @Override
+    public boolean signInputs(Transaction t, KeyBag keyBag) {
+        return false;
+    }
+}

--- a/core/src/main/java/com/google/bitcoin/wallet/KeyBag.java
+++ b/core/src/main/java/com/google/bitcoin/wallet/KeyBag.java
@@ -18,6 +18,8 @@ package com.google.bitcoin.wallet;
 
 import com.google.bitcoin.core.ECKey;
 
+import javax.annotation.Nullable;
+
 /**
  * A KeyBag is simply an object that can map public keys and their 160-bit hashes to ECKey objects. All
  * {@link com.google.bitcoin.wallet.KeyChain}s are key bags.
@@ -29,6 +31,7 @@ public interface KeyBag {
      *
      * @return ECKey object or null if no such key was found.
      */
+    @Nullable
     public ECKey findKeyFromPubHash(byte[] pubkeyHash);
 
     /**
@@ -36,5 +39,6 @@ public interface KeyBag {
      *
      * @return ECKey or null if no such key was found.
      */
+    @Nullable
     public ECKey findKeyFromPubKey(byte[] pubkey);
 }

--- a/core/src/main/java/com/google/bitcoin/wallet/KeyChainGroup.java
+++ b/core/src/main/java/com/google/bitcoin/wallet/KeyChainGroup.java
@@ -63,7 +63,7 @@ import static com.google.common.base.Preconditions.*;
  * <p>Deterministic key chains have a concept of a lookahead size and threshold. Please see the discussion in the
  * class docs for {@link com.google.bitcoin.wallet.DeterministicKeyChain} for more information on this topic.</p>
  */
-public class KeyChainGroup {
+public class KeyChainGroup implements KeyBag {
     private static final Logger log = LoggerFactory.getLogger(KeyChainGroup.class);
 
     private BasicKeyChain basic;
@@ -430,6 +430,7 @@ public class KeyChainGroup {
     }
 
     @Nullable
+    @Override
     public ECKey findKeyFromPubHash(byte[] pubkeyHash) {
         ECKey result;
         if ((result = basic.findKeyFromPubHash(pubkeyHash)) != null)
@@ -477,6 +478,7 @@ public class KeyChainGroup {
     }
 
     @Nullable
+    @Override
     public ECKey findKeyFromPubKey(byte[] pubkey) {
         ECKey result;
         if ((result = basic.findKeyFromPubKey(pubkey)) != null)

--- a/core/src/main/java/org/bitcoinj/wallet/Protos.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Protos.java
@@ -12553,6 +12553,659 @@ public final class Protos {
     // @@protoc_insertion_point(class_scope:wallet.Tag)
   }
 
+  public interface TransactionSignerOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
+
+    // required string class_name = 1;
+    /**
+     * <code>required string class_name = 1;</code>
+     *
+     * <pre>
+     * fully qualified class name of TransactionSigner implementation
+     * </pre>
+     */
+    boolean hasClassName();
+    /**
+     * <code>required string class_name = 1;</code>
+     *
+     * <pre>
+     * fully qualified class name of TransactionSigner implementation
+     * </pre>
+     */
+    java.lang.String getClassName();
+    /**
+     * <code>required string class_name = 1;</code>
+     *
+     * <pre>
+     * fully qualified class name of TransactionSigner implementation
+     * </pre>
+     */
+    com.google.protobuf.ByteString
+        getClassNameBytes();
+
+    // optional bytes data = 2;
+    /**
+     * <code>optional bytes data = 2;</code>
+     *
+     * <pre>
+     * arbitrary data required for signer to function
+     * </pre>
+     */
+    boolean hasData();
+    /**
+     * <code>optional bytes data = 2;</code>
+     *
+     * <pre>
+     * arbitrary data required for signer to function
+     * </pre>
+     */
+    com.google.protobuf.ByteString getData();
+  }
+  /**
+   * Protobuf type {@code wallet.TransactionSigner}
+   *
+   * <pre>
+   **
+   * Data required to reconstruct TransactionSigner.
+   * </pre>
+   */
+  public static final class TransactionSigner extends
+      com.google.protobuf.GeneratedMessage
+      implements TransactionSignerOrBuilder {
+    // Use TransactionSigner.newBuilder() to construct.
+    private TransactionSigner(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+      this.unknownFields = builder.getUnknownFields();
+    }
+    private TransactionSigner(boolean noInit) { this.unknownFields = com.google.protobuf.UnknownFieldSet.getDefaultInstance(); }
+
+    private static final TransactionSigner defaultInstance;
+    public static TransactionSigner getDefaultInstance() {
+      return defaultInstance;
+    }
+
+    public TransactionSigner getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+
+    private final com.google.protobuf.UnknownFieldSet unknownFields;
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+        getUnknownFields() {
+      return this.unknownFields;
+    }
+    private TransactionSigner(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      initFields();
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+            case 10: {
+              bitField0_ |= 0x00000001;
+              className_ = input.readBytes();
+              break;
+            }
+            case 18: {
+              bitField0_ |= 0x00000002;
+              data_ = input.readBytes();
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e.getMessage()).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.bitcoinj.wallet.Protos.internal_static_wallet_TransactionSigner_descriptor;
+    }
+
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.bitcoinj.wallet.Protos.internal_static_wallet_TransactionSigner_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.bitcoinj.wallet.Protos.TransactionSigner.class, org.bitcoinj.wallet.Protos.TransactionSigner.Builder.class);
+    }
+
+    public static com.google.protobuf.Parser<TransactionSigner> PARSER =
+        new com.google.protobuf.AbstractParser<TransactionSigner>() {
+      public TransactionSigner parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new TransactionSigner(input, extensionRegistry);
+      }
+    };
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<TransactionSigner> getParserForType() {
+      return PARSER;
+    }
+
+    private int bitField0_;
+    // required string class_name = 1;
+    public static final int CLASS_NAME_FIELD_NUMBER = 1;
+    private java.lang.Object className_;
+    /**
+     * <code>required string class_name = 1;</code>
+     *
+     * <pre>
+     * fully qualified class name of TransactionSigner implementation
+     * </pre>
+     */
+    public boolean hasClassName() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <code>required string class_name = 1;</code>
+     *
+     * <pre>
+     * fully qualified class name of TransactionSigner implementation
+     * </pre>
+     */
+    public java.lang.String getClassName() {
+      java.lang.Object ref = className_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          className_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <code>required string class_name = 1;</code>
+     *
+     * <pre>
+     * fully qualified class name of TransactionSigner implementation
+     * </pre>
+     */
+    public com.google.protobuf.ByteString
+        getClassNameBytes() {
+      java.lang.Object ref = className_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        className_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    // optional bytes data = 2;
+    public static final int DATA_FIELD_NUMBER = 2;
+    private com.google.protobuf.ByteString data_;
+    /**
+     * <code>optional bytes data = 2;</code>
+     *
+     * <pre>
+     * arbitrary data required for signer to function
+     * </pre>
+     */
+    public boolean hasData() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <code>optional bytes data = 2;</code>
+     *
+     * <pre>
+     * arbitrary data required for signer to function
+     * </pre>
+     */
+    public com.google.protobuf.ByteString getData() {
+      return data_;
+    }
+
+    private void initFields() {
+      className_ = "";
+      data_ = com.google.protobuf.ByteString.EMPTY;
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+
+      if (!hasClassName()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeBytes(1, getClassNameBytes());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeBytes(2, data_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(1, getClassNameBytes());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(2, data_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+
+    public static org.bitcoinj.wallet.Protos.TransactionSigner parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.bitcoinj.wallet.Protos.TransactionSigner parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.bitcoinj.wallet.Protos.TransactionSigner parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.bitcoinj.wallet.Protos.TransactionSigner parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.bitcoinj.wallet.Protos.TransactionSigner parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.bitcoinj.wallet.Protos.TransactionSigner parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+    public static org.bitcoinj.wallet.Protos.TransactionSigner parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input);
+    }
+    public static org.bitcoinj.wallet.Protos.TransactionSigner parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseDelimitedFrom(input, extensionRegistry);
+    }
+    public static org.bitcoinj.wallet.Protos.TransactionSigner parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input);
+    }
+    public static org.bitcoinj.wallet.Protos.TransactionSigner parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return PARSER.parseFrom(input, extensionRegistry);
+    }
+
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.bitcoinj.wallet.Protos.TransactionSigner prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code wallet.TransactionSigner}
+     *
+     * <pre>
+     **
+     * Data required to reconstruct TransactionSigner.
+     * </pre>
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements org.bitcoinj.wallet.Protos.TransactionSignerOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.bitcoinj.wallet.Protos.internal_static_wallet_TransactionSigner_descriptor;
+      }
+
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.bitcoinj.wallet.Protos.internal_static_wallet_TransactionSigner_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.bitcoinj.wallet.Protos.TransactionSigner.class, org.bitcoinj.wallet.Protos.TransactionSigner.Builder.class);
+      }
+
+      // Construct using org.bitcoinj.wallet.Protos.TransactionSigner.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+
+      public Builder clear() {
+        super.clear();
+        className_ = "";
+        bitField0_ = (bitField0_ & ~0x00000001);
+        data_ = com.google.protobuf.ByteString.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.bitcoinj.wallet.Protos.internal_static_wallet_TransactionSigner_descriptor;
+      }
+
+      public org.bitcoinj.wallet.Protos.TransactionSigner getDefaultInstanceForType() {
+        return org.bitcoinj.wallet.Protos.TransactionSigner.getDefaultInstance();
+      }
+
+      public org.bitcoinj.wallet.Protos.TransactionSigner build() {
+        org.bitcoinj.wallet.Protos.TransactionSigner result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      public org.bitcoinj.wallet.Protos.TransactionSigner buildPartial() {
+        org.bitcoinj.wallet.Protos.TransactionSigner result = new org.bitcoinj.wallet.Protos.TransactionSigner(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.className_ = className_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.data_ = data_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.bitcoinj.wallet.Protos.TransactionSigner) {
+          return mergeFrom((org.bitcoinj.wallet.Protos.TransactionSigner)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.bitcoinj.wallet.Protos.TransactionSigner other) {
+        if (other == org.bitcoinj.wallet.Protos.TransactionSigner.getDefaultInstance()) return this;
+        if (other.hasClassName()) {
+          bitField0_ |= 0x00000001;
+          className_ = other.className_;
+          onChanged();
+        }
+        if (other.hasData()) {
+          setData(other.getData());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+
+      public final boolean isInitialized() {
+        if (!hasClassName()) {
+          
+          return false;
+        }
+        return true;
+      }
+
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.bitcoinj.wallet.Protos.TransactionSigner parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.bitcoinj.wallet.Protos.TransactionSigner) e.getUnfinishedMessage();
+          throw e;
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      // required string class_name = 1;
+      private java.lang.Object className_ = "";
+      /**
+       * <code>required string class_name = 1;</code>
+       *
+       * <pre>
+       * fully qualified class name of TransactionSigner implementation
+       * </pre>
+       */
+      public boolean hasClassName() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <code>required string class_name = 1;</code>
+       *
+       * <pre>
+       * fully qualified class name of TransactionSigner implementation
+       * </pre>
+       */
+      public java.lang.String getClassName() {
+        java.lang.Object ref = className_;
+        if (!(ref instanceof java.lang.String)) {
+          java.lang.String s = ((com.google.protobuf.ByteString) ref)
+              .toStringUtf8();
+          className_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>required string class_name = 1;</code>
+       *
+       * <pre>
+       * fully qualified class name of TransactionSigner implementation
+       * </pre>
+       */
+      public com.google.protobuf.ByteString
+          getClassNameBytes() {
+        java.lang.Object ref = className_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          className_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>required string class_name = 1;</code>
+       *
+       * <pre>
+       * fully qualified class name of TransactionSigner implementation
+       * </pre>
+       */
+      public Builder setClassName(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        className_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required string class_name = 1;</code>
+       *
+       * <pre>
+       * fully qualified class name of TransactionSigner implementation
+       * </pre>
+       */
+      public Builder clearClassName() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        className_ = getDefaultInstance().getClassName();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>required string class_name = 1;</code>
+       *
+       * <pre>
+       * fully qualified class name of TransactionSigner implementation
+       * </pre>
+       */
+      public Builder setClassNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        className_ = value;
+        onChanged();
+        return this;
+      }
+
+      // optional bytes data = 2;
+      private com.google.protobuf.ByteString data_ = com.google.protobuf.ByteString.EMPTY;
+      /**
+       * <code>optional bytes data = 2;</code>
+       *
+       * <pre>
+       * arbitrary data required for signer to function
+       * </pre>
+       */
+      public boolean hasData() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <code>optional bytes data = 2;</code>
+       *
+       * <pre>
+       * arbitrary data required for signer to function
+       * </pre>
+       */
+      public com.google.protobuf.ByteString getData() {
+        return data_;
+      }
+      /**
+       * <code>optional bytes data = 2;</code>
+       *
+       * <pre>
+       * arbitrary data required for signer to function
+       * </pre>
+       */
+      public Builder setData(com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        data_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional bytes data = 2;</code>
+       *
+       * <pre>
+       * arbitrary data required for signer to function
+       * </pre>
+       */
+      public Builder clearData() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        data_ = getDefaultInstance().getData();
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:wallet.TransactionSigner)
+    }
+
+    static {
+      defaultInstance = new TransactionSigner(true);
+      defaultInstance.initFields();
+    }
+
+    // @@protoc_insertion_point(class_scope:wallet.TransactionSigner)
+  }
+
   public interface WalletOrBuilder
       extends com.google.protobuf.MessageOrBuilder {
 
@@ -12846,6 +13499,51 @@ public final class Protos {
      */
     org.bitcoinj.wallet.Protos.TagOrBuilder getTagsOrBuilder(
         int index);
+
+    // repeated .wallet.TransactionSigner transaction_signers = 17;
+    /**
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+     *
+     * <pre>
+     * transaction signers added to the wallet
+     * </pre>
+     */
+    java.util.List<org.bitcoinj.wallet.Protos.TransactionSigner> 
+        getTransactionSignersList();
+    /**
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+     *
+     * <pre>
+     * transaction signers added to the wallet
+     * </pre>
+     */
+    org.bitcoinj.wallet.Protos.TransactionSigner getTransactionSigners(int index);
+    /**
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+     *
+     * <pre>
+     * transaction signers added to the wallet
+     * </pre>
+     */
+    int getTransactionSignersCount();
+    /**
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+     *
+     * <pre>
+     * transaction signers added to the wallet
+     * </pre>
+     */
+    java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionSignerOrBuilder> 
+        getTransactionSignersOrBuilderList();
+    /**
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+     *
+     * <pre>
+     * transaction signers added to the wallet
+     * </pre>
+     */
+    org.bitcoinj.wallet.Protos.TransactionSignerOrBuilder getTransactionSignersOrBuilder(
+        int index);
   }
   /**
    * Protobuf type {@code wallet.Wallet}
@@ -13001,6 +13699,14 @@ public final class Protos {
               tags_.add(input.readMessage(org.bitcoinj.wallet.Protos.Tag.PARSER, extensionRegistry));
               break;
             }
+            case 138: {
+              if (!((mutable_bitField0_ & 0x00004000) == 0x00004000)) {
+                transactionSigners_ = new java.util.ArrayList<org.bitcoinj.wallet.Protos.TransactionSigner>();
+                mutable_bitField0_ |= 0x00004000;
+              }
+              transactionSigners_.add(input.readMessage(org.bitcoinj.wallet.Protos.TransactionSigner.PARSER, extensionRegistry));
+              break;
+            }
           }
         }
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -13023,6 +13729,9 @@ public final class Protos {
         }
         if (((mutable_bitField0_ & 0x00002000) == 0x00002000)) {
           tags_ = java.util.Collections.unmodifiableList(tags_);
+        }
+        if (((mutable_bitField0_ & 0x00004000) == 0x00004000)) {
+          transactionSigners_ = java.util.Collections.unmodifiableList(transactionSigners_);
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -13609,6 +14318,62 @@ public final class Protos {
       return tags_.get(index);
     }
 
+    // repeated .wallet.TransactionSigner transaction_signers = 17;
+    public static final int TRANSACTION_SIGNERS_FIELD_NUMBER = 17;
+    private java.util.List<org.bitcoinj.wallet.Protos.TransactionSigner> transactionSigners_;
+    /**
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+     *
+     * <pre>
+     * transaction signers added to the wallet
+     * </pre>
+     */
+    public java.util.List<org.bitcoinj.wallet.Protos.TransactionSigner> getTransactionSignersList() {
+      return transactionSigners_;
+    }
+    /**
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+     *
+     * <pre>
+     * transaction signers added to the wallet
+     * </pre>
+     */
+    public java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionSignerOrBuilder> 
+        getTransactionSignersOrBuilderList() {
+      return transactionSigners_;
+    }
+    /**
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+     *
+     * <pre>
+     * transaction signers added to the wallet
+     * </pre>
+     */
+    public int getTransactionSignersCount() {
+      return transactionSigners_.size();
+    }
+    /**
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+     *
+     * <pre>
+     * transaction signers added to the wallet
+     * </pre>
+     */
+    public org.bitcoinj.wallet.Protos.TransactionSigner getTransactionSigners(int index) {
+      return transactionSigners_.get(index);
+    }
+    /**
+     * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+     *
+     * <pre>
+     * transaction signers added to the wallet
+     * </pre>
+     */
+    public org.bitcoinj.wallet.Protos.TransactionSignerOrBuilder getTransactionSignersOrBuilder(
+        int index) {
+      return transactionSigners_.get(index);
+    }
+
     private void initFields() {
       networkIdentifier_ = "";
       lastSeenBlockHash_ = com.google.protobuf.ByteString.EMPTY;
@@ -13624,6 +14389,7 @@ public final class Protos {
       description_ = "";
       keyRotationTime_ = 0L;
       tags_ = java.util.Collections.emptyList();
+      transactionSigners_ = java.util.Collections.emptyList();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -13666,6 +14432,12 @@ public final class Protos {
       }
       for (int i = 0; i < getTagsCount(); i++) {
         if (!getTags(i).isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      for (int i = 0; i < getTransactionSignersCount(); i++) {
+        if (!getTransactionSigners(i).isInitialized()) {
           memoizedIsInitialized = 0;
           return false;
         }
@@ -13718,6 +14490,9 @@ public final class Protos {
       }
       for (int i = 0; i < tags_.size(); i++) {
         output.writeMessage(16, tags_.get(i));
+      }
+      for (int i = 0; i < transactionSigners_.size(); i++) {
+        output.writeMessage(17, transactionSigners_.get(i));
       }
       getUnknownFields().writeTo(output);
     }
@@ -13783,6 +14558,10 @@ public final class Protos {
       for (int i = 0; i < tags_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(16, tags_.get(i));
+      }
+      for (int i = 0; i < transactionSigners_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(17, transactionSigners_.get(i));
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -13902,6 +14681,7 @@ public final class Protos {
           getEncryptionParametersFieldBuilder();
           getExtensionFieldBuilder();
           getTagsFieldBuilder();
+          getTransactionSignersFieldBuilder();
         }
       }
       private static Builder create() {
@@ -13961,6 +14741,12 @@ public final class Protos {
           bitField0_ = (bitField0_ & ~0x00002000);
         } else {
           tagsBuilder_.clear();
+        }
+        if (transactionSignersBuilder_ == null) {
+          transactionSigners_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00004000);
+        } else {
+          transactionSignersBuilder_.clear();
         }
         return this;
       }
@@ -14074,6 +14860,15 @@ public final class Protos {
           result.tags_ = tags_;
         } else {
           result.tags_ = tagsBuilder_.build();
+        }
+        if (transactionSignersBuilder_ == null) {
+          if (((bitField0_ & 0x00004000) == 0x00004000)) {
+            transactionSigners_ = java.util.Collections.unmodifiableList(transactionSigners_);
+            bitField0_ = (bitField0_ & ~0x00004000);
+          }
+          result.transactionSigners_ = transactionSigners_;
+        } else {
+          result.transactionSigners_ = transactionSignersBuilder_.build();
         }
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -14252,6 +15047,32 @@ public final class Protos {
             }
           }
         }
+        if (transactionSignersBuilder_ == null) {
+          if (!other.transactionSigners_.isEmpty()) {
+            if (transactionSigners_.isEmpty()) {
+              transactionSigners_ = other.transactionSigners_;
+              bitField0_ = (bitField0_ & ~0x00004000);
+            } else {
+              ensureTransactionSignersIsMutable();
+              transactionSigners_.addAll(other.transactionSigners_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.transactionSigners_.isEmpty()) {
+            if (transactionSignersBuilder_.isEmpty()) {
+              transactionSignersBuilder_.dispose();
+              transactionSignersBuilder_ = null;
+              transactionSigners_ = other.transactionSigners_;
+              bitField0_ = (bitField0_ & ~0x00004000);
+              transactionSignersBuilder_ = 
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getTransactionSignersFieldBuilder() : null;
+            } else {
+              transactionSignersBuilder_.addAllMessages(other.transactionSigners_);
+            }
+          }
+        }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
       }
@@ -14293,6 +15114,12 @@ public final class Protos {
         }
         for (int i = 0; i < getTagsCount(); i++) {
           if (!getTags(i).isInitialized()) {
+            
+            return false;
+          }
+        }
+        for (int i = 0; i < getTransactionSignersCount(); i++) {
+          if (!getTransactionSigners(i).isInitialized()) {
             
             return false;
           }
@@ -16112,6 +16939,318 @@ public final class Protos {
         return tagsBuilder_;
       }
 
+      // repeated .wallet.TransactionSigner transaction_signers = 17;
+      private java.util.List<org.bitcoinj.wallet.Protos.TransactionSigner> transactionSigners_ =
+        java.util.Collections.emptyList();
+      private void ensureTransactionSignersIsMutable() {
+        if (!((bitField0_ & 0x00004000) == 0x00004000)) {
+          transactionSigners_ = new java.util.ArrayList<org.bitcoinj.wallet.Protos.TransactionSigner>(transactionSigners_);
+          bitField0_ |= 0x00004000;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.bitcoinj.wallet.Protos.TransactionSigner, org.bitcoinj.wallet.Protos.TransactionSigner.Builder, org.bitcoinj.wallet.Protos.TransactionSignerOrBuilder> transactionSignersBuilder_;
+
+      /**
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+       *
+       * <pre>
+       * transaction signers added to the wallet
+       * </pre>
+       */
+      public java.util.List<org.bitcoinj.wallet.Protos.TransactionSigner> getTransactionSignersList() {
+        if (transactionSignersBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(transactionSigners_);
+        } else {
+          return transactionSignersBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+       *
+       * <pre>
+       * transaction signers added to the wallet
+       * </pre>
+       */
+      public int getTransactionSignersCount() {
+        if (transactionSignersBuilder_ == null) {
+          return transactionSigners_.size();
+        } else {
+          return transactionSignersBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+       *
+       * <pre>
+       * transaction signers added to the wallet
+       * </pre>
+       */
+      public org.bitcoinj.wallet.Protos.TransactionSigner getTransactionSigners(int index) {
+        if (transactionSignersBuilder_ == null) {
+          return transactionSigners_.get(index);
+        } else {
+          return transactionSignersBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+       *
+       * <pre>
+       * transaction signers added to the wallet
+       * </pre>
+       */
+      public Builder setTransactionSigners(
+          int index, org.bitcoinj.wallet.Protos.TransactionSigner value) {
+        if (transactionSignersBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureTransactionSignersIsMutable();
+          transactionSigners_.set(index, value);
+          onChanged();
+        } else {
+          transactionSignersBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+       *
+       * <pre>
+       * transaction signers added to the wallet
+       * </pre>
+       */
+      public Builder setTransactionSigners(
+          int index, org.bitcoinj.wallet.Protos.TransactionSigner.Builder builderForValue) {
+        if (transactionSignersBuilder_ == null) {
+          ensureTransactionSignersIsMutable();
+          transactionSigners_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          transactionSignersBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+       *
+       * <pre>
+       * transaction signers added to the wallet
+       * </pre>
+       */
+      public Builder addTransactionSigners(org.bitcoinj.wallet.Protos.TransactionSigner value) {
+        if (transactionSignersBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureTransactionSignersIsMutable();
+          transactionSigners_.add(value);
+          onChanged();
+        } else {
+          transactionSignersBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+       *
+       * <pre>
+       * transaction signers added to the wallet
+       * </pre>
+       */
+      public Builder addTransactionSigners(
+          int index, org.bitcoinj.wallet.Protos.TransactionSigner value) {
+        if (transactionSignersBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureTransactionSignersIsMutable();
+          transactionSigners_.add(index, value);
+          onChanged();
+        } else {
+          transactionSignersBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+       *
+       * <pre>
+       * transaction signers added to the wallet
+       * </pre>
+       */
+      public Builder addTransactionSigners(
+          org.bitcoinj.wallet.Protos.TransactionSigner.Builder builderForValue) {
+        if (transactionSignersBuilder_ == null) {
+          ensureTransactionSignersIsMutable();
+          transactionSigners_.add(builderForValue.build());
+          onChanged();
+        } else {
+          transactionSignersBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+       *
+       * <pre>
+       * transaction signers added to the wallet
+       * </pre>
+       */
+      public Builder addTransactionSigners(
+          int index, org.bitcoinj.wallet.Protos.TransactionSigner.Builder builderForValue) {
+        if (transactionSignersBuilder_ == null) {
+          ensureTransactionSignersIsMutable();
+          transactionSigners_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          transactionSignersBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+       *
+       * <pre>
+       * transaction signers added to the wallet
+       * </pre>
+       */
+      public Builder addAllTransactionSigners(
+          java.lang.Iterable<? extends org.bitcoinj.wallet.Protos.TransactionSigner> values) {
+        if (transactionSignersBuilder_ == null) {
+          ensureTransactionSignersIsMutable();
+          super.addAll(values, transactionSigners_);
+          onChanged();
+        } else {
+          transactionSignersBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+       *
+       * <pre>
+       * transaction signers added to the wallet
+       * </pre>
+       */
+      public Builder clearTransactionSigners() {
+        if (transactionSignersBuilder_ == null) {
+          transactionSigners_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00004000);
+          onChanged();
+        } else {
+          transactionSignersBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+       *
+       * <pre>
+       * transaction signers added to the wallet
+       * </pre>
+       */
+      public Builder removeTransactionSigners(int index) {
+        if (transactionSignersBuilder_ == null) {
+          ensureTransactionSignersIsMutable();
+          transactionSigners_.remove(index);
+          onChanged();
+        } else {
+          transactionSignersBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+       *
+       * <pre>
+       * transaction signers added to the wallet
+       * </pre>
+       */
+      public org.bitcoinj.wallet.Protos.TransactionSigner.Builder getTransactionSignersBuilder(
+          int index) {
+        return getTransactionSignersFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+       *
+       * <pre>
+       * transaction signers added to the wallet
+       * </pre>
+       */
+      public org.bitcoinj.wallet.Protos.TransactionSignerOrBuilder getTransactionSignersOrBuilder(
+          int index) {
+        if (transactionSignersBuilder_ == null) {
+          return transactionSigners_.get(index);  } else {
+          return transactionSignersBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+       *
+       * <pre>
+       * transaction signers added to the wallet
+       * </pre>
+       */
+      public java.util.List<? extends org.bitcoinj.wallet.Protos.TransactionSignerOrBuilder> 
+           getTransactionSignersOrBuilderList() {
+        if (transactionSignersBuilder_ != null) {
+          return transactionSignersBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(transactionSigners_);
+        }
+      }
+      /**
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+       *
+       * <pre>
+       * transaction signers added to the wallet
+       * </pre>
+       */
+      public org.bitcoinj.wallet.Protos.TransactionSigner.Builder addTransactionSignersBuilder() {
+        return getTransactionSignersFieldBuilder().addBuilder(
+            org.bitcoinj.wallet.Protos.TransactionSigner.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+       *
+       * <pre>
+       * transaction signers added to the wallet
+       * </pre>
+       */
+      public org.bitcoinj.wallet.Protos.TransactionSigner.Builder addTransactionSignersBuilder(
+          int index) {
+        return getTransactionSignersFieldBuilder().addBuilder(
+            index, org.bitcoinj.wallet.Protos.TransactionSigner.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .wallet.TransactionSigner transaction_signers = 17;</code>
+       *
+       * <pre>
+       * transaction signers added to the wallet
+       * </pre>
+       */
+      public java.util.List<org.bitcoinj.wallet.Protos.TransactionSigner.Builder> 
+           getTransactionSignersBuilderList() {
+        return getTransactionSignersFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          org.bitcoinj.wallet.Protos.TransactionSigner, org.bitcoinj.wallet.Protos.TransactionSigner.Builder, org.bitcoinj.wallet.Protos.TransactionSignerOrBuilder> 
+          getTransactionSignersFieldBuilder() {
+        if (transactionSignersBuilder_ == null) {
+          transactionSignersBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              org.bitcoinj.wallet.Protos.TransactionSigner, org.bitcoinj.wallet.Protos.TransactionSigner.Builder, org.bitcoinj.wallet.Protos.TransactionSignerOrBuilder>(
+                  transactionSigners_,
+                  ((bitField0_ & 0x00004000) == 0x00004000),
+                  getParentForChildren(),
+                  isClean());
+          transactionSigners_ = null;
+        }
+        return transactionSignersBuilder_;
+      }
+
       // @@protoc_insertion_point(builder_scope:wallet.Wallet)
     }
 
@@ -16184,6 +17323,11 @@ public final class Protos {
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_wallet_Tag_fieldAccessorTable;
   private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_wallet_TransactionSigner_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_wallet_TransactionSigner_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_wallet_Wallet_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -16251,22 +17395,24 @@ public final class Protos {
       " \001(\003:\00516384\022\014\n\001r\030\003 \001(\005:\0018\022\014\n\001p\030\004 \001(\005:\0011\"" +
       "8\n\tExtension\022\n\n\002id\030\001 \002(\t\022\014\n\004data\030\002 \002(\014\022\021" +
       "\n\tmandatory\030\003 \002(\010\" \n\003Tag\022\013\n\003tag\030\001 \002(\t\022\014\n" +
-      "\004data\030\002 \002(\014\"\261\004\n\006Wallet\022\032\n\022network_identi" +
-      "fier\030\001 \002(\t\022\034\n\024last_seen_block_hash\030\002 \001(\014" +
-      "\022\036\n\026last_seen_block_height\030\014 \001(\r\022!\n\031last" +
-      "_seen_block_time_secs\030\016 \001(\003\022\030\n\003key\030\003 \003(\013" +
-      "2\013.wallet.Key\022(\n\013transaction\030\004 \003(\0132\023.wal" +
-      "let.Transaction\022&\n\016watched_script\030\017 \003(\0132",
-      "\016.wallet.Script\022C\n\017encryption_type\030\005 \001(\016" +
-      "2\035.wallet.Wallet.EncryptionType:\013UNENCRY" +
-      "PTED\0227\n\025encryption_parameters\030\006 \001(\0132\030.wa" +
-      "llet.ScryptParameters\022\022\n\007version\030\007 \001(\005:\001" +
-      "1\022$\n\textension\030\n \003(\0132\021.wallet.Extension\022" +
-      "\023\n\013description\030\013 \001(\t\022\031\n\021key_rotation_tim" +
-      "e\030\r \001(\004\022\031\n\004tags\030\020 \003(\0132\013.wallet.Tag\";\n\016En" +
-      "cryptionType\022\017\n\013UNENCRYPTED\020\001\022\030\n\024ENCRYPT" +
-      "ED_SCRYPT_AES\020\002B\035\n\023org.bitcoinj.walletB\006" +
-      "Protos"
+      "\004data\030\002 \002(\014\"5\n\021TransactionSigner\022\022\n\nclas" +
+      "s_name\030\001 \002(\t\022\014\n\004data\030\002 \001(\014\"\351\004\n\006Wallet\022\032\n" +
+      "\022network_identifier\030\001 \002(\t\022\034\n\024last_seen_b" +
+      "lock_hash\030\002 \001(\014\022\036\n\026last_seen_block_heigh" +
+      "t\030\014 \001(\r\022!\n\031last_seen_block_time_secs\030\016 \001" +
+      "(\003\022\030\n\003key\030\003 \003(\0132\013.wallet.Key\022(\n\013transact",
+      "ion\030\004 \003(\0132\023.wallet.Transaction\022&\n\016watche" +
+      "d_script\030\017 \003(\0132\016.wallet.Script\022C\n\017encryp" +
+      "tion_type\030\005 \001(\0162\035.wallet.Wallet.Encrypti" +
+      "onType:\013UNENCRYPTED\0227\n\025encryption_parame" +
+      "ters\030\006 \001(\0132\030.wallet.ScryptParameters\022\022\n\007" +
+      "version\030\007 \001(\005:\0011\022$\n\textension\030\n \003(\0132\021.wa" +
+      "llet.Extension\022\023\n\013description\030\013 \001(\t\022\031\n\021k" +
+      "ey_rotation_time\030\r \001(\004\022\031\n\004tags\030\020 \003(\0132\013.w" +
+      "allet.Tag\0226\n\023transaction_signers\030\021 \003(\0132\031" +
+      ".wallet.TransactionSigner\";\n\016EncryptionT",
+      "ype\022\017\n\013UNENCRYPTED\020\001\022\030\n\024ENCRYPTED_SCRYPT" +
+      "_AES\020\002B\035\n\023org.bitcoinj.walletB\006Protos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -16345,12 +17491,18 @@ public final class Protos {
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_wallet_Tag_descriptor,
               new java.lang.String[] { "Tag", "Data", });
-          internal_static_wallet_Wallet_descriptor =
+          internal_static_wallet_TransactionSigner_descriptor =
             getDescriptor().getMessageTypes().get(12);
+          internal_static_wallet_TransactionSigner_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_wallet_TransactionSigner_descriptor,
+              new java.lang.String[] { "ClassName", "Data", });
+          internal_static_wallet_Wallet_descriptor =
+            getDescriptor().getMessageTypes().get(13);
           internal_static_wallet_Wallet_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_wallet_Wallet_descriptor,
-              new java.lang.String[] { "NetworkIdentifier", "LastSeenBlockHash", "LastSeenBlockHeight", "LastSeenBlockTimeSecs", "Key", "Transaction", "WatchedScript", "EncryptionType", "EncryptionParameters", "Version", "Extension", "Description", "KeyRotationTime", "Tags", });
+              new java.lang.String[] { "NetworkIdentifier", "LastSeenBlockHash", "LastSeenBlockHeight", "LastSeenBlockTimeSecs", "Key", "Transaction", "WatchedScript", "EncryptionType", "EncryptionParameters", "Version", "Extension", "Description", "KeyRotationTime", "Tags", "TransactionSigners", });
           return null;
         }
       };

--- a/core/src/wallet.proto
+++ b/core/src/wallet.proto
@@ -300,6 +300,16 @@ message Tag {
     required bytes data = 2;
 }
 
+/**
+ * Data required to reconstruct TransactionSigner.
+ */
+message TransactionSigner {
+	// fully qualified class name of TransactionSigner implementation
+	required string class_name = 1;
+	// arbitrary data required for signer to function
+	optional bytes data = 2;
+}
+
 /** A bitcoin wallet */
 message Wallet {
   /**
@@ -352,5 +362,8 @@ message Wallet {
 
   repeated Tag tags = 16;
 
-  // Next tag: 17
+  // transaction signers added to the wallet
+  repeated TransactionSigner transaction_signers = 17;
+
+  // Next tag: 18
 }

--- a/tools/src/main/java/com/google/bitcoin/tools/WalletTool.java
+++ b/tools/src/main/java/com/google/bitcoin/tools/WalletTool.java
@@ -549,7 +549,7 @@ public class WalletTool {
                     // For lock times to take effect, at least one output must have a non-final sequence number.
                     t.getInputs().get(0).setSequenceNumber(0);
                     // And because we modified the transaction after it was completed, we must re-sign the inputs.
-                    t.signInputs(Transaction.SigHash.ALL, wallet);
+                    wallet.signTransaction(t, Transaction.SigHash.ALL, req.aesKey);
                 }
             } catch (ParseException e) {
                 System.err.println("Could not understand --locktime of " + lockTimeStr);


### PR DESCRIPTION
First portion of work on pluggable signers.

Introduced transaction signer notion. Instances of TransactionSigner could be added into the wallet, so that they subsequently applied to transaction to complete it.
Existing signing code (Transaction.signInputs) was refactored into LocalTransactionSigner, which is always implicitly added to any wallet.

~~Several things I don't like about proposed design:
1. Every signer has to be accompanied with corresponding WalletExtension implementation, otherwise it would be lost after deserialization. It looks error-prone for me. I think of making TransactionSigner to be WalletExtension itself, so that we could implicitly register new extension in addTransactionSigner method.
2. If signer throws an exception, it is treated as incompatible signer and exception is swallowed. It doesn't look neat, real errors in implementation may be missed. Maybe it worth obliging TransactionSigner to throw some specific exception if it's not compatible?
3. As KeyBagTransactionSigner may be provided with encrypted KeyBag, signer needs a password to decrypt it. I see no way to pass DecryptingKeyBag to signer during construction -- KeyBagTransactionSigner is being constructed on wallet creation when password isn't available. So I'm passing password as an argument for TransactionSigner.signInputs. This does the trick, but used only for KeyBag-aware implementation and thus is polluting method signature.~~
