### PR TITLE
NPE when invoking `PeerGroup.broadcastTransaction()` on peer group with no block chain.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
@@ -103,7 +103,7 @@ public class TransactionBroadcast {
             List<Peer> peers = peerGroup.getConnectedPeers();    // snapshots
             // We intern the tx here so we are using a canonical version of the object (as it's unfortunately mutable).
             // TODO: Once confidence state is moved out of Transaction we can kill off this step.
-            pinnedTx = context != null ? context.getConfidenceTable().intern(tx) : pinnedTx;
+            pinnedTx = context != null ? context.getConfidenceTable().intern(tx) : tx;
             // Prepare to send the transaction by adding a listener that'll be called when confidence changes.
             // Only bother with this if we might actually hear back:
             if (minConnections > 1)


### PR DESCRIPTION
The modified line here seems to have been assuming that `pinnedTx` was being initialized elsewhere, but it wasn't.  I'm not sure this is the correct fix.  If not, hopefully someone who understands this better can tell me what I'm missing.  Thanks.