### PR TITLE
When reading wallets, catch another possible data inconsistency...

### DIFF
--- a/core/src/main/java/org/bitcoinj/store/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/store/WalletProtobufSerializer.java
@@ -386,6 +386,8 @@ public class WalletProtobufSerializer {
             return readWallet(params, null, walletProto);
         } catch (IOException e) {
             throw new UnreadableWalletException("Could not parse input stream to protobuf", e);
+        } catch (IllegalStateException e) {
+            throw new UnreadableWalletException("Could not parse input stream to protobuf", e);
         }
     }
 


### PR DESCRIPTION
...and throw UnreadableWalletException.

FWIW, here is the exception that kept the wallet from loading:

E/AndroidRuntime( 5367): Caused by: java.lang.IllegalStateException
E/AndroidRuntime( 5367):    at com.google.common.base.Preconditions.checkState(Preconditions.java:161)
E/AndroidRuntime( 5367):    at org.bitcoinj.wallet.DeterministicKeyChain.fromProtobuf(DeterministicKeyChain.java:773)
E/AndroidRuntime( 5367):    at org.bitcoinj.wallet.KeyChainGroup.fromProtobufUnencrypted(KeyChainGroup.java:735)
E/AndroidRuntime( 5367):    at org.bitcoinj.store.WalletProtobufSerializer.readWallet(WalletProtobufSerializer.java:422)
E/AndroidRuntime( 5367):    at org.bitcoinj.store.WalletProtobufSerializer.readWallet(WalletProtobufSerializer.java:389)
E/AndroidRuntime( 5367):    at de.schildbach.wallet.WalletApplication.loadWalletFromProtobuf(WalletApplication.java:248)
E/AndroidRuntime( 5367):    at de.schildbach.wallet.WalletApplication.onCreate(WalletApplication.java:132)
