### PR TITLE
Configure continuous integration using Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+# configuration for https://travis-ci.org/bitcoinj/bitcoinj
+language: java
+jdk: openjdk6
+before_install: lsb_release -a
+script: mvn clean install


### PR DESCRIPTION
Builds will be visible at https://travis-ci.org/bitcoinj/bitcoinj
