### PR TITLE
Add SendRequest.missingSigsMode

### DIFF
--- a/core/src/main/java/com/google/bitcoin/signers/TransactionSigner.java
+++ b/core/src/main/java/com/google/bitcoin/signers/TransactionSigner.java
@@ -57,6 +57,9 @@ public interface TransactionSigner {
         }
     }
 
+    public static class MissingSignatureException extends RuntimeException {
+    }
+
     /**
      * Returns true if this signer is ready to be used.
      */


### PR DESCRIPTION
Instead of useDummySignatures flag there is now a MissingSigMode enum
allowing to specify what to do with missing signatures.

Available modes:
USE_OP_ZERO - do nothing. OP_0 will be left in place of missing
signature
USE_DUMMY_SIG - insert dummy signature in place of missing sig.
THROW - throw an exception. It would be either MissingSignatureException
for P2SH or MissingPrivateKeyException for other tx types

Default mode is USE_DUMMY_SIG (for backward compatibility).
