### PR TITLE
Wallet throws on missing signature by default

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/Wallet.java
+++ b/core/src/main/java/com/google/bitcoin/core/Wallet.java
@@ -3028,10 +3028,10 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
 
         /**
          * Specifies what to do with missing signatures left after completing this request. Default strategy is to
-         * replace missing signatures with dummy sigs ({@link MissingSigsMode#USE_DUMMY_SIG}).
+         * throw an exception on missing signature ({@link MissingSigsMode#THROW}).
          * @see MissingSigsMode
          */
-        public MissingSigsMode missingSigsMode = MissingSigsMode.USE_DUMMY_SIG;
+        public MissingSigsMode missingSigsMode = MissingSigsMode.THROW;
 
         /**
          * If not null, this exchange rate is recorded with the transaction during completion.

--- a/core/src/test/java/com/google/bitcoin/core/WalletTest.java
+++ b/core/src/test/java/com/google/bitcoin/core/WalletTest.java
@@ -2449,6 +2449,16 @@ public class WalletTest extends TestWithWallet {
         completeTxPartiallySignedMarried(Wallet.MissingSigsMode.THROW, emptySig);
     }
 
+    @Test (expected = TransactionSigner.MissingSignatureException.class)
+    public void completeTxPartiallySignedMarriedThrowsByDefault() throws Exception {
+        createMarriedWallet(false);
+        myAddress = wallet.currentAddress(KeyChain.KeyPurpose.RECEIVE_FUNDS);
+        sendMoneyToWallet(wallet, COIN, myAddress, AbstractBlockChain.NewBlockType.BEST_CHAIN);
+
+        Wallet.SendRequest req = Wallet.SendRequest.emptyWallet(new ECKey().toAddress(params));
+        wallet.completeTx(req);
+    }
+
     public void completeTxPartiallySignedMarried(Wallet.MissingSigsMode missSigMode, byte[] expectedSig) throws Exception {
         // create married wallet without signer
         createMarriedWallet(false);


### PR DESCRIPTION
Using dummy sigs by default may be confusing for multi-sig scenarios.
