### PR TITLE
eclipse m2 plugin configuration

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -25,9 +25,9 @@
         <version>0.12-SNAPSHOT</version>
     </parent>
 
-    <artifactId>bitcoinj</artifactId>
+    <artifactId>bitcoinj-core</artifactId>
 
-    <name>bitcoinj</name>
+    <name>bitcoinj-core</name>
     <description>A Java Bitcoin library</description>
 
     <packaging>jar</packaging>
@@ -295,6 +295,41 @@
                 </executions>
             </plugin>
         </plugins>
+        <pluginManagement>
+        	<plugins>
+        		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        		<plugin>
+        			<groupId>org.eclipse.m2e</groupId>
+        			<artifactId>lifecycle-mapping</artifactId>
+        			<version>1.0.0</version>
+        			<configuration>
+        				<lifecycleMappingMetadata>
+        					<pluginExecutions>
+        						<pluginExecution>
+        							<pluginExecutionFilter>
+        								<groupId>
+        									org.apache.maven.plugins
+        								</groupId>
+        								<artifactId>
+        									maven-dependency-plugin
+        								</artifactId>
+        								<versionRange>
+        									[2.8,)
+        								</versionRange>
+        								<goals>
+        									<goal>unpack</goal>
+        								</goals>
+        							</pluginExecutionFilter>
+        							<action>
+        								<ignore></ignore>
+        							</action>
+        						</pluginExecution>
+        					</pluginExecutions>
+        				</lifecycleMappingMetadata>
+        			</configuration>
+        		</plugin>
+        	</plugins>
+        </pluginManagement>
     </build>
 
     <dependencies>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -33,7 +33,7 @@
     <dependencies>
         <dependency>
             <groupId>com.google</groupId>
-            <artifactId>bitcoinj</artifactId>
+            <artifactId>bitcoinj-core</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -75,7 +75,7 @@
   <dependencies>
     <dependency>
       <groupId>com.google</groupId>
-      <artifactId>bitcoinj</artifactId>
+      <artifactId>bitcoinj-core</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>

--- a/wallettemplate/pom.xml
+++ b/wallettemplate/pom.xml
@@ -25,7 +25,7 @@
     <dependencies>
         <dependency>
             <groupId>com.google</groupId>
-            <artifactId>bitcoinj</artifactId>
+            <artifactId>bitcoinj-core</artifactId>
             <version>0.12-SNAPSHOT</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
By default Eclipse->Import->Existing Maven Projects does not work correctly.
I updated pom.xml files and resolved 'enforce' verify execution under M2 Eclipse Plugin. 
