### PR TITLE
Makes UTXO use property Script instead of scriptBytes and addressType.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
@@ -177,7 +177,7 @@ public class FullPrunedBlockChain extends AbstractBlockChain {
     }
 
     /**
-     * Get the {@link Script} from the script bytes or null if it doesn't parse.
+     * Get the {@link Script} from the script bytes or return Script of empty byte array.
      */
     private Script getScript(byte[] scriptBytes) {
         try {

--- a/core/src/main/java/org/bitcoinj/core/UTXO.java
+++ b/core/src/main/java/org/bitcoinj/core/UTXO.java
@@ -33,29 +33,40 @@ public class UTXO implements Serializable {
     private static final long serialVersionUID = -8744924157056340509L;
 
     /**
-     *  A transaction output has some value and a script used for authenticating that the redeemer is allowed to spend
-     *  this output.
+     * A transaction output has some value and a script used for authenticating that the redeemer is allowed to spend
+     * this output.
      */
     private Coin value;
     private Script script;
 
-    /** Hash of the transaction to which we refer. */
+    /**
+     * Hash of the transaction to which we refer.
+     */
     private Sha256Hash hash;
-    /** Which output of that transaction we are talking about. */
+    /**
+     * Which output of that transaction we are talking about.
+     */
     private long index;
-    /** The height of the tx of this output */
+    /**
+     * The height of the tx of this output
+     */
     private int height;
-    /** If this output is from a coinbase tx */
+    /**
+     * If this output is from a coinbase tx
+     */
     private boolean coinbase;
-    /** The address of this output */
+    /**
+     * The address of this output
+     */
     private String address;
 
     /**
      * Creates a stored transaction output.
-     * @param hash The hash of the containing transaction.
-     * @param index The outpoint.
-     * @param value The value available.
-     * @param height The height this output was created in.
+     *
+     * @param hash     The hash of the containing transaction.
+     * @param index    The outpoint.
+     * @param value    The value available.
+     * @param height   The height this output was created in.
      * @param coinbase The coinbase flag.
      */
     public UTXO(Sha256Hash hash,
@@ -75,12 +86,13 @@ public class UTXO implements Serializable {
 
     /**
      * Creates a stored transaction output.
-     * @param hash The hash of the containing transaction.
-     * @param index The outpoint.
-     * @param value The value available.
-     * @param height The height this output was created in.
+     *
+     * @param hash     The hash of the containing transaction.
+     * @param index    The outpoint.
+     * @param value    The value available.
+     * @param height   The height this output was created in.
      * @param coinbase The coinbase flag.
-     * @param address The address.
+     * @param address  The address.
      */
     public UTXO(Sha256Hash hash,
                 long index,
@@ -134,6 +146,7 @@ public class UTXO implements Serializable {
 
     /**
      * The value which this Transaction output holds.
+     *
      * @return the value.
      */
     public Coin getValue() {
@@ -142,6 +155,7 @@ public class UTXO implements Serializable {
 
     /**
      * The Script object which you can use to get address, script bytes or script type.
+     *
      * @return the script.
      */
     public Script getScript() {
@@ -150,6 +164,7 @@ public class UTXO implements Serializable {
 
     /**
      * The hash of the transaction which holds this output.
+     *
      * @return the hash.
      */
     public Sha256Hash getHash() {
@@ -158,6 +173,7 @@ public class UTXO implements Serializable {
 
     /**
      * The index of this output in the transaction which holds it.
+     *
      * @return the index.
      */
     public long getIndex() {
@@ -166,6 +182,7 @@ public class UTXO implements Serializable {
 
     /**
      * Gets the height of the block that created this output.
+     *
      * @return The height.
      */
     public int getHeight() {
@@ -174,6 +191,7 @@ public class UTXO implements Serializable {
 
     /**
      * Gets the flag of whether this was created by a coinbase tx.
+     *
      * @return The coinbase flag.
      */
     public boolean isCoinbase() {
@@ -182,6 +200,7 @@ public class UTXO implements Serializable {
 
     /**
      * The address of this output.
+     *
      * @return The address.
      */
     public String getAddress() {

--- a/core/src/main/java/org/bitcoinj/core/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/core/Wallet.java
@@ -3977,7 +3977,7 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
      *
      * @param vUTXOProvider The UTXO provider.
      */
-    public void setUTXOProvider(@Nullable FullPrunedBlockStore vUTXOProvider) {
+    public void setUTXOProvider(@Nullable UTXOProvider vUTXOProvider) {
         lock.lock();
         try {
             checkArgument(vUTXOProvider == null ? true : vUTXOProvider.getParams().equals(params));

--- a/core/src/main/java/org/bitcoinj/core/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/core/Wallet.java
@@ -4006,7 +4006,7 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
          * @param output The stored output (free standing).
          */
         public FreeStandingTransactionOutput(NetworkParameters params, UTXO output, int chainHeight) {
-            super(params, null, output.getValue(), output.getScriptBytes());
+            super(params, null, output.getValue(), output.getScript().getProgram());
             this.output = output;
             this.chainHeight = chainHeight;
         }

--- a/core/src/main/java/org/bitcoinj/store/DatabaseFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/DatabaseFullPrunedBlockStore.java
@@ -19,6 +19,7 @@ package org.bitcoinj.store;
 
 import com.google.common.collect.Lists;
 import org.bitcoinj.core.*;
+import org.bitcoinj.script.Script;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -929,15 +930,13 @@ public abstract class DatabaseFullPrunedBlockStore implements FullPrunedBlockSto
             byte[] scriptBytes = results.getBytes(3);
             boolean coinbase = results.getBoolean(4);
             String address = results.getString(5);
-            int addressType = results.getInt(6);
             UTXO txout = new UTXO(hash,
                     index,
                     value,
                     height,
                     coinbase,
-                    scriptBytes,
-                    address,
-                    addressType);
+                    new Script(scriptBytes),
+                    address);
             return txout;
         } catch (SQLException ex) {
             throw new BlockStoreException(ex);
@@ -963,9 +962,9 @@ public abstract class DatabaseFullPrunedBlockStore implements FullPrunedBlockSto
             s.setInt(2, (int) out.getIndex());
             s.setInt(3, out.getHeight());
             s.setLong(4, out.getValue().value);
-            s.setBytes(5, out.getScriptBytes());
+            s.setBytes(5, out.getScript().getProgram());
             s.setString(6, out.getAddress());
-            s.setInt(7, out.getAddressType());
+            s.setInt(7, out.getScript().getScriptType().ordinal());
             s.setBoolean(8, out.isCoinbase());
             s.executeUpdate();
             s.close();
@@ -1173,15 +1172,13 @@ public abstract class DatabaseFullPrunedBlockStore implements FullPrunedBlockSto
                     int index = rs.getInt(5);
                     boolean coinbase = rs.getBoolean(6);
                     String toAddress = rs.getString(7);
-                    int addressType = rs.getInt(8);
                     UTXO output = new UTXO(hash,
                             index,
                             amount,
                             height,
                             coinbase,
-                            scriptBytes,
-                            toAddress,
-                            addressType);
+                            new Script(scriptBytes),
+                            toAddress);
                     outputs.add(output);
                 }
             }


### PR DESCRIPTION
There were two fields in UTXO: scriptBytes and addressType. 

The fields substituted with Script script.
All code usages of UTXO getters changed.

FullPrunedBlockChain.getScript() changed to avoid returning null.

Cosmetic changes of UTXO and FullPrunedBlockChain.