### PR TITLE
Increase wallet autosave delay for wallet-tool.

### DIFF
--- a/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
+++ b/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
@@ -346,7 +346,7 @@ public class WalletAppKit extends AbstractIdleService {
             wallet.saveToFile(vWalletFile);
         }
 
-        if (useAutoSave) wallet.autosaveToFile(vWalletFile, 200, TimeUnit.MILLISECONDS, null);
+        if (useAutoSave) wallet.autosaveToFile(vWalletFile, 5, TimeUnit.SECONDS, null);
 
         return wallet;
     }

--- a/tools/src/main/java/org/bitcoinj/tools/WalletTool.java
+++ b/tools/src/main/java/org/bitcoinj/tools/WalletTool.java
@@ -826,7 +826,7 @@ public class WalletTool {
             chain = new FullPrunedBlockChain(params, wallet, s);
         }
         // This will ensure the wallet is saved when it changes.
-        wallet.autosaveToFile(walletFile, 200, TimeUnit.MILLISECONDS, null);
+        wallet.autosaveToFile(walletFile, 5, TimeUnit.SECONDS, null);
         if (options.has("tor")) {
             try {
                 peers = PeerGroup.newWithTor(params, chain, new TorClient());


### PR DESCRIPTION
Since we have some recovery for out-of-sync wallets in place, we can afford to save less often.