### PR TITLE
Allow building a MarriedKeyChain with a watchingKey

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -162,6 +162,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
         protected long seedCreationTimeSecs;
         protected byte[] entropy;
         protected DeterministicSeed seed;
+        protected DeterministicKey watchingKey;
 
         protected Builder() {
         }
@@ -214,6 +215,12 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
             return self();
         }
 
+        
+        public T watchingKey(DeterministicKey watchingKey) {
+            this.watchingKey = watchingKey;
+            return self();
+        }
+
         /** The passphrase to use with the generated mnemonic, or null if you would like to use the default empty string. Currently must be the empty string. */
         public T passphrase(String passphrase) {
             // FIXME support non-empty passphrase
@@ -223,7 +230,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
 
 
         public DeterministicKeyChain build() {
-            checkState(random != null || entropy != null || seed != null, "Must provide either entropy or random");
+            checkState(random != null || entropy != null || seed != null || watchingKey!= null, "Must provide either entropy or random or seed or watchingKey");
             checkState(passphrase == null || seed == null, "Passphrase must not be specified with seed");
             DeterministicKeyChain chain;
 
@@ -232,8 +239,10 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
                 chain = new DeterministicKeyChain(random, bits, getPassphrase(), seedCreationTimeSecs);
             } else if (entropy != null) {
                 chain = new DeterministicKeyChain(entropy, getPassphrase(), seedCreationTimeSecs);
-            } else {
+            } else if (seed != null) {
                 chain = new DeterministicKeyChain(seed);
+            } else {
+                chain = new DeterministicKeyChain(watchingKey, seedCreationTimeSecs);
             }
 
             return chain;

--- a/core/src/main/java/org/bitcoinj/wallet/MarriedKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/MarriedKeyChain.java
@@ -91,7 +91,7 @@ public class MarriedKeyChain extends DeterministicKeyChain {
         }
 
         public MarriedKeyChain build() {
-            checkState(random != null || entropy != null || seed != null, "Must provide either entropy or random");
+            checkState(random != null || entropy != null || seed != null || watchingKey!= null, "Must provide either entropy or random or seed or watchingKey");
             checkNotNull(followingKeys, "followingKeys must be provided");
             MarriedKeyChain chain;
             if (threshold == 0)
@@ -100,8 +100,10 @@ public class MarriedKeyChain extends DeterministicKeyChain {
                 chain = new MarriedKeyChain(random, bits, getPassphrase(), seedCreationTimeSecs);
             } else if (entropy != null) {
                 chain = new MarriedKeyChain(entropy, getPassphrase(), seedCreationTimeSecs);
-            } else {
+            } else if (seed != null) {
                 chain = new MarriedKeyChain(seed);
+            } else {
+                chain = new MarriedKeyChain(watchingKey, seedCreationTimeSecs);
             }
             chain.addFollowingAccountKeys(followingKeys, threshold);
             return chain;
@@ -115,6 +117,10 @@ public class MarriedKeyChain extends DeterministicKeyChain {
     // Protobuf deserialization constructors
     MarriedKeyChain(DeterministicKey accountKey) {
         super(accountKey, false);
+    }
+
+    MarriedKeyChain(DeterministicKey accountKey, long seedCreationTimeSecs) {
+        super(accountKey, seedCreationTimeSecs);
     }
 
     MarriedKeyChain(DeterministicSeed seed, KeyCrypter crypter) {


### PR DESCRIPTION
Fix to solve this problem:
During HD / married wallets code refactor KeyChainGroup.addFollowingAccountKeys() was removed and now MarriedKeyChain should be used.
The thing is I find no way to create an HD multisig full watching wallet. MarriedKeyChain builder forces me to supply either a DeterministicSeed, SecureRandom or byte[] entropy (ie to be able to generate at least one side of the private keys of the multisig wallet)