### PR TITLE
Use daemon threads on FullPrunedBlockChain

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
@@ -21,6 +21,7 @@ import org.bitcoinj.script.Script;
 import org.bitcoinj.script.Script.VerifyFlag;
 import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.store.FullPrunedBlockStore;
+import org.bitcoinj.utils.DaemonThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,7 +122,8 @@ public class FullPrunedBlockChain extends AbstractBlockChain {
     //TODO: Remove lots of duplicated code in the two connectTransactions
     
     // TODO: execute in order of largest transaction (by input count) first
-    ExecutorService scriptVerificationExecutor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+    ExecutorService scriptVerificationExecutor = Executors.newFixedThreadPool(
+            Runtime.getRuntime().availableProcessors(), new DaemonThreadFactory());
 
     /** A job submitted to the executor which verifies signatures. */
     private static class Verifier implements Callable<VerificationException> {

--- a/core/src/main/java/org/bitcoinj/net/discovery/DnsDiscovery.java
+++ b/core/src/main/java/org/bitcoinj/net/discovery/DnsDiscovery.java
@@ -19,6 +19,7 @@ package org.bitcoinj.net.discovery;
 
 import org.bitcoinj.core.NetworkParameters;
 import com.google.common.collect.Lists;
+import org.bitcoinj.utils.DaemonThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,7 +72,7 @@ public class DnsDiscovery implements PeerDiscovery {
 
         // Java doesn't have an async DNS API so we have to do all lookups in a thread pool, as sometimes seeds go
         // hard down and it takes ages to give up and move on.
-        ExecutorService threadPool = Executors.newFixedThreadPool(dnsSeeds.length);
+        ExecutorService threadPool = Executors.newFixedThreadPool(dnsSeeds.length, new DaemonThreadFactory());
         try {
             List<Callable<InetAddress[]>> tasks = Lists.newArrayList();
             for (final String seed : dnsSeeds) {

--- a/core/src/main/java/org/bitcoinj/net/discovery/TorDiscovery.java
+++ b/core/src/main/java/org/bitcoinj/net/discovery/TorDiscovery.java
@@ -34,6 +34,7 @@ import com.subgraph.orchid.circuits.path.CircuitPathChooser;
 import com.subgraph.orchid.data.HexDigest;
 import com.subgraph.orchid.data.exitpolicy.ExitTarget;
 
+import org.bitcoinj.utils.DaemonThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -252,8 +253,8 @@ public class TorDiscovery implements PeerDiscovery {
     }
 
     private synchronized void createThreadPool(int size) {
-        threadPool =
-                MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(size));
+        threadPool = MoreExecutors.listeningDecorator(
+                Executors.newFixedThreadPool(size, new DaemonThreadFactory()));
     }
 
     private InetAddress lookup(Circuit circuit, String seed) throws UnknownHostException {

--- a/core/src/main/java/org/bitcoinj/utils/DaemonThreadFactory.java
+++ b/core/src/main/java/org/bitcoinj/utils/DaemonThreadFactory.java
@@ -1,0 +1,16 @@
+package org.bitcoinj.utils;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+/** Thread factory whose threads are marked as daemon and won't prevent process exit. */
+public class DaemonThreadFactory implements ThreadFactory {
+
+    @Override
+    public Thread newThread(@Nonnull Runnable runnable) {
+        Thread thread = Executors.defaultThreadFactory().newThread(runnable);
+        thread.setDaemon(true);
+        return thread;
+    }
+}


### PR DESCRIPTION
This way, the thread pool used to run the transaction scripts won’t
prevent applications from exiting. This issue was commented in https://groups.google.com/forum/#!topic/bitcoinj/uCKEJeX2iIA
