### PR TITLE
Updating DefaultRiskAnalysis to check transaction size

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/DefaultRiskAnalysis.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DefaultRiskAnalysis.java
@@ -103,12 +103,8 @@ public class DefaultRiskAnalysis implements RiskAnalysis {
                 return Result.NON_FINAL;
             }
         }
-        
-<<<<<<< HEAD
-        //Lets make sure this is not a crazy large transaction 
-=======
+
         //Lets make sure this is not a crazy large transaction
->>>>>>> origin/master
         if (tx.bitcoinSerialize().length > Transaction.MAX_STANDARD_TX_SIZE) {
             return Result.NON_STANDARD;
         }

--- a/core/src/main/java/org/bitcoinj/wallet/DefaultRiskAnalysis.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DefaultRiskAnalysis.java
@@ -96,12 +96,19 @@ public class DefaultRiskAnalysis implements RiskAnalysis {
             nonFinal = tx;
             return Result.NON_FINAL;
         }
+        
         for (Transaction dep : dependencies) {
             if (!dep.isFinal(adjustedHeight, time)) {
                 nonFinal = dep;
                 return Result.NON_FINAL;
             }
         }
+        
+        //Lets make sure this is not a crazy large transaction 
+        if (tx.bitcoinSerialize().length > Transaction.MAX_STANDARD_TX_SIZE) {
+            return Result.NON_STANDARD;
+        }
+        
         return Result.OK;
     }
 

--- a/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
@@ -142,6 +142,20 @@ public class DefaultRiskAnalysisTest {
         edgeCaseTx.addOutput(DefaultRiskAnalysis.MIN_ANALYSIS_NONDUST_OUTPUT, key1); // Dust threshold
         assertEquals(RiskAnalysis.Result.OK, DefaultRiskAnalysis.FACTORY.create(wallet, edgeCaseTx, NO_DEPS).analyze());
     }
+    
+    @Test
+    public void nonStandardExceedSize() {
+        Transaction nonStandardTx = new Transaction(params);
+        nonStandardTx.addInput(params.getGenesisBlock().getTransactions().get(0).getOutput(0));
+        
+        //Our non-standard transaction is 100021 bytes
+        for (int i=0; i<2272; i++) {
+            nonStandardTx.addOutput(MILLICOIN.divide(4), key1);
+        }
+        
+        assertEquals(RiskAnalysis.Result.NON_STANDARD, DefaultRiskAnalysis.FACTORY.create(wallet, nonStandardTx, NO_DEPS).analyze());
+
+    }
 
     @Test
     public void nonShortestPossiblePushData() {


### PR DESCRIPTION
I mentioned this a week or two ago - got around to downloading github etc. 

DefaultRiskAnalysis should be able to warn the user if a transaction they seen on the network or have received via an external method of communication - if the transaction IsStandard() or not - one of the checks includes the size of the transaction. 

More can be done to this class, but I have did this small change for now to understand how GitHub etc works. Once I get time i'll try and update it to take into account all the IsStandard() rules. 

If I have done something wrong let me know - this is all magic to me. 

Paddy 