### PR TITLE
Don't fail when deserializing a parentless HD key having depth greater than one

### DIFF
--- a/core/src/main/java/com/google/bitcoin/crypto/DeterministicKey.java
+++ b/core/src/main/java/com/google/bitcoin/crypto/DeterministicKey.java
@@ -381,17 +381,13 @@ public class DeterministicKey extends ECKey {
             if (path.size() != depth)
                 throw new IllegalArgumentException("Depth does not match");
         } else {
-            if (depth == 0) {
-                path = ImmutableList.of();
-            } else if (depth == 1) {
-                // We have been given a key that is not a root key, yet we also don't have any object representing
-                // the parent. This can happen when deserializing an account key for a watching wallet. In this case,
-                // we assume that the parent has a path of zero.
+            if (depth >= 1)
+                // We have been given a key that is not a root key, yet we lack any object representing the parent.
+                // This can happen when deserializing an account key for a watching wallet. In this case, we assume that
+                // the client wants to conceal the key's position in the hierarchy. The parent is deemed to be the
+                // root of the hierarchy.
                 path = ImmutableList.of(childNumber);
-            } else {
-                throw new IllegalArgumentException("Depth is " + depth + " and no parent key was provided, so we " +
-                                                   "cannot reconstruct the key path from the provided data.");
-            }
+            else path = ImmutableList.of();
         }
         byte[] chainCode = new byte[32];
         buffer.get(chainCode);

--- a/core/src/test/java/com/google/bitcoin/crypto/ChildKeyDerivationTest.java
+++ b/core/src/test/java/com/google/bitcoin/crypto/ChildKeyDerivationTest.java
@@ -208,6 +208,17 @@ public class ChildKeyDerivationTest {
         }
     }
 
+    @Test
+    public void parentlessDeserialization() {
+        DeterministicKey key1 = HDKeyDerivation.createMasterPrivateKey("satoshi lives!".getBytes());
+        DeterministicKey key2 = HDKeyDerivation.deriveChildKey(key1, ChildNumber.ZERO_HARDENED);
+        DeterministicKey key3 = HDKeyDerivation.deriveChildKey(key2, ChildNumber.ZERO_HARDENED);
+        DeterministicKey key4 = HDKeyDerivation.deriveChildKey(key3, ChildNumber.ZERO_HARDENED);
+        assertEquals(key4.getPath().size(), 3);
+        assertEquals(DeterministicKey.deserialize(key3, key4.serializePrivate()).getPath().size(), 3);
+        assertEquals(DeterministicKey.deserialize(null, key4.serializePrivate()).getPath().size(), 1);
+    }
+
     private static String hexEncodePub(DeterministicKey pubKey) {
         return HEX.encode(pubKey.getPubKey());
     }


### PR DESCRIPTION
Currently, deserializing an HD key will fail if both (1) the parent object is null, and (2) the hierarchy depth is greater than one.  This patch changes that; rather than throwing an exception, the (null) parent is considered to be the root of the deterministic hierarchy.

_Note_: I am not an HD-Key expert and there may be a good reason not to do this of which I am ignorant, or there may be a better way to accomplish the same end.  That said, I don't see the benefit of causing a failure when deserializing an HD key just because I lack the parent, since that is the normal state of affairs when working with a listening wallet, the whole point of which is to provide some increased security by limiting the portion of the key hierarchy that is on one machine.  Furthermore, if it's wrong to deserialize a key that lacks a parent then perhaps the deserialization method ought not to accept a null `parent` parameter.  The current state of the code seems to be based on an unstated assumption that a missing parent is acceptable as long as the path is known, and if that is the case I'm interested to know why.  If not, then the raised exception seems only an unnecessary hindrance to usage and this patch may be warranted.

Another way I can think of to deal with this issue would be a method in the `DeterministicKey` class that returns a clone of the key with the path removed.  That would mean the client has to intend explicitly to change the path of the parentless key, rather than having it happen automatically as this patch does.  However, the same intention seems to be indicated by passing a null `parent` object to the `deserialize` method, so the way I've done it here seems to be a simpler way of achieving the same thing.
