### PR TITLE
Removes deprecation warnings. 

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/core/ECKey.java
@@ -804,7 +804,7 @@ public class ECKey implements EncryptableItem, Serializable {
      */
     public String signMessage(String message, @Nullable KeyParameter aesKey) throws KeyCrypterException {
         byte[] data = Utils.formatMessageForSigning(message);
-        Sha256Hash hash = Sha256Hash.createDouble(data);
+        Sha256Hash hash = Sha256Hash.hashTwice(data);
         ECDSASignature sig = sign(hash, aesKey);
         // Now we have to work backwards to figure out the recId needed to recover the signature.
         int recId = -1;
@@ -858,7 +858,7 @@ public class ECKey implements EncryptableItem, Serializable {
         byte[] messageBytes = Utils.formatMessageForSigning(message);
         // Note that the C++ code doesn't actually seem to specify any character encoding. Presumably it's whatever
         // JSON-SPIRIT hands back. Assume UTF-8 for now.
-        Sha256Hash messageHash = Sha256Hash.createDouble(messageBytes);
+        Sha256Hash messageHash = Sha256Hash.hashTwice(messageBytes);
         boolean compressed = false;
         if (header >= 31) {
             compressed = true;

--- a/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
@@ -87,7 +87,7 @@ public class BIP38PrivateKey extends VersionedChecksummedBytes {
     public ECKey decrypt(String passphrase) throws BadPassphraseException {
         String normalizedPassphrase = Normalizer.normalize(passphrase, Normalizer.Form.NFC);
         ECKey key = ecMultiply ? decryptEC(normalizedPassphrase) : decryptNoEC(normalizedPassphrase);
-        Sha256Hash hash = Sha256Hash.createDouble(key.toAddress(params).toString().getBytes(Charsets.US_ASCII));
+        Sha256Hash hash = Sha256Hash.hashTwice(key.toAddress(params).toString().getBytes(Charsets.US_ASCII));
         byte[] actualAddressHash = Arrays.copyOfRange(hash.getBytes(), 0, 4);
         if (!Arrays.equals(actualAddressHash, addressHash))
             throw new BadPassphraseException();
@@ -122,7 +122,7 @@ public class BIP38PrivateKey extends VersionedChecksummedBytes {
             if (hasLotAndSequence) {
                 byte[] hashBytes = Bytes.concat(passFactorBytes, ownerEntropy);
                 checkState(hashBytes.length == 40);
-                passFactorBytes = Sha256Hash.createDouble(hashBytes).getBytes();
+                passFactorBytes = Sha256Hash.hashTwice(hashBytes).getBytes();
             }
             BigInteger passFactor = new BigInteger(1, passFactorBytes);
             ECKey k = ECKey.fromPrivate(passFactor, true);
@@ -150,7 +150,7 @@ public class BIP38PrivateKey extends VersionedChecksummedBytes {
 
             byte[] seed = Bytes.concat(decrypted1, Arrays.copyOfRange(decrypted2, 8, 16));
             checkState(seed.length == 24);
-            BigInteger seedFactor = new BigInteger(1, Sha256Hash.createDouble(seed).getBytes());
+            BigInteger seedFactor = new BigInteger(1, Sha256Hash.hashTwice(seed).getBytes());
             checkState(passFactor.signum() >= 0);
             checkState(seedFactor.signum() >= 0);
             BigInteger priv = passFactor.multiply(seedFactor).mod(ECKey.CURVE.getN());

--- a/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
+++ b/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
@@ -147,7 +147,7 @@ public class LazyECPoint {
     }
 
     public ECFieldElement getY() {
-        return get().getY();
+        return this.normalize().getYCoord();
     }
 
     public ECPoint twice() {
@@ -163,7 +163,7 @@ public class LazyECPoint {
     }
 
     public ECFieldElement getX() {
-        return get().getX();
+        return this.normalize().getXCoord();
     }
 
     @Override

--- a/wallettemplate/pom.xml
+++ b/wallettemplate/pom.xml
@@ -42,10 +42,10 @@
                             <shadedClassifierName>bundled</shadedClassifierName>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>${artifactId}.Main</mainClass>
+                                    <mainClass>${project.artifactId}.Main</mainClass>
                                 </transformer>
                             </transformers>
-                            <outputFile>target/${artifactId}-shaded.jar</outputFile>
+                            <outputFile>target/${project.artifactId}-shaded.jar</outputFile>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
In usages of maven's ${artifactId}, Sha256.createHash and LazyECPoint.getX, getY