### PR TITLE
Run core tests in alphabetical order

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -301,6 +301,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <argLine>${surefireArgLine}</argLine> <!-- This is required for code coverage to work. -->
+                    <runOrder>alphabetical</runOrder>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
The [default order](http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#runOrder) in maven-surefire-plugin is 'filesystem' which may produce different results across platforms