### PR TITLE
Fix for issue 539, adds atomic operation for changing wallet encryption key and password.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/core/Wallet.java
@@ -1144,6 +1144,28 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
         return getEncryptionType() != EncryptionType.UNENCRYPTED;
     }
 
+    /** Changes wallet encryption password, this is atomic operation. */
+    public void changeEncryptionPassword(CharSequence currentPassword, CharSequence newPassword){
+        keychainLock.lock();
+        try {
+            decrypt(currentPassword);
+            encrypt(newPassword);
+        } finally {
+            keychainLock.unlock();
+        }
+    }
+
+    /** Changes wallet AES encryption key, this is atomic operation. */
+    public void changeEncryptionKey(KeyCrypter keyCrypter, KeyParameter currentAesKey, KeyParameter newAesKey){
+        keychainLock.lock();
+        try {
+            decrypt(currentAesKey);
+            encrypt(keyCrypter, newAesKey);
+        } finally {
+            keychainLock.unlock();
+        }
+    }
+
     //endregion
 
     /******************************************************************************************************************/

--- a/core/src/test/java/org/bitcoinj/core/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/core/WalletTest.java
@@ -1565,6 +1565,33 @@ public class WalletTest extends TestWithWallet {
     }
 
     @Test
+    public void changePasswordTest() {
+        Wallet encryptedWallet = new Wallet(params);
+        encryptedWallet.encrypt(PASSWORD1);
+        CharSequence newPassword = "My name is Tom";
+        encryptedWallet.changeEncryptionPassword(PASSWORD1, newPassword);
+        assertTrue(encryptedWallet.checkPassword(newPassword));
+        assertFalse(encryptedWallet.checkPassword(WRONG_PASSWORD));
+    }
+
+    @Test
+    public void changeAesKeyTest() {
+        Wallet encryptedWallet = new Wallet(params);
+        encryptedWallet.encrypt(PASSWORD1);
+
+        KeyCrypter keyCrypter = encryptedWallet.getKeyCrypter();
+        KeyParameter aesKey = keyCrypter.deriveKey(PASSWORD1);
+
+        CharSequence newPassword = "My name is Tom";
+        KeyParameter newAesKey = keyCrypter.deriveKey(newPassword);
+
+        encryptedWallet.changeEncryptionKey(keyCrypter, aesKey, newAesKey);
+
+        assertTrue(encryptedWallet.checkAESKey(newAesKey));
+        assertFalse(encryptedWallet.checkAESKey(aesKey));
+    }
+
+    @Test
     public void encryptionDecryptionCheckExceptions() throws Exception {
         Wallet encryptedWallet = new Wallet(params);
         encryptedWallet.encrypt(PASSWORD1);


### PR DESCRIPTION
This is a fix for https://code.google.com/p/bitcoinj/issues/detail?id=539

Please verify if I'm using correct lock. Two options are: `lock` or `keychainLock`
