### PR TITLE
Wallet.loadFromFile takes WalletExtensions to deserialize

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/core/Wallet.java
@@ -1336,12 +1336,18 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
         return params;
     }
 
-    /** Deserializes a wallet given extensions that know how to deserialize themeslves */
-    public static Wallet loadFromFile(File f, @Nullable WalletExtension... walletExtensions) throws UnreadableWalletException {
+    /**
+     * <p>Returns a wallet deserialized from the given file. Extensions previously saved with the wallet can be
+     * deserialized by calling @{@link WalletExtension#deserializeWalletExtension(Wallet, byte[])}}</p>
+     *
+     * @param file the wallet file to read
+     * @param walletExtensions extensions possibly added to the wallet.
+     */
+    public static Wallet loadFromFile(File file, @Nullable WalletExtension... walletExtensions) throws UnreadableWalletException {
         try {
             FileInputStream stream = null;
             try {
-                stream = new FileInputStream(f);
+                stream = new FileInputStream(file);
                 return loadFromFileStream(stream, walletExtensions);
             } finally {
                 if (stream != null) stream.close();
@@ -1350,9 +1356,6 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
             throw new UnreadableWalletException("Could not open file", e);
         }
     }
-
-    /**  Returns a wallet deserialized from the given file. */
-    public static Wallet loadFromFile(File f) throws UnreadableWalletException { return loadFromFile(f, null); }
 
     public boolean isConsistent() {
         lock.lock();
@@ -1412,11 +1415,6 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
             log.error("Loaded an inconsistent wallet");
         }
         return wallet;
-    }
-
-    /** Returns a wallet deserialized from the given input stream. */
-    public static Wallet loadFromFileStream(InputStream stream) throws UnreadableWalletException {
-        return loadFromFileStream(stream, null);
     }
 
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {

--- a/core/src/main/java/org/bitcoinj/store/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/store/WalletProtobufSerializer.java
@@ -367,24 +367,13 @@ public class WalletProtobufSerializer {
     }
 
     /**
-     * <p>Parses a wallet from the given stream, using the provided Wallet instance to load data into. Data in the proto
-     * will be added into the wallet where applicable and overwritten where not.</p>
+     * <p>Loads wallet data from the given protocol buffer and inserts it into the given Wallet object. This is primarily
+     * useful when you wish to pre-register extension objects. Note that if loading fails the provided Wallet object
+     * may be in an indeterminate state and should be thrown away.</p>
      *
      * <p>A wallet can be unreadable for various reasons, such as inability to open the file, corrupt data, internally
      * inconsistent data, a wallet extension marked as mandatory that cannot be handled and so on. You should always
      * handle {@link UnreadableWalletException} and communicate failure to the user in an appropriate manner.</p>
-     *
-     * @throws UnreadableWalletException thrown in various error conditions (see description).
-     */
-    public Wallet readWallet(InputStream input) throws UnreadableWalletException { return readWallet(input, null); }
-
-    /**
-     * <p>Parses a wallet from the given stream. The input stream might contain wallet extensions, which are identified and
-     * loaded into the wallet by calling their deserialization method. </p>
-     *
-     * <p>A wallet can be unreadable for various reasons, such as inability to open the file, corrupt data, internally
-     * inconsistent data and so on. You should always handle {@link UnreadableWalletException} and communicate failure
-     * to the user in an appropriate manner.</p>
      *
      * @throws UnreadableWalletException thrown in various error conditions (see description).
      */


### PR DESCRIPTION
When saving a wallet with an extension, i would like to get the wallet including the extension back without using parseToProto(input).
