### PR TITLE
More meaningful exception when reaching past end of ASN.1 stream.

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/ECKey.java
+++ b/core/src/main/java/com/google/bitcoin/core/ECKey.java
@@ -500,9 +500,12 @@ public class ECKey implements EncryptableItem, Serializable {
         }
 
         public static ECDSASignature decodeFromDER(byte[] bytes) {
+            ASN1InputStream decoder = null;
             try {
-                ASN1InputStream decoder = new ASN1InputStream(bytes);
+                decoder = new ASN1InputStream(bytes);
                 DLSequence seq = (DLSequence) decoder.readObject();
+                if (seq == null)
+                    throw new RuntimeException("Reached past end of ASN.1 stream.");
                 ASN1Integer r, s;
                 try {
                     r = (ASN1Integer) seq.getObjectAt(0);
@@ -510,12 +513,14 @@ public class ECKey implements EncryptableItem, Serializable {
                 } catch (ClassCastException e) {
                     throw new IllegalArgumentException(e);
                 }
-                decoder.close();
                 // OpenSSL deviates from the DER spec by interpreting these values as unsigned, though they should not be
                 // Thus, we always use the positive versions. See: http://r6.ca/blog/20111119T211504Z.html
                 return new ECDSASignature(r.getPositiveValue(), s.getPositiveValue());
             } catch (IOException e) {
                 throw new RuntimeException(e);
+            } finally {
+                if (decoder != null)
+                    try { decoder.close(); } catch (IOException x) {}
             }
         }
 


### PR DESCRIPTION
Properly close ASN.1 decoder in exception paths.

A way to trigger the exception is running ScriptTest.dataDrivenValidTransactions().
