### PR TITLE
Catch libcore.io.ErrnoException when connecting to sockets.

### DIFF
--- a/core/src/main/java/com/google/bitcoin/net/NioClientManager.java
+++ b/core/src/main/java/com/google/bitcoin/net/NioClientManager.java
@@ -143,7 +143,7 @@ public class NioClientManager extends AbstractExecutionThreadService implements 
             sc.connect(serverAddress);
             newConnectionChannels.offer(new SocketChannelAndParser(sc, parser));
             selector.wakeup();
-        } catch (IOException e) {
+        } catch (Exception e) { // Android throws libcore.io.ErrnoException (extends Exception) in sc.connect().
             log.error("Could not connect to " + serverAddress);
             throw new RuntimeException(e); // This should only happen if we are, eg, out of system resources
         }


### PR DESCRIPTION
Annoyingly this is thrown on Android sometimes, rather than just an IOException. Because we cannot depend on (internal) Android API, the workaround is to catch any Exception in NioClientManager.openConnection().

https://android.googlesource.com/platform/libcore/+/android-4.4.2_r2/luni/src/main/java/libcore/io/ErrnoException.java

Here is the stacktrace:

java.lang.AssertionError: libcore.io.ErrnoException: getsockname failed: EINVAL (Invalid argument)
at java.nio.SocketChannelImpl.initLocalAddressAndPort(SocketChannelImpl.java:217)
at java.nio.SocketChannelImpl.connect(SocketChannelImpl.java:195)
at com.google.bitcoin.net.NioClientManager.openConnection(NioClientManager.java:143)
at com.google.bitcoin.core.PeerGroup.connectTo$9cebd97(PeerGroup.java:869)
at com.google.bitcoin.core.PeerGroup.connectToAnyPeer(PeerGroup.java:665)
at com.google.bitcoin.core.PeerGroup$6.run(PeerGroup.java:343)
at com.google.bitcoin.core.PeerGroup.run(PeerGroup.java:604)
at com.google.common.util.concurrent.AbstractExecutionThreadService$1$2.run(AbstractExecutionThreadService.java:60)
at com.google.common.util.concurrent.Callables$3.run(Callables.java:93)
at java.lang.Thread.run(Thread.java:856)
Caused by: libcore.io.ErrnoException: getsockname failed: EINVAL (Invalid argument)
at libcore.io.Posix.getsockname(Native Method)
at libcore.io.ForwardingOs.getsockname(ForwardingOs.java:69)
at java.nio.SocketChannelImpl.initLocalAddressAndPort(SocketChannelImpl.java:215)
... 9 more

Cause:

libcore.io.ErrnoException: getsockname failed: EINVAL (Invalid argument)
at libcore.io.Posix.getsockname(Native Method)
at libcore.io.ForwardingOs.getsockname(ForwardingOs.java:69)
at java.nio.SocketChannelImpl.initLocalAddressAndPort(SocketChannelImpl.java:215)
at java.nio.SocketChannelImpl.connect(SocketChannelImpl.java:195)
at com.google.bitcoin.net.NioClientManager.openConnection(NioClientManager.java:143)
at com.google.bitcoin.core.PeerGroup.connectTo$9cebd97(PeerGroup.java:869)
at com.google.bitcoin.core.PeerGroup.connectToAnyPeer(PeerGroup.java:665)
at com.google.bitcoin.core.PeerGroup$6.run(PeerGroup.java:343)
at com.google.bitcoin.core.PeerGroup.run(PeerGroup.java:604)
at com.google.common.util.concurrent.AbstractExecutionThreadService$1$2.run(AbstractExecutionThreadService.java:60)
at com.google.common.util.concurrent.Callables$3.run(Callables.java:93)
at java.lang.Thread.run(Thread.java:856)
