### PR TITLE
bugfix for incomplete message headers at the end of the buffer

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerSocketHandler.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerSocketHandler.java
@@ -140,6 +140,7 @@ public abstract class PeerSocketHandler extends AbstractTimeoutHandler implement
                         processMessage(serializer.deserializePayload(header, ByteBuffer.wrap(largeReadBuffer)));
                         largeReadBuffer = null;
                         header = null;
+                        firstMessage = false;
                     } else // ...or just returning if we don't have enough bytes yet
                         return buff.position();
                 }

--- a/core/src/main/java/org/bitcoinj/core/PeerSocketHandler.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerSocketHandler.java
@@ -124,11 +124,12 @@ public abstract class PeerSocketHandler extends AbstractTimeoutHandler implement
                 buff.capacity() >= BitcoinSerializer.BitcoinPacketHeader.HEADER_LENGTH + 4);
         try {
             // Repeatedly try to deserialize messages until we hit a BufferUnderflowException
-            for (int i = 0; true; i++) {
+            boolean firstMessage = true;
+            while (true) {
                 // If we are in the middle of reading a message, try to fill that one first, before we expect another
                 if (largeReadBuffer != null) {
                     // This can only happen in the first iteration
-                    checkState(i == 0);
+                    checkState(firstMessage);
                     // Read new bytes into the largeReadBuffer
                     int bytesToGet = Math.min(buff.remaining(), largeReadBuffer.length - largeReadBufferPos);
                     buff.get(largeReadBuffer, largeReadBufferPos, bytesToGet);
@@ -149,7 +150,7 @@ public abstract class PeerSocketHandler extends AbstractTimeoutHandler implement
                     message = serializer.deserialize(buff);
                 } catch (BufferUnderflowException e) {
                     // If we went through the whole buffer without a full message, we need to use the largeReadBuffer
-                    if (i == 0 && buff.limit() == buff.capacity()) {
+                    if (firstMessage && buff.limit() == buff.capacity()) {
                         // ...so reposition the buffer to 0 and read the next message header
                         buff.position(0);
                         try {
@@ -176,6 +177,7 @@ public abstract class PeerSocketHandler extends AbstractTimeoutHandler implement
                 }
                 // Process our freshly deserialized message
                 processMessage(message);
+                firstMessage = false;
             }
         } catch (Exception e) {
             exceptionCaught(e);


### PR DESCRIPTION
There is a bug when there is a incomplete message header at the end of the buffer 

This is the description of the bug:

Let's say PeerSocketHandler.receiveBuffer() is called with a Buffer of 65536 bytes which contains:
a) the last part of a Block message (65530 bytes) 
b) the first 6 bytes of the next Block message.

Part "a" is processed using a `largeReadBuffer`.
While processing part "b" https://github.com/bitcoinj/bitcoinj/blob/0a6f901b23524af1ee178174a35d06de3d0e29fd/core/src/main/java/org/bitcoinj/core/PeerSocketHandler.java#L149 throws `BufferUnderflowException` because it can not deserialize the whole message.
Since `i==0`, it attempts to use `largeReadBuffer`
Then https://github.com/bitcoinj/bitcoinj/blob/0a6f901b23524af1ee178174a35d06de3d0e29fd/core/src/main/java/org/bitcoinj/core/PeerSocketHandler.java#L157 also throws BufferUnderflowException because it can not even read the whole header. 
Then `ProtocolException` is thrown https://github.com/bitcoinj/bitcoinj/blob/0a6f901b23524af1ee178174a35d06de3d0e29fd/core/src/main/java/org/bitcoinj/core/PeerSocketHandler.java#L168
That exception will cause bitcoinj to disconnect the Peer.

