### PR TITLE
When connecting outputs to inputs, cache its value in the input.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -60,7 +60,7 @@ public class TransactionInput extends ChildMessage implements Serializable {
     transient private WeakReference<Script> scriptSig;
     /** Value of the output connected to the input, if known. This field does not participate in equals()/hashCode(). */
     @Nullable
-    private final Coin value;
+    private Coin value;
 
     /**
      * Creates an input that connects to nothing - used only in creation of coinbase transactions.
@@ -375,6 +375,7 @@ public class TransactionInput extends ChildMessage implements Serializable {
     public void connect(TransactionOutput out) {
         outpoint.fromTx = out.getParentTransaction();
         out.markAsSpent(this);
+        value = out.getValue();
     }
 
     /**


### PR DESCRIPTION
This will make sure the fee is also known after a blockchain replay.

I noticed that with this change we could have done without persisting input values to the wallet protobuf, at least for transaction we created outselves.