### PR TITLE
Separate Transaction and Wallet classes

### DIFF
--- a/core/src/main/java/com/google/bitcoin/core/TransactionBag.java
+++ b/core/src/main/java/com/google/bitcoin/core/TransactionBag.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2014 Giannis Dzegoutanis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.bitcoin.core;
+
+import com.google.bitcoin.script.Script;
+import com.google.bitcoin.wallet.WalletTransaction;
+
+import java.util.Map;
+
+/**
+ * This interface is used to abstract the {@link com.google.bitcoin.core.Wallet} and the {@link com.google.bitcoin.core.Transaction}
+ */
+public interface TransactionBag {
+    /** Returns true if this wallet contains a public key which hashes to the given hash. */
+    public boolean isPubKeyHashMine(byte[] pubkeyHash);
+
+    /** Returns true if this wallet is watching transactions for outputs with the script. */
+    public boolean isWatchedScript(Script script);
+
+    /** Returns true if this wallet contains a keypair with the given public key. */
+    public boolean isPubKeyMine(byte[] pubkey);
+
+    /** Returns true if this wallet knows the script corresponding to the given hash. */
+    public boolean isPayToScriptHashMine(byte[] payToScriptHash);
+
+    /** Returns transactions from a specific pool. */
+    public Map<Sha256Hash, Transaction> getTransactionPool(WalletTransaction.Pool pool);
+}

--- a/core/src/main/java/com/google/bitcoin/core/TransactionOutput.java
+++ b/core/src/main/java/com/google/bitcoin/core/TransactionOutput.java
@@ -310,17 +310,17 @@ public class TransactionOutput extends ChildMessage implements Serializable {
     /**
      * Returns true if this output is to a key in the wallet or to an address/script we are watching.
      */
-    public boolean isMineOrWatched(Wallet wallet) {
-        return isMine(wallet) || isWatched(wallet);
+    public boolean isMineOrWatched(TransactionBag transactionBag) {
+        return isMine(transactionBag) || isWatched(transactionBag);
     }
 
     /**
      * Returns true if this output is to a key, or an address we have the keys for, in the wallet.
      */
-    public boolean isWatched(Wallet wallet) {
+    public boolean isWatched(TransactionBag transactionBag) {
         try {
             Script script = getScriptPubKey();
-            return wallet.isWatchedScript(script);
+            return transactionBag.isWatchedScript(script);
         } catch (ScriptException e) {
             // Just means we didn't understand the output of this transaction: ignore it.
             log.debug("Could not parse tx output script: {}", e.toString());
@@ -331,17 +331,17 @@ public class TransactionOutput extends ChildMessage implements Serializable {
     /**
      * Returns true if this output is to a key, or an address we have the keys for, in the wallet.
      */
-    public boolean isMine(Wallet wallet) {
+    public boolean isMine(TransactionBag transactionBag) {
         try {
             Script script = getScriptPubKey();
             if (script.isSentToRawPubKey()) {
                 byte[] pubkey = script.getPubKey();
-                return wallet.isPubKeyMine(pubkey);
+                return transactionBag.isPubKeyMine(pubkey);
             } if (script.isPayToScriptHash()) {
-                return wallet.isPayToScriptHashMine(script.getPubKeyHash());
+                return transactionBag.isPayToScriptHashMine(script.getPubKeyHash());
             } else {
                 byte[] pubkeyHash = script.getPubKeyHash();
-                return wallet.isPubKeyHashMine(pubkeyHash);
+                return transactionBag.isPubKeyHashMine(pubkeyHash);
             }
         } catch (ScriptException e) {
             // Just means we didn't understand the output of this transaction: ignore it.

--- a/core/src/main/java/com/google/bitcoin/core/Wallet.java
+++ b/core/src/main/java/com/google/bitcoin/core/Wallet.java
@@ -102,7 +102,7 @@ import static com.google.common.base.Preconditions.*;
  * {@link Wallet#autosaveToFile(java.io.File, long, java.util.concurrent.TimeUnit, com.google.bitcoin.wallet.WalletFiles.Listener)}
  * for more information about this.</p>
  */
-public class Wallet extends BaseTaggableObject implements Serializable, BlockChainListener, PeerFilterProvider, KeyBag {
+public class Wallet extends BaseTaggableObject implements Serializable, BlockChainListener, PeerFilterProvider, KeyBag, TransactionBag {
     private static final Logger log = LoggerFactory.getLogger(Wallet.class);
     private static final long serialVersionUID = 2L;
     private static final int MINIMUM_BLOOM_DATA_LENGTH = 8;
@@ -829,14 +829,14 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
         }
     }
 
-    /**
-     * Returns true if this wallet contains a public key which hashes to the given hash.
-     */
+    /** {@inheritDoc} */
+    @Override
     public boolean isPubKeyHashMine(byte[] pubkeyHash) {
         return findKeyFromPubHash(pubkeyHash) != null;
     }
 
-    /** Returns true if this wallet is watching transactions for outputs with the script. */
+    /** {@inheritDoc} */
+    @Override
     public boolean isWatchedScript(Script script) {
         lock.lock();
         try {
@@ -861,9 +861,8 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
         }
     }
 
-    /**
-     * Returns true if this wallet contains a keypair with the given public key.
-     */
+    /** {@inheritDoc} */
+    @Override
     public boolean isPubKeyMine(byte[] pubkey) {
         return findKeyFromPubKey(pubkey) != null;
     }
@@ -883,9 +882,8 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
         }
     }
 
-    /**
-     * Returns true if this wallet knows the script corresponding to the given hash
-     */
+    /** {@inheritDoc} */
+    @Override
     public boolean isPayToScriptHashMine(byte[] payToScriptHash) {
         return findRedeemDataFromScriptHash(payToScriptHash) != null;
     }
@@ -2351,6 +2349,28 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
         lock.lock();
         try {
             return transactions.get(hash);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Map<Sha256Hash, Transaction> getTransactionPool(Pool pool) {
+        lock.lock();
+        try {
+            switch (pool) {
+                case UNSPENT:
+                    return unspent;
+                case SPENT:
+                    return spent;
+                case PENDING:
+                    return pending;
+                case DEAD:
+                    return dead;
+                default:
+                    throw new RuntimeException("Unknown wallet transaction type " + pool);
+            }
         } finally {
             lock.unlock();
         }


### PR DESCRIPTION
This is from the discussion https://groups.google.com/forum/#!topic/bitcoinj/IrAblPXxvuQ

tl;dr The Transaction classes cannot be used with custom wallets because it uses the Wallet class directly
