### PR TITLE
Make PaymentChannel.ServerConnection.paymentIncrease asynchronous.

### DIFF
--- a/core/src/main/java/com/google/bitcoin/jni/NativePaymentChannelServerConnectionEventHandler.java
+++ b/core/src/main/java/com/google/bitcoin/jni/NativePaymentChannelServerConnectionEventHandler.java
@@ -3,6 +3,7 @@ package com.google.bitcoin.jni;
 import com.google.bitcoin.core.*;
 import com.google.bitcoin.protocols.channels.PaymentChannelCloseException;
 import com.google.bitcoin.protocols.channels.ServerConnectionEventHandler;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
 
 /**
@@ -17,7 +18,7 @@ public class NativePaymentChannelServerConnectionEventHandler extends ServerConn
     public native void channelOpen(Sha256Hash channelId);
 
     @Override
-    public native ByteString paymentIncrease(Coin by, Coin to, ByteString info);
+    public native ListenableFuture<ByteString> paymentIncrease(Coin by, Coin to, ByteString info);
 
     @Override
     public native void channelClosed(PaymentChannelCloseException.CloseReason reason);

--- a/core/src/main/java/com/google/bitcoin/protocols/channels/PaymentChannelCloseException.java
+++ b/core/src/main/java/com/google/bitcoin/protocols/channels/PaymentChannelCloseException.java
@@ -61,6 +61,9 @@ public class PaymentChannelCloseException extends Exception {
 
         /** The connection was closed without an ERROR/CLOSE message */
         CONNECTION_CLOSED,
+
+        /** The server failed processing an UpdatePayment message */
+        UPDATE_PAYMENT_FAILED,
     }
 
     private final CloseReason error;

--- a/core/src/main/java/com/google/bitcoin/protocols/channels/PaymentChannelServerListener.java
+++ b/core/src/main/java/com/google/bitcoin/protocols/channels/PaymentChannelServerListener.java
@@ -25,6 +25,7 @@ import com.google.bitcoin.net.NioServer;
 import com.google.bitcoin.net.ProtobufParser;
 import com.google.bitcoin.net.StreamParserFactory;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
 import org.bitcoin.paymentchannel.Protos;
 
@@ -83,7 +84,7 @@ public class PaymentChannelServerListener {
                     eventHandler.channelOpen(contractHash);
                 }
 
-                @Override public ByteString paymentIncrease(Coin by, Coin to, @Nullable ByteString info) {
+                @Override public ListenableFuture<ByteString> paymentIncrease(Coin by, Coin to, @Nullable ByteString info) {
                     return eventHandler.paymentIncrease(by, to, info);
                 }
             });

--- a/core/src/main/java/com/google/bitcoin/protocols/channels/ServerConnectionEventHandler.java
+++ b/core/src/main/java/com/google/bitcoin/protocols/channels/ServerConnectionEventHandler.java
@@ -20,6 +20,7 @@ import com.google.bitcoin.core.Coin;
 import com.google.bitcoin.core.Sha256Hash;
 import com.google.bitcoin.net.ProtobufParser;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
 import org.bitcoin.paymentchannel.Protos;
 
@@ -74,7 +75,7 @@ public abstract class ServerConnectionEventHandler {
      * @return acknowledgment information to be sent to the client.
      */
     @Nullable
-    public abstract ByteString paymentIncrease(Coin by, Coin to, ByteString info);
+    public abstract ListenableFuture<ByteString> paymentIncrease(Coin by, Coin to, ByteString info);
 
     /**
      * <p>Called when the channel was closed for some reason. May be called without a call to

--- a/core/src/test/java/com/google/bitcoin/protocols/channels/ChannelTestUtils.java
+++ b/core/src/test/java/com/google/bitcoin/protocols/channels/ChannelTestUtils.java
@@ -5,6 +5,9 @@ import com.google.bitcoin.core.Sha256Hash;
 import com.google.bitcoin.core.TransactionBroadcaster;
 import com.google.bitcoin.core.Wallet;
 
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 import com.google.protobuf.ByteString;
 import org.bitcoin.paymentchannel.Protos;
 
@@ -37,9 +40,9 @@ public class ChannelTestUtils {
         }
 
         @Override
-        public ByteString paymentIncrease(Coin by, Coin to, @Nullable ByteString info) {
+        public ListenableFuture<ByteString> paymentIncrease(Coin by, Coin to, @Nullable ByteString info) {
             q.add(new UpdatePair(to, info));
-            return ByteString.copyFromUtf8(by.toPlainString());
+            return Futures.immediateFuture(ByteString.copyFromUtf8(by.toPlainString()));
         }
 
         public Protos.TwoWayChannelMessage getNextMsg() throws InterruptedException {

--- a/examples/src/main/java/com/google/bitcoin/examples/ExamplePaymentChannelServer.java
+++ b/examples/src/main/java/com/google/bitcoin/examples/ExamplePaymentChannelServer.java
@@ -28,6 +28,7 @@ import com.google.bitcoin.protocols.channels.*;
 import com.google.bitcoin.utils.BriefLogFormatter;
 import com.google.common.collect.ImmutableList;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
 import org.slf4j.LoggerFactory;
 
@@ -102,7 +103,7 @@ public class ExamplePaymentChannelServer implements PaymentChannelServerListener
             }
 
             @Override
-            public ByteString paymentIncrease(Coin by, Coin to, ByteString info) {
+            public ListenableFuture<ByteString> paymentIncrease(Coin by, Coin to, ByteString info) {
                 log.info("Client {} paid increased payment by {} for a total of " + to.toString(), clientAddress, by);
                 return null;
             }


### PR DESCRIPTION
When I implemented a payment channel server with akka, I would have good use of having the server side paymentIncrease method to be asynchronous. This a proposal.
I'm note sure if the addCallback should use an explicit exciter coming from the PaymentChannelServerConstructor, defaulting to SameThreadExecutor. For now I left it.
