### PR TITLE
Client payment channel state, deserialized from wrong data

### DIFF
--- a/core/src/main/java/org/bitcoinj/protocols/channels/StoredPaymentChannelClientStates.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/StoredPaymentChannelClientStates.java
@@ -300,8 +300,10 @@ public class StoredPaymentChannelClientStates implements WalletExtension {
                         ECKey.fromPrivate(storedState.getMyKey().toByteArray()),
                         Coin.valueOf(storedState.getValueToMe()),
                         Coin.valueOf(storedState.getRefundFees()), false);
-                if (storedState.hasCloseTransactionHash())
-                    channel.close = containingWallet.getTransaction(new Sha256Hash(storedState.toByteArray()));
+                if (storedState.hasCloseTransactionHash()) {
+                    Sha256Hash closeTxHash = new Sha256Hash(storedState.getCloseTransactionHash().toByteArray());
+                    channel.close = containingWallet.getTransaction(closeTxHash);
+                }
                 putChannel(channel, false);
             }
         } finally {


### PR DESCRIPTION
A simple bug: A missing a call to getCloseTransactionHash() on storedState, in wallet extension StoredPaymentChannelClientStates deserialization. Effect was failure to construct Sha256Hash instance, resulting in failure when reading wallet.
