### PR TITLE
fix issue with MnemonicCode

### DIFF
--- a/core/src/main/java/com/google/bitcoin/crypto/MnemonicCode.java
+++ b/core/src/main/java/com/google/bitcoin/crypto/MnemonicCode.java
@@ -148,6 +148,9 @@ public class MnemonicCode {
         if (words.size() % 3 > 0)
             throw new MnemonicException.MnemonicLengthException("Word list size must be multiple of three words.");
 
+        if (words.size() == 0)
+            throw new MnemonicException.MnemonicLengthException("Word list is empty.");
+
         // Look up all the words in the list and construct the
         // concatenation of the original entropy and the checksum.
         //
@@ -193,7 +196,10 @@ public class MnemonicCode {
      */
     public List<String> toMnemonic(byte[] entropy) throws MnemonicException.MnemonicLengthException {
         if (entropy.length % 4 > 0)
-            throw new MnemonicException.MnemonicLengthException("entropy length not multiple of 32 bits");
+            throw new MnemonicException.MnemonicLengthException("Entropy length not multiple of 32 bits.");
+
+        if (entropy.length == 0)
+            throw new MnemonicException.MnemonicLengthException("Entropy is empty.");
 
         // We take initial entropy of ENT bits and compute its
         // checksum by taking first ENT / 32 bits of its SHA256 hash.

--- a/core/src/test/java/com/google/bitcoin/crypto/MnemonicCodeTest.java
+++ b/core/src/test/java/com/google/bitcoin/crypto/MnemonicCodeTest.java
@@ -18,6 +18,7 @@
 package com.google.bitcoin.crypto;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -197,6 +198,18 @@ public class MnemonicCodeTest {
     public void testBadChecksum() throws Exception {
         List<String> words = split("bless cloud wheel regular tiny venue bird web grief security dignity zoo");
         mc.check(words);
+    }
+
+    @Test(expected = MnemonicException.MnemonicLengthException.class)
+    public void testEmptyMnemonic() throws Exception {
+        List<String> words = Lists.newArrayList();
+        mc.check(words);
+    }
+
+    @Test(expected = MnemonicException.MnemonicLengthException.class)
+    public void testEmptyEntropy() throws Exception {
+        byte[] entropy = new byte[]{};
+        mc.toMnemonic(entropy);
     }
 
     static public List<String> split(String words) {


### PR DESCRIPTION
When checking if an empty seed or entropy value is valid, MnemonicCode does not throw the appropriate exception.
