### PR TITLE
Fix error when using Block.verify() after the Block constructor

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/Block.java
+++ b/core/src/main/java/com/google/bitcoin/core/Block.java
@@ -239,7 +239,7 @@ public class Block extends Message {
         maybeParseTransactions();
         if (optimalEncodingMessageSize != 0)
             return optimalEncodingMessageSize;
-        optimalEncodingMessageSize = getMessageSize();
+        optimalEncodingMessageSize = bitcoinSerialize().length;
         return optimalEncodingMessageSize;
     }
 


### PR DESCRIPTION
...which takes all the elements of the block as paramters.

ie:
Block(NetworkParameters params, long version, Sha256Hash prevBlockHash, Sha256Hash merkleRoot, long time,  long difficultyTarget, long nonce, List<Transaction> transactions)
then verify() calls getOptimalEncodingMessageSize() calls getMessageSize(), which throws for blocks.
