### PR TITLE
Repair workDone when loading wallet.

### DIFF
--- a/core/src/main/java/com/google/bitcoin/store/WalletProtobufSerializer.java
+++ b/core/src/main/java/com/google/bitcoin/store/WalletProtobufSerializer.java
@@ -672,7 +672,13 @@ public class WalletProtobufSerializer {
                 log.warn("Have workDone but not BUILDING for tx {}", tx.getHashAsString());
                 return;
             }
-            confidence.setWorkDone(BigInteger.valueOf(confidenceProto.getWorkDone()));
+            long workDone = confidenceProto.getWorkDone();
+            if (workDone < 0) {
+                // Somehow these values get negative and we don't know how. Reset bad values so wallets still load.
+                log.warn("Repairing negative work done: ", workDone);
+                workDone = 0;
+            }
+            confidence.setWorkDone(BigInteger.valueOf(workDone));
         }
         if (confidenceProto.hasOverridingTransaction()) {
             if (confidence.getConfidenceType() != ConfidenceType.DEAD) {


### PR DESCRIPTION
We want to get to the bottom of the issue so the assert in Confidence.setWorkDone() should not fire on loading currupt wallets. And we need this repair fix anyway if we ever want to use the field.
