### PR TITLE
Married wallets: multisig threshold could be specified

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/Wallet.java
+++ b/core/src/main/java/com/google/bitcoin/core/Wallet.java
@@ -294,6 +294,21 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
     }
 
     /**
+     * Returns the number of signatures required to spend from this wallet. For a normal non-married wallet this will
+     * always be 1. For a married wallet this will be the N from N-of-M CHECKMULTISIG scripts used in this wallet.
+     * This value is either directly specified during the marriage (see {@link #addFollowingAccountKeys(java.util.List, int)})
+     * or, if not specified, calculated implicitly as a simple majority of keys.
+     */
+    public int getSigsRequiredToSpend() {
+        lock.lock();
+        try {
+            return keychain.getSigsRequiredToSpend();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
      * <p>Adds given transaction signer to the list of signers. It will be added to the end of the signers list, so if
      * this wallet already has some signers added, given signer will be executed after all of them.</p>
      * <p>Transaction signer should be fully initialized before adding to the wallet, otherwise {@link IllegalStateException}
@@ -615,14 +630,35 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
     }
 
     /**
-     * Makes given account keys follow the account key of the active keychain. After that you will be able
-     * to get P2SH addresses to receive coins to.
-     * This method should be called only once before key rotation, otherwise it will throw an IllegalStateException.
+     * <p>Alias for <code>addFollowingAccountKeys(followingAccountKeys, (followingAccountKeys.size() + 1) / 2 + 1)</code></p>
+     * <p>Creates married wallet requiring majority of keys to spend (2-of-3, 3-of-5 and so on)</p>
+     * <p>IMPORTANT: As of Bitcoin Core 0.9 all multisig transactions which require more than 3 public keys are
+     * non-standard and such spends won't be processed by peers with default settings, essentially making such
+     * transactions almost nonspendable</p>
      */
     public void addFollowingAccountKeys(List<DeterministicKey> followingAccountKeys) {
         lock.lock();
         try {
             keychain.addFollowingAccountKeys(followingAccountKeys);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Makes given account keys follow the account key of the active keychain. After that you will be able
+     * to get P2SH addresses to receive coins to. Given threshold value specifies how many signatures required to
+     * spend transactions for this married wallet. This value should not exceed total number of keys involved
+     * (one followed key plus number of following keys).</p>
+     * <p>IMPORTANT: As of Bitcoin Core 0.9 all multisig transactions which require more than 3 public keys are
+     * non-standard and such spends won't be processed by peers with default settings, essentially making such
+     * transactions almost nonspendable</p>
+     * This method should be called only once before key rotation, otherwise it will throw an IllegalStateException.
+     */
+    public void addFollowingAccountKeys(List<DeterministicKey> followingAccountKeys, int threshold) {
+        lock.lock();
+        try {
+            keychain.addFollowingAccountKeys(followingAccountKeys, threshold);
         } finally {
             lock.unlock();
         }

--- a/core/src/main/java/com/google/bitcoin/store/WalletProtobufSerializer.java
+++ b/core/src/main/java/com/google/bitcoin/store/WalletProtobufSerializer.java
@@ -205,6 +205,8 @@ public class WalletProtobufSerializer {
             walletBuilder.addTransactionSigners(protoSigner);
         }
 
+        walletBuilder.setSigsRequiredToSpend(wallet.getSigsRequiredToSpend());
+
         // Populate the wallet version.
         walletBuilder.setVersion(wallet.getVersion());
 
@@ -408,14 +410,16 @@ public class WalletProtobufSerializer {
         if (!walletProto.getNetworkIdentifier().equals(params.getId()))
             throw new UnreadableWalletException.WrongNetwork();
 
+        int sigsRequiredToSpend = walletProto.getSigsRequiredToSpend();
+
         // Read the scrypt parameters that specify how encryption and decryption is performed.
         KeyChainGroup chain;
         if (walletProto.hasEncryptionParameters()) {
             Protos.ScryptParameters encryptionParameters = walletProto.getEncryptionParameters();
             final KeyCrypterScrypt keyCrypter = new KeyCrypterScrypt(encryptionParameters);
-            chain = KeyChainGroup.fromProtobufEncrypted(params, walletProto.getKeyList(), keyCrypter);
+            chain = KeyChainGroup.fromProtobufEncrypted(params, walletProto.getKeyList(), sigsRequiredToSpend, keyCrypter);
         } else {
-            chain = KeyChainGroup.fromProtobufUnencrypted(params, walletProto.getKeyList());
+            chain = KeyChainGroup.fromProtobufUnencrypted(params, walletProto.getKeyList(), sigsRequiredToSpend);
         }
         Wallet wallet = factory.create(params, chain);
 

--- a/core/src/main/java/com/google/bitcoin/testing/KeyChainTransactionSigner.java
+++ b/core/src/main/java/com/google/bitcoin/testing/KeyChainTransactionSigner.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2014 Kosta Korenkov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.bitcoin.testing;
+
+import com.google.bitcoin.core.Sha256Hash;
+import com.google.bitcoin.crypto.ChildNumber;
+import com.google.bitcoin.crypto.DeterministicKey;
+import com.google.bitcoin.signers.CustomTransactionSigner;
+import com.google.bitcoin.wallet.DeterministicKeyChain;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+/**
+ * <p>Transaction signer which uses provided keychain to get signing keys from. It relies on previous signer to provide
+ * derivation path to be used to get signing key and, once gets the key, just signs given transaction immediately.</p>
+ * It should not be used in test scenarios involving serialization as it doesn't have proper serialize/deserialize
+ * implementation.
+ */
+public class KeyChainTransactionSigner extends CustomTransactionSigner {
+
+    private DeterministicKeyChain keyChain;
+
+    public KeyChainTransactionSigner() {
+    }
+
+    public KeyChainTransactionSigner(DeterministicKeyChain keyChain) {
+        this.keyChain = keyChain;
+    }
+
+    @Override
+    protected SignatureAndKey getSignature(Sha256Hash sighash, List<ChildNumber> derivationPath) {
+        ImmutableList<ChildNumber> keyPath = ImmutableList.copyOf(derivationPath);
+        DeterministicKey key = keyChain.getKeyByPath(keyPath, true);
+        return new SignatureAndKey(key.sign(sighash), key.getPubOnly());
+    }
+}

--- a/core/src/main/java/org/bitcoinj/wallet/Protos.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Protos.java
@@ -13903,6 +13903,26 @@ public final class Protos {
      */
     org.bitcoinj.wallet.Protos.TransactionSignerOrBuilder getTransactionSignersOrBuilder(
         int index);
+
+    // optional uint32 sigsRequiredToSpend = 18 [default = 1];
+    /**
+     * <code>optional uint32 sigsRequiredToSpend = 18 [default = 1];</code>
+     *
+     * <pre>
+     * Number of signatures required to spend. This field is needed only for married wallets to reconstruct KeyChainGroup
+     * and represents the N value from N-of-M CHECKMULTISIG script. For regular single wallets it will always be 1.
+     * </pre>
+     */
+    boolean hasSigsRequiredToSpend();
+    /**
+     * <code>optional uint32 sigsRequiredToSpend = 18 [default = 1];</code>
+     *
+     * <pre>
+     * Number of signatures required to spend. This field is needed only for married wallets to reconstruct KeyChainGroup
+     * and represents the N value from N-of-M CHECKMULTISIG script. For regular single wallets it will always be 1.
+     * </pre>
+     */
+    int getSigsRequiredToSpend();
   }
   /**
    * Protobuf type {@code wallet.Wallet}
@@ -14064,6 +14084,11 @@ public final class Protos {
                 mutable_bitField0_ |= 0x00004000;
               }
               transactionSigners_.add(input.readMessage(org.bitcoinj.wallet.Protos.TransactionSigner.PARSER, extensionRegistry));
+              break;
+            }
+            case 144: {
+              bitField0_ |= 0x00000200;
+              sigsRequiredToSpend_ = input.readUInt32();
               break;
             }
           }
@@ -14733,6 +14758,32 @@ public final class Protos {
       return transactionSigners_.get(index);
     }
 
+    // optional uint32 sigsRequiredToSpend = 18 [default = 1];
+    public static final int SIGSREQUIREDTOSPEND_FIELD_NUMBER = 18;
+    private int sigsRequiredToSpend_;
+    /**
+     * <code>optional uint32 sigsRequiredToSpend = 18 [default = 1];</code>
+     *
+     * <pre>
+     * Number of signatures required to spend. This field is needed only for married wallets to reconstruct KeyChainGroup
+     * and represents the N value from N-of-M CHECKMULTISIG script. For regular single wallets it will always be 1.
+     * </pre>
+     */
+    public boolean hasSigsRequiredToSpend() {
+      return ((bitField0_ & 0x00000200) == 0x00000200);
+    }
+    /**
+     * <code>optional uint32 sigsRequiredToSpend = 18 [default = 1];</code>
+     *
+     * <pre>
+     * Number of signatures required to spend. This field is needed only for married wallets to reconstruct KeyChainGroup
+     * and represents the N value from N-of-M CHECKMULTISIG script. For regular single wallets it will always be 1.
+     * </pre>
+     */
+    public int getSigsRequiredToSpend() {
+      return sigsRequiredToSpend_;
+    }
+
     private void initFields() {
       networkIdentifier_ = "";
       lastSeenBlockHash_ = com.google.protobuf.ByteString.EMPTY;
@@ -14749,6 +14800,7 @@ public final class Protos {
       keyRotationTime_ = 0L;
       tags_ = java.util.Collections.emptyList();
       transactionSigners_ = java.util.Collections.emptyList();
+      sigsRequiredToSpend_ = 1;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -14853,6 +14905,9 @@ public final class Protos {
       for (int i = 0; i < transactionSigners_.size(); i++) {
         output.writeMessage(17, transactionSigners_.get(i));
       }
+      if (((bitField0_ & 0x00000200) == 0x00000200)) {
+        output.writeUInt32(18, sigsRequiredToSpend_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -14921,6 +14976,10 @@ public final class Protos {
       for (int i = 0; i < transactionSigners_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(17, transactionSigners_.get(i));
+      }
+      if (((bitField0_ & 0x00000200) == 0x00000200)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt32Size(18, sigsRequiredToSpend_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -15107,6 +15166,8 @@ public final class Protos {
         } else {
           transactionSignersBuilder_.clear();
         }
+        sigsRequiredToSpend_ = 1;
+        bitField0_ = (bitField0_ & ~0x00008000);
         return this;
       }
 
@@ -15229,6 +15290,10 @@ public final class Protos {
         } else {
           result.transactionSigners_ = transactionSignersBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00008000) == 0x00008000)) {
+          to_bitField0_ |= 0x00000200;
+        }
+        result.sigsRequiredToSpend_ = sigsRequiredToSpend_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -15431,6 +15496,9 @@ public final class Protos {
               transactionSignersBuilder_.addAllMessages(other.transactionSigners_);
             }
           }
+        }
+        if (other.hasSigsRequiredToSpend()) {
+          setSigsRequiredToSpend(other.getSigsRequiredToSpend());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         return this;
@@ -17610,6 +17678,59 @@ public final class Protos {
         return transactionSignersBuilder_;
       }
 
+      // optional uint32 sigsRequiredToSpend = 18 [default = 1];
+      private int sigsRequiredToSpend_ = 1;
+      /**
+       * <code>optional uint32 sigsRequiredToSpend = 18 [default = 1];</code>
+       *
+       * <pre>
+       * Number of signatures required to spend. This field is needed only for married wallets to reconstruct KeyChainGroup
+       * and represents the N value from N-of-M CHECKMULTISIG script. For regular single wallets it will always be 1.
+       * </pre>
+       */
+      public boolean hasSigsRequiredToSpend() {
+        return ((bitField0_ & 0x00008000) == 0x00008000);
+      }
+      /**
+       * <code>optional uint32 sigsRequiredToSpend = 18 [default = 1];</code>
+       *
+       * <pre>
+       * Number of signatures required to spend. This field is needed only for married wallets to reconstruct KeyChainGroup
+       * and represents the N value from N-of-M CHECKMULTISIG script. For regular single wallets it will always be 1.
+       * </pre>
+       */
+      public int getSigsRequiredToSpend() {
+        return sigsRequiredToSpend_;
+      }
+      /**
+       * <code>optional uint32 sigsRequiredToSpend = 18 [default = 1];</code>
+       *
+       * <pre>
+       * Number of signatures required to spend. This field is needed only for married wallets to reconstruct KeyChainGroup
+       * and represents the N value from N-of-M CHECKMULTISIG script. For regular single wallets it will always be 1.
+       * </pre>
+       */
+      public Builder setSigsRequiredToSpend(int value) {
+        bitField0_ |= 0x00008000;
+        sigsRequiredToSpend_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional uint32 sigsRequiredToSpend = 18 [default = 1];</code>
+       *
+       * <pre>
+       * Number of signatures required to spend. This field is needed only for married wallets to reconstruct KeyChainGroup
+       * and represents the N value from N-of-M CHECKMULTISIG script. For regular single wallets it will always be 1.
+       * </pre>
+       */
+      public Builder clearSigsRequiredToSpend() {
+        bitField0_ = (bitField0_ & ~0x00008000);
+        sigsRequiredToSpend_ = 1;
+        onChanged();
+        return this;
+      }
+
       // @@protoc_insertion_point(builder_scope:wallet.Wallet)
     }
 
@@ -18538,7 +18659,7 @@ public final class Protos {
       "8\n\tExtension\022\n\n\002id\030\001 \002(\t\022\014\n\004data\030\002 \002(\014\022\021" +
       "\n\tmandatory\030\003 \002(\010\" \n\003Tag\022\013\n\003tag\030\001 \002(\t\022\014\n" +
       "\004data\030\002 \002(\014\"5\n\021TransactionSigner\022\022\n\nclas" +
-      "s_name\030\001 \002(\t\022\014\n\004data\030\002 \001(\014\"\351\004\n\006Wallet\022\032\n" +
+      "s_name\030\001 \002(\t\022\014\n\004data\030\002 \001(\014\"\211\005\n\006Wallet\022\032\n" +
       "\022network_identifier\030\001 \002(\t\022\034\n\024last_seen_b" +
       "lock_hash\030\002 \001(\014\022\036\n\026last_seen_block_heigh" +
       "t\030\014 \001(\r\022!\n\031last_seen_block_time_secs\030\016 \001",
@@ -18552,12 +18673,12 @@ public final class Protos {
       "llet.Extension\022\023\n\013description\030\013 \001(\t\022\031\n\021k" +
       "ey_rotation_time\030\r \001(\004\022\031\n\004tags\030\020 \003(\0132\013.w" +
       "allet.Tag\0226\n\023transaction_signers\030\021 \003(\0132\031",
-      ".wallet.TransactionSigner\";\n\016EncryptionT" +
-      "ype\022\017\n\013UNENCRYPTED\020\001\022\030\n\024ENCRYPTED_SCRYPT" +
-      "_AES\020\002\"R\n\014ExchangeRate\022\022\n\ncoin_value\030\001 \002" +
-      "(\003\022\022\n\nfiat_value\030\002 \002(\003\022\032\n\022fiat_currency_" +
-      "code\030\003 \002(\tB\035\n\023org.bitcoinj.walletB\006Proto" +
-      "s"
+      ".wallet.TransactionSigner\022\036\n\023sigsRequire" +
+      "dToSpend\030\022 \001(\r:\0011\";\n\016EncryptionType\022\017\n\013U" +
+      "NENCRYPTED\020\001\022\030\n\024ENCRYPTED_SCRYPT_AES\020\002\"R" +
+      "\n\014ExchangeRate\022\022\n\ncoin_value\030\001 \002(\003\022\022\n\nfi" +
+      "at_value\030\002 \002(\003\022\032\n\022fiat_currency_code\030\003 \002" +
+      "(\tB\035\n\023org.bitcoinj.walletB\006Protos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -18647,7 +18768,7 @@ public final class Protos {
           internal_static_wallet_Wallet_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_wallet_Wallet_descriptor,
-              new java.lang.String[] { "NetworkIdentifier", "LastSeenBlockHash", "LastSeenBlockHeight", "LastSeenBlockTimeSecs", "Key", "Transaction", "WatchedScript", "EncryptionType", "EncryptionParameters", "Version", "Extension", "Description", "KeyRotationTime", "Tags", "TransactionSigners", });
+              new java.lang.String[] { "NetworkIdentifier", "LastSeenBlockHash", "LastSeenBlockHeight", "LastSeenBlockTimeSecs", "Key", "Transaction", "WatchedScript", "EncryptionType", "EncryptionParameters", "Version", "Extension", "Description", "KeyRotationTime", "Tags", "TransactionSigners", "SigsRequiredToSpend", });
           internal_static_wallet_ExchangeRate_descriptor =
             getDescriptor().getMessageTypes().get(14);
           internal_static_wallet_ExchangeRate_fieldAccessorTable = new

--- a/core/src/test/java/com/google/bitcoin/wallet/KeyChainGroupTest.java
+++ b/core/src/test/java/com/google/bitcoin/wallet/KeyChainGroupTest.java
@@ -58,7 +58,7 @@ public class KeyChainGroupTest {
     private KeyChainGroup createMarriedKeyChainGroup() {
         byte[] entropy = Sha256Hash.create("don't use a seed like this in real life".getBytes()).getBytes();
         DeterministicSeed seed = new DeterministicSeed(entropy, "", MnemonicCode.BIP39_STANDARDISATION_TIME_SECS);
-        KeyChainGroup group = new KeyChainGroup(params, seed, ImmutableList.of(watchingAccountKey));
+        KeyChainGroup group = new KeyChainGroup(params, seed, ImmutableList.of(watchingAccountKey), 2);
         group.setLookaheadSize(LOOKAHEAD_SIZE);
         group.getActiveKeyChain();
         return group;
@@ -400,7 +400,7 @@ public class KeyChainGroupTest {
     @Test
     public void serialization() throws Exception {
         assertEquals(INITIAL_KEYS + 1 /* for the seed */, group.serializeToProtobuf().size());
-        group = KeyChainGroup.fromProtobufUnencrypted(params, group.serializeToProtobuf());
+        group = KeyChainGroup.fromProtobufUnencrypted(params, group.serializeToProtobuf(), 1);
         group.freshKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         DeterministicKey key1 = group.freshKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         DeterministicKey key2 = group.freshKey(KeyChain.KeyPurpose.CHANGE);
@@ -411,13 +411,13 @@ public class KeyChainGroupTest {
         List<Protos.Key> protoKeys2 = group.serializeToProtobuf();
         assertEquals(INITIAL_KEYS + ((LOOKAHEAD_SIZE + 1) * 2) + 1 /* for the seed */ + 2, protoKeys2.size());
 
-        group = KeyChainGroup.fromProtobufUnencrypted(params, protoKeys1);
+        group = KeyChainGroup.fromProtobufUnencrypted(params, protoKeys1, 1);
         assertEquals(INITIAL_KEYS + ((LOOKAHEAD_SIZE + 1)  * 2)  + 1 /* for the seed */ + 1, protoKeys1.size());
         assertTrue(group.hasKey(key1));
         assertTrue(group.hasKey(key2));
         assertEquals(key2, group.currentKey(KeyChain.KeyPurpose.CHANGE));
         assertEquals(key1, group.currentKey(KeyChain.KeyPurpose.RECEIVE_FUNDS));
-        group = KeyChainGroup.fromProtobufUnencrypted(params, protoKeys2);
+        group = KeyChainGroup.fromProtobufUnencrypted(params, protoKeys2, 1);
         assertEquals(INITIAL_KEYS + ((LOOKAHEAD_SIZE + 1) * 2) + 1 /* for the seed */ + 2, protoKeys2.size());
         assertTrue(group.hasKey(key1));
         assertTrue(group.hasKey(key2));
@@ -426,7 +426,7 @@ public class KeyChainGroupTest {
         final KeyParameter aesKey = scrypt.deriveKey("password");
         group.encrypt(scrypt, aesKey);
         List<Protos.Key> protoKeys3 = group.serializeToProtobuf();
-        group = KeyChainGroup.fromProtobufEncrypted(params, protoKeys3, scrypt);
+        group = KeyChainGroup.fromProtobufEncrypted(params, protoKeys3, 1, scrypt);
         assertTrue(group.isEncrypted());
         assertTrue(group.checkPassword("password"));
         group.decrypt(aesKey);
@@ -443,7 +443,7 @@ public class KeyChainGroupTest {
         group.getBloomFilterElementCount();  // Force lookahead.
         List<Protos.Key> protoKeys1 = group.serializeToProtobuf();
         assertEquals(3 + (group.getLookaheadSize() + group.getLookaheadThreshold() + 1) * 2, protoKeys1.size());
-        group = KeyChainGroup.fromProtobufUnencrypted(params, protoKeys1);
+        group = KeyChainGroup.fromProtobufUnencrypted(params, protoKeys1, 1);
         assertEquals(3 + (group.getLookaheadSize() + group.getLookaheadThreshold() + 1) * 2, group.serializeToProtobuf().size());
     }
 
@@ -452,10 +452,12 @@ public class KeyChainGroupTest {
         group = createMarriedKeyChainGroup();
         Address address1 = group.currentAddress(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         assertTrue(group.isMarried());
+        assertEquals(2, group.getSigsRequiredToSpend());
 
         List<Protos.Key> protoKeys = group.serializeToProtobuf();
-        KeyChainGroup group2 = KeyChainGroup.fromProtobufUnencrypted(params, protoKeys);
+        KeyChainGroup group2 = KeyChainGroup.fromProtobufUnencrypted(params, protoKeys, 2);
         assertTrue(group2.isMarried());
+        assertEquals(2, group.getSigsRequiredToSpend());
         Address address2 = group2.currentAddress(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         assertEquals(address1, address2);
     }
@@ -517,7 +519,7 @@ public class KeyChainGroupTest {
         DeterministicSeed seed1 = group.getActiveKeyChain().getSeed();
         assertNotNull(seed1);
 
-        group = KeyChainGroup.fromProtobufUnencrypted(params, protobufs);
+        group = KeyChainGroup.fromProtobufUnencrypted(params, protobufs, 1);
         group.upgradeToDeterministic(0, null);  // Should give same result as last time.
         DeterministicKey dkey2 = group.freshKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         DeterministicSeed seed2 = group.getActiveKeyChain().getSeed();

--- a/core/src/wallet.proto
+++ b/core/src/wallet.proto
@@ -105,6 +105,7 @@ message Key {
   // Either the private EC key bytes (without any ASN.1 wrapping), or the deterministic root seed.
   // If the secret is encrypted, or this is a "watching entry" then this is missing.
   optional bytes secret_bytes = 2;
+
   // If the secret data is encrypted, then secret_bytes is missing and this field is set.
   optional EncryptedData encrypted_data = 6;
 
@@ -371,7 +372,11 @@ message Wallet {
   // transaction signers added to the wallet
   repeated TransactionSigner transaction_signers = 17;
 
-  // Next tag: 18
+  // Number of signatures required to spend. This field is needed only for married wallets to reconstruct KeyChainGroup
+  // and represents the N value from N-of-M CHECKMULTISIG script. For regular single wallets it will always be 1.
+  optional uint32 sigsRequiredToSpend = 18 [default = 1];
+
+  // Next tag: 19
 }
 
 /** An exchange rate between Bitcoin and some fiat currency. */


### PR DESCRIPTION
That allows to create multisigs like 3-of-3. If not specified, majority of
keys will be required (2-of-3, 3-of-5 and so on)
