### PR TITLE
Add javadoc comment for `VersionedChecksummedBytes.toString()`.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/VersionedChecksummedBytes.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionedChecksummedBytes.java
@@ -49,6 +49,10 @@ public class VersionedChecksummedBytes implements Serializable {
         this.bytes = bytes;
     }
 
+    /**
+     * Returns the base-58 encoded String representation of this
+     * object, including version and checksum bytes.
+     */
     @Override
     public String toString() {
         // A stringified buffer is:


### PR DESCRIPTION
I am constantly forgetting whether `Address.toString()` gives me the base-58 encoding of an Address.  This patch adds a javadoc comment telling me that it does so I don't have to keep looking at the source code.
