### PR TITLE
Fix DeterministicKeyChainTest failing on Windows

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/Utils.java
+++ b/core/src/main/java/com/google/bitcoin/core/Utils.java
@@ -18,9 +18,11 @@
 package com.google.bitcoin.core;
 
 import com.google.common.base.Charsets;
+import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.google.common.io.BaseEncoding;
+import com.google.common.io.Resources;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.UnsignedLongs;
 
@@ -30,6 +32,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigInteger;
+import java.net.URL;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
@@ -591,4 +594,13 @@ public class Utils {
         }
         return maxItem;
     }
+
+    /**
+     * Reads and joins together with LF char (\n) all the lines from given file. It's assumed that file is in UTF-8.
+     */
+    public static String getResourceAsString(URL url) throws IOException {
+        List<String> lines = Resources.readLines(url, Charsets.UTF_8);
+        return Joiner.on('\n').join(lines);
+    }
+
 }

--- a/core/src/test/java/com/google/bitcoin/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/com/google/bitcoin/wallet/DeterministicKeyChainTest.java
@@ -23,9 +23,7 @@ import com.google.bitcoin.params.UnitTestParams;
 import com.google.bitcoin.store.UnreadableWalletException;
 import com.google.bitcoin.utils.BriefLogFormatter;
 import com.google.bitcoin.utils.Threading;
-import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
-import com.google.common.io.Resources;
 import org.bitcoinj.wallet.Protos;
 import org.junit.Before;
 import org.junit.Test;
@@ -310,7 +308,7 @@ public class DeterministicKeyChainTest {
     private String checkSerialization(List<Protos.Key> keys, String filename) {
         try {
             String sb = protoToString(keys);
-            String expected = Resources.toString(getClass().getResource(filename), Charsets.UTF_8);
+            String expected = Utils.getResourceAsString(getClass().getResource(filename));
             assertEquals(expected, sb);
             return expected;
         } catch (IOException e) {


### PR DESCRIPTION
Git changes line endings in files to CR+LF on Windows by default, while
protobuf always uses LF. That makes serialization tests fail.
