### PR TITLE
Make block chain be part of the context, rather than the other way around

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
@@ -86,7 +86,6 @@ public abstract class AbstractBlockChain {
 
     /** Keeps a map of block hashes to StoredBlocks. */
     private final BlockStore blockStore;
-    private final Context context;
 
     /**
      * Tracks the top of the best known chain.<p>
@@ -150,11 +149,6 @@ public abstract class AbstractBlockChain {
         this.params = params;
         this.listeners = new CopyOnWriteArrayList<ListenerRegistration<BlockChainListener>>();
         for (BlockChainListener l : listeners) addListener(l, Threading.SAME_THREAD);
-        context = new Context();
-    }
-
-    public Context getContext() {
-        return context;
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/Context.java
+++ b/core/src/main/java/org/bitcoinj/core/Context.java
@@ -1,15 +1,20 @@
 package org.bitcoinj.core;
 
+import javax.annotation.Nullable;
+
 /**
  * The Context object holds various objects that are scoped to a specific instantiation of bitcoinj for a specific
- * network. You can get an instance of this class through {@link AbstractBlockChain#getContext()}. At the momemnt it
+ * network. You can get an instance of this class through {@link PeerGroup#getContext()}. At the momemnt it
  * only contains a {@link org.bitcoinj.core.TxConfidenceTable} but in future it will likely contain file paths and
  * other global configuration of use.
  */
 public class Context {
     protected TxConfidenceTable confidenceTable;
+    private AbstractBlockChain chain;
 
-    protected Context() {
+    // The only reason this constructor is not protected is so TestWithNetworkConections can use it.
+    public Context(@Nullable AbstractBlockChain chain) {
+        this.chain = chain;
         confidenceTable = new TxConfidenceTable();
     }
 
@@ -21,5 +26,12 @@ public class Context {
      */
     public TxConfidenceTable getConfidenceTable() {
         return confidenceTable;
+    }
+
+    /**
+     * Returns the BlockChain associated with this Context, or null.
+     */
+    public AbstractBlockChain getBlockChain() {
+        return chain;
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -135,7 +135,7 @@ public class PeerGroup implements TransactionBroadcaster {
     @GuardedBy("lock") private boolean ipv6Unreachable = false;
 
     private final NetworkParameters params;
-    @Nullable private final AbstractBlockChain chain;
+    private final Context context;
     @GuardedBy("lock") private long fastCatchupTimeSecs;
     private final CopyOnWriteArrayList<Wallet> wallets;
     private final CopyOnWriteArrayList<PeerFilterProvider> peerFilterProviders;
@@ -150,8 +150,8 @@ public class PeerGroup implements TransactionBroadcaster {
 
         @Override
         public void onBlocksDownloaded(Peer peer, Block block, int blocksLeft) {
-            if (chain == null) return;
-            final double rate = chain.getFalsePositiveRate();
+            if (context.getBlockChain() == null) return;
+            final double rate = context.getBlockChain().getFalsePositiveRate();
             final double target = bloomFilterMerger.getBloomFilterFPRate() * MAX_FP_RATE_INCREASE;
             if (rate > target) {
                 // TODO: Avoid hitting this path if the remote peer didn't acknowledge applying a new filter yet.
@@ -312,7 +312,7 @@ public class PeerGroup implements TransactionBroadcaster {
      */
     private PeerGroup(NetworkParameters params, @Nullable AbstractBlockChain chain, ClientConnectionManager connectionManager, @Nullable TorClient torClient) {
         this.params = checkNotNull(params);
-        this.chain = chain;
+        this.context = new Context(chain);
         fastCatchupTimeSecs = params.getGenesisBlock().getTimeSeconds();
         wallets = new CopyOnWriteArrayList<Wallet>();
         peerFilterProviders = new CopyOnWriteArrayList<PeerFilterProvider>();
@@ -352,6 +352,10 @@ public class PeerGroup implements TransactionBroadcaster {
         peerEventListeners = new CopyOnWriteArrayList<ListenerRegistration<PeerEventListener>>();
         runningBroadcasts = Collections.synchronizedSet(new HashSet<TransactionBroadcast>());
         bloomFilterMerger = new FilterMerger(DEFAULT_BLOOM_FILTER_FP_RATE);
+    }
+
+    public Context getContext() {
+        return context;
     }
 
     private CountDownLatch executorStartupLatch = new CountDownLatch(1);
@@ -524,7 +528,7 @@ public class PeerGroup implements TransactionBroadcaster {
             while (it.hasNext()) {
                 InventoryItem item = it.next();
                 // Check the confidence pool first.
-                Transaction tx = chain != null ? chain.getContext().getConfidenceTable().get(item.hash) : null;
+                Transaction tx = context.getConfidenceTable().get(item.hash);
                 if (tx != null) {
                     transactions.add(tx);
                     it.remove();
@@ -583,7 +587,7 @@ public class PeerGroup implements TransactionBroadcaster {
      */
     public void setUserAgent(String name, String version, @Nullable String comments) {
         //TODO Check that height is needed here (it wasnt, but it should be, no?)
-        int height = chain == null ? 0 : chain.getBestChainHeight();
+        int height = context.getBlockChain() == null ? 0 : context.getBlockChain().getBestChainHeight();
         VersionMessage ver = new VersionMessage(params, height);
         ver.relayTxesBeforeFilter = false;
         updateVersionMessageRelayTxesBeforeFilter(ver);
@@ -598,7 +602,7 @@ public class PeerGroup implements TransactionBroadcaster {
         // Note that the default here means that no tx invs will be received if no wallet is ever added
         lock.lock();
         try {
-            boolean spvMode = chain != null && !chain.shouldVerifyTransactions();
+            boolean spvMode = context.getBlockChain() != null && !context.getBlockChain().shouldVerifyTransactions();
             boolean willSendFilter = spvMode && peerFilterProviders.size() > 0;
             ver.relayTxesBeforeFilter = !willSendFilter;
         } finally {
@@ -820,7 +824,7 @@ public class PeerGroup implements TransactionBroadcaster {
      */
     public ListenableFuture startAsync() {
         // This is run in a background thread by the Service implementation.
-        if (chain == null) {
+        if (context.getBlockChain() == null) {
             // Just try to help catch what might be a programming error.
             log.warn("Starting up with no attached block chain. Did you forget to pass one to the constructor?");
         }
@@ -1044,7 +1048,7 @@ public class PeerGroup implements TransactionBroadcaster {
             public void go() {
                 checkState(!lock.isHeldByCurrentThread());
                 // Fully verifying mode doesn't use this optimization (it can't as it needs to see all transactions).
-                if (chain != null && chain.shouldVerifyTransactions())
+                if (context.getBlockChain() != null && context.getBlockChain().shouldVerifyTransactions())
                     return;
                 // We only ever call bloomFilterMerger.calculate on jobQueue, so we cannot be calculating two filters at once.
                 FilterMerger.Result result = bloomFilterMerger.calculate(ImmutableList.copyOf(peerFilterProviders /* COW */));
@@ -1071,8 +1075,8 @@ public class PeerGroup implements TransactionBroadcaster {
                     }
                     // Reset the false positive estimate so that we don't send a flood of filter updates
                     // if the estimate temporarily overshoots our threshold.
-                    if (chain != null)
-                        chain.resetFalsePositiveEstimate();
+                    if (context.getBlockChain() != null)
+                        context.getBlockChain().resetFalsePositiveEstimate();
                 }
                 // Do this last so that bloomFilter is already set when it gets called.
                 setFastCatchupTimeSecs(result.earliestKeyTimeSecs);
@@ -1160,10 +1164,10 @@ public class PeerGroup implements TransactionBroadcaster {
     protected Peer connectTo(PeerAddress address, boolean incrementMaxConnections, int connectTimeoutMillis) {
         checkState(lock.isHeldByCurrentThread());
         VersionMessage ver = getVersionMessage().duplicate();
-        ver.bestHeight = chain == null ? 0 : chain.getBestChainHeight();
+        ver.bestHeight = context.getBlockChain() == null ? 0 : context.getBlockChain().getBestChainHeight();
         ver.time = Utils.currentTimeSeconds();
 
-        Peer peer = new Peer(params, ver, address, chain, downloadTxDependencies);
+        Peer peer = new Peer(params, ver, address, context, downloadTxDependencies);
         peer.addEventListener(startupListener, Threading.SAME_THREAD);
         peer.setMinProtocolVersion(vMinRequiredProtocolVersion);
         pendingPeers.add(peer);
@@ -1261,7 +1265,7 @@ public class PeerGroup implements TransactionBroadcaster {
             Peer newDownloadPeer = selectDownloadPeer(peers);
             if (downloadPeer != newDownloadPeer) {
                 setDownloadPeer(newDownloadPeer);
-                boolean shouldDownloadChain = downloadListener != null && chain != null;
+                boolean shouldDownloadChain = downloadListener != null && context.getBlockChain() != null;
                 if (shouldDownloadChain) {
                     startBlockChainDownloadFromPeer(downloadPeer);
                 }
@@ -1335,7 +1339,7 @@ public class PeerGroup implements TransactionBroadcaster {
                 if (downloadListener != null)
                     peer.addEventListener(downloadListener, Threading.SAME_THREAD);
                 downloadPeer.setDownloadData(true);
-                if (chain != null)
+                if (context.getBlockChain() != null)
                     downloadPeer.setDownloadParameters(fastCatchupTimeSecs, bloomFilterMerger.getLastFilter() != null);
             }
         } finally {
@@ -1345,12 +1349,11 @@ public class PeerGroup implements TransactionBroadcaster {
 
     /**
      * Use {@link org.bitcoinj.core.Context#getConfidenceTable()} instead, which can be retrieved via
-     * {@link org.bitcoinj.core.AbstractBlockChain#getContext()}. Can return null if this peer group was
-     * configured without a block chain object.
+     * {@link getContext()}.
      */
-    @Deprecated @Nullable
+    @Deprecated
     public TxConfidenceTable getMemoryPool() {
-        return chain == null ? null : chain.getContext().getConfidenceTable();
+        return context.getConfidenceTable();
     }
 
     /**
@@ -1361,7 +1364,8 @@ public class PeerGroup implements TransactionBroadcaster {
     public void setFastCatchupTimeSecs(long secondsSinceEpoch) {
         lock.lock();
         try {
-            checkState(chain == null || !chain.shouldVerifyTransactions(), "Fast catchup is incompatible with fully verifying");
+            checkState(context.getBlockChain() == null || !context.getBlockChain().shouldVerifyTransactions(),
+                       "Fast catchup is incompatible with fully verifying");
             fastCatchupTimeSecs = secondsSinceEpoch;
             if (downloadPeer != null) {
                 downloadPeer.setDownloadParameters(secondsSinceEpoch, bloomFilterMerger.getLastFilter() != null);
@@ -1630,8 +1634,7 @@ public class PeerGroup implements TransactionBroadcaster {
      * bringup of the peer group you can lower it.</p>
      */
     public ListenableFuture<Transaction> broadcastTransaction(final Transaction tx, final int minConnections) {
-        // TODO: Context being owned by BlockChain isn't right w.r.t future intentions so it shouldn't really be optional here.
-        final TransactionBroadcast broadcast = new TransactionBroadcast(this, chain != null ? chain.getContext() : null, tx);
+        final TransactionBroadcast broadcast = new TransactionBroadcast(this, tx);
         broadcast.setMinConnections(minConnections);
         // Send the TX to the wallet once we have a successful broadcast.
         Futures.addCallback(broadcast.future(), new FutureCallback<Transaction>() {

--- a/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
@@ -42,7 +42,7 @@ public class TransactionBroadcast {
     private final SettableFuture<Transaction> future = SettableFuture.create();
     private final PeerGroup peerGroup;
     private final Transaction tx;
-    @Nullable private final Context context;
+    private final Context context;
     private int minConnections;
     private int numWaitingFor;
 
@@ -51,12 +51,16 @@ public class TransactionBroadcast {
     public static Random random = new Random();
     private Transaction pinnedTx;
 
-    // TODO: Context being owned by BlockChain isn't right w.r.t future intentions so it shouldn't really be optional here.
-    TransactionBroadcast(PeerGroup peerGroup, @Nullable Context context, Transaction tx) {
+    @Deprecated
+    TransactionBroadcast(PeerGroup peerGroup, Context context, Transaction tx) {
         this.peerGroup = peerGroup;
         this.context = context;
         this.tx = tx;
         this.minConnections = Math.max(1, peerGroup.getMinBroadcastConnections());
+    }
+
+    TransactionBroadcast(PeerGroup peerGroup, Transaction tx) {
+        this(peerGroup, peerGroup.getContext(), tx);
     }
 
     public ListenableFuture<Transaction> future() {

--- a/core/src/main/java/org/bitcoinj/testing/TestWithNetworkConnections.java
+++ b/core/src/main/java/org/bitcoinj/testing/TestWithNetworkConnections.java
@@ -47,6 +47,7 @@ public class TestWithNetworkConnections {
     protected NetworkParameters unitTestParams;
     protected BlockStore blockStore;
     protected BlockChain blockChain;
+    protected Context context;
     protected Wallet wallet;
     protected ECKey key;
     protected Address address;
@@ -89,6 +90,7 @@ public class TestWithNetworkConnections {
         key = wallet.freshReceiveKey();
         address = key.toAddress(unitTestParams);
         blockChain = new BlockChain(unitTestParams, wallet, blockStore);
+        context = new Context(blockChain);
 
         startPeerServers();
         if (clientType == ClientType.NIO_CLIENT_MANAGER || clientType == ClientType.BLOCKING_CLIENT_MANAGER) {

--- a/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
@@ -86,7 +86,8 @@ public class BitcoindComparisonTool {
         VersionMessage ver = new VersionMessage(params, 42);
         ver.appendToSubVer("BlockAcceptanceComparisonTool", "1.1", null);
         ver.localServices = VersionMessage.NODE_NETWORK;
-        final Peer bitcoind = new Peer(params, ver, new BlockChain(params, new MemoryBlockStore(params)), new PeerAddress(InetAddress.getLocalHost()));
+        final Peer bitcoind = new Peer(params, ver, new Context(new BlockChain(params, new MemoryBlockStore(params))),
+                                       new PeerAddress(InetAddress.getLocalHost()));
         Preconditions.checkState(bitcoind.getVersionMessage().hasBlockChain());
 
         final BlockWrapper currentBlock = new BlockWrapper();

--- a/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -376,7 +376,8 @@ public class PeerGroupTest extends TestWithPeerGroup {
         inbound(p2, inv);
         assertTrue(outbound(p2) instanceof GetDataMessage);
         assertEquals(0, tx.getConfidence().numBroadcastPeers());
-        assertTrue(blockChain.getContext().getConfidenceTable().maybeWasSeen(tx.getHash()));
+        //        assertTrue(blockChain.getContext().getConfidenceTable().maybeWasSeen(tx.getHash()));
+        assertTrue(peerGroup.getContext().getConfidenceTable().maybeWasSeen(tx.getHash()));
         assertNull(event[0]);
         // Peer 1 advertises the tx, we don't do anything as it's already been requested.
         inbound(p1, inv);

--- a/core/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -77,10 +77,10 @@ public class PeerTest extends TestWithNetworkConnections {
     public void setUp() throws Exception {
         super.setUp();
 
-        confidenceTable = blockChain.getContext().getConfidenceTable();
+        confidenceTable = context.getConfidenceTable();
         VersionMessage ver = new VersionMessage(unitTestParams, 100);
         InetSocketAddress address = new InetSocketAddress("127.0.0.1", 4000);
-        peer = new Peer(unitTestParams, ver, new PeerAddress(address), blockChain);
+        peer = new Peer(unitTestParams, ver, new PeerAddress(address), context);
         peer.addWallet(wallet);
     }
 
@@ -269,7 +269,7 @@ public class PeerTest extends TestWithNetworkConnections {
         // Check co-ordination of which peer to download via the memory pool.
         VersionMessage ver = new VersionMessage(unitTestParams, 100);
         InetSocketAddress address = new InetSocketAddress("127.0.0.1", 4242);
-        Peer peer2 = new Peer(unitTestParams, ver, new PeerAddress(address), blockChain);
+        Peer peer2 = new Peer(unitTestParams, ver, new PeerAddress(address), context);
         peer2.addWallet(wallet);
         VersionMessage peerVersion = new VersionMessage(unitTestParams, OTHER_PEER_CHAIN_HEIGHT);
         peerVersion.clientVersion = 70001;

--- a/core/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
@@ -72,7 +72,7 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
     public void fourPeers() throws Exception {
         InboundMessageQueuer[] channels = { connectPeer(1), connectPeer(2), connectPeer(3), connectPeer(4) };
         Transaction tx = new Transaction(params);
-        TransactionBroadcast broadcast = new TransactionBroadcast(peerGroup, blockChain.getContext(), tx);
+        TransactionBroadcast broadcast = new TransactionBroadcast(peerGroup, tx);
         ListenableFuture<Transaction> future = broadcast.broadcast();
         assertFalse(future.isDone());
         // We expect two peers to receive a tx message, and at least one of the others must announce for the future to


### PR DESCRIPTION
Right now there's a problem when a `PeerGroup` with no `BlockChain` tries to broadcast a transaction, because the peers don't have access to the same context.  We broadcast to some peers, then wait to hear from others, but in this case those others don't know the transaction they see is being waited for, the confidence is unchanged, and the broadcast procedure times out because [the future that's waiting to be called back never completes](https://github.com/bitcoinj/bitcoinj/blob/master/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java#L171).

Rather than having the required `Context` be a member of the optional `BlockChain`, this patch makes the `Context` a member of the `PeerGroup`, and the `BlockChain` an optional member of the `Context`.  Actually, I'm unclear why there needs to be a separate `Context`, since the `PeerGroup` seems to _be_ the context, but I attempted to change as little as necessary for the `PeerGroup` to be able to see that transactions are being broadcast successfully.

I have limited prior experience with the code I altered, so (assuming no other problems) hopefully this will get a careful review from someone competent.  In particular I note:

1. I had to change the access of the `Context` class constructor from `protected` to `public` only because the `TestWithNetworkConnection` class uses it.
2. [Line 109 (né 105) of `TransactionBroadcast.java`](https://github.com/bitcoinj/bitcoinj/blob/master/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java#L105) has a `TODO` that sounds as if this might be resolved by this patch, but I'm not sure.  If so, then that line should be changed as well.
3. This runs for me, and the tests compile, but I'm unable to run the tests to completion, so someone else should make sure all the tests will complete.

Incidentally, and slightly off-topic, here's the last thing I see before the tests hang for me; perhaps it gives some indication of what might be wrong.

    11:17:31 789 PeerGroup$7.run: Starting ...
    11:17:31 789 PeerGroup.discoverPeers: Peer discovery took 0msec and returned 0 items
    11:17:31 790 NioClientManager.handleKey: Successfully connected to /127.0.0.1:2001
    11:17:31 790 Peer.connectionOpened: Announcing to /127.0.0.1:2001 as: /bitcoinj:0.13-SNAPSHOT/
    11:17:31 790 Peer.processVersionMessage: Connected to 127.0.0.1: version=70001, subVer='/bitcoinj:0.13-SNAPSHOT/', services=0x1, time=2015-01-15 23:17:31, blocks=1
    11:17:31 790 PeerGroup.handleNewPeer: [127.0.0.1]:2001: New peer
    11:17:31 790 PeerGroup.setDownloadPeer: Setting download peer: [127.0.0.1]:2001
    11:17:32 790 NioClientManager.handleKey: Successfully connected to /127.0.0.1:2002
    11:17:32 790 Peer.connectionOpened: Announcing to /127.0.0.1:2002 as: /bitcoinj:0.13-SNAPSHOT/
    11:17:32 790 Peer.processVersionMessage: Connected to 127.0.0.1: version=70001, subVer='/bitcoinj:0.13-SNAPSHOT/', services=0x1, time=2015-01-15 23:17:31, blocks=1
    11:17:32 790 PeerGroup.handleNewPeer: [127.0.0.1]:2002: New peer
    11:17:32 75 PeerSocketHandler.timeoutOccurred: [127.0.0.1]:18333: Timed out
    11:17:35 75 PeerSocketHandler.timeoutOccurred: [127.0.0.1]:1: Timed out
    11:17:36 75 PeerSocketHandler.timeoutOccurred: [127.0.0.1]:2001: Timed out
    11:17:36 75 PeerSocketHandler.timeoutOccurred: [127.0.0.1]:2002: Timed out
    11:17:36 75 PeerSocketHandler.timeoutOccurred: [127.0.0.1]:2001: Timed out
    11:17:36 75 PeerSocketHandler.timeoutOccurred: [127.0.0.1]:2002: Timed out
    11:17:36 75 PeerSocketHandler.timeoutOccurred: [127.0.0.1]:2001: Timed out
    11:17:36 75 PeerSocketHandler.timeoutOccurred: [127.0.0.1]:2002: Timed out
    11:17:36 75 PeerSocketHandler.timeoutOccurred: [127.0.0.1]:2001: Timed out
    11:17:36 75 PeerSocketHandler.timeoutOccurred: [127.0.0.1]:2002: Timed out
    