### PR TITLE
Don't allow creation of seeds with null passphrase

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -214,7 +214,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
             return self();
         }
 
-        /** The passphrase to use with the generated mnemonic, or null. Currently must be empty. */
+        /** The passphrase to use with the generated mnemonic, or null if you would like to use the default empty string. Currently must be the empty string. */
         public T passphrase(String passphrase) {
             // FIXME support non-empty passphrase
             this.passphrase = passphrase;
@@ -228,14 +228,19 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
             DeterministicKeyChain chain;
 
             if (random != null) {
-                chain = new DeterministicKeyChain(random, bits, passphrase, seedCreationTimeSecs);
+                // Default passphrase to "" if not specified
+                chain = new DeterministicKeyChain(random, bits, getPassphrase(), seedCreationTimeSecs);
             } else if (entropy != null) {
-                chain = new DeterministicKeyChain(entropy, passphrase, seedCreationTimeSecs);
+                chain = new DeterministicKeyChain(entropy, getPassphrase(), seedCreationTimeSecs);
             } else {
                 chain = new DeterministicKeyChain(seed);
             }
 
             return chain;
+        }
+
+        protected String getPassphrase() {
+            return passphrase != null ? passphrase : DEFAULT_PASSPHRASE_FOR_MNEMONIC;
         }
     }
 

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
@@ -30,6 +30,7 @@ import java.io.UnsupportedEncodingException;
 import java.security.SecureRandom;
 import java.util.List;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.bitcoinj.core.Utils.HEX;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
@@ -78,7 +79,7 @@ public class DeterministicSeed implements EncryptableItem {
      * @param creationTimeSeconds When the seed was originally created, UNIX time.
      */
     public DeterministicSeed(List<String> mnemonicCode, @Nullable byte[] seed, String passphrase, long creationTimeSeconds) {
-        this((seed != null ? seed : MnemonicCode.toSeed(mnemonicCode, passphrase)), mnemonicCode, creationTimeSeconds);
+        this((seed != null ? seed : MnemonicCode.toSeed(mnemonicCode, checkNotNull(passphrase))), mnemonicCode, creationTimeSeconds);
     }
 
     /**
@@ -90,7 +91,7 @@ public class DeterministicSeed implements EncryptableItem {
      * @param creationTimeSeconds When the seed was originally created, UNIX time.
      */
     public DeterministicSeed(SecureRandom random, int bits, String passphrase, long creationTimeSeconds) {
-        this(getEntropy(random, bits), passphrase, creationTimeSeconds);
+        this(getEntropy(random, bits), checkNotNull(passphrase), creationTimeSeconds);
     }
 
     /**
@@ -101,8 +102,9 @@ public class DeterministicSeed implements EncryptableItem {
      * @param creationTimeSeconds When the seed was originally created, UNIX time.
      */
     public DeterministicSeed(byte[] entropy, String passphrase, long creationTimeSeconds) {
-        Preconditions.checkArgument(entropy.length % 4 == 0, "entropy size in bits not divisible by 32");
-        Preconditions.checkArgument(entropy.length * 8 >= DEFAULT_SEED_ENTROPY_BITS, "entropy size too small");
+        checkArgument(entropy.length % 4 == 0, "entropy size in bits not divisible by 32");
+        checkArgument(entropy.length * 8 >= DEFAULT_SEED_ENTROPY_BITS, "entropy size too small");
+        checkNotNull(passphrase);
 
         try {
             this.mnemonicCode = MnemonicCode.INSTANCE.toMnemonic(entropy);
@@ -116,7 +118,7 @@ public class DeterministicSeed implements EncryptableItem {
     }
 
     private static byte[] getEntropy(SecureRandom random, int bits) {
-        Preconditions.checkArgument(bits <= MAX_SEED_ENTROPY_BITS, "requested entropy size too large");
+        checkArgument(bits <= MAX_SEED_ENTROPY_BITS, "requested entropy size too large");
 
         byte[] seed = new byte[bits / 8];
         random.nextBytes(seed);

--- a/core/src/main/java/org/bitcoinj/wallet/MarriedKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/MarriedKeyChain.java
@@ -97,9 +97,9 @@ public class MarriedKeyChain extends DeterministicKeyChain {
             if (threshold == 0)
                 threshold = (followingKeys.size() + 1) / 2 + 1;
             if (random != null) {
-                chain = new MarriedKeyChain(random, bits, passphrase, seedCreationTimeSecs);
+                chain = new MarriedKeyChain(random, bits, getPassphrase(), seedCreationTimeSecs);
             } else if (entropy != null) {
-                chain = new MarriedKeyChain(entropy, passphrase, seedCreationTimeSecs);
+                chain = new MarriedKeyChain(entropy, getPassphrase(), seedCreationTimeSecs);
             } else {
                 chain = new MarriedKeyChain(seed);
             }


### PR DESCRIPTION
It should be the empty string as the standard default.  Right now if people use the builder pattern, they get the string "null" in the passphrase.  Since this is a new API as of 0.12, I'm assuming that nobody ran into this yet.
