### PR TITLE
Payment channel extension should be able to be initialized in two steps

### DIFF
--- a/examples/src/main/java/com/google/bitcoin/examples/ExamplePaymentChannelServer.java
+++ b/examples/src/main/java/com/google/bitcoin/examples/ExamplePaymentChannelServer.java
@@ -61,7 +61,7 @@ public class ExamplePaymentChannelServer implements PaymentChannelServerListener
                 // The StoredPaymentChannelClientStates object is responsible for, amongst other things, broadcasting
                 // the refund transaction if its lock time has expired. It also persists channels so we can resume them
                 // after a restart.
-                return ImmutableList.<WalletExtension>of(new StoredPaymentChannelServerStates(null, peerGroup()));
+                return ImmutableList.<WalletExtension>of(new StoredPaymentChannelServerStates(null));
             }
         };
         appKit.connectToLocalHost();


### PR DESCRIPTION
Payment channel extension should be able to be initialized in two steps:
- A constructor that only takes the wallet as an argument
- A setTransactionBroadcaster() which should be called when the Bitcoin network is ready

Motivation: Some wallets (MultiBitHD) does not use WalletAppKit, and starts with reading the wallet before initializing the bitcoin network.
Now these wallets can create the wallet (and the wallet file is read), and call the setter after the bitcoin network is up.
