### PR TITLE
Fix KeyChainGroup.toString double keys output

### DIFF
--- a/core/src/main/java/com/google/bitcoin/wallet/KeyChainGroup.java
+++ b/core/src/main/java/com/google/bitcoin/wallet/KeyChainGroup.java
@@ -868,8 +868,6 @@ public class KeyChainGroup {
                 for (ECKey key : chain.getKeys())
                     formatKeyWithAddress(includePrivateKeys, key, builder2);
             }
-            for (ECKey key : chain.getKeys())
-                formatKeyWithAddress(includePrivateKeys, key, builder2);
             chainStrs.add(builder2.toString());
         }
         builder.append(Joiner.on(String.format("%n")).join(chainStrs));


### PR DESCRIPTION
Keys being printed out twice
