### PR TITLE
When manually constructing SimpleDateFormat, specify Locale.US…

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/Transaction.java
+++ b/core/src/main/java/com/google/bitcoin/core/Transaction.java
@@ -1262,7 +1262,7 @@ public class Transaction extends ChildMessage implements Serializable {
      */
     public static long parseLockTimeStr(String lockTimeStr) throws ParseException {
         if (lockTimeStr.indexOf("/") != -1) {
-            SimpleDateFormat format = new SimpleDateFormat("yyyy/MM/dd");
+            SimpleDateFormat format = new SimpleDateFormat("yyyy/MM/dd", Locale.US);
             Date date = format.parse(lockTimeStr);
             return date.getTime() / 1000;
         }

--- a/core/src/test/java/com/google/bitcoin/core/BlockChainTest.java
+++ b/core/src/test/java/com/google/bitcoin/core/BlockChainTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import java.math.BigInteger;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 
 import static com.google.bitcoin.core.Coin.*;
 import static com.google.bitcoin.testing.FakeTxBuilder.createFakeBlock;
@@ -396,7 +397,7 @@ public class BlockChainTest {
         BlockChain prod = new BlockChain(params, new MemoryBlockStore(params));
         Date d = prod.estimateBlockTime(200000);
         // The actual date of block 200,000 was 2012-09-22 10:47:00
-        assertEquals(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").parse("2012-10-23T08:35:05.000-0700"), d);
+        assertEquals(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US).parse("2012-10-23T08:35:05.000-0700"), d);
     }
 
     @Test


### PR DESCRIPTION
…or otherwise we may end up on non-latin scripts.

See SimpleDateFormat javadoc for a discussion.
