### PR TITLE
Handle Height Mismatch

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/BlockChain.java
+++ b/core/src/main/java/com/google/bitcoin/core/BlockChain.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2011 Google Inc.
+ * Copyright 2014 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +16,8 @@
  */
 
 package com.google.bitcoin.core;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.bitcoin.store.BlockStore;
 import com.google.bitcoin.store.BlockStoreException;
@@ -78,6 +81,31 @@ public class BlockChain extends AbstractBlockChain {
         StoredBlock newBlock = storedPrev.build(blockHeader);
         blockStore.put(newBlock);
         return newBlock;
+    }
+
+    @Override
+    protected void rollbackBlockStore(int height) throws BlockStoreException {
+        lock.lock();
+        try {
+            int currentHeight = getBestChainHeight();
+            checkArgument(height >= 0 && height <= currentHeight, "Bad height: %s", height);
+            if (height == currentHeight)
+                return; // nothing to do
+
+            // Look for the block we want to be the new chain head
+            StoredBlock newChainHead = blockStore.getChainHead();
+            while (newChainHead.getHeight() > height) {
+                newChainHead = newChainHead.getPrev(blockStore);
+                if (newChainHead == null)
+                    throw new BlockStoreException("Unreachable height");
+            }
+
+            // Modify store directly
+            blockStore.put(newChainHead);
+            this.setChainHead(newChainHead);
+        } finally {
+            lock.unlock();
+        }
     }
 
     @Override

--- a/core/src/main/java/com/google/bitcoin/core/FullPrunedBlockChain.java
+++ b/core/src/main/java/com/google/bitcoin/core/FullPrunedBlockChain.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2012 Matt Corallo.
+ * Copyright 2014 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,6 +92,11 @@ public class FullPrunedBlockChain extends AbstractBlockChain {
         StoredBlock newBlock = storedPrev.build(block);
         blockStore.put(newBlock, new StoredUndoableBlock(newBlock.getHeader().getHash(), block.transactions));
         return newBlock;
+    }
+
+    @Override
+    protected void rollbackBlockStore(int height) throws BlockStoreException {
+        throw new BlockStoreException("Unsupported");
     }
 
     @Override

--- a/core/src/test/java/com/google/bitcoin/core/BlockChainTest.java
+++ b/core/src/test/java/com/google/bitcoin/core/BlockChainTest.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2011 Google Inc.
+ * Copyright 2014 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -423,5 +424,34 @@ public class BlockChainTest {
         assertEquals(decay * 55, chain.getFalsePositiveRate(), 1e-4);
         chain.trackFilteredTransactions(550);
         assertEquals(rate1, chain.getFalsePositiveRate(), 1e-4);
+    }
+
+    @Test
+    public void rollbackBlockStore() throws Exception {
+        // This test simulates an issue on Android, that causes the VM to crash while receiving a block, so that the
+        // block store is persisted but the wallet is not.
+        Block b1 = unitTestParams.getGenesisBlock().createNextBlock(coinbaseTo);
+        Block b2 = b1.createNextBlock(coinbaseTo);
+        // Add block 1, no frills.
+        assertTrue(chain.add(b1));
+        assertEquals(b1.cloneAsHeader(), chain.getChainHead().getHeader());
+        assertEquals(1, chain.getBestChainHeight());
+        assertEquals(1, wallet.getLastBlockSeenHeight());
+        // Add block 2 while wallet is disconnected, to simulate crash.
+        chain.removeWallet(wallet);
+        assertTrue(chain.add(b2));
+        assertEquals(b2.cloneAsHeader(), chain.getChainHead().getHeader());
+        assertEquals(2, chain.getBestChainHeight());
+        assertEquals(1, wallet.getLastBlockSeenHeight());
+        // Add wallet back. This will detect the height mismatch and repair the damage done.
+        chain.addWallet(wallet);
+        assertEquals(b1.cloneAsHeader(), chain.getChainHead().getHeader());
+        assertEquals(1, chain.getBestChainHeight());
+        assertEquals(1, wallet.getLastBlockSeenHeight());
+        // Now add block 2 correctly.
+        assertTrue(chain.add(b2));
+        assertEquals(b2.cloneAsHeader(), chain.getChainHead().getHeader());
+        assertEquals(2, chain.getBestChainHeight());
+        assertEquals(2, wallet.getLastBlockSeenHeight());
     }
 }


### PR DESCRIPTION
When a wallet is added to a block chain that has a lower block height than the chain, try to repair.

Adds a "crash simulation" unit test.
