### PR TITLE
Signers: map derivation paths to scriptPubKeys..

### DIFF
--- a/core/src/main/java/com/google/bitcoin/signers/CustomTransactionSigner.java
+++ b/core/src/main/java/com/google/bitcoin/signers/CustomTransactionSigner.java
@@ -55,8 +55,8 @@ public abstract class CustomTransactionSigner extends StatelessTransactionSigner
             if (txOut == null) {
                 continue;
             }
-
-            if (!txOut.getScriptPubKey().isPayToScriptHash()) {
+            Script scriptPubKey = txOut.getScriptPubKey();
+            if (!scriptPubKey.isPayToScriptHash()) {
                 log.warn("CustomTransactionSigner works only with P2SH transactions");
                 return false;
             }
@@ -69,12 +69,12 @@ public abstract class CustomTransactionSigner extends StatelessTransactionSigner
             }
 
             Sha256Hash sighash = tx.hashForSignature(i, redeemData.redeemScript, Transaction.SigHash.ALL, false);
-            SignatureAndKey sigKey = getSignature(sighash, propTx.keyPaths.get(txIn));
+            SignatureAndKey sigKey = getSignature(sighash, propTx.keyPaths.get(scriptPubKey));
             TransactionSignature txSig = new TransactionSignature(sigKey.sig, Transaction.SigHash.ALL, false);
             int sigIndex = redeemData.getKeyIndex(sigKey.pubKey);
             if (sigIndex < 0)
                 throw new RuntimeException("Redeem script doesn't contain our key"); // This should not happen
-            inputScript = txOut.getScriptPubKey().getScriptSigWithSignature(inputScript, txSig.encodeToBitcoin(), sigIndex);
+            inputScript = scriptPubKey.getScriptSigWithSignature(inputScript, txSig.encodeToBitcoin(), sigIndex);
             txIn.setScriptSig(inputScript);
         }
         return true;

--- a/core/src/main/java/com/google/bitcoin/signers/LocalTransactionSigner.java
+++ b/core/src/main/java/com/google/bitcoin/signers/LocalTransactionSigner.java
@@ -101,7 +101,7 @@ public class LocalTransactionSigner extends StatelessTransactionSigner {
                 // for P2SH inputs we need to share derivation path of the signing key with other signers, so that they
                 // use correct key to calculate their signatures
                 if (key instanceof DeterministicKey)
-                    propTx.keyPaths.put(txIn, (((DeterministicKey) key).getPath()));
+                    propTx.keyPaths.put(scriptPubKey, (((DeterministicKey) key).getPath()));
             } catch (ECKey.KeyIsEncryptedException e) {
                 throw e;
             } catch (ECKey.MissingPrivateKeyException e) {

--- a/core/src/main/java/com/google/bitcoin/signers/TransactionSigner.java
+++ b/core/src/main/java/com/google/bitcoin/signers/TransactionSigner.java
@@ -16,8 +16,8 @@
 package com.google.bitcoin.signers;
 
 import com.google.bitcoin.core.Transaction;
-import com.google.bitcoin.core.TransactionInput;
 import com.google.bitcoin.crypto.ChildNumber;
+import com.google.bitcoin.script.Script;
 import com.google.bitcoin.wallet.KeyBag;
 
 import java.util.HashMap;
@@ -46,13 +46,14 @@ public interface TransactionSigner {
          * HD key paths used for each input to derive a signing key. It's useful for multisig inputs only.
          * The keys used to create a single P2SH address have the same derivation path, so to use a correct key each signer
          * has to know a derivation path of signing keys used by previous signers. For each input signers will use the
-         * same derivation path and we need to store only one key path per input.
+         * same derivation path and we need to store only one key path per input. As TransactionInput is mutable, inputs
+         * are identified by their scriptPubKeys (keys in this map).
          */
-        public final Map<TransactionInput, List<ChildNumber>> keyPaths;
+        public final Map<Script, List<ChildNumber>> keyPaths;
 
         public ProposedTransaction(Transaction partialTx) {
             this.partialTx = partialTx;
-            this.keyPaths = new HashMap<TransactionInput, List<ChildNumber>>();
+            this.keyPaths = new HashMap<Script, List<ChildNumber>>();
         }
     }
 


### PR DESCRIPTION
.. instead of TransactionInput objects since the latter are mutable.
