### PR TITLE
Refactor The TransactionBag Dependency in Transaction.java; Improve TransactionTest coverage

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -303,7 +303,7 @@ public class TransactionInput extends ChildMessage implements Serializable {
      * @return The TransactionOutput or null if the transactions map doesn't contain the referenced tx.
      */
     @Nullable
-    TransactionOutput getConnectedOutput(Map<Sha256Hash, Transaction> transactions) {
+    public TransactionOutput getConnectedOutput(Map<Sha256Hash, Transaction> transactions) {
         Transaction tx = transactions.get(outpoint.getHash());
         if (tx == null)
             return null;

--- a/core/src/main/java/org/bitcoinj/utils/TransactionUtils.java
+++ b/core/src/main/java/org/bitcoinj/utils/TransactionUtils.java
@@ -1,0 +1,129 @@
+package org.bitcoinj.utils;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.ScriptException;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionBag;
+import org.bitcoinj.core.TransactionInput;
+import org.bitcoinj.core.TransactionOutput;
+import org.bitcoinj.wallet.WalletTransaction.Pool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TransactionUtils {
+
+	private static final Logger log = LoggerFactory.getLogger(TransactionUtils.class);
+	
+    public static boolean isTransactionUnspent(Transaction tx, TransactionBag transactionBag) {
+        return isTransactionConsistent(tx, transactionBag, false);
+    }
+
+    public static boolean isTransactionSpent(Transaction tx, TransactionBag transactionBag) {
+        return isTransactionConsistent(tx, transactionBag, true);
+    }
+
+    /*
+     * If isSpent - check that all transaction outputs spent, otherwise check that there at least
+     * one unspent.
+     */
+    public static boolean isTransactionConsistent(Transaction tx, TransactionBag transactionBag, boolean isSpent) {
+        boolean isActuallySpent = true;
+        for (TransactionOutput o : tx.getOutputs()) {
+            if (o.isAvailableForSpending()) {
+                if (o.isMineOrWatched(transactionBag)) isActuallySpent = false;
+                if (o.getSpentBy() != null) {
+                    log.error("isAvailableForSpending != spentBy");
+                    return false;
+                }
+            } else {
+                if (o.getSpentBy() == null) {
+                    log.error("isAvailableForSpending != spentBy");
+                    return false;
+                }
+            }
+        }
+        return isActuallySpent == isSpent;
+    }
+    
+    /**
+     * Calculates the sum of the outputs that are sending coins to a key in the wallet. The flag controls whether to
+     * include spent outputs or not.
+     */
+    public static Coin getValueSentToTx(Transaction tx, TransactionBag transactionBag, boolean includeSpent) {
+        // This is tested in WalletTest.
+        Coin v = Coin.ZERO;
+        for (TransactionOutput o : tx.getOutputs()) {
+            if (!o.isMineOrWatched(transactionBag)) continue;
+            if (!includeSpent && !o.isAvailableForSpending()) continue;
+            v = v.add(o.getValue());
+        }
+        return v;
+    }
+    
+    public static Coin getValueSentToTx(Transaction tx, TransactionBag transactionBag) {
+    	return getValueSentToTx(tx, transactionBag, true);
+    }
+
+    /**
+     * Calculates the sum of the inputs that are spending coins with keys in the wallet. This requires the
+     * transactions sending coins to those keys to be in the wallet. This method will not attempt to download the
+     * blocks containing the input transactions if the key is in the wallet but the transactions are not.
+     *
+     * @return sum of the inputs that are spending coins with keys in the wallet
+     */
+    public static Coin getValueSentFromTx(Transaction tx, TransactionBag wallet) throws ScriptException {
+        // This is tested in WalletTest.
+        Coin v = Coin.ZERO;
+        for (TransactionInput input : tx.getInputs()) {
+            // This input is taking value from a transaction in our wallet. To discover the value,
+            // we must find the connected transaction.
+            TransactionOutput connected = input.getConnectedOutput(wallet.getTransactionPool(Pool.UNSPENT));
+            if (connected == null)
+                connected = input.getConnectedOutput(wallet.getTransactionPool(Pool.SPENT));
+            if (connected == null)
+                connected = input.getConnectedOutput(wallet.getTransactionPool(Pool.PENDING));
+            if (connected == null)
+                continue;
+            // The connected output may be the change to the sender of a previous input sent to this wallet. In this
+            // case we ignore it.
+            if (!connected.isMineOrWatched(wallet))
+                continue;
+            v = v.add(connected.getValue());
+        }
+        return v;
+    }
+
+    /**
+     * Returns false if this transaction has at least one output that is owned by the given wallet and unspent, true
+     * otherwise.
+     */
+    public static boolean isEveryOwnedOutputSpent(Transaction tx, TransactionBag transactionBag) {
+        for (TransactionOutput output : tx.getOutputs()) {
+            if (output.isAvailableForSpending() && output.isMineOrWatched(transactionBag))
+                return false;
+        }
+        return true;
+    }
+
+    /**
+     * <p>Returns the list of transacion outputs, whether spent or unspent, that match a wallet by address or that are
+     * watched by a wallet, i.e., transaction outputs whose script's address is controlled by the wallet and transaction
+     * outputs whose script is watched by the wallet.</p>
+     *
+     * @param transactionBag The wallet that controls addresses and watches scripts.
+     * @return linked list of outputs relevant to the wallet in this transaction
+     */
+    public static List<TransactionOutput> getWalletOutputs(Transaction tx, TransactionBag transactionBag){
+        List<TransactionOutput> walletOutputs = new LinkedList<TransactionOutput>();
+        Coin v = Coin.ZERO;
+        for (TransactionOutput o : tx.getOutputs()) {
+            if (!o.isMineOrWatched(transactionBag)) continue;
+            walletOutputs.add(o);
+        }
+
+        return walletOutputs;
+    }
+}

--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -17,7 +17,17 @@
 
 package org.bitcoinj.core;
 
-import com.google.common.collect.Lists;
+import static org.bitcoinj.core.Coin.FIFTY_COINS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.lang.ref.WeakReference;
+import java.util.Arrays;
+import java.util.List;
+
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.UnitTestParams;
 import org.bitcoinj.script.Script;
@@ -25,19 +35,14 @@ import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.store.FullPrunedBlockStore;
 import org.bitcoinj.utils.BlockFileLoader;
 import org.bitcoinj.utils.BriefLogFormatter;
+import org.bitcoinj.utils.TransactionUtils;
 import org.bitcoinj.wallet.WalletTransaction;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.lang.ref.WeakReference;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.bitcoinj.core.Coin.FIFTY_COINS;
-import static org.junit.Assert.*;
+import com.google.common.collect.Lists;
 
 /**
  * We don't do any wallet tests here, we leave that to {@link ChainSplitTest}
@@ -328,7 +333,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         assertEquals("Wrong number of PENDING.4", 1, wallet.getPoolSize(WalletTransaction.Pool.PENDING));
         Coin totalPendingTxAmount = Coin.ZERO;
         for (Transaction tx : wallet.getPendingTransactions()) {
-            totalPendingTxAmount = totalPendingTxAmount.add(tx.getValueSentToMe(wallet));
+            totalPendingTxAmount = totalPendingTxAmount.add(TransactionUtils.getValueSentToTx(tx, wallet));
         }
 
         // The availbale balance should be the 0 (as we spent the 1 BTC that's pending) and estimated should be 1/2 - fee BTC

--- a/core/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
@@ -17,26 +17,36 @@
 
 package org.bitcoinj.core;
 
-import com.google.common.util.concurrent.*;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.bitcoinj.core.Coin.COIN;
+import static org.bitcoinj.core.Coin.FIFTY_COINS;
+import static org.bitcoinj.core.Coin.valueOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+
 import org.bitcoinj.params.UnitTestParams;
 import org.bitcoinj.testing.FakeTxBuilder;
 import org.bitcoinj.testing.InboundMessageQueuer;
 import org.bitcoinj.testing.TestWithPeerGroup;
 import org.bitcoinj.utils.Threading;
+import org.bitcoinj.utils.TransactionUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Random;
-import java.util.concurrent.*;
-
-import static org.bitcoinj.core.Coin.*;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.junit.Assert.*;
+import com.google.common.util.concurrent.AtomicDouble;
+import com.google.common.util.concurrent.ListenableFuture;
 
 @RunWith(value = Parameterized.class)
 public class TransactionBroadcastTest extends TestWithPeerGroup {
@@ -210,7 +220,7 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
         }
         assertNotNull(t1);
         // 49 BTC in change.
-        assertEquals(valueOf(49, 0), t1.getValueSentToMe(wallet));
+        assertEquals(valueOf(49, 0), TransactionUtils.getValueSentToTx(t1, wallet));
         // The future won't complete until it's heard back from the network on p2.
         InventoryMessage inv = new InventoryMessage(params);
         inv.addTransaction(t1);

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -1,12 +1,24 @@
 package org.bitcoinj.core;
 
+import org.bitcoinj.core.TransactionConfidence.ConfidenceType;
 import org.bitcoinj.params.UnitTestParams;
+import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.testing.FakeTxBuilder;
 import org.junit.Before;
 import org.junit.Test;
+import org.easymock.EasyMock;
 
 import static org.junit.Assert.assertEquals;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.replay;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 /**
  * Just check the Transaction.verify() method. Most methods that have complicated logic in Transaction are tested
@@ -24,9 +36,24 @@ public class TransactionTest {
     @Before
     public void setUp() throws Exception {
         dummy = FakeTxBuilder.createFakeTx(PARAMS, Coin.COIN, ADDRESS);
-        tx = new Transaction(PARAMS);
-        tx.addOutput(Coin.COIN, ADDRESS);
-        tx.addInput(dummy.getOutput(0));
+        tx = newTransaction();
+    }
+
+    private Transaction newTransaction(boolean newToAddress) {
+        Address addr = newToAddress ? new ECKey().toAddress(PARAMS): ADDRESS;
+        return newTransaction(new TransactionOutput(PARAMS, null, Coin.COIN, addr));
+    }
+
+    private Transaction newTransaction() {
+        return newTransaction(new TransactionOutput(PARAMS, null, Coin.COIN, ADDRESS));
+    }
+
+    private Transaction newTransaction(TransactionOutput to) {
+        Transaction newTx = new Transaction(PARAMS);
+        newTx.addOutput(to);
+        newTx.addInput(dummy.getOutput(0));
+
+        return newTx;
     }
 
     @Test(expected = VerificationException.EmptyInputsOrOutputs.class)
@@ -88,5 +115,152 @@ public class TransactionTest {
         TransactionInput input = tx.addInput(Sha256Hash.ZERO_HASH, 0xFFFFFFFFL, new ScriptBuilder().data(new byte[99]).build());
         assertEquals(101, input.getScriptBytes().length);
         tx.verify();
+    }
+
+    @Test
+    public void testEstimatedLockTime_WhenParameterSignifiesBlockHeight() {
+        int TEST_LOCK_TIME = 20;
+        Date now = Calendar.getInstance().getTime();
+
+        BlockChain mockBlockChain = createMock(BlockChain.class);
+        EasyMock.expect(mockBlockChain.estimateBlockTime(TEST_LOCK_TIME)).andReturn(now);
+
+        Transaction tx = newTransaction();
+        tx.setLockTime(TEST_LOCK_TIME); // less than five hundred million
+
+        replay(mockBlockChain);
+
+        assertEquals(tx.estimateLockTime(mockBlockChain), now);
+    }
+
+    @Test
+    public void testOptimalEncodingMessageSize() {
+        Transaction tx = new Transaction(PARAMS);
+
+        int length = tx.length;
+
+        // add basic transaction input, check the length
+        tx.addOutput(new TransactionOutput(PARAMS, null, Coin.COIN, ADDRESS));
+        length += getCombinedLength(tx.getOutputs());
+
+        // add basic output, check the length
+        tx.addInput(dummy.getOutput(0));
+        length += getCombinedLength(tx.getInputs());
+
+        // optimal encoding size should equal the length we just calculated
+        assertEquals(tx.getOptimalEncodingMessageSize(), length);
+    }
+
+    private int getCombinedLength(List<? extends Message> list) {
+        int sumOfAllMsgSizes = 0;
+        for (Message m: list) { sumOfAllMsgSizes += m.getMessageSize() + 1; }
+        return sumOfAllMsgSizes;
+    }
+
+    @Test
+    public void testIsMatureReturnsFalseIfTransactionIsCoinbaseAndConfidenceTypeIsNotEqualToBuilding() {
+        Transaction tx = new Transaction(PARAMS);
+        tx.addInput(dummy.getOutput(0));
+
+        // make this into a coinbase transaction
+        TransactionInput input = tx.getInput(0);
+        input.getOutpoint().setHash(Sha256Hash.ZERO_HASH);
+        input.getOutpoint().setIndex(-1);
+
+        tx.getConfidence().setConfidenceType(ConfidenceType.UNKNOWN);
+        assertEquals(tx.isMature(), false);
+
+        tx.getConfidence().setConfidenceType(ConfidenceType.PENDING);
+        assertEquals(tx.isMature(), false);
+
+        tx.getConfidence().setConfidenceType(ConfidenceType.DEAD);
+        assertEquals(tx.isMature(), false);
+    }
+
+    @Test
+    public void testToStringWhenLockTimeIsSpecifiedInBlockHeight() {
+        Transaction tx = newTransaction();
+        TransactionInput input = tx.getInput(0);
+        input.setSequenceNumber(42);
+
+        int TEST_LOCK_TIME = 20;
+        tx.setLockTime(TEST_LOCK_TIME);
+
+        Calendar cal = Calendar.getInstance();
+        cal.set(2085, 10, 4, 17, 53, 21);
+        cal.set(Calendar.MILLISECOND, 0);
+
+        BlockChain mockBlockChain = createMock(BlockChain.class);
+        EasyMock.expect(mockBlockChain.estimateBlockTime(TEST_LOCK_TIME)).andReturn(cal.getTime());
+
+        replay(mockBlockChain);
+
+        String str = tx.toString(mockBlockChain);
+
+        assertEquals(str.contains("block " + TEST_LOCK_TIME), true);
+        assertEquals(str.contains("estimated to be reached at"), true);
+    }
+
+    @Test
+    public void testToStringWhenIteratingOverAnInputCatchesAnException() {
+        Transaction tx = newTransaction();
+        TransactionInput ti = new TransactionInput(PARAMS, tx, new byte[0]) {
+            @Override
+            public Script getScriptSig() throws ScriptException {
+                throw new ScriptException("");
+            }
+        };
+
+        tx.addInput(ti);
+        assertEquals(tx.toString().contains("[exception: "), true);
+    }
+
+    @Test
+    public void testToStringWhenThereAreZeroInputs() {
+        Transaction tx = new Transaction(PARAMS);
+        assertEquals(tx.toString().contains("No inputs!"), true);
+    }
+
+    @Test
+    public void testTheTXByHeightComparator() {
+        final boolean USE_UNIQUE_ADDRESS = true;
+        Transaction tx1 = newTransaction(USE_UNIQUE_ADDRESS);
+        tx1.getConfidence().setAppearedAtChainHeight(1);
+
+        Transaction tx2 = newTransaction(USE_UNIQUE_ADDRESS);
+        tx2.getConfidence().setAppearedAtChainHeight(2);
+
+        Transaction tx3 = newTransaction(USE_UNIQUE_ADDRESS);
+        tx3.getConfidence().setAppearedAtChainHeight(3);
+
+        SortedSet<Transaction> set = new TreeSet<Transaction>(Transaction.SORT_TX_BY_HEIGHT);
+        set.add(tx2);
+        set.add(tx1);
+        set.add(tx3);
+
+        Iterator<Transaction> iterator = set.iterator();
+
+        assertEquals(tx1.equals(tx2), false);
+        assertEquals(tx1.equals(tx3), false);
+        assertEquals(tx1.equals(tx1), true);
+
+        assertEquals(iterator.next().equals(tx3), true);
+        assertEquals(iterator.next().equals(tx2), true);
+        assertEquals(iterator.next().equals(tx1), true);
+        assertEquals(iterator.hasNext(), false);
+    }
+
+    @Test(expected = ScriptException.class)
+    public void testAddSignedInputThrowsExceptionWhenScriptIsNotToRawPubKeyAndIsNotToAddress() {
+        ECKey key = new ECKey();
+        Address addr = key.toAddress(PARAMS);
+        Transaction fakeTx = FakeTxBuilder.createFakeTx(PARAMS, Coin.COIN, addr);
+
+        Transaction tx = new Transaction(PARAMS);
+        tx.addOutput(fakeTx.getOutput(0));
+
+        Script script = ScriptBuilder.createOpReturnScript(new byte[0]);
+
+        tx.addSignedInput(fakeTx.getOutput(0).getOutPointFor(), script, key);
     }
 }

--- a/core/src/test/java/org/bitcoinj/core/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/core/WalletTest.java
@@ -17,8 +17,51 @@
 
 package org.bitcoinj.core;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.bitcoinj.core.Coin.CENT;
+import static org.bitcoinj.core.Coin.COIN;
+import static org.bitcoinj.core.Coin.SATOSHI;
+import static org.bitcoinj.core.Coin.ZERO;
+import static org.bitcoinj.core.Coin.valueOf;
+import static org.bitcoinj.core.Utils.HEX;
+import static org.bitcoinj.testing.FakeTxBuilder.createFakeBlock;
+import static org.bitcoinj.testing.FakeTxBuilder.createFakeTx;
+import static org.bitcoinj.testing.FakeTxBuilder.createFakeTxWithChangeAddress;
+import static org.bitcoinj.testing.FakeTxBuilder.makeSolvedTestBlock;
+import static org.bitcoinj.testing.FakeTxBuilder.roundTripTransaction;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.bitcoinj.core.Wallet.SendRequest;
-import org.bitcoinj.crypto.*;
+import org.bitcoinj.crypto.ChildNumber;
+import org.bitcoinj.crypto.DeterministicKey;
+import org.bitcoinj.crypto.KeyCrypter;
+import org.bitcoinj.crypto.KeyCrypterException;
+import org.bitcoinj.crypto.KeyCrypterScrypt;
+import org.bitcoinj.crypto.MnemonicException;
+import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptOpCodes;
@@ -28,17 +71,31 @@ import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.store.UnreadableWalletException;
 import org.bitcoinj.store.WalletProtobufSerializer;
-import org.bitcoinj.testing.*;
+import org.bitcoinj.testing.FakeTxBuilder;
+import org.bitcoinj.testing.FakeTxBuilder.BlockPair;
+import org.bitcoinj.testing.KeyChainTransactionSigner;
+import org.bitcoinj.testing.MockTransactionBroadcaster;
+import org.bitcoinj.testing.NopTransactionSigner;
+import org.bitcoinj.testing.TestWithWallet;
 import org.bitcoinj.utils.ExchangeRate;
 import org.bitcoinj.utils.Fiat;
 import org.bitcoinj.utils.Threading;
-import org.bitcoinj.wallet.*;
-import org.bitcoinj.wallet.WalletTransaction.Pool;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.protobuf.ByteString;
+import org.bitcoinj.utils.TransactionUtils;
+import org.bitcoinj.wallet.AllowUnconfirmedCoinSelector;
+import org.bitcoinj.wallet.DefaultCoinSelector;
+import org.bitcoinj.wallet.DeterministicKeyChain;
+import org.bitcoinj.wallet.DeterministicUpgradeRequiresPassword;
+import org.bitcoinj.wallet.KeyBag;
+import org.bitcoinj.wallet.KeyChain;
+import org.bitcoinj.wallet.KeyChainGroup;
+import org.bitcoinj.wallet.KeyTimeCoinSelector;
+import org.bitcoinj.wallet.MarriedKeyChain;
+import org.bitcoinj.wallet.Protos;
 import org.bitcoinj.wallet.Protos.Wallet.EncryptionType;
+import org.bitcoinj.wallet.RiskAnalysis;
+import org.bitcoinj.wallet.WalletFiles;
+import org.bitcoinj.wallet.WalletTransaction;
+import org.bitcoinj.wallet.WalletTransaction.Pool;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,22 +103,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.crypto.params.KeyParameter;
 
-import java.io.File;
-import java.math.BigInteger;
-import java.net.InetAddress;
-import java.security.SecureRandom;
-import java.util.*;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
-
-import static org.bitcoinj.core.Coin.*;
-import static org.bitcoinj.core.Utils.HEX;
-import static org.bitcoinj.testing.FakeTxBuilder.*;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.junit.Assert.*;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.protobuf.ByteString;
 
 public class WalletTest extends TestWithWallet {
     private static final Logger log = LoggerFactory.getLogger(WalletTest.class);
@@ -619,13 +664,13 @@ public class WalletTest extends TestWithWallet {
     public void balances() throws Exception {
         Coin nanos = COIN;
         Transaction tx1 = sendMoneyToWallet(nanos, AbstractBlockChain.NewBlockType.BEST_CHAIN);
-        assertEquals(nanos, tx1.getValueSentToMe(wallet, true));
-        assertTrue(tx1.getWalletOutputs(wallet).size() >= 1);
+        assertEquals(nanos, TransactionUtils.getValueSentToTx(tx1, wallet, true));
+        assertTrue(TransactionUtils.getWalletOutputs(tx1, wallet).size() >= 1);
         // Send 0.10 to somebody else.
         Transaction send1 = wallet.createSend(new ECKey().toAddress(params), valueOf(0, 10));
         // Reserialize.
         Transaction send2 = new Transaction(params, send1.bitcoinSerialize());
-        assertEquals(nanos, send2.getValueSentFromMe(wallet));
+        assertEquals(nanos, TransactionUtils.getValueSentFromTx(send2, wallet));
         assertEquals(ZERO.subtract(valueOf(0, 10)), send2.getValue(wallet));
     }
 
@@ -680,8 +725,44 @@ public class WalletTest extends TestWithWallet {
     }
 
     @Test
+    public void isNotConsistent_WhenTransactionOutputHasValueForSpentByButIsAvailableForSpendingIsTrue() throws Exception {
+        // Due to checks in the core code, this condition should never happen. In fact, this
+        //  test is to test code that returns false when and if this impossible case happens
+        Transaction tx = createFakeTx(params, COIN, myAddress);
+        TransactionOutput output = new TransactionOutput(params, tx, valueOf(0, 5), new ECKey().toAddress(params)) {
+            public boolean isAvailableForSpending() { return true; }
+            public boolean isMineOrWatched(TransactionBag tb) { return true; }
+            public TransactionInput getSpentBy() { return getParentTransaction().getInput(0); }
+        };
+
+        tx.addOutput(output);
+
+        wallet.addWalletTransaction(new WalletTransaction(Pool.UNSPENT, tx));
+
+        assertFalse(wallet.isConsistent());
+    }
+
+    @Test
+    public void isNotConsistent_WhenTransactionOutputHasNoValueForSpentByButIsAvailableForSpendingIsFalse() throws Exception {
+        // Due to checks in the core code, this condition should never happen. In fact, this
+        //  test is to test code that returns false when and if this impossible case happens
+        Transaction tx = createFakeTx(params, COIN, myAddress);
+        TransactionOutput output = new TransactionOutput(params, tx, valueOf(0, 5), new ECKey().toAddress(params)) {
+            public boolean isAvailableForSpending() { return false; }
+            public boolean isMineOrWatched(TransactionBag tb) { return true; }
+            public TransactionInput getSpentBy() { return null; }
+        };
+
+        tx.addOutput(output);
+
+        wallet.addWalletTransaction(new WalletTransaction(Pool.SPENT, tx));
+
+        assertFalse(wallet.isConsistent());
+    }
+
+    @Test
     public void transactions() throws Exception {
-        // This test covers a bug in which Transaction.getValueSentFromMe was calculating incorrectly.
+        // This test covers a bug in which TransactionUtils.getValueSentFromTx was calculating incorrectly.
         Transaction tx = createFakeTx(params, COIN, myAddress);
         // Now add another output (ie, change) that goes to some other address.
         Address someOtherGuy = new ECKey().toAddress(params);
@@ -696,7 +777,7 @@ public class WalletTest extends TestWithWallet {
         tx2.addInput(output);
         tx2.addOutput(new TransactionOutput(params, tx2, valueOf(0, 5), myAddress));
         // tx2 doesn't send any coins from us, even though the output is in the wallet.
-        assertEquals(ZERO, tx2.getValueSentFromMe(wallet));
+        assertEquals(ZERO, TransactionUtils.getValueSentFromTx(tx2, wallet));
     }
 
     @Test
@@ -714,11 +795,11 @@ public class WalletTest extends TestWithWallet {
         Transaction outbound1 = wallet.createSend(someOtherGuy, coinHalf);
         wallet.commitTx(outbound1);
         sendMoneyToWallet(outbound1, AbstractBlockChain.NewBlockType.BEST_CHAIN);
-        assertTrue(outbound1.getWalletOutputs(wallet).size() <= 1); //the change address at most
+        assertTrue(TransactionUtils.getWalletOutputs(outbound1, wallet).size() <= 1); //the change address at most
         // That other guy gives us the coins right back.
         Transaction inbound2 = new Transaction(params);
         inbound2.addOutput(new TransactionOutput(params, inbound2, coinHalf, myAddress));
-        assertTrue(outbound1.getWalletOutputs(wallet).size() >= 1);
+        assertTrue(TransactionUtils.getWalletOutputs(outbound1, wallet).size() >= 1);
         inbound2.addInput(outbound1.getOutputs().get(0));
         sendMoneyToWallet(inbound2, AbstractBlockChain.NewBlockType.BEST_CHAIN);
         assertEquals(coin1, wallet.getBalance());
@@ -1192,7 +1273,7 @@ public class WalletTest extends TestWithWallet {
         wallet.addWatchedAddress(watchedAddress);
         Coin value = valueOf(5, 0);
         Transaction t1 = createFakeTx(params, value, watchedAddress);
-        assertTrue(t1.getWalletOutputs(wallet).size() >= 1);
+        assertTrue(TransactionUtils.getWalletOutputs(t1, wallet).size() >= 1);
         assertTrue(wallet.isPendingTransactionRelevant(t1));
     }
 
@@ -1233,7 +1314,7 @@ public class WalletTest extends TestWithWallet {
         assertEquals(baseElements + 2, wallet.getBloomFilterElementCount());
         wallet.receiveFromBlock(st2, b1, BlockChain.NewBlockType.BEST_CHAIN, 0);
         assertEquals(baseElements + 2, wallet.getBloomFilterElementCount());
-        assertEquals(CENT, st2.getValueSentFromMe(wallet));
+        assertEquals(CENT, TransactionUtils.getValueSentFromTx(st2, wallet));
     }
 
     @Test
@@ -2640,8 +2721,8 @@ public class WalletTest extends TestWithWallet {
 
         Transaction tx = broadcaster.waitForTransactionAndSucceed();
         final Coin THREE_CENTS = CENT.add(CENT).add(CENT);
-        assertEquals(THREE_CENTS, tx.getValueSentFromMe(wallet));
-        assertEquals(THREE_CENTS.subtract(Transaction.REFERENCE_DEFAULT_MIN_TX_FEE), tx.getValueSentToMe(wallet));
+        assertEquals(THREE_CENTS, TransactionUtils.getValueSentFromTx(tx, wallet));
+        assertEquals(THREE_CENTS.subtract(Transaction.REFERENCE_DEFAULT_MIN_TX_FEE), TransactionUtils.getValueSentToTx(tx, wallet));
         // TX sends to one of our addresses (for now we ignore married wallets).
         final Address toAddress = tx.getOutput(0).getScriptPubKey().getToAddress(params);
         final ECKey rotatingToKey = wallet.findKeyFromPubHash(toAddress.getHash160());
@@ -2792,8 +2873,8 @@ public class WalletTest extends TestWithWallet {
         wallet.doMaintenance(null, true);
 
         Transaction tx = broadcaster.waitForTransactionAndSucceed();
-        final Coin valueSentToMe = tx.getValueSentToMe(wallet);
-        Coin fee = tx.getValueSentFromMe(wallet).subtract(valueSentToMe);
+        final Coin valueSentToMe = TransactionUtils.getValueSentToTx(tx, wallet);
+        Coin fee = TransactionUtils.getValueSentFromTx(tx, wallet).subtract(valueSentToMe);
         assertEquals(Coin.valueOf(900000), fee);
         assertEquals(KeyTimeCoinSelector.MAX_SIMULTANEOUS_INPUTS, tx.getInputs().size());
         assertEquals(Coin.valueOf(599100000), valueSentToMe);

--- a/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
@@ -17,20 +17,29 @@
 
 package org.bitcoinj.examples;
 
-import org.bitcoinj.core.*;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.File;
+
+import org.bitcoinj.core.AbstractWalletEventListener;
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.InsufficientMoneyException;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionConfidence;
+import org.bitcoinj.core.Wallet;
 import org.bitcoinj.crypto.KeyCrypterException;
 import org.bitcoinj.kits.WalletAppKit;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.RegTestParams;
 import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.utils.BriefLogFormatter;
+import org.bitcoinj.utils.TransactionUtils;
+
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
-
-import java.io.File;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * ForwardingService demonstrates basic usage of the library. It sits on the network and when it receives coins, simply
@@ -84,7 +93,7 @@ public class ForwardingService {
                 // Runs in the dedicated "user thread" (see bitcoinj docs for more info on this).
                 //
                 // The transaction "tx" can either be pending, or included into a block (we didn't see the broadcast).
-                Coin value = tx.getValueSentToMe(w);
+                Coin value = TransactionUtils.getValueSentToTx(tx, w);
                 System.out.println("Received tx for " + value.toFriendlyString() + ": " + tx);
                 System.out.println("Transaction will be forwarded after it confirms.");
                 // Wait until it's made it into the block chain (may run immediately if it's already there).
@@ -119,7 +128,7 @@ public class ForwardingService {
 
     private static void forwardCoins(Transaction tx) {
         try {
-            Coin value = tx.getValueSentToMe(kit.wallet());
+            Coin value = TransactionUtils.getValueSentToTx(tx, kit.wallet());
             System.out.println("Forwarding " + value.toFriendlyString());
             // Now send the coins back! Send with a small fee attached to ensure rapid confirmation.
             final Coin amountToSend = value.subtract(Transaction.REFERENCE_DEFAULT_MIN_TX_FEE);


### PR DESCRIPTION
I moved all methods that required a TransactionBag parameter from Transaction to TransactionUtils. I believe this is a more correct placement because when the method is in Transaction, it requires a TransactionBag (ie: a Wallet) to be passed in. So, for TransactionTest, that means a mock. Also, Wallet is the only code that called these methods. So they all support/enhance Wallet's functionality, and not Transaction's. Transaction is not, then, the best place for them.

My original purpose sprung from trying to remove the mocks necessary to test Transaction.isConsistent(). But that mock would always be required, as a TransactionBag of some sort must be passed in to exercise that method's code. I did, however, notice that the implementation of the method did not depend on any private/protected parts of the Transaction object. And further it was only called by Wallet. It could be moved to a neutral location (along with the mock necessary to test it) and Wallet could call it there, keeping all functionality it had, and the mock presently in TransactionTest.isConsistent() would be gone.

There's more to say, but I will let the code talk... I've been in my head on this for days.. do let me know what you think.. I think this is the right move, but it may need some polish.