### PR TITLE
Insert sigs in scriptSig in order of the signers

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/ECKey.java
+++ b/core/src/main/java/com/google/bitcoin/core/ECKey.java
@@ -90,16 +90,6 @@ import static com.google.common.base.Preconditions.*;
 public class ECKey implements EncryptableItem, Serializable {
     private static final Logger log = LoggerFactory.getLogger(ECKey.class);
 
-    /** Compares pub key bytes using {@link com.google.common.primitives.UnsignedBytes#lexicographicalComparator()} **/
-    public static final Comparator<ECKey> PUBKEY_COMPARATOR = new Comparator<ECKey>() {
-        private Comparator comparator = UnsignedBytes.lexicographicalComparator();
-
-        @Override
-        public int compare(ECKey k1, ECKey k2) {
-            return comparator.compare(k1.getPubKey(), k2.getPubKey());
-        }
-    };
-
     /** The parameters of the secp256k1 curve that Bitcoin uses. */
     public static final X9ECParameters CURVE_PARAMS = CustomNamedCurves.getByName("secp256k1");
 

--- a/core/src/main/java/com/google/bitcoin/script/Script.java
+++ b/core/src/main/java/com/google/bitcoin/script/Script.java
@@ -402,6 +402,24 @@ public class Script {
     }
 
     /**
+     * Assuming this Script is a scriptSig, returns an index of the first empty signature in this script.
+     * Empty signature is designated by OP_0. This method tries to mitigate the off-by-one error in multisig scripts and
+     * returned index doesn't include offset for such script. For instance, for empty multisig scriptSig this method will
+     * return 0 even though first empty signature is located in a second chunk (chunk index 1). The caller should take
+     * this into account and act accordingly.
+     * If no empty sigs found, -1 will be returned.
+     */
+    public int getFirstEmptySigIndex(boolean isMultisig) {
+        int offset = isMultisig ? 1 : 0;
+        for (int i = offset; i < chunks.size(); i++) {
+            ScriptChunk chunk = chunks.get(i);
+            if (chunk.equalsOpCode(OP_0))
+                return i - offset; // compensate multisig offset
+        }
+        return -1;
+    }
+
+    /**
      * Returns a copy of the given scriptSig with a signature placeholder on the given position replaced with the given signature.
      */
     public Script getScriptSigWithSignature(Script scriptSig, byte[] sigBytes, int index) {

--- a/core/src/main/java/com/google/bitcoin/signers/CustomTransactionSigner.java
+++ b/core/src/main/java/com/google/bitcoin/signers/CustomTransactionSigner.java
@@ -71,7 +71,7 @@ public abstract class CustomTransactionSigner extends StatelessTransactionSigner
             Sha256Hash sighash = tx.hashForSignature(i, redeemData.redeemScript, Transaction.SigHash.ALL, false);
             SignatureAndKey sigKey = getSignature(sighash, propTx.keyPaths.get(scriptPubKey));
             TransactionSignature txSig = new TransactionSignature(sigKey.sig, Transaction.SigHash.ALL, false);
-            int sigIndex = redeemData.getKeyIndex(sigKey.pubKey);
+            int sigIndex = inputScript.getFirstEmptySigIndex(true);
             if (sigIndex < 0)
                 throw new RuntimeException("Redeem script doesn't contain our key"); // This should not happen
             inputScript = scriptPubKey.getScriptSigWithSignature(inputScript, txSig.encodeToBitcoin(), sigIndex);

--- a/core/src/main/java/com/google/bitcoin/signers/LocalTransactionSigner.java
+++ b/core/src/main/java/com/google/bitcoin/signers/LocalTransactionSigner.java
@@ -90,10 +90,9 @@ public class LocalTransactionSigner extends StatelessTransactionSigner {
                 // at this point we have incomplete inputScript with OP_0 in place of one or more signatures. We already
                 // have calculated the signature using the local key and now need to insert it in the correct place
                 // within inputScript. For pay-to-address and pay-to-key script there is only one signature and it always
-                // goes first in an inputScript (sigIndex = 0). In P2SH input scripts we need to get an index of the
-                // signing key within CHECKMULTISIG program as signatures are placed in the same order as public keys
-                // in redeem script
-                int sigIndex = redeemData.getKeyIndex(key);
+                // goes first in an inputScript (sigIndex = 0). In P2SH input scripts we assume that local key goes the
+                // first in redeemScript and local signer is the first to run therefore sigIndex is also 0
+                int sigIndex = 0;
                 // update input script with the signature at the proper position
                 inputScript = scriptPubKey.getScriptSigWithSignature(inputScript, signature.encodeToBitcoin(), sigIndex);
                 txIn.setScriptSig(inputScript);

--- a/core/src/main/java/com/google/bitcoin/wallet/KeyChainGroup.java
+++ b/core/src/main/java/com/google/bitcoin/wallet/KeyChainGroup.java
@@ -319,11 +319,11 @@ public class KeyChainGroup implements KeyBag {
 
     private List<ECKey> getMarriedKeysWithFollowed(DeterministicKey followedKey, Collection<DeterministicKeyChain> followingChains) {
         ImmutableList.Builder<ECKey> keys = ImmutableList.builder();
+        keys.add(followedKey);
         for (DeterministicKeyChain keyChain : followingChains) {
             keyChain.maybeLookAhead();
             keys.add(keyChain.getKeyByPath(followedKey.getPath()));
         }
-        keys.add(followedKey);
         return keys.build();
     }
 

--- a/core/src/main/java/com/google/bitcoin/wallet/RedeemData.java
+++ b/core/src/main/java/com/google/bitcoin/wallet/RedeemData.java
@@ -29,9 +29,8 @@ import static com.google.common.base.Preconditions.checkArgument;
  * This class aggregates data required to spend transaction output.
  *
  * For pay-to-address and pay-to-pubkey transactions it will have only a single key and CHECKSIG program as redeemScript.
- * For multisignature transactions there will be multiple keys one of which will be a full key and the rest are watch only,
- * redeem script will be a CHECKMULTISIG program. Keys will be sorted in the same order they appear in
- * a program (lexicographical order).
+ * For multisignature transactions there will be multiple keys one of which may (or may not) be a full key and the rest
+ * are watch only, redeem script will be a CHECKMULTISIG program.
  */
 public class RedeemData {
     public final Script redeemScript;
@@ -39,9 +38,7 @@ public class RedeemData {
 
     private RedeemData(List<ECKey> keys, Script redeemScript) {
         this.redeemScript = redeemScript;
-        List<ECKey> sortedKeys = new ArrayList<ECKey>(keys);
-        Collections.sort(sortedKeys, ECKey.PUBKEY_COMPARATOR);
-        this.keys = sortedKeys;
+        this.keys = keys;
     }
 
     public static RedeemData of(List<ECKey> keys, Script redeemScript) {
@@ -76,23 +73,4 @@ public class RedeemData {
         return null;
     }
 
-    /**
-     * Returns index of the given key in program that this RedeemData satisfies. For CHECKSIG programs this
-     * will always be 0. Returned index may be used to insert corresponding signature into proper place in input script.
-     * If key is not found, -1 is returned.
-     */
-    public int getKeyIndex(ECKey key) {
-        boolean isMultisig = keys.size() > 0;
-        if (isMultisig) {
-            for (int i = 0; i < keys.size(); i++) {
-                byte[] pubKey = keys.get(i).getPubKey();
-                if (Arrays.equals(pubKey, key.getPubKey()))
-                    return i;
-            }
-            return -1;
-        } else {
-            return 0;
-        }
-
-    }
 }

--- a/core/src/test/java/com/google/bitcoin/core/AddressTest.java
+++ b/core/src/test/java/com/google/bitcoin/core/AddressTest.java
@@ -126,16 +126,13 @@ public class AddressTest {
     @Test
     public void p2shAddressCreationFromKeys() throws Exception {
         // import some keys from this example: https://gist.github.com/gavinandresen/3966071
-        ECKey key1 = new DumpedPrivateKey(mainParams, "5JaTXbAUmfPYZFRwrYaALK48fN6sFJp4rHqq2QSXs8ucfpE4yQU").getKey();
-        key1 = ECKey.fromPrivate(key1.getPrivKeyBytes());
-        ECKey key2 = new DumpedPrivateKey(mainParams, "5Jb7fCeh1Wtm4yBBg3q3XbT6B525i17kVhy3vMC9AqfR6FH2qGk").getKey();
-        key2 = ECKey.fromPrivate(key2.getPrivKeyBytes());
-        ECKey key3 = new DumpedPrivateKey(mainParams, "5JFjmGo5Fww9p8gvx48qBYDJNAzR9pmH5S389axMtDyPT8ddqmw").getKey();
-        key3 = ECKey.fromPrivate(key3.getPrivKeyBytes());
+        ECKey key1 = ECKey.fromPublicOnly(Utils.HEX.decode("0491bba2510912a5bd37da1fb5b1673010e43d2c6d812c514e91bfa9f2eb129e1c183329db55bd868e209aac2fbc02cb33d98fe74bf23f0c235d6126b1d8334f86"));
+        ECKey key2 = ECKey.fromPublicOnly(Utils.HEX.decode("04865c40293a680cb9c020e7b1e106d8c1916d3cef99aa431a56d253e69256dac09ef122b1a986818a7cb624532f062c1d1f8722084861c5c3291ccffef4ec6874"));
+        ECKey key3 = ECKey.fromPublicOnly(Utils.HEX.decode("048d2455d2403e08708fc1f556002f1b6cd83f992d085097f9974ab08a28838f07896fbab08f39495e15fa6fad6edbfb1e754e35fa1c7844c41f322a1863d46213"));
 
         List<ECKey> keys = Arrays.asList(key1, key2, key3);
         Script p2shScript = ScriptBuilder.createP2SHOutputScript(2, keys);
         Address address = Address.fromP2SHScript(mainParams, p2shScript);
-        assertEquals("3N25saC4dT24RphDAwLtD8LUN4E2gZPJke", address.toString());
+        assertEquals("3QJmV3qfvL9SuYo34YihAf3sRCW3qSinyC", address.toString());
     }
 }

--- a/core/src/test/java/com/google/bitcoin/script/ScriptTest.java
+++ b/core/src/test/java/com/google/bitcoin/script/ScriptTest.java
@@ -158,7 +158,10 @@ public class ScriptTest {
         Script inputScript = ScriptBuilder.createInputScript(dummySig);
         assertThat(inputScript.getChunks().get(0).data, equalTo(dummySig.encodeToBitcoin()));
         inputScript = ScriptBuilder.createInputScript(null);
+        assertEquals(0, inputScript.getFirstEmptySigIndex(false));
         assertThat(inputScript.getChunks().get(0).opcode, equalTo(OP_0));
+        inputScript = ScriptBuilder.updateScriptWithSignature(inputScript, dummySig.encodeToBitcoin(), 0, false);
+        assertEquals(-1, inputScript.getFirstEmptySigIndex(false));
 
         // pay-to-address
         inputScript = ScriptBuilder.createInputScript(dummySig, key);
@@ -177,16 +180,26 @@ public class ScriptTest {
         assertThat(inputScript.getChunks().get(3).data, equalTo(multisigScript.getProgram()));
 
         inputScript = ScriptBuilder.createP2SHMultiSigInputScript(null, multisigScript);
+        assertEquals(0, inputScript.getFirstEmptySigIndex(true));
         assertThat(inputScript.getChunks().get(0).opcode, equalTo(OP_0));
         assertThat(inputScript.getChunks().get(1).opcode, equalTo(OP_0));
         assertThat(inputScript.getChunks().get(2).opcode, equalTo(OP_0));
         assertThat(inputScript.getChunks().get(3).data, equalTo(multisigScript.getProgram()));
 
-        inputScript = ScriptBuilder.updateScriptWithSignature(inputScript, dummySig.encodeToBitcoin(), 1, true);
+        inputScript = ScriptBuilder.updateScriptWithSignature(inputScript, dummySig.encodeToBitcoin(), 0, true);
+        assertEquals(1, inputScript.getFirstEmptySigIndex(true));
         assertThat(inputScript.getChunks().get(0).opcode, equalTo(OP_0));
-        assertThat(inputScript.getChunks().get(1).opcode, equalTo(OP_0));
-        assertThat(inputScript.getChunks().get(2).data, equalTo(dummySig.encodeToBitcoin()));
+        assertThat(inputScript.getChunks().get(1).data, equalTo(dummySig.encodeToBitcoin()));
+        assertThat(inputScript.getChunks().get(2).opcode, equalTo(OP_0));
         assertThat(inputScript.getChunks().get(3).data, equalTo(multisigScript.getProgram()));
+
+        inputScript = ScriptBuilder.updateScriptWithSignature(inputScript, dummySig.encodeToBitcoin(), 1, true);
+        assertEquals(-1, inputScript.getFirstEmptySigIndex(true));
+    }
+
+    @Test
+    public void findNextEmptySigIndex() throws Exception {
+
     }
 
     private Script parseScriptString(String string) throws Exception {


### PR DESCRIPTION
This way the first sig will be the one from LocalTransactionSigner, the
second sig will be the one from the next signer added to the wallet and so
on.
To achieve this, following keys should be added to the wallet in the same
order as signers. Pubkeys aren't sorted anymore when creating redeem
script, so now the order of the keys matter. The first pubkey in redeem script
will always be the pubkey from the local (followed) keychain, the rest are
in the same order as following keys passed to the Wallet.addFollowingAccountKeys.

I've tried to describe all the above in javadocs, although explaining
things in English is not my best skill. Let me know if you feel it's not enough
or simply wrong.
