### PR TITLE
Deserializing wallet extensions, lock order is now wallet and then extension.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/core/Wallet.java
@@ -3969,6 +3969,26 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
         }
     }
 
+    /** 
+     * Deserialize the wallet extension with the supplied data and add
+     * it to the wallet, unless there exists an extension with the
+     * same id.
+     */ 
+    public void deserializeAndAddExtension(WalletExtension extension, byte[] data) throws Exception {
+        String id = checkNotNull(extension).getWalletExtensionID();
+        lock.lock();
+        try {
+            if (extensions.containsKey(id)) {
+                return;
+            } else {
+                extension.deserializeWalletExtension(this, data);
+                addExtension(extension);
+            }
+        } finally {
+            lock.unlock();
+        }        
+    }
+    
     @Override
     public synchronized void setTag(String tag, ByteString value) {
         super.setTag(tag, value);

--- a/core/src/main/java/org/bitcoinj/store/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/store/WalletProtobufSerializer.java
@@ -513,13 +513,14 @@ public class WalletProtobufSerializer {
             } else {
                 log.info("Loading wallet extension {}", id);
                 try {
-                    extension.deserializeWalletExtension(wallet, extProto.getData().toByteArray());
-                    wallet.addOrGetExistingExtension(extension);
+                    wallet.deserializeAndAddExtension(extension, extProto.getData().toByteArray());
                 } catch (Exception e) {
-                    if (extProto.getMandatory() && requireMandatoryExtensions)
+                    if (extProto.getMandatory() && requireMandatoryExtensions) {
+                        log.error("Error whilst reading extension {}, failing to read wallet", id, e);
                         throw new UnreadableWalletException("Could not parse mandatory extension in wallet: " + id);
-                    else
+                    } else {
                         log.error("Error whilst reading extension {}, ignoring", id, e);
+                    }
                 }
             }
         }


### PR DESCRIPTION
A deadlock condition exists for locks on Wallet and WalletExtension. At save of wallet, wallet lock is acquired and then wallet extensions lock is acquired. At deserialization of a WalletExtension, the extension's lock is acquired and then the wallet lock can be acquired. This happens if the WalletExtension access the wallet, e.g. getTransaction as used in StoredPaymentChannelClientStates. The proposed fix unconditionally acquires the wallet lock before any extension locks.
