### PR TITLE
On MacOS and Linux with java 1.8, I would get a weird error when trying ...

### DIFF
--- a/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
+++ b/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
@@ -113,6 +113,17 @@ public class WalletAppKit extends AbstractIdleService {
         }
     }
 
+    //TODO: Need to check for valid IPs
+    public WalletAppKit connectToRemoteHost(String ip) {
+        try {
+            final InetAddress remoteHost = InetAddress.getByName(ip);
+            return setPeerNodes(new PeerAddress(remoteHost, params.getPort()));
+        } catch (UnknownHostException e) {
+            // Borked machine with no loopback adapter configured properly.
+            throw new RuntimeException(e);
+        }
+    }
+
     /** If true, the wallet will save itself to disk automatically whenever it changes. */
     public WalletAppKit setAutoSave(boolean value) {
         checkState(state() == State.NEW, "Cannot call after startup");

--- a/wallettemplate/src/main/java/wallettemplate/SendMoneyController.java
+++ b/wallettemplate/src/main/java/wallettemplate/SendMoneyController.java
@@ -88,6 +88,7 @@ public class SendMoneyController {
     private void askForPasswordAndRetry() {
         Main.OverlayUI<WalletPasswordController> pwd = Main.instance.overlayUI("wallet_password.fxml");
         final String addressStr = address.getText();
+        final String amountStr = amountEdit.getText();
         pwd.controller.aesKeyProperty().addListener((observable, old, cur) -> {
             // We only get here if the user found the right password. If they don't or they cancel, we end up back on
             // the main UI screen. By now the send money screen is history so we must recreate it.
@@ -95,6 +96,7 @@ public class SendMoneyController {
             Main.OverlayUI<SendMoneyController> screen = Main.instance.overlayUI("send_money.fxml");
             screen.controller.aesKey = cur;
             screen.controller.address.setText(addressStr);
+            screen.controller.amountEdit.setText(amountStr);
             screen.controller.send(null);
         });
     }


### PR DESCRIPTION
On MacOS and Linux (latest java - 1.8.0_31), I would get an error message (insufficient funds) when trying to send BTC (any amount less than the balance). 

Essentially, after asking for password, the wallet was trying to send whatever was on the wallet's balance instead of what the user had entered in the amountEdit field. As a result, I was unable to send money. To fix this, I added the field the same way the address was updated after entering the password. 

The change is minor, and folks working on the wallet could figure it out eventually. But this would save them some time :)
