### PR TITLE
make DeterministicSeed constructors public

### DIFF
--- a/core/src/main/java/com/google/bitcoin/wallet/DeterministicSeed.java
+++ b/core/src/main/java/com/google/bitcoin/wallet/DeterministicSeed.java
@@ -50,18 +50,18 @@ public class DeterministicSeed implements EncryptableItem {
     @Nullable private EncryptedData encryptedMnemonicCode;
     private final long creationTimeSeconds;
 
-    DeterministicSeed(String mnemonicCode, String passphrase, long creationTimeSeconds) throws UnreadableWalletException {
+    public DeterministicSeed(String mnemonicCode, String passphrase, long creationTimeSeconds) throws UnreadableWalletException {
         this(decodeMnemonicCode(mnemonicCode), passphrase, creationTimeSeconds);
     }
 
-    DeterministicSeed(byte[] seed, List<String> mnemonic, long creationTimeSeconds) {
+    public DeterministicSeed(byte[] seed, List<String> mnemonic, long creationTimeSeconds) {
         this.seed = checkNotNull(seed);
         this.mnemonicCode = checkNotNull(mnemonic);
         this.encryptedMnemonicCode = null;
         this.creationTimeSeconds = creationTimeSeconds;
     }
 
-    DeterministicSeed(EncryptedData encryptedMnemonic, long creationTimeSeconds) {
+    public DeterministicSeed(EncryptedData encryptedMnemonic, long creationTimeSeconds) {
         this.seed = null;
         this.mnemonicCode = null;
         this.encryptedMnemonicCode = checkNotNull(encryptedMnemonic);


### PR DESCRIPTION
I am experimenting with the HD wallets and looking into the DeterministicSeed class. 

I've assumed a possible usage is 

``` java
new DeterministicSeed("mnemonicCode as string", "passphrase", 12345);
```

But so far this is not a public constructor[1] - though passing the mnemonicCode as List<String> is a public constructor [2].

The constructor accepting the code as String simply also does the String decoding/splitting of the word list and I assume it could be marked as public. 

This PR makes the constructors public. 

---

[1] https://github.com/bitcoinj/bitcoinj/blob/master/core/src/main/java/com/google/bitcoin/wallet/DeterministicSeed.java#L53
[2] https://github.com/bitcoinj/bitcoinj/blob/master/core/src/main/java/com/google/bitcoin/wallet/DeterministicSeed.java#L78
