### PR TITLE
Change PeerGroup.addPeerFilterProvider() to return a ListenableFuture

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -962,8 +962,14 @@ public class PeerGroup implements TransactionBroadcaster {
      *
      * <p>Note that this should be done before chain download commences because if you add a listener with keys earlier
      * than the current chain head, the relevant parts of the chain won't be redownloaded for you.</p>
+     *
+     * <p>This method invokes {@link PeerGroup#recalculateFastCatchupAndFilter(FilterRecalculateMode)}.
+     * The return value of this method is the <code>ListenableFuture</code> returned by that invocation.</p>
+     *
+     * @return a future that completes once each <code>Peer</code> in this group has had its
+     *         <code>BloomFilter</code> (re)set.
      */
-    public void addPeerFilterProvider(PeerFilterProvider provider) {
+    public ListenableFuture<BloomFilter> addPeerFilterProvider(PeerFilterProvider provider) {
         lock.lock();
         try {
             checkNotNull(provider);
@@ -982,8 +988,9 @@ public class PeerGroup implements TransactionBroadcaster {
             // if a key is added. Of course, by then we may have downloaded the chain already. Ideally adding keys would
             // automatically rewind the block chain and redownload the blocks to find transactions relevant to those keys,
             // all transparently and in the background. But we are a long way from that yet.
-            recalculateFastCatchupAndFilter(FilterRecalculateMode.SEND_IF_CHANGED);
+            ListenableFuture<BloomFilter> future = recalculateFastCatchupAndFilter(FilterRecalculateMode.SEND_IF_CHANGED);
             updateVersionMessageRelayTxesBeforeFilter(getVersionMessage());
+            return future;
         } finally {
             lock.unlock();
         }


### PR DESCRIPTION
Currently `PeerGroup.addPeerFilterProvider()` returns `void`.  After this patch it returns the `ListenableFuture<BloomFilter>` that returns from its invocation of `recalculateFastCatchupAndFilter()`.

#### Background

I am working with a custom wallet implementation that has a so-called "lookahead" feature to be certain its bloom filter includes a certain number of receive addresses that have not yet been shared with prospective payors.

When the number of spare addresses in the bloom filter is low enough, the lookahead feature invokes `PeerGroup.recalculateFastCatchupAndFilter()`, which results in my `PeerFilterProvider` performing the following procedure:

1. Generate new receive addresses;
2. Stash the new addresses in a temporary variable;
3. Calculate the new bloom filter and give it back to the `PeerGroup`.

The return value of the `recalculateFastCatchupAndFilter()` invocation that triggers this procedure is a `ListenableFuture`, to which I add a listener that, when the future completes, moves the new addresses from the temporary variable described in step 2 into the pool of addresses that are available to be shared with prospective payors.  The rationale for doing this is the same as that for having a lookahead feature: to delay sharing publicly any receive addresses until I am as certain as possible that the peers to which I am connected will match any payments sent to those addresses.

#### The Problem

The foregoing only works when `recalculateFastCatchupAndFilter()` is triggered by the number of spare addresses falling below the lookahead threshold.  But `recalculateFastCatchupAndFilter()` is invoked initially not by that process but rather by the `PeerGroup.addPeerFilterProvider()` by which the bloom filter provider is added to the peer group.  That method discards the future, making it impossible to add a listener that will be triggered when filter calculation is complete and all `Peers` have had their bloom filters set.  This is how I propose to initially populate my pool of available receive addresses.

####  This Patch

This patch simply changes the return value of `addPeerFilterProvider` from `void` to the future returned by its invocation of `recalculateFastCatchupAndFilter`.  Since it currently returns void, it seems unlikely that the change to returning a future will cause a problem for existing code.  Thus far, it is working to solve for me the problem described, and if it is acceptable I request it be merged into the repository.

Alternatively, I am interested to learn of any superior solution to the problem this patch addresses.