### PR TITLE
During CI builds, make Maven output less clutter.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@
 language: java
 jdk: openjdk6
 before_install: lsb_release -a
-script: mvn clean install
+install: true # remove default
+script: mvn -q clean install
 
 notifications:
   irc:
     channels: "irc.freenode.net#bitcoinj"
-    use_notice: true
     skip_join: true


### PR DESCRIPTION
Also, the build now runs 1 minute shorter (-:
