### PR TITLE
Make `TransactionBroadcast` recognize network rejection of transmitted transaction

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -396,6 +396,8 @@ public class Peer extends PeerSocketHandler {
                 utxosFuture = null;
                 future.set((UTXOsMessage)m);
             }
+        } else if (m instanceof RejectMessage) {
+            log.error("Received Message {}", m);
         } else {
             log.warn("Received unhandled message: {}", m);
         }

--- a/core/src/main/java/org/bitcoinj/core/RejectMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/RejectMessage.java
@@ -137,6 +137,13 @@ public class RejectMessage extends Message {
         return reason;
     }
 
+
+    /**
+     * A String representation of the relevant details of this reject message.
+     * Be aware that the value returned by this method includes the value returned by
+     * {@link #getReasonString() getReasonString}, which is taken from the reject message unchecked.
+     * Through malice or otherwise, it might contain control characters or other harmful content.
+     */
     @Override
     public String toString() {
         Sha256Hash hash = getRejectedObjectHash();

--- a/core/src/main/java/org/bitcoinj/core/RejectedTransactionException.java
+++ b/core/src/main/java/org/bitcoinj/core/RejectedTransactionException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014 Adam Mackler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.core;
+
+/**
+ * This exception is used by the TransactionBroadcast class to indicate that a broadcast
+ * Transaction has been rejected by the network, for example because it violates a
+ * protocol rule. Note that not all invalid transactions generate a reject message, and
+ * some peers may never do so.
+ */
+public class RejectedTransactionException extends Exception {
+    private Transaction tx;
+    private RejectMessage rejectMessage;
+    
+    public RejectedTransactionException(Transaction tx, RejectMessage rejectMessage) {
+        super(rejectMessage.toString());
+        this.tx = tx;
+        this.rejectMessage = rejectMessage;
+    }
+
+    /** Return the original Transaction object whose broadcast was rejected. */
+    public Transaction getTransaction() { return tx; }
+
+    /** Return the RejectMessage object representing the broadcast rejection. */
+    public RejectMessage getRejectMessage() { return rejectMessage; }
+}


### PR DESCRIPTION
Currently, if you broadcast a transaction and it is rejected, the `TransactionBroadcast` class will not see the reject message, and you have to wait for the timeout to know there was an error.  This patch changes that; the reject message is immediately recognized and the future is completed with a new type of Exception.

Two points:

First, I found it necessary to add the `PeerEventListener` that sets the exception to each connected Peer individually by looping through all connected Peers.  I was under the impression that simply adding a listener to the `PeerGroup` would do that, but apparently that's incorrect.  I'm thinking that either:
1. I'm missing something, and would appreciate correction; or
2. The [comment for `PeerGroup.addEventListener`](https://github.com/bitcoinj/bitcoinj/blob/master/core/src/main/java/org/bitcoinj/core/PeerGroup.java#L555) ought to be rewritten to explain that the added listener only applies to `Peers` that are connected after that method is invoked; or
3. `PeerGroup.addEventListener()` and `PeerGroup.removeEventListener()` ought to be modified so that listeners are added and removed from currently connected Peers.

Second, there are no tests with this patch.  I'm not a super test-writing expert, especially when it comes to tests that interact with the outside world, such as the network.  Also, I don't see any existing tests for `TransactionBroadcast`.  Maybe someone could give me some guidance how this patch should be tested.

One thing in particular that concerns me is that when the listener is added or removed from the Peers it uses the `PeerGroup.getConnectedPeers()` method to get the list of Peers to loop through.  There is also a `getPendingPeers()` method.  Is it possible that a Peer could be connected at such a time that the listener is not added correctly?  Should this patch add/remove the listener from the pending Peers as well as connected Peers?
