### PR TITLE
Improve Coin range check to cope with Long.MIN_VALUE correctly

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Coin.java
+++ b/core/src/main/java/org/bitcoinj/core/Coin.java
@@ -82,9 +82,11 @@ public final class Coin implements Monetary, Comparable<Coin>, Serializable {
      */
     public final long value;
 
+    private final long MAX_SATOSHIS = COIN_VALUE * NetworkParameters.MAX_COINS;
+
     private Coin(final long satoshis) {
-        checkArgument(Math.abs(satoshis) <= COIN_VALUE * NetworkParameters.MAX_COINS,
-                      "%s satoshis exceeds maximum possible quantity of Bitcoin.", satoshis);
+        checkArgument(-MAX_SATOSHIS <= satoshis && satoshis <= MAX_SATOSHIS,
+            "%s satoshis exceeds maximum possible quantity of Bitcoin.", satoshis);
         this.value = satoshis;
     }
 

--- a/core/src/test/java/org/bitcoinj/core/CoinTest.java
+++ b/core/src/test/java/org/bitcoinj/core/CoinTest.java
@@ -63,6 +63,11 @@ public class CoinTest {
         }
 
         try {
+            valueOf(Long.MIN_VALUE);
+            fail();
+        } catch (IllegalArgumentException e) {}
+
+        try {
             valueOf(1, -1);
             fail();
         } catch (IllegalArgumentException e) {}


### PR DESCRIPTION
The use of Math.abs() in the existing check doesn't work for Long.MIN_VALUE. Added alternate check and a test case.
