### PR TITLE
Make sure connectionClosed is executed just once

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -288,17 +288,29 @@ public class Peer extends PeerSocketHandler {
         }
     }
 
+    protected final ReentrantLock connectionClosedAlreadyNotifiedLock = Threading.lock("peerConnectionClosedAlreadyNotified");
+    private boolean connectionClosedAlreadyNotified = false;
+    
     @Override
     public void connectionClosed() {
-        for (final PeerListenerRegistration registration : eventListeners) {
-            if (registration.callOnDisconnect)
-                registration.executor.execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        registration.listener.onPeerDisconnected(Peer.this, 0);
-                    }
-                });
+        connectionClosedAlreadyNotifiedLock.lock();
+        try {
+            if (!connectionClosedAlreadyNotified) {
+                connectionClosedAlreadyNotified=true;
+                for (final PeerListenerRegistration registration : eventListeners) {
+                    if (registration.callOnDisconnect)
+                        registration.executor.execute(new Runnable() {
+                            @Override
+                            public void run() {
+                                registration.listener.onPeerDisconnected(Peer.this, 0);
+                            }
+                        });
+                }            
+            }
+        } finally {
+            connectionClosedAlreadyNotifiedLock.unlock();
         }
+        
     }
 
     @Override


### PR DESCRIPTION
This is a bugfix for https://code.google.com/p/bitcoinj/issues/detail?id=611
I understand this solution is not ideal: it adds another lock object (using the main Peer lock causes circular locks) and we should avoid calling Peer.connectionClosed() several times instead of this "hack".
I just created the PR to open the debate.
