### PR TITLE
Change HD-Key path notation to reflect BIP-32.

### DIFF
--- a/core/src/main/java/com/google/bitcoin/crypto/ChildNumber.java
+++ b/core/src/main/java/com/google/bitcoin/crypto/ChildNumber.java
@@ -71,7 +71,7 @@ public class ChildNumber {
 
     @Override
     public String toString() {
-        return String.format("%d%s", num(), isHardened() ? "'" : "");
+        return String.format("%d%s", num(), isHardened() ? "H" : "");
     }
 
     @Override

--- a/core/src/main/java/com/google/bitcoin/crypto/HDUtils.java
+++ b/core/src/main/java/com/google/bitcoin/crypto/HDUtils.java
@@ -78,9 +78,9 @@ public final class HDUtils {
     /**
      * The path is a human-friendly representation of the deterministic path. For example:
      *
-     * "44' / 0' / 0' / 1 / 1"
+     * "44H / 0H / 0H / 1 / 1"
      *
-     * Where a single quote (') means hardened key. Spaces are ignored.
+     * Where a letter "H" means hardened key. Spaces are ignored.
      */
     public static List<ChildNumber> parsePath(@Nonnull String path) {
         String[] parsedNodes = path.replace("M", "").split("/");
@@ -89,7 +89,7 @@ public final class HDUtils {
         for (String n : parsedNodes) {
             n = n.replaceAll(" ", "");
             if (n.length() == 0) continue;
-            boolean isHard = n.endsWith("'");
+            boolean isHard = n.endsWith("H");
             if (isHard) n = n.substring(0, n.length() - 1);
             int nodeNumber = Integer.parseInt(n);
             nodes.add(new ChildNumber(nodeNumber, isHard));

--- a/core/src/test/java/com/google/bitcoin/crypto/BIP32Test.java
+++ b/core/src/test/java/com/google/bitcoin/crypto/BIP32Test.java
@@ -45,31 +45,31 @@ public class BIP32Test {
                     "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8",
                     Arrays.asList(
                             new HDWTestVector.DerivedTestCase(
-                                    "Test1 m/0'",
+                                    "Test1 m/0H",
                                     new ChildNumber[]{new ChildNumber(0, true)},
                                     "xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7",
                                     "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw"
                             ),
                             new HDWTestVector.DerivedTestCase(
-                                    "Test1 m/0'/1",
+                                    "Test1 m/0H/1",
                                     new ChildNumber[]{new ChildNumber(0, true), new ChildNumber(1, false)},
                                     "xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLnvSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs",
                                     "xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ"
                             ),
                             new HDWTestVector.DerivedTestCase(
-                                    "Test1 m/0'/1/2'",
+                                    "Test1 m/0H/1/2H",
                                     new ChildNumber[]{new ChildNumber(0, true), new ChildNumber(1, false), new ChildNumber(2, true)},
                                     "xprv9z4pot5VBttmtdRTWfWQmoH1taj2axGVzFqSb8C9xaxKymcFzXBDptWmT7FwuEzG3ryjH4ktypQSAewRiNMjANTtpgP4mLTj34bhnZX7UiM",
                                     "xpub6D4BDPcP2GT577Vvch3R8wDkScZWzQzMMUm3PWbmWvVJrZwQY4VUNgqFJPMM3No2dFDFGTsxxpG5uJh7n7epu4trkrX7x7DogT5Uv6fcLW5"
                             ),
                             new HDWTestVector.DerivedTestCase(
-                                    "Test1 m/0'/1/2'/2",
+                                    "Test1 m/0H/1/2H/2",
                                     new ChildNumber[]{new ChildNumber(0, true), new ChildNumber(1, false), new ChildNumber(2, true), new ChildNumber(2, false)},
                                     "xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334",
                                     "xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV"
                             ),
                             new HDWTestVector.DerivedTestCase(
-                                    "Test1 m/0'/1/2'/2/1000000000",
+                                    "Test1 m/0H/1/2H/2/1000000000",
                                     new ChildNumber[]{new ChildNumber(0, true), new ChildNumber(1, false), new ChildNumber(2, true), new ChildNumber(2, false), new ChildNumber(1000000000, false)},
                                     "xprvA41z7zogVVwxVSgdKUHDy1SKmdb533PjDz7J6N6mV6uS3ze1ai8FHa8kmHScGpWmj4WggLyQjgPie1rFSruoUihUZREPSL39UNdE3BBDu76",
                                     "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy"
@@ -88,25 +88,25 @@ public class BIP32Test {
                                     "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH"
                             ),
                             new HDWTestVector.DerivedTestCase(
-                                    "Test2 m/0/2147483647'",
+                                    "Test2 m/0/2147483647H",
                                     new ChildNumber[]{new ChildNumber(0, false), new ChildNumber(2147483647, true)},
                                     "xprv9wSp6B7kry3Vj9m1zSnLvN3xH8RdsPP1Mh7fAaR7aRLcQMKTR2vidYEeEg2mUCTAwCd6vnxVrcjfy2kRgVsFawNzmjuHc2YmYRmagcEPdU9",
                                     "xpub6ASAVgeehLbnwdqV6UKMHVzgqAG8Gr6riv3Fxxpj8ksbH9ebxaEyBLZ85ySDhKiLDBrQSARLq1uNRts8RuJiHjaDMBU4Zn9h8LZNnBC5y4a"
                             ),
                             new HDWTestVector.DerivedTestCase(
-                                    "Test2 m/0/2147483647'/1",
+                                    "Test2 m/0/2147483647H/1",
                                     new ChildNumber[]{new ChildNumber(0, false), new ChildNumber(2147483647, true), new ChildNumber(1, false)},
                                     "xprv9zFnWC6h2cLgpmSA46vutJzBcfJ8yaJGg8cX1e5StJh45BBciYTRXSd25UEPVuesF9yog62tGAQtHjXajPPdbRCHuWS6T8XA2ECKADdw4Ef",
                                     "xpub6DF8uhdarytz3FWdA8TvFSvvAh8dP3283MY7p2V4SeE2wyWmG5mg5EwVvmdMVCQcoNJxGoWaU9DCWh89LojfZ537wTfunKau47EL2dhHKon"
                             ),
                             new HDWTestVector.DerivedTestCase(
-                                    "Test2 m/0/2147483647'/1/2147483646'",
+                                    "Test2 m/0/2147483647H/1/2147483646H",
                                     new ChildNumber[]{new ChildNumber(0, false), new ChildNumber(2147483647, true), new ChildNumber(1, false), new ChildNumber(2147483646, true)},
                                     "xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc",
                                     "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL"
                             ),
                             new HDWTestVector.DerivedTestCase(
-                                    "Test2 m/0/2147483647'/1/2147483646'/2",
+                                    "Test2 m/0/2147483647H/1/2147483646H/2",
                                     new ChildNumber[]{new ChildNumber(0, false), new ChildNumber(2147483647, true), new ChildNumber(1, false), new ChildNumber(2147483646, true), new ChildNumber(2, false)},
                                     "xprvA2nrNbFZABcdryreWet9Ea4LvTJcGsqrMzxHx98MMrotbir7yrKCEXw7nadnHM8Dq38EGfSh6dqA9QWTyefMLEcBYJUuekgW4BYPJcr9E7j",
                                     "xpub6FnCn6nSzZAw5Tw7cgR9bi15UV96gLZhjDstkXXxvCLsUXBGXPdSnLFbdpq8p9HmGsApME5hQTZ3emM2rnY5agb9rXpVGyy3bdW6EEgAtqt"

--- a/core/src/test/java/com/google/bitcoin/crypto/HDUtilsTest.java
+++ b/core/src/test/java/com/google/bitcoin/crypto/HDUtilsTest.java
@@ -128,15 +128,15 @@ public class HDUtilsTest {
     @Test
     public void testFormatPath() {
         Object tv[] = {
-                "M/44'/0'/0'/1/1",
+                "M/44H/0H/0H/1/1",
                 ImmutableList.of(new ChildNumber(44, true), new ChildNumber(0, true), new ChildNumber(0, true),
                         new ChildNumber(1, false), new ChildNumber(1, false)),
 
-                "M/7'/3/3/1'",
+                "M/7H/3/3/1H",
                 ImmutableList.of(new ChildNumber(7, true), new ChildNumber(3, false), new ChildNumber(3, false),
                         new ChildNumber(1, true)),
 
-                "M/1'/2'/3'",
+                "M/1H/2H/3H",
                 ImmutableList.of(new ChildNumber(1, true), new ChildNumber(2, true), new ChildNumber(3, true)),
 
                 "M/1/2/3",
@@ -157,15 +157,15 @@ public class HDUtilsTest {
     @Test
     public void testParsePath() {
         Object tv[] = {
-                "M / 44' / 0' / 0' / 1 / 1",
+                "M / 44H / 0H / 0H / 1 / 1",
                 ImmutableList.of(new ChildNumber(44, true), new ChildNumber(0, true), new ChildNumber(0, true),
                         new ChildNumber(1, false), new ChildNumber(1, false)),
 
-                "M/7'/3/3/1'/",
+                "M/7H/3/3/1H/",
                 ImmutableList.of(new ChildNumber(7, true), new ChildNumber(3, false), new ChildNumber(3, false),
                         new ChildNumber(1, true)),
 
-                "1 ' / 2 ' / 3 ' /",
+                "1 H / 2 H / 3 H /",
                 ImmutableList.of(new ChildNumber(1, true), new ChildNumber(2, true), new ChildNumber(3, true)),
 
                 "1 / 2 / 3 /",


### PR DESCRIPTION
BIP-32 [originally](https://github.com/bitcoin/bips/blob/152cc283a29a4538d8eed03d57591c5f7889652a/bip-0032.mediawiki) distinguished between "public" and "private" key derivation, and its notation used a single quotation-mark character in the key path to indicate private derivation.  The string representation of HD-Key paths generated by bitcoinj uses this notation.  Later, BIP-32 [was changed](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki); the term "private" was replaced by "hardened," and the notation was changed by replacing the single quote with a subscript letter "H".  This patch updates bitcoinj to reflect the change in the BIP-32 path-notation.
