### PR TITLE
HD Wallets: final part needed before release.

### DIFF
--- a/core/src/main/java/com/google/bitcoin/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/com/google/bitcoin/wallet/DeterministicKeyChain.java
@@ -130,6 +130,12 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
     // How many keys on each path have actually been used. This may be fewer than the number that have been deserialized
     // or held in memory, because of the lookahead zone.
     private int issuedExternalKeys, issuedInternalKeys;
+    // A counter that is incremented each time a key in the lookahead threshold zone is marked as used and lookahead
+    // is triggered. The Wallet/KCG reads these counters and combines them so it can tell the Peer whether to throw
+    // away the current block (and any future blocks in the same download batch) and restart chain sync once a new
+    // filter has been calculated. This field isn't persisted to the wallet as it's only relevant within a network
+    // session.
+    private int keyLookaheadEpoch;
 
     // We simplify by wrapping a basic key chain and that way we get some functionality like key lookup and event
     // listeners "for free". All keys in the key tree appear here, even if they aren't meant to be used for receiving
@@ -920,8 +926,9 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
     }
 
     /**
-     * Gets the threshold for the key pre-generation.
-     * See {@link #setLookaheadThreshold(int)} for details on what this is.
+     * Gets the threshold for the key pre-generation. See {@link #setLookaheadThreshold(int)} for details on what this
+     * is. The default is a third of the lookahead size (100 / 3 == 33). If you don't modify it explicitly then this
+     * value will always be one third of the lookahead size.
      */
     public int getLookaheadThreshold() {
         lock.lock();
@@ -943,6 +950,9 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
         try {
             List<DeterministicKey> keys = maybeLookAhead(externalKey, issuedExternalKeys);
             keys.addAll(maybeLookAhead(internalKey, issuedInternalKeys));
+            if (keys.isEmpty())
+                return;
+            keyLookaheadEpoch++;
             // Batch add all keys at once so there's only one event listener invocation, as this will be listened to
             // by the wallet and used to rebuild/broadcast the Bloom filter. That's expensive so we don't want to do
             // it more often than necessary.
@@ -1058,5 +1068,18 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
             }
         }
         return keys.build();
+    }
+
+    /**
+     * Returns a counter that is incremented each time new keys are generated due to lookahead. Used by the network
+     * code to learn whether to discard the current block and await calculation of a new filter.
+     */
+    public int getKeyLookaheadEpoch() {
+        lock.lock();
+        try {
+            return keyLookaheadEpoch;
+        } finally {
+            lock.unlock();
+        }
     }
 }

--- a/core/src/test/java/com/google/bitcoin/core/PeerGroupTest.java
+++ b/core/src/test/java/com/google/bitcoin/core/PeerGroupTest.java
@@ -662,4 +662,102 @@ public class PeerGroupTest extends TestWithPeerGroup {
             local.close();
         }
     }
+
+    private <T extends Message> T assertNextMessageIs(InboundMessageQueuer q, Class<T> klass) throws Exception {
+        Message outbound = waitForOutbound(q);
+        assertEquals(klass, outbound.getClass());
+        return (T) outbound;
+    }
+
+    @Test
+    public void autoRescanOnKeyExhaustion() throws Exception {
+        // Check that if the last key that was inserted into the bloom filter is seen in some requested blocks,
+        // that the exhausting block is discarded, a new filter is calculated and sent, and then the download resumes.
+
+        final int NUM_KEYS = 9;
+
+        // First, grab a load of keys from the wallet, and then recreate it so it forgets that those keys were issued.
+        Wallet shadow = Wallet.fromSeed(wallet.getParams(), wallet.getKeyChainSeed());
+        List<ECKey> keys = new ArrayList<ECKey>(NUM_KEYS);
+        for (int i = 0; i < NUM_KEYS; i++) {
+            keys.add(shadow.freshReceiveKey());
+        }
+        // Reduce the number of keys we need to work with to speed up this test.
+        wallet.setKeychainLookaheadSize(4);
+        wallet.setKeychainLookaheadThreshold(2);
+
+        peerGroup.startAsync();
+        peerGroup.awaitRunning();
+        InboundMessageQueuer p1 = connectPeer(1);
+        assertTrue(p1.lastReceivedFilter.contains(keys.get(0).getPubKey()));
+        assertTrue(p1.lastReceivedFilter.contains(keys.get(5).getPubKeyHash()));
+        assertFalse(p1.lastReceivedFilter.contains(keys.get(keys.size() - 1).getPubKey()));
+        peerGroup.startBlockChainDownload(null);
+        assertNextMessageIs(p1, GetBlocksMessage.class);
+
+        // Make some transactions and blocks that send money to the wallet thus using up all the keys.
+        List<Block> blocks = Lists.newArrayList();
+        Coin expectedBalance = Coin.ZERO;
+        Block prev = blockStore.getChainHead().getHeader();
+        for (ECKey key1 : keys) {
+            Address addr = key1.toAddress(params);
+            Block next = FakeTxBuilder.makeSolvedTestBlock(prev, FakeTxBuilder.createFakeTx(params, Coin.FIFTY_COINS, addr));
+            expectedBalance = expectedBalance.add(next.getTransactions().get(2).getOutput(0).getValue());
+            blocks.add(next);
+            prev = next;
+        }
+
+        // Send the chain that doesn't have all the transactions in it. The blocks after the exhaustion point should all
+        // be ignored.
+        int epoch = wallet.keychain.getCombinedKeyLookaheadEpochs();
+        BloomFilter filter = new BloomFilter(params, p1.lastReceivedFilter.bitcoinSerialize());
+        filterAndSend(p1, blocks, filter);
+        Block exhaustionPoint = blocks.get(3);
+        pingAndWait(p1);
+
+        assertNotEquals(epoch, wallet.keychain.getCombinedKeyLookaheadEpochs());
+        // 4th block was end of the lookahead zone and thus was discarded, so we got 3 blocks worth of money (50 each).
+        assertEquals(Coin.FIFTY_COINS.multiply(3), wallet.getBalance());
+        assertEquals(exhaustionPoint.getPrevBlockHash(), blockChain.getChainHead().getHeader().getHash());
+
+        // Await the new filter.
+        peerGroup.waitForJobQueue();
+        BloomFilter newFilter = assertNextMessageIs(p1, BloomFilter.class);
+        assertNotEquals(filter, newFilter);
+        assertNextMessageIs(p1, MemoryPoolMessage.class);
+        Ping ping = assertNextMessageIs(p1, Ping.class);
+        inbound(p1, new Pong(ping.getNonce()));
+
+        // Await restart of the chain download.
+        GetDataMessage getdata = assertNextMessageIs(p1, GetDataMessage.class);
+        assertEquals(exhaustionPoint.getHash(), getdata.getHashOf(0));
+        assertEquals(InventoryItem.Type.FilteredBlock, getdata.getItems().get(0).type);
+        List<Block> newBlocks = blocks.subList(3, blocks.size());
+        filterAndSend(p1, newBlocks, newFilter);
+        assertNextMessageIs(p1, Ping.class);
+
+        // It happened again.
+        peerGroup.waitForJobQueue();
+        newFilter = assertNextMessageIs(p1, BloomFilter.class);
+        assertNextMessageIs(p1, MemoryPoolMessage.class);
+        inbound(p1, new Pong(assertNextMessageIs(p1, Ping.class).getNonce()));
+        assertNextMessageIs(p1, GetDataMessage.class);
+        newBlocks = blocks.subList(6, blocks.size());
+        filterAndSend(p1, newBlocks, newFilter);
+        // Send a non-tx message so the peer knows the filtered block is over and force processing.
+        inbound(p1, new Ping());
+        pingAndWait(p1);
+
+        assertEquals(expectedBalance, wallet.getBalance());
+        assertEquals(blocks.get(blocks.size() - 1).getHash(), blockChain.getChainHead().getHeader().getHash());
+    }
+
+    private void filterAndSend(InboundMessageQueuer p1, List<Block> blocks, BloomFilter filter) {
+        for (Block block : blocks) {
+            FilteredBlock fb = filter.applyAndUpdate(block);
+            inbound(p1, fb);
+            for (Transaction tx : fb.getAssociatedTransactions().values())
+                inbound(p1, tx);
+        }
+    }
 }


### PR DESCRIPTION
If a key is seen in a filtered block that is too far inside our lookahead zone, discard that block and any further blocks being sent to us by a remote peer and recalculate the Bloom filter after more keys are pre-calculated. Then restart the chain download process. This ensures that we can catch up/replay the block chain and keep up with the deterministic key sequence.
