### PR TITLE
Don't bother pointless attempt to construct thread pool with no open cir...

### DIFF
--- a/core/src/main/java/com/google/bitcoin/net/discovery/TorDiscovery.java
+++ b/core/src/main/java/com/google/bitcoin/net/discovery/TorDiscovery.java
@@ -128,6 +128,9 @@ public class TorDiscovery implements PeerDiscovery {
 
         try {
             List<Circuit> circuits = getCircuits(timeoutValue, timeoutUnit, routers);
+            if (circuits.isEmpty())
+                throw new PeerDiscoveryException("Failed to open any circuit within " +
+                                                 String.valueOf(timeoutValue) + " " + timeoutUnit);
 
             Collection<InetSocketAddress> addresses = lookupAddresses(timeoutValue, timeoutUnit, circuits);
 


### PR DESCRIPTION
...cuits.

It seems to be pointless for `TorDiscovery` to try to look up addresses if it has failed to open any circuits, especially as doing so results in `java.util.concurrent.ThreadPoolExecutor` raising an `IllegalArgumentException` that lacks any further diagnostic information.
