### PR TITLE
Fix for issue 570 - NetworkParams to DeterministicKey serialization/deserialization

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -75,6 +75,8 @@ public abstract class NetworkParameters implements Serializable {
     protected int interval;
     protected int targetTimespan;
     protected byte[] alertSigningKey;
+    protected int bip32HeaderPub;
+    protected int bip32HeaderPriv;
 
     /**
      * See getId(). This may be null for old deserialized wallets. In that case we derive it heuristically
@@ -343,5 +345,15 @@ public abstract class NetworkParameters implements Serializable {
      */
     public byte[] getAlertSigningKey() {
         return alertSigningKey;
+    }
+
+    /** Returns the 4 byte header for BIP32 (HD) wallet - public key part. */
+    public int getBip32HeaderPub() {
+        return bip32HeaderPub;
+    }
+
+    /** Returns the 4 byte header for BIP32 (HD) wallet - private key part. */
+    public int getBip32HeaderPriv() {
+        return bip32HeaderPriv;
     }
 }

--- a/core/src/main/java/org/bitcoinj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/MainNetParams.java
@@ -37,6 +37,9 @@ public class MainNetParams extends NetworkParameters {
         acceptableAddressCodes = new int[] { addressHeader, p2shHeader };
         port = 8333;
         packetMagic = 0xf9beb4d9L;
+        bip32HeaderPub = 0x0488B21E; //The 4 byte header that serializes in base58 to "xpub".
+        bip32HeaderPriv = 0x0488ADE4; //The 4 byte header that serializes in base58 to "xprv"
+
         genesisBlock.setDifficultyTarget(0x1d00ffffL);
         genesisBlock.setTime(1231006505L);
         genesisBlock.setNonce(2083236893);

--- a/core/src/main/java/org/bitcoinj/params/TestNet2Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet2Params.java
@@ -46,6 +46,8 @@ public class TestNet2Params extends NetworkParameters {
         String genesisHash = genesisBlock.getHashAsString();
         checkState(genesisHash.equals("00000007199508e34a9ff81e6ec0c477a4cccff2a4767a8eee39c11db367b008"));
         dnsSeeds = null;
+        bip32HeaderPub = 0x043587CF;
+        bip32HeaderPriv = 0x04358394;
     }
 
     private static TestNet2Params instance;

--- a/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
@@ -54,6 +54,8 @@ public class TestNet3Params extends NetworkParameters {
                 "testnet-seed.bitcoin.schildbach.de", // Andreas Schildbach
                 "testnet-seed.bitcoin.petertodd.org"  // Peter Todd
         };
+        bip32HeaderPub = 0x043587CF;
+        bip32HeaderPriv = 0x04358394;
     }
 
     private static TestNet3Params instance;

--- a/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
@@ -44,6 +44,8 @@ public class UnitTestParams extends NetworkParameters {
         spendableCoinbaseDepth = 5;
         subsidyDecreaseBlockCount = 100;
         dnsSeeds = null;
+        bip32HeaderPub = 0x043587CF;
+        bip32HeaderPriv = 0x04358394;
     }
 
     private static UnitTestParams instance;

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -1285,7 +1285,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
         // due to the parent fingerprint being missing/not stored. In future we could store the parent fingerprint
         // optionally as well to fix this, but it seems unimportant for now.
         if (watchingKey.getParent() != null) {
-            builder2.append(String.format("Key to watch:  %s%n", watchingKey.serializePubB58()));
+            builder2.append(String.format("Key to watch:  %s%n", watchingKey.serializePubB58(params)));
         }
         formatAddresses(includePrivateKeys, params, builder2);
         return builder2.toString();

--- a/core/src/main/java/org/bitcoinj/wallet/MarriedKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/MarriedKeyChain.java
@@ -232,7 +232,7 @@ public class MarriedKeyChain extends DeterministicKeyChain {
     @Override
     protected void formatAddresses(boolean includePrivateKeys, NetworkParameters params, StringBuilder builder2) {
         for (DeterministicKeyChain followingChain : followingKeyChains) {
-            builder2.append(String.format("Following chain:  %s%n", followingChain.getWatchingKey().serializePubB58()));
+            builder2.append(String.format("Following chain:  %s%n", followingChain.getWatchingKey().serializePubB58(params)));
         }
         builder2.append(String.format("%n"));
         for (RedeemData redeemData : marriedKeysRedeemData.values())

--- a/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
@@ -21,6 +21,7 @@ import org.bitcoinj.params.MainNetParams;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.net.InetAddress;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -63,6 +64,12 @@ public class BitcoinSerializerTest {
         assertEquals("10.0.0.1", pa.getAddr().getHostAddress());
         ByteArrayOutputStream bos = new ByteArrayOutputStream(addrMessage.length);
         bs.serialize(a, bos);
+
+        assertEquals(31, a.getMessageSize());
+        a.addAddress(new PeerAddress(InetAddress.getLocalHost()));
+        assertEquals(61, a.getMessageSize());
+        a.removeAddress(0);
+        assertEquals(31, a.getMessageSize());
 
         //this wont be true due to dynamic timestamps.
         //assertTrue(LazyParseByteCacheTest.arrayContains(bos.toByteArray(), addrMessage));

--- a/core/src/test/java/org/bitcoinj/core/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/core/WalletTest.java
@@ -110,7 +110,7 @@ public class WalletTest extends TestWithWallet {
         List<DeterministicKey> followingKeys = Lists.newArrayList();
         for (int i = 0; i < numKeys - 1; i++) {
             final DeterministicKeyChain keyChain = new DeterministicKeyChain(new SecureRandom());
-            DeterministicKey partnerKey = DeterministicKey.deserializeB58(null, keyChain.getWatchingKey().serializePubB58());
+            DeterministicKey partnerKey = DeterministicKey.deserializeB58(null, keyChain.getWatchingKey().serializePubB58(params), params);
             followingKeys.add(partnerKey);
             if (addSigners && i < threshold - 1)
                 wallet.addTransactionSigner(new KeyChainTransactionSigner(keyChain));
@@ -1154,8 +1154,8 @@ public class WalletTest extends TestWithWallet {
     @Test(expected = ECKey.MissingPrivateKeyException.class)
     public void watchingWallet() throws Exception {
         DeterministicKey watchKey = wallet.getWatchingKey();
-        String serialized = watchKey.serializePubB58();
-        watchKey = DeterministicKey.deserializeB58(null, serialized);
+        String serialized = watchKey.serializePubB58(params);
+        watchKey = DeterministicKey.deserializeB58(null, serialized, params);
         Wallet watchingWallet = Wallet.fromWatchingKey(params, watchKey);
         DeterministicKey key2 = watchingWallet.freshReceiveKey();
         assertEquals(myKey, key2);
@@ -1170,8 +1170,8 @@ public class WalletTest extends TestWithWallet {
     @Test(expected = ECKey.MissingPrivateKeyException.class)
     public void watchingWalletWithCreationTime() throws Exception {
         DeterministicKey watchKey = wallet.getWatchingKey();
-        String serialized = watchKey.serializePubB58();
-        watchKey = DeterministicKey.deserializeB58(null, serialized);
+        String serialized = watchKey.serializePubB58(params);
+        watchKey = DeterministicKey.deserializeB58(null, serialized, params);
         Wallet watchingWallet = Wallet.fromWatchingKey(params, watchKey, 1415282801);
         DeterministicKey key2 = watchingWallet.freshReceiveKey();
         assertEquals(myKey, key2);
@@ -2916,14 +2916,14 @@ public class WalletTest extends TestWithWallet {
     @Test
     public void watchingMarriedWallet() throws Exception {
         DeterministicKey watchKey = wallet.getWatchingKey();
-        String serialized = watchKey.serializePubB58();
-        watchKey = DeterministicKey.deserializeB58(null, serialized);
+        String serialized = watchKey.serializePubB58(params);
+        watchKey = DeterministicKey.deserializeB58(null, serialized, params);
         Wallet wallet = Wallet.fromWatchingKey(params, watchKey);
         blockStore = new MemoryBlockStore(params);
         chain = new BlockChain(params, wallet, blockStore);
 
         final DeterministicKeyChain keyChain = new DeterministicKeyChain(new SecureRandom());
-        DeterministicKey partnerKey = DeterministicKey.deserializeB58(null, keyChain.getWatchingKey().serializePubB58());
+        DeterministicKey partnerKey = DeterministicKey.deserializeB58(null, keyChain.getWatchingKey().serializePubB58(params), params);
 
         TransactionSigner signer = new StatelessTransactionSigner() {
             @Override

--- a/core/src/test/java/org/bitcoinj/crypto/BIP32Test.java
+++ b/core/src/test/java/org/bitcoinj/crypto/BIP32Test.java
@@ -22,6 +22,9 @@ import org.bitcoinj.core.Base58;
 import com.google.common.base.Functions;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Iterables;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.params.MainNetParams;
+import org.bitcoinj.params.UnitTestParams;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -128,9 +131,10 @@ public class BIP32Test {
     private void testVector(int testCase) throws AddressFormatException {
         log.info("=======  Test vector {}", testCase);
         HDWTestVector tv = tvs[testCase];
+        NetworkParameters params = MainNetParams.get();
         DeterministicKey masterPrivateKey = HDKeyDerivation.createMasterPrivateKey(HEX.decode(tv.seed));
-        assertEquals(testEncode(tv.priv), testEncode(masterPrivateKey.serializePrivB58()));
-        assertEquals(testEncode(tv.pub), testEncode(masterPrivateKey.serializePubB58()));
+        assertEquals(testEncode(tv.priv), testEncode(masterPrivateKey.serializePrivB58(params)));
+        assertEquals(testEncode(tv.pub), testEncode(masterPrivateKey.serializePubB58(params)));
         DeterministicHierarchy dh = new DeterministicHierarchy(masterPrivateKey);
         for (int i = 0; i < tv.derived.size(); i++) {
             HDWTestVector.DerivedTestCase tc = tv.derived.get(i);
@@ -138,8 +142,8 @@ public class BIP32Test {
             assertEquals(tc.name, String.format("Test%d %s", testCase + 1, tc.getPathDescription()));
             int depth = tc.path.length - 1;
             DeterministicKey ehkey = dh.deriveChild(Arrays.asList(tc.path).subList(0, depth), false, true, tc.path[depth]);
-            assertEquals(testEncode(tc.priv), testEncode(ehkey.serializePrivB58()));
-            assertEquals(testEncode(tc.pub), testEncode(ehkey.serializePubB58()));
+            assertEquals(testEncode(tc.priv), testEncode(ehkey.serializePrivB58(params)));
+            assertEquals(testEncode(tc.pub), testEncode(ehkey.serializePubB58(params)));
         }
     }
 

--- a/core/src/test/java/org/bitcoinj/crypto/ChildKeyDerivationTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ChildKeyDerivationTest.java
@@ -18,7 +18,11 @@
 package org.bitcoinj.crypto;
 
 import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Sha256Hash;
+import org.bitcoinj.params.MainNetParams;
+import org.bitcoinj.params.TestNet3Params;
+import org.bitcoinj.params.UnitTestParams;
 import org.junit.Test;
 import org.spongycastle.crypto.params.KeyParameter;
 
@@ -174,6 +178,21 @@ public class ChildKeyDerivationTest {
     }
 
     @Test
+    public void testSerializationMainAndTestNetworks() {
+        DeterministicKey key1 = HDKeyDerivation.createMasterPrivateKey("satoshi lives!".getBytes());
+        NetworkParameters params = MainNetParams.get();
+        String pub58 = key1.serializePubB58(params);
+        String priv58 = key1.serializePrivB58(params);
+        assertEquals("xpub661MyMwAqRbcF7mq7Aejj5xZNzFfgi3ABamE9FedDHVmViSzSxYTgAQGcATDo2J821q7Y9EAagjg5EP3L7uBZk11PxZU3hikL59dexfLkz3", pub58);
+        assertEquals("xprv9s21ZrQH143K2dhN197jMx1ppxRBHFKJpMqdLsF1ewxncv7quRED8N5nksxphju3W7naj1arF56L5PUEWfuSk8h73Sb2uh7bSwyXNrjzhAZ", priv58);
+        params = TestNet3Params.get();
+        pub58 = key1.serializePubB58(params);
+        priv58 = key1.serializePrivB58(params);
+        assertEquals("tpubD6NzVbkrYhZ4WuxgZMdpw1Hvi7MKg6YDjDMXVohmZCFfF17hXBPYpc56rCY1KXFMovN29ik37nZimQseiykRTBTJTZJmjENyv2k3R12BJ1M", pub58);
+        assertEquals("tprv8ZgxMBicQKsPdSvtfhyEXbdp95qPWmMK9ukkDHfU8vTGQWrvtnZxe7TEg48Ui7HMsZKMj7CcQRg8YF1ydtFPZBxha5oLa3qeN3iwpYhHPVZ", priv58);
+    }
+
+    @Test
     public void serializeToTextAndBytes() {
         DeterministicKey key1 = HDKeyDerivation.createMasterPrivateKey("satoshi lives!".getBytes());
         DeterministicKey key2 = HDKeyDerivation.deriveChildKey(key1, ChildNumber.ZERO_HARDENED);
@@ -181,47 +200,49 @@ public class ChildKeyDerivationTest {
         // Creation time can't survive the xpub serialization format unfortunately.
         key1.setCreationTimeSeconds(0);
         key2.setCreationTimeSeconds(0);
+        NetworkParameters params = MainNetParams.get();
 
         {
-            final String pub58 = key1.serializePubB58();
-            final String priv58 = key1.serializePrivB58();
-            final byte[] pub = key1.serializePublic();
-            final byte[] priv = key1.serializePrivate();
+            final String pub58 = key1.serializePubB58(params);
+            final String priv58 = key1.serializePrivB58(params);
+            final byte[] pub = key1.serializePublic(params);
+            final byte[] priv = key1.serializePrivate(params);
             assertEquals("xpub661MyMwAqRbcF7mq7Aejj5xZNzFfgi3ABamE9FedDHVmViSzSxYTgAQGcATDo2J821q7Y9EAagjg5EP3L7uBZk11PxZU3hikL59dexfLkz3", pub58);
             assertEquals("xprv9s21ZrQH143K2dhN197jMx1ppxRBHFKJpMqdLsF1ewxncv7quRED8N5nksxphju3W7naj1arF56L5PUEWfuSk8h73Sb2uh7bSwyXNrjzhAZ", priv58);
             assertArrayEquals(new byte[]{4, -120, -78, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 57, -68, 93, -104, -97, 31, -105, -18, 109, 112, 104, 45, -77, -77, 18, 85, -29, -120, 86, -113, 26, 48, -18, -79, -110, -6, -27, 87, 86, 24, 124, 99, 3, 96, -33, -14, 67, -19, -47, 16, 76, -49, -11, -30, -123, 7, 56, 101, 91, 74, 125, -127, 61, 42, -103, 90, -93, 66, -36, 2, -126, -107, 30, 24, -111}, pub);
             assertArrayEquals(new byte[]{4, -120, -83, -28, 0, 0, 0, 0, 0, 0, 0, 0, 0, 57, -68, 93, -104, -97, 31, -105, -18, 109, 112, 104, 45, -77, -77, 18, 85, -29, -120, 86, -113, 26, 48, -18, -79, -110, -6, -27, 87, 86, 24, 124, 99, 0, -96, -75, 47, 90, -49, 92, -74, 92, -128, -125, 23, 38, -10, 97, -66, -19, 50, -112, 30, -111, -57, -124, 118, -86, 126, -35, -4, -51, 19, 109, 67, 116}, priv);
-            assertEquals(DeterministicKey.deserializeB58(null, priv58), key1);
-            assertEquals(DeterministicKey.deserializeB58(priv58), key1);
-            assertEquals(DeterministicKey.deserializeB58(null, pub58).getPubKeyPoint(), key1.getPubKeyPoint());
-            assertEquals(DeterministicKey.deserializeB58(pub58).getPubKeyPoint(), key1.getPubKeyPoint());
-            assertEquals(DeterministicKey.deserialize(null, priv), key1);
-            assertEquals(DeterministicKey.deserialize(priv), key1);
-            assertEquals(DeterministicKey.deserialize(null, pub).getPubKeyPoint(), key1.getPubKeyPoint());
-            assertEquals(DeterministicKey.deserialize(pub).getPubKeyPoint(), key1.getPubKeyPoint());
+            assertEquals(DeterministicKey.deserializeB58(null, priv58, params), key1);
+            assertEquals(DeterministicKey.deserializeB58(priv58, params), key1);
+            assertEquals(DeterministicKey.deserializeB58(null, pub58, params).getPubKeyPoint(), key1.getPubKeyPoint());
+            assertEquals(DeterministicKey.deserializeB58(pub58, params).getPubKeyPoint(), key1.getPubKeyPoint());
+            assertEquals(DeterministicKey.deserialize(null, priv, params), key1);
+            assertEquals(DeterministicKey.deserialize(priv, params), key1);
+            assertEquals(DeterministicKey.deserialize(null, pub, params).getPubKeyPoint(), key1.getPubKeyPoint());
+            assertEquals(DeterministicKey.deserialize(pub, params).getPubKeyPoint(), key1.getPubKeyPoint());
         }
         {
-            final String pub58 = key2.serializePubB58();
-            final String priv58 = key2.serializePrivB58();
-            final byte[] pub = key2.serializePublic();
-            final byte[] priv = key2.serializePrivate();
-            assertEquals(DeterministicKey.deserializeB58(key1, priv58), key2);
-            assertEquals(DeterministicKey.deserializeB58(key1, pub58).getPubKeyPoint(), key2.getPubKeyPoint());
-            assertEquals(DeterministicKey.deserialize(key1, priv), key2);
-            assertEquals(DeterministicKey.deserialize(key1, pub).getPubKeyPoint(), key2.getPubKeyPoint());
+            final String pub58 = key2.serializePubB58(params);
+            final String priv58 = key2.serializePrivB58(params);
+            final byte[] pub = key2.serializePublic(params);
+            final byte[] priv = key2.serializePrivate(params);
+            assertEquals(DeterministicKey.deserializeB58(key1, priv58, params), key2);
+            assertEquals(DeterministicKey.deserializeB58(key1, pub58, params).getPubKeyPoint(), key2.getPubKeyPoint());
+            assertEquals(DeterministicKey.deserialize(key1, priv, params), key2);
+            assertEquals(DeterministicKey.deserialize(key1, pub, params).getPubKeyPoint(), key2.getPubKeyPoint());
         }
     }
 
     @Test
     public void parentlessDeserialization() {
+        NetworkParameters params = UnitTestParams.get();
         DeterministicKey key1 = HDKeyDerivation.createMasterPrivateKey("satoshi lives!".getBytes());
         DeterministicKey key2 = HDKeyDerivation.deriveChildKey(key1, ChildNumber.ZERO_HARDENED);
         DeterministicKey key3 = HDKeyDerivation.deriveChildKey(key2, ChildNumber.ZERO_HARDENED);
         DeterministicKey key4 = HDKeyDerivation.deriveChildKey(key3, ChildNumber.ZERO_HARDENED);
         assertEquals(key4.getPath().size(), 3);
-        assertEquals(DeterministicKey.deserialize(key3, key4.serializePrivate()).getPath().size(), 3);
-        assertEquals(DeterministicKey.deserialize(null, key4.serializePrivate()).getPath().size(), 1);
-        assertEquals(DeterministicKey.deserialize(key4.serializePrivate()).getPath().size(), 1);
+        assertEquals(DeterministicKey.deserialize(key3, key4.serializePrivate(params), params).getPath().size(), 3);
+        assertEquals(DeterministicKey.deserialize(null, key4.serializePrivate(params), params).getPath().size(), 1);
+        assertEquals(DeterministicKey.deserialize(key4.serializePrivate(params), params).getPath().size(), 1);
     }
 
     private static String hexEncodePub(DeterministicKey pubKey) {

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -290,7 +290,7 @@ public class WalletProtobufSerializerTest {
         // create 2-of-2 married wallet
         myWallet = new Wallet(params);
         final DeterministicKeyChain partnerChain = new DeterministicKeyChain(new SecureRandom());
-        DeterministicKey partnerKey = DeterministicKey.deserializeB58(null, partnerChain.getWatchingKey().serializePubB58());
+        DeterministicKey partnerKey = DeterministicKey.deserializeB58(null, partnerChain.getWatchingKey().serializePubB58(params), params);
         MarriedKeyChain chain = MarriedKeyChain.builder()
                 .random(new SecureRandom())
                 .followingKeys(partnerKey)

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -19,6 +19,7 @@ package org.bitcoinj.wallet;
 import org.bitcoinj.core.*;
 import org.bitcoinj.crypto.DeterministicHierarchy;
 import org.bitcoinj.crypto.DeterministicKey;
+import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.UnitTestParams;
 import org.bitcoinj.store.UnreadableWalletException;
 import org.bitcoinj.utils.BriefLogFormatter;
@@ -238,10 +239,11 @@ public class DeterministicKeyChainTest {
         DeterministicKey key3 = chain.getKey(KeyChain.KeyPurpose.CHANGE);
         DeterministicKey key4 = chain.getKey(KeyChain.KeyPurpose.CHANGE);
 
+        NetworkParameters params = MainNetParams.get();
         DeterministicKey watchingKey = chain.getWatchingKey();
-        final String pub58 = watchingKey.serializePubB58();
+        final String pub58 = watchingKey.serializePubB58(params);
         assertEquals("xpub69KR9epSNBM59KLuasxMU5CyKytMJjBP5HEZ5p8YoGUCpM6cM9hqxB9DDPCpUUtqmw5duTckvPfwpoWGQUFPmRLpxs5jYiTf2u6xRMcdhDf", pub58);
-        watchingKey = DeterministicKey.deserializeB58(null, pub58);
+        watchingKey = DeterministicKey.deserializeB58(null, pub58, params);
         watchingKey.setCreationTimeSeconds(100000);
         chain = DeterministicKeyChain.watch(watchingKey);
         assertEquals(DeterministicHierarchy.BIP32_STANDARDISATION_TIME_SECS, chain.getEarliestKeyCreationTime());

--- a/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
@@ -52,7 +52,7 @@ public class KeyChainGroupTest {
         group.setLookaheadSize(LOOKAHEAD_SIZE);   // Don't want slow tests.
         group.getActiveKeyChain();  // Force create a chain.
 
-        watchingAccountKey = DeterministicKey.deserializeB58(null, XPUB);
+        watchingAccountKey = DeterministicKey.deserializeB58(null, XPUB, params);
     }
 
     private KeyChainGroup createMarriedKeyChainGroup() {

--- a/tools/src/main/java/org/bitcoinj/tools/WalletTool.java
+++ b/tools/src/main/java/org/bitcoinj/tools/WalletTool.java
@@ -432,7 +432,7 @@ public class WalletTool {
         String[] xpubkeys = options.valueOf(xpubkeysFlag).split(",");
         ImmutableList.Builder<DeterministicKey> keys = ImmutableList.builder();
         for (String xpubkey : xpubkeys) {
-            keys.add(DeterministicKey.deserializeB58(null, xpubkey.trim()));
+            keys.add(DeterministicKey.deserializeB58(null, xpubkey.trim(), params));
         }
         MarriedKeyChain chain = MarriedKeyChain.builder()
                 .random(new SecureRandom())
@@ -913,7 +913,7 @@ public class WalletTool {
             }
             wallet = Wallet.fromSeed(params, seed);
         } else if (options.has(watchFlag)) {
-            DeterministicKey watchKey = DeterministicKey.deserializeB58(null, options.valueOf(watchFlag));
+            DeterministicKey watchKey = DeterministicKey.deserializeB58(null, options.valueOf(watchFlag), params);
             wallet = Wallet.fromWatchingKey(params, watchKey);
         } else {
             wallet = new Wallet(params);


### PR DESCRIPTION
I have added NetworkParams everywhere in DeterministicKey serialization/deserialization. At the same time I have added one test to cover serialization with different networks and added more asserts to one test in BitcoinSerializerTest.
