### PR TITLE
updated toString in ECKey, added helper methods and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target
 *.chain
 *.spvchain
 *.wallet
+test.lock.db

--- a/core/src/main/java/org/bitcoinj/core/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/core/ECKey.java
@@ -1117,23 +1117,36 @@ public class ECKey implements EncryptableItem, Serializable {
 
     @Override
     public String toString() {
-        return toString(false);
+        return toString(false, null);
     }
 
     /**
      * Produce a string rendering of the ECKey INCLUDING the private key.
      * Unless you absolutely need the private key it is better for security reasons to just use {@link #toString()}.
      */
-    public String toStringWithPrivate() {
-        return toString(true);
+    public String toStringWithPrivate(NetworkParameters params) {
+        return toString(true, params);
     }
 
-    private String toString(boolean includePrivate) {
+    public String getPrivateKeyAsHex() {
+        return Utils.HEX.encode(getPrivKeyBytes());
+    }
+
+    public String getPublicKeyAsHex() {
+        return Utils.HEX.encode(pub.getEncoded());
+    }
+
+    public String getPrivateKeyAsWiF(NetworkParameters params) {
+        return getPrivateKeyEncoded(params).toString();
+    }
+
+    private String toString(boolean includePrivate, NetworkParameters params) {
         final ToStringHelper helper = Objects.toStringHelper(this).omitNullValues();
-        helper.add("pub", Utils.HEX.encode(pub.getEncoded()));
+        helper.add("pub HEX", getPublicKeyAsHex());
         if (includePrivate) {
             try {
-                helper.add("priv", Utils.HEX.encode(getPrivKey().toByteArray()));
+                helper.add("priv HEX", getPrivateKeyAsHex());
+                helper.add("priv WIF", getPrivateKeyAsWiF(params));
             } catch (IllegalStateException e) {
                 // TODO: Make hasPrivKey() work for deterministic keys and fix this.
             }
@@ -1156,7 +1169,7 @@ public class ECKey implements EncryptableItem, Serializable {
         builder.append("\n");
         if (includePrivateKeys) {
             builder.append("  ");
-            builder.append(toStringWithPrivate());
+            builder.append(toStringWithPrivate(params));
             builder.append("\n");
         }
     }

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -482,7 +482,7 @@ public class DeterministicKey extends ECKey {
         builder.append("\n");
         if (includePrivateKeys) {
             builder.append("  ");
-            builder.append(toStringWithPrivate());
+            builder.append(toStringWithPrivate(params));
             builder.append("\n");
         }
     }

--- a/core/src/test/java/org/bitcoinj/core/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ECKeyTest.java
@@ -317,9 +317,21 @@ public class ECKeyTest {
     @Test
     public void testToString() throws Exception {
         ECKey key = ECKey.fromPrivate(BigInteger.TEN).decompress(); // An example private key.
+        NetworkParameters params = MainNetParams.get();
+        assertEquals("ECKey{pub HEX=04a0434d9e47f3c86235477c7b1ae6ae5d3442d49b1943c2b752a68e2a47e247c7893aba425419bc27a3b6c7e693a24c696f794c2ed877a1593cbee53b037368d7, isEncrypted=false}", key.toString());
+        assertEquals("ECKey{pub HEX=04a0434d9e47f3c86235477c7b1ae6ae5d3442d49b1943c2b752a68e2a47e247c7893aba425419bc27a3b6c7e693a24c696f794c2ed877a1593cbee53b037368d7, priv HEX=000000000000000000000000000000000000000000000000000000000000000a, priv WIF=5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreBoNWTw6, isEncrypted=false}", key.toStringWithPrivate(params));
+    }
 
-        assertEquals("ECKey{pub=04a0434d9e47f3c86235477c7b1ae6ae5d3442d49b1943c2b752a68e2a47e247c7893aba425419bc27a3b6c7e693a24c696f794c2ed877a1593cbee53b037368d7, isEncrypted=false}", key.toString());
-        assertEquals("ECKey{pub=04a0434d9e47f3c86235477c7b1ae6ae5d3442d49b1943c2b752a68e2a47e247c7893aba425419bc27a3b6c7e693a24c696f794c2ed877a1593cbee53b037368d7, priv=0a, isEncrypted=false}", key.toStringWithPrivate());
+    @Test
+    public void testGetPrivateKeyAsHex() throws Exception {
+        ECKey key = ECKey.fromPrivate(BigInteger.TEN).decompress(); // An example private key.
+        assertEquals("000000000000000000000000000000000000000000000000000000000000000a", key.getPrivateKeyAsHex());
+    }
+
+    @Test
+    public void testGetPublicKeyAsHex() throws Exception {
+        ECKey key = ECKey.fromPrivate(BigInteger.TEN).decompress(); // An example private key.
+        assertEquals("04a0434d9e47f3c86235477c7b1ae6ae5d3442d49b1943c2b752a68e2a47e247c7893aba425419bc27a3b6c7e693a24c696f794c2ed877a1593cbee53b037368d7", key.getPublicKeyAsHex());
     }
 
     @Test


### PR DESCRIPTION
Based on this discussion: https://groups.google.com/forum/?fromgroups=#!topic/bitcoinj/QxLpodGLNhw

I have updated toString method in ECKey to include WIF formats in the output. It assumes that we want this on main network - not sure how to parametrize that right now
