### PR TITLE
Release Orchid sub-module as a preparation for the bitcoinj 0.12 release...

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -373,7 +373,7 @@
         <dependency>
             <groupId>org.bitcoinj</groupId>
             <artifactId>orchid</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0</version>
         </dependency>
     </dependencies>
 

--- a/orchid/pom.xml
+++ b/orchid/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.bitcoinj</groupId>
     <artifactId>orchid</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0</version>
 
     <name>Orchid</name>
     <description>Tor library</description>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,6 @@
     <module>core</module>
     <module>examples</module>
     <module>tools</module>
-    <module>orchid</module>
   </modules>
 
   <parent>


### PR DESCRIPTION
Steps:
1. Merge this PR
2. Deploy Orchid 1.0 to Maven central
3. In a new commit/PR, add enforcer hash based on the jar that was uploaded
