### PR TITLE
Make Coin.parseCoin method to throw an IllegalArgumentException

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Coin.java
+++ b/core/src/main/java/org/bitcoinj/core/Coin.java
@@ -128,7 +128,12 @@ public final class Coin implements Monetary, Comparable<Coin>, Serializable {
      * @throws IllegalArgumentException if you try to specify fractional satoshis, or a value out of range.
      */
     public static Coin parseCoin(final String str) {
-        return Coin.valueOf(new BigDecimal(str).movePointRight(SMALLEST_UNIT_EXPONENT).toBigIntegerExact().longValue());
+        try {
+            long satoshis = new BigDecimal(str).movePointRight(SMALLEST_UNIT_EXPONENT).toBigIntegerExact().longValue();
+            return Coin.valueOf(satoshis);
+        } catch (ArithmeticException e) {
+            throw new IllegalArgumentException(e); // Repackage exception to honor method contract
+        }
     }
 
     public Coin add(final Coin value) {

--- a/core/src/test/java/org/bitcoinj/core/CoinTest.java
+++ b/core/src/test/java/org/bitcoinj/core/CoinTest.java
@@ -39,7 +39,9 @@ public class CoinTest {
         try {
             parseCoin("2E-20");
             org.junit.Assert.fail("should not have accepted fractional satoshis");
-        } catch (ArithmeticException e) {
+        } catch (IllegalArgumentException expected) {
+        } catch (Exception e) {
+            org.junit.Assert.fail("should throw IllegalArgumentException");
         }
     }
 


### PR DESCRIPTION
The Coin.parseCoin method description says:

`@throws IllegalArgumentException if you try to specify fractional satoshis, or a value out of range.`

But throws an ArithmeticException in cases of fractional satoshis.
