### PR TITLE
Make RedeemData to sort keys.

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/ECKey.java
+++ b/core/src/main/java/com/google/bitcoin/core/ECKey.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
 import com.google.common.base.Preconditions;
+import com.google.common.primitives.UnsignedBytes;
 import org.bitcoin.NativeSecp256k1;
 import org.bitcoinj.wallet.Protos;
 import org.slf4j.Logger;
@@ -51,6 +52,7 @@ import java.nio.charset.Charset;
 import java.security.SecureRandom;
 import java.security.SignatureException;
 import java.util.Arrays;
+import java.util.Comparator;
 
 import static com.google.common.base.Preconditions.*;
 
@@ -87,6 +89,16 @@ import static com.google.common.base.Preconditions.*;
  */
 public class ECKey implements EncryptableItem, Serializable {
     private static final Logger log = LoggerFactory.getLogger(ECKey.class);
+
+    /** Compares pub key bytes using {@link com.google.common.primitives.UnsignedBytes#lexicographicalComparator()} **/
+    public static final Comparator<ECKey> PUBKEY_COMPARATOR = new Comparator<ECKey>() {
+        private Comparator comparator = UnsignedBytes.lexicographicalComparator();
+
+        @Override
+        public int compare(ECKey k1, ECKey k2) {
+            return comparator.compare(k1.getPubKey(), k2.getPubKey());
+        }
+    };
 
     /** The parameters of the secp256k1 curve that Bitcoin uses. */
     public static final X9ECParameters CURVE_PARAMS = CustomNamedCurves.getByName("secp256k1");

--- a/core/src/main/java/com/google/bitcoin/script/ScriptBuilder.java
+++ b/core/src/main/java/com/google/bitcoin/script/ScriptBuilder.java
@@ -21,10 +21,12 @@ import com.google.bitcoin.core.ECKey;
 import com.google.bitcoin.core.Utils;
 import com.google.bitcoin.crypto.TransactionSignature;
 import com.google.common.collect.Lists;
-import com.google.common.primitives.UnsignedBytes;
 
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static com.google.bitcoin.script.ScriptOpCodes.*;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -233,14 +235,7 @@ public class ScriptBuilder {
      */
     public static Script createRedeemScript(int threshold, List<ECKey> pubkeys) {
         pubkeys = new ArrayList<ECKey>(pubkeys);
-        final Comparator comparator = UnsignedBytes.lexicographicalComparator();
-        Collections.sort(pubkeys, new Comparator<ECKey>() {
-            @Override
-            public int compare(ECKey k1, ECKey k2) {
-                return comparator.compare(k1.getPubKey(), k2.getPubKey());
-            }
-        });
-
+        Collections.sort(pubkeys, ECKey.PUBKEY_COMPARATOR);
         return ScriptBuilder.createMultiSigOutputScript(threshold, pubkeys);
     }
 }

--- a/core/src/main/java/com/google/bitcoin/wallet/RedeemData.java
+++ b/core/src/main/java/com/google/bitcoin/wallet/RedeemData.java
@@ -19,6 +19,8 @@ import com.google.bitcoin.core.ECKey;
 import com.google.bitcoin.script.Script;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -26,6 +28,7 @@ import java.util.List;
  *
  * For pay-to-address and pay-to-pubkey transactions it will have only a single key and no redeem script.
  * For multisignature transactions there will be multiple keys one of which will be a full key and the rest are watch only.
+ * These keys will be sorted in the same order they appear in a program (lexicographical order).
  * For P2SH transactions there also will be a redeem script.
  */
 public class RedeemData {
@@ -34,7 +37,9 @@ public class RedeemData {
 
     private RedeemData(List<ECKey> keys, @Nullable Script redeemScript) {
         this.redeemScript = redeemScript;
-        this.keys = keys;
+        List<ECKey> sortedKeys = new ArrayList<ECKey>(keys);
+        Collections.sort(sortedKeys, ECKey.PUBKEY_COMPARATOR);
+        this.keys = sortedKeys;
     }
 
     public static RedeemData of(List<ECKey> keys, @Nullable Script redeemScript) {


### PR DESCRIPTION
So that these keys are stored in the same order they appear in redeem script. That would make easier for signers to locate signature position in scriptSig.
