### PR TITLE
Overload HD Key deserialization methods with single-argument versions that use a null parent.

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -352,6 +352,15 @@ public class DeterministicKey extends ECKey {
         return Base58.encode(addChecksum(ser));
     }
 
+    /** Deserialize a base-58-encoded HD Key with no parent */
+    public static DeterministicKey deserializeB58(String base58) {
+        return deserializeB58(null, base58);
+    }
+
+    /**
+     * Deserialize a base-58-encoded HD Key.
+     *  @param parent The parent node in the given key's deterministic hierarchy.
+     */
     public static DeterministicKey deserializeB58(@Nullable DeterministicKey parent, String base58) {
         try {
             return deserialize(parent, Base58.decodeChecked(base58));
@@ -360,6 +369,17 @@ public class DeterministicKey extends ECKey {
         }
     }
 
+    /**
+     * Deserialize an HD Key with no parent
+     */
+    public static DeterministicKey deserialize(byte[] serializedKey) {
+        return deserialize(null, serializedKey);
+    }
+
+    /**
+     * Deserialize an HD Key.
+     * @param parent The parent node in the given key's deterministic hierarchy.
+     */
     public static DeterministicKey deserialize(@Nullable DeterministicKey parent, byte[] serializedKey) {
         ByteBuffer buffer = ByteBuffer.wrap(serializedKey);
         int header = buffer.getInt();

--- a/core/src/test/java/org/bitcoinj/crypto/ChildKeyDerivationTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ChildKeyDerivationTest.java
@@ -192,9 +192,13 @@ public class ChildKeyDerivationTest {
             assertArrayEquals(new byte[]{4, -120, -78, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 57, -68, 93, -104, -97, 31, -105, -18, 109, 112, 104, 45, -77, -77, 18, 85, -29, -120, 86, -113, 26, 48, -18, -79, -110, -6, -27, 87, 86, 24, 124, 99, 3, 96, -33, -14, 67, -19, -47, 16, 76, -49, -11, -30, -123, 7, 56, 101, 91, 74, 125, -127, 61, 42, -103, 90, -93, 66, -36, 2, -126, -107, 30, 24, -111}, pub);
             assertArrayEquals(new byte[]{4, -120, -83, -28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 57, -68, 93, -104, -97, 31, -105, -18, 109, 112, 104, 45, -77, -77, 18, 85, -29, -120, 86, -113, 26, 48, -18, -79, -110, -6, -27, 87, 86, 24, 124, 99, 0, -96, -75, 47, 90, -49, 92, -74, 92, -128, -125, 23, 38, -10, 97, -66, -19, 50, -112, 30, -111, -57, -124, 118, -86, 126, -35, -4, -51, 19, 109, 67, 116}, priv);
             assertEquals(DeterministicKey.deserializeB58(null, priv58), key1);
+            assertEquals(DeterministicKey.deserializeB58(priv58), key1);
             assertEquals(DeterministicKey.deserializeB58(null, pub58).getPubKeyPoint(), key1.getPubKeyPoint());
+            assertEquals(DeterministicKey.deserializeB58(pub58).getPubKeyPoint(), key1.getPubKeyPoint());
             assertEquals(DeterministicKey.deserialize(null, priv), key1);
+            assertEquals(DeterministicKey.deserialize(priv), key1);
             assertEquals(DeterministicKey.deserialize(null, pub).getPubKeyPoint(), key1.getPubKeyPoint());
+            assertEquals(DeterministicKey.deserialize(pub).getPubKeyPoint(), key1.getPubKeyPoint());
         }
         {
             final String pub58 = key2.serializePubB58();
@@ -217,6 +221,7 @@ public class ChildKeyDerivationTest {
         assertEquals(key4.getPath().size(), 3);
         assertEquals(DeterministicKey.deserialize(key3, key4.serializePrivate()).getPath().size(), 3);
         assertEquals(DeterministicKey.deserialize(null, key4.serializePrivate()).getPath().size(), 1);
+        assertEquals(DeterministicKey.deserialize(key4.serializePrivate()).getPath().size(), 1);
     }
 
     private static String hexEncodePub(DeterministicKey pubKey) {


### PR DESCRIPTION
For convenience; no new features.  Also added some minimal comments for the deserialization methods.
