### PR TITLE
PeerGroup: add/remove wallets to/from connected peers

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -881,6 +881,9 @@ public class PeerGroup extends AbstractExecutionThreadService implements Transac
             wallet.setTransactionBroadcaster(this);
             wallet.addEventListener(walletEventListener, Threading.SAME_THREAD);
             addPeerFilterProvider(wallet);
+            for (Peer peer : peers) {
+                peer.addWallet(wallet);
+            }
         } finally {
             lock.unlock();
         }
@@ -919,6 +922,9 @@ public class PeerGroup extends AbstractExecutionThreadService implements Transac
         peerFilterProviders.remove(wallet);
         wallet.removeEventListener(walletEventListener);
         wallet.setTransactionBroadcaster(null);
+        for (Peer peer : peers) {
+            peer.removeWallet(wallet);
+        }        
     }
 
     public static enum FilterRecalculateMode {


### PR DESCRIPTION
Description of the problem:
I have an environment where I use multiple wallets. Bitcoinj is started, peers connected. Then I add a wallet by calling peerGroup.addWallet(wallet). Connected peers' wallet lists are not updated, and when I receive a transaction for the new wallet, wallet balance not updated.

Solution:
Add/Remove wallets to the connected peers as they are added/removed to/from the PeerGroup

Current workaround:

``` java
peerGroup.addWallet(wallet);
for (Peer peer : peerGroup.getConnectedPeers()) {
  peer.addWallet(wallet);
}
```
