### PR TITLE
Add readObject method to initialise listeners object which would be null...

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
@@ -141,7 +141,8 @@ public class TransactionConfidence implements Serializable {
     }
 
     /**
-     * In case the class gets created from a serialised version, we need to recreate the listeners object as it is set as transient and only created in the constructor.
+     * In case the class gets created from a serialised version, we need to recreate the listeners object as it is set 
+     * as transient and only created in the constructor.
      */
     private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();

--- a/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
@@ -141,6 +141,14 @@ public class TransactionConfidence implements Serializable {
     }
 
     /**
+     * In case the class gets created from a serialised version, we need to recreate the listeners object as it is set as transient and only created in the constructor.
+     */
+    private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        listeners = new CopyOnWriteArrayList<ListenerRegistration<Listener>>();
+    }
+
+    /**
      * <p>A confidence listener is informed when the level of {@link TransactionConfidence} is updated by something, like
      * for example a {@link Wallet}. You can add listeners to update your user interface or manage your order tracking
      * system when confidence levels pass a certain threshold. <b>Note that confidence can go down as well as up.</b>


### PR DESCRIPTION
... in case the confidence object gets created from Serialisation.

I got a null pointer for the listeners object from a serialised transaction. It was a transaction form the own wallet. 