### PR TITLE
Add Script.getCastedToAddress()…

### DIFF
--- a/core/src/main/java/com/google/bitcoin/script/Script.java
+++ b/core/src/main/java/com/google/bitcoin/script/Script.java
@@ -291,10 +291,23 @@ public class Script {
      * Gets the destination address from this script, if it's in the required form (see getPubKey).
      */
     public Address getToAddress(NetworkParameters params) throws ScriptException {
+        return getToAddress(params, false);
+    }
+
+    /**
+     * Gets the destination address from this script, if it's in the required form (see getPubKey).
+     * 
+     * @param forcePayToPubKey
+     *            If true, allow payToPubKey to be casted to the corresponding address. This is useful if you prefer
+     *            showing addresses rather than pubkeys.
+     */
+    public Address getToAddress(NetworkParameters params, boolean forcePayToPubKey) throws ScriptException {
         if (isSentToAddress())
             return new Address(params, getPubKeyHash());
         else if (isPayToScriptHash())
             return Address.fromP2SHScript(params, this);
+        else if (forcePayToPubKey && isSentToRawPubKey())
+            return ECKey.fromPublicOnly(getPubKey()).toAddress(params);
         else
             throw new ScriptException("Cannot cast this script to a pay-to-address type");
     }

--- a/core/src/test/java/com/google/bitcoin/script/ScriptTest.java
+++ b/core/src/test/java/com/google/bitcoin/script/ScriptTest.java
@@ -518,4 +518,23 @@ public class ScriptTest {
         }
         in.close();
     }
+
+    @Test
+    public void getToAddress() throws Exception {
+        // pay to pubkey
+        ECKey toKey = new ECKey();
+        Address toAddress = toKey.toAddress(params);
+        assertEquals(toAddress, ScriptBuilder.createOutputScript(toKey).getToAddress(params, true));
+        // pay to pubkey hash
+        assertEquals(toAddress, ScriptBuilder.createOutputScript(toAddress).getToAddress(params, true));
+        // pay to script hash
+        Script p2shScript = ScriptBuilder.createP2SHOutputScript(new byte[20]);
+        Address scriptAddress = Address.fromP2SHScript(params, p2shScript);
+        assertEquals(scriptAddress, p2shScript.getToAddress(params, true));
+    }
+
+    @Test(expected = ScriptException.class)
+    public void getToAddressNoPubKey() throws Exception {
+        ScriptBuilder.createOutputScript(new ECKey()).getToAddress(params, false);
+    }
 }


### PR DESCRIPTION
…which tries harder than .getToAddress() to determine a destination address.

I ended up duplicating this piece of code several times, so I thought it may be useful to have it in the framework.
