### PR TITLE
ECKey/DeterministicKey: replace ECPoint with a LazyECPoint wrapper that ...

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -49,7 +49,7 @@ public class DeterministicKey extends ECKey {
     /** Constructs a key from its components. This is not normally something you should use. */
     public DeterministicKey(ImmutableList<ChildNumber> childNumberPath,
                             byte[] chainCode,
-                            ECPoint publicAsPoint,
+                            LazyECPoint publicAsPoint,
                             @Nullable BigInteger priv,
                             @Nullable DeterministicKey parent) {
         super(priv, compressPoint(checkNotNull(publicAsPoint)));
@@ -74,7 +74,10 @@ public class DeterministicKey extends ECKey {
     /** Constructs a key from its components. This is not normally something you should use. */
     public DeterministicKey(ImmutableList<ChildNumber> childNumberPath,
                             byte[] chainCode,
-                            KeyCrypter crypter, ECPoint pub, EncryptedData priv, @Nullable DeterministicKey parent) {
+                            KeyCrypter crypter,
+                            LazyECPoint pub,
+                            EncryptedData priv,
+                            @Nullable DeterministicKey parent) {
         this(childNumberPath, chainCode, pub, null, parent);
         this.encryptedPrivateKey = checkNotNull(priv);
         this.keyCrypter = checkNotNull(crypter);
@@ -82,7 +85,7 @@ public class DeterministicKey extends ECKey {
 
     /** Clones the key */
     public DeterministicKey(DeterministicKey keyToClone, DeterministicKey newParent) {
-        super(keyToClone.priv, keyToClone.pub);
+        super(keyToClone.priv, keyToClone.pub.get());
         this.parent = newParent;
         this.childNumberPath = keyToClone.childNumberPath;
         this.chainCode = keyToClone.chainCode;
@@ -155,8 +158,7 @@ public class DeterministicKey extends ECKey {
      */
     public DeterministicKey getPubOnly() {
         if (isPubKeyOnly()) return this;
-        //final DeterministicKey parentPub = getParent() == null ? null : getParent().getPubOnly();
-        return new DeterministicKey(getPath(), getChainCode(), getPubKeyPoint(), null, parent);
+        return new DeterministicKey(getPath(), getChainCode(), pub, null, parent);
     }
 
 
@@ -413,7 +415,7 @@ public class DeterministicKey extends ECKey {
         checkArgument(!buffer.hasRemaining(), "Found unexpected data in key");
         if (pub) {
             ECPoint point = ECKey.CURVE.getCurve().decodePoint(data);
-            return new DeterministicKey(path, chainCode, point, null, parent);
+            return new DeterministicKey(path, chainCode, new LazyECPoint(point), null, parent);
         } else {
             return new DeterministicKey(path, chainCode, new BigInteger(1, data), parent);
         }

--- a/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
@@ -86,7 +86,7 @@ public final class HDKeyDerivation {
     }
 
     public static DeterministicKey createMasterPubKeyFromBytes(byte[] pubKeyBytes, byte[] chainCode) {
-        return new DeterministicKey(ImmutableList.<ChildNumber>of(), chainCode, ECKey.CURVE.getCurve().decodePoint(pubKeyBytes), null, null);
+        return new DeterministicKey(ImmutableList.<ChildNumber>of(), chainCode, new LazyECPoint(ECKey.CURVE.getCurve(), pubKeyBytes), null, null);
     }
 
     /**
@@ -130,7 +130,7 @@ public final class HDKeyDerivation {
             return new DeterministicKey(
                     HDUtils.append(parent.getPath(), childNumber),
                     rawKey.chainCode,
-                    ECKey.CURVE.getCurve().decodePoint(rawKey.keyBytes),   // c'tor will compress
+                    new LazyECPoint(ECKey.CURVE.getCurve(), rawKey.keyBytes),
                     null,
                     parent);
         } else {

--- a/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
+++ b/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
@@ -1,0 +1,179 @@
+package org.bitcoinj.crypto;
+
+import org.spongycastle.math.ec.ECCurve;
+import org.spongycastle.math.ec.ECFieldElement;
+import org.spongycastle.math.ec.ECPoint;
+
+import javax.annotation.Nullable;
+import java.math.BigInteger;
+import java.util.Arrays;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A wrapper around ECPoint that delays decoding of the point for as long as possible. This is useful because point
+ * encode/decode in Bouncy Castle is quite slow especially on Dalvik, as it often involves decompression/recompression.
+ */
+public class LazyECPoint {
+    private ECCurve curve;
+    private byte[] bits;
+    @Nullable
+    private ECPoint point;
+
+    public LazyECPoint(ECCurve curve, byte[] bits) {
+        this.curve = curve;
+        this.bits = bits;
+    }
+
+    public LazyECPoint(ECPoint point) {
+        this.point = checkNotNull(point);
+    }
+
+    public ECPoint get() {
+        if (point == null)
+            point = curve.decodePoint(bits);
+        return point;
+    }
+
+    // Delegated methods.
+
+    public ECPoint getDetachedPoint() {
+        return get().getDetachedPoint();
+    }
+
+    public byte[] getEncoded() {
+        if (bits != null)
+            return Arrays.copyOf(bits, bits.length);
+        else
+            return get().getEncoded();
+    }
+
+    public boolean isInfinity() {
+        return get().isInfinity();
+    }
+
+    public ECPoint timesPow2(int e) {
+        return get().timesPow2(e);
+    }
+
+    public ECFieldElement getYCoord() {
+        return get().getYCoord();
+    }
+
+    public ECFieldElement[] getZCoords() {
+        return get().getZCoords();
+    }
+
+    public boolean isNormalized() {
+        return get().isNormalized();
+    }
+
+    public boolean isCompressed() {
+        if (bits != null)
+            return bits[0] == 2 || bits[0] == 3;
+        else
+            return get().isCompressed();
+    }
+
+    public ECPoint multiply(BigInteger k) {
+        return get().multiply(k);
+    }
+
+    public ECPoint subtract(ECPoint b) {
+        return get().subtract(b);
+    }
+
+    public boolean isValid() {
+        return get().isValid();
+    }
+
+    public ECPoint scaleY(ECFieldElement scale) {
+        return get().scaleY(scale);
+    }
+
+    public ECFieldElement getXCoord() {
+        return get().getXCoord();
+    }
+
+    public ECPoint scaleX(ECFieldElement scale) {
+        return get().scaleX(scale);
+    }
+
+    public boolean equals(ECPoint other) {
+        return get().equals(other);
+    }
+
+    public ECPoint negate() {
+        return get().negate();
+    }
+
+    public ECPoint threeTimes() {
+        return get().threeTimes();
+    }
+
+    public ECFieldElement getZCoord(int index) {
+        return get().getZCoord(index);
+    }
+
+    public byte[] getEncoded(boolean compressed) {
+        if (compressed == isCompressed() && bits != null)
+            return Arrays.copyOf(bits, bits.length);
+        else
+            return get().getEncoded(compressed);
+    }
+
+    public ECPoint add(ECPoint b) {
+        return get().add(b);
+    }
+
+    public ECPoint twicePlus(ECPoint b) {
+        return get().twicePlus(b);
+    }
+
+    public ECCurve getCurve() {
+        return get().getCurve();
+    }
+
+    public ECPoint normalize() {
+        return get().normalize();
+    }
+
+    public ECFieldElement getY() {
+        return get().getY();
+    }
+
+    public ECPoint twice() {
+        return get().twice();
+    }
+
+    public ECFieldElement getAffineYCoord() {
+        return get().getAffineYCoord();
+    }
+
+    public ECFieldElement getAffineXCoord() {
+        return get().getAffineXCoord();
+    }
+
+    public ECFieldElement getX() {
+        return get().getX();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LazyECPoint point1 = (LazyECPoint) o;
+        if (bits != null && point1.bits != null)
+            return Arrays.equals(bits, point1.bits);
+        else
+            return get().equals(point1.get());
+    }
+
+    @Override
+    public int hashCode() {
+        if (bits != null)
+            return Arrays.hashCode(bits);
+        else
+            return get().hashCode();
+    }
+}

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -797,7 +797,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
                 for (int i : key.getDeterministicKey().getPathList())
                     path.add(new ChildNumber(i));
                 // Deserialize the public key and path.
-                ECPoint pubkey = ECKey.CURVE.getCurve().decodePoint(key.getPublicKey().toByteArray());
+                LazyECPoint pubkey = new LazyECPoint(ECKey.CURVE.getCurve(), key.getPublicKey().toByteArray());
                 final ImmutableList<ChildNumber> immutablePath = ImmutableList.copyOf(path);
                 // Possibly create the chain, if we didn't already do so yet.
                 boolean isWatchingAccountKey = false;

--- a/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -470,7 +470,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         versionMessage.clientVersion = FilteredBlock.MIN_PROTOCOL_VERSION;
         versionMessage.localServices = VersionMessage.NODE_NETWORK;
         InboundMessageQueuer p1 = connectPeer(1, versionMessage);
-        Ping ping = (Ping) outbound(p1);
+        Ping ping = (Ping) waitForOutbound(p1);
         inbound(p1, new Pong(ping.getNonce()));
         pingAndWait(p1);
         assertTrue(peerGroup.getConnectedPeers().get(0).getLastPingTime() < Long.MAX_VALUE);


### PR DESCRIPTION
...doesn't delays parsing of key bytes into a key structure until it's needed. The process of decoding keys from the wallet previously involved decompressing/recompressing them which was taking ~seconds for hundreds of keys on Dalvik/2012 era Androids. After this patch loading such a wallet takes a few hundred milliseconds, most of which is spent inside RIPEMD160.
