### PR TITLE
Separate extension initialization into two steps.

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/WalletExtension.java
+++ b/core/src/main/java/com/google/bitcoin/core/WalletExtension.java
@@ -41,4 +41,15 @@ public interface WalletExtension {
     public byte[] serializeWalletExtension();
     /** Loads the contents of this object from the wallet. */
     public void deserializeWalletExtension(Wallet containingWallet, byte[] data) throws Exception;
+
+    /**
+     * This method must be called during extension startup phase, but after deserializeWalletExtension() and
+     * after the bitcoin network has been initialized.
+     * When this method runs, the extension will use the transaction broadcaster to access the Bitcoin network,
+     * and any initialization logic that needs Bitcoin network should be done here.
+     *
+     * (If you use WalletAppKit, then WalletAppKit calls this method for you, but if you don't you have to call this
+     * method somewhere in your code)
+     */
+    public void startWalletExtension(TransactionBroadcaster broadcaster);
 }

--- a/core/src/main/java/com/google/bitcoin/protocols/channels/PaymentChannelServerState.java
+++ b/core/src/main/java/com/google/bitcoin/protocols/channels/PaymentChannelServerState.java
@@ -493,8 +493,9 @@ public class PaymentChannelServerState {
             return;
 
         log.info("Storing state with contract hash {}.", multisigContract.getHash());
-        StoredPaymentChannelServerStates channels = (StoredPaymentChannelServerStates)
-                wallet.addOrGetExistingExtension(new StoredPaymentChannelServerStates(wallet, broadcaster));
+        StoredPaymentChannelServerStates backupChannels = new StoredPaymentChannelServerStates(wallet);
+        backupChannels.startWalletExtension(broadcaster);
+        StoredPaymentChannelServerStates channels = (StoredPaymentChannelServerStates) wallet.addOrGetExistingExtension(backupChannels);
         storedServerChannel = new StoredServerChannel(this, multisigContract, clientOutput, refundTransactionUnlockTimeSecs, serverKey, bestValueToMe, bestValueSignature);
         if (connectedHandler != null)
             checkState(storedServerChannel.setConnectedHandler(connectedHandler, false) == connectedHandler);

--- a/core/src/test/java/com/google/bitcoin/protocols/channels/PaymentChannelStateTest.java
+++ b/core/src/test/java/com/google/bitcoin/protocols/channels/PaymentChannelStateTest.java
@@ -62,13 +62,15 @@ public class PaymentChannelStateTest extends TestWithWallet {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        wallet.addExtension(new StoredPaymentChannelClientStates(wallet, new TransactionBroadcaster() {
+        StoredPaymentChannelClientStates channels = new StoredPaymentChannelClientStates(wallet);
+        channels.startWalletExtension(new TransactionBroadcaster() {
             @Override
             public ListenableFuture<Transaction> broadcastTransaction(Transaction tx) {
                 fail();
                 return null;
-            }
-        }));
+           }
+        });
+        wallet.addExtension(channels);
         sendMoneyToWallet(COIN, AbstractBlockChain.NewBlockType.BEST_CHAIN);
         chain = new BlockChain(params, wallet, blockStore); // Recreate chain as sendMoneyToWallet will confuse it
         serverWallet = new Wallet(params);
@@ -225,7 +227,8 @@ public class PaymentChannelStateTest extends TestWithWallet {
         assertEquals(CENT, wallet.getBalance());
 
         // Set the wallet's stored states to use our real test PeerGroup
-        StoredPaymentChannelClientStates stateStorage = new StoredPaymentChannelClientStates(wallet, mockBroadcaster);
+        StoredPaymentChannelClientStates stateStorage = new StoredPaymentChannelClientStates(wallet);
+        stateStorage.startWalletExtension(mockBroadcaster);
         wallet.addOrUpdateExtension(stateStorage);
 
         Utils.setMockClock(); // Use mock clock

--- a/core/src/test/java/com/google/bitcoin/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/com/google/bitcoin/store/WalletProtobufSerializerTest.java
@@ -370,5 +370,10 @@ public class WalletProtobufSerializerTest {
         public void deserializeWalletExtension(Wallet wallet, byte[] data) {
             assertArrayEquals(this.data, data);
         }
+
+        @Override
+        public void startWalletExtension(TransactionBroadcaster transactionBroadcaster) {
+           // do nothing
+        }
     }
 }

--- a/examples/src/main/java/com/google/bitcoin/examples/ExamplePaymentChannelServer.java
+++ b/examples/src/main/java/com/google/bitcoin/examples/ExamplePaymentChannelServer.java
@@ -61,7 +61,7 @@ public class ExamplePaymentChannelServer implements PaymentChannelServerListener
                 // The StoredPaymentChannelClientStates object is responsible for, amongst other things, broadcasting
                 // the refund transaction if its lock time has expired. It also persists channels so we can resume them
                 // after a restart.
-                return ImmutableList.<WalletExtension>of(new StoredPaymentChannelServerStates(null, peerGroup()));
+                return ImmutableList.<WalletExtension>of(new StoredPaymentChannelServerStates(null));
             }
         };
         appKit.connectToLocalHost();


### PR DESCRIPTION
Hi. 

I work with Martin Zachrison at Strawpay, and I am currently trying to enable payment channels in MultiBitHD. I will send Mike a mail abt this too.

We need to separate extension initialization into two steps: deserializeWalletExtension() and startWalletExtension().
- deserializeWalletExtension() is responsible for interpreting the extension's serialized form into objects.
- startWalletExtension() will perform initialization using the bitcoin network (i.e. the peer group)

Motivation:
Some wallets (MultiBitHD) do not use WalletAppKit, and begin with reading the wallet before initializing the bitcoin network.
This makes it very hard for the old payment channel impl, since deserializeWalletExtension() needed the peer group to run.
But with this change these wallets can call deserializeWalletExtension() when the wallet file is read, and call startWalletExtension() after the bitcoin network is up.
