### PR TITLE
ExamplePaymentChannelClient should not send PeerGroup to the extension

### DIFF
--- a/examples/src/main/java/org/bitcoinj/examples/ExamplePaymentChannelClient.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ExamplePaymentChannelClient.java
@@ -73,7 +73,9 @@ public class ExamplePaymentChannelClient {
                 // The StoredPaymentChannelClientStates object is responsible for, amongst other things, broadcasting
                 // the refund transaction if its lock time has expired. It also persists channels so we can resume them
                 // after a restart.
-                return ImmutableList.<WalletExtension>of(new StoredPaymentChannelClientStates(null, peerGroup()));
+                // We should not send a PeerGroup in the StoredPaymentChannelClientStates constructor
+                // since WalletAppKit will find it for us.
+                return ImmutableList.<WalletExtension>of(new StoredPaymentChannelClientStates(null));
             }
         };
         appKit.connectToLocalHost();


### PR DESCRIPTION
ExamplePaymentChannelClient should not send PeerGroup to the extension StoredPaymentChannelClientStates, since it uses WalletAppKit (Bugfix).
