### PR TITLE
Adds coveralls.io support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ script:
   - jdk_switcher use oraclejdk8
   - mvn -q clean install
 
+after_success:
+  - cd ../core
+  - mvn jacoco:report coveralls:report
+
 notifications:
   irc:
     channels: "irc.freenode.net#bitcoinj"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-Build status: [![Build Status](https://travis-ci.org/bitcoinj/bitcoinj.png?branch=master)](https://travis-ci.org/bitcoinj/bitcoinj)
+Build status: [![Build Status](https://travis-ci.org/bitcoinj/bitcoinj.png?branch=master)](https://travis-ci.org/bitcoinj/bitcoinj)  
+Coverage status: [![Coverage Status](https://coveralls.io/repos/bitcoinj/bitcoinj/badge.png?branch=master)](https://coveralls.io/r/bitcoinj/bitcoinj?branch=master)
 
 ### Welcome to bitcoinj
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -196,6 +196,7 @@
                                         <url>com.fasterxml.jackson.core:jackson-core:2.4.2:jar:null:test:ceb72830d95c512b4b300a38f29febc85bdf6e4b</url>
                                         <url>com.fasterxml.jackson.core:jackson-annotations:2.4.2:jar:null:test:6bb52af09372d5064206d47d7887d41671f00f7d</url>
                                         <urn>org.jacoco:jacoco-maven-plugin:0.7.2.201409121644:maven-plugin:null:runtime:b2cb310459d082db505fdfa66dbadd4d8bac8e34</urn>
+                                        <urn>org.eluder.coveralls:coveralls-maven-plugin:3.0.1:maven-plugin:null:runtime:3907ee5cf1e5c85af7bb90e486ce4c7b1408a552</urn>
                                         <!-- A check for the rules themselves -->
                                         <urn>uk.co.froot.maven.enforcer:digest-enforcer-rules:0.0.1:jar:null:runtime:16a9e04f3fe4bb143c42782d07d5faf65b32106f</urn>
                                     </urns>
@@ -293,6 +294,13 @@
                 <configuration>
                     <argLine>${surefireArgLine}</argLine> <!-- This is required for code coverage to work. -->
                 </configuration>
+            </plugin>
+
+            <!-- Coveralls is a online code coverage tool, you can track code coverage here: https://coveralls.io/r/bitcoinj/bitcoinj -->
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>3.0.1</version>
             </plugin>
 
             <!-- Create a bundled executable test jar that runs the regtester/pulltester.


### PR DESCRIPTION
This PR is a followup to #256, JaCoCo coverages will be generated by travis-ci and published to coveralls.io, the report will be here: https://coveralls.io/r/bitcoinj/bitcoinj

This is required by someone with github access:
1. Signup on coveralls.io
2. Add repository "bitcoinj"
After travis builds a project you should see code coverage reports there and also the badge on README.md page will show correct values.
