### PR TITLE
Add support for replacing all codes in a MonetaryFormat as a single operation

### DIFF
--- a/core/src/main/java/org/bitcoinj/utils/MonetaryFormat.java
+++ b/core/src/main/java/org/bitcoinj/utils/MonetaryFormat.java
@@ -25,10 +25,9 @@ import static com.google.common.math.LongMath.divide;
 import java.math.RoundingMode;
 import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Monetary;
@@ -61,6 +60,8 @@ public final class MonetaryFormat {
     /** Currency code for base 1/1000000 Bitcoin. */
     public static final String CODE_UBTC = "µBTC";
 
+    public static final int MAX_DECIMALS = 8;
+
     private final char negativeSign;
     private final char positiveSign;
     private final char zeroDigit;
@@ -69,7 +70,7 @@ public final class MonetaryFormat {
     private final List<Integer> decimalGroups;
     private final int shift;
     private final RoundingMode roundingMode;
-    private final Map<Integer, String> codes;
+    private final String[] codes;
     private final char codeSeparator;
     private final boolean codePrefixed;
 
@@ -233,10 +234,11 @@ public final class MonetaryFormat {
      */
     public MonetaryFormat code(int codeShift, String code) {
         checkArgument(codeShift >= 0);
-        Map<Integer, String> codes = new HashMap<Integer, String>();
-        if (this.codes != null)
-            codes.putAll(this.codes);
-        codes.put(codeShift, code);
+        final String[] codes = null == this.codes
+            ? new String[MAX_DECIMALS]
+            : Arrays.copyOf(this.codes, this.codes.length);
+
+        codes[codeShift] = code;
         return new MonetaryFormat(negativeSign, positiveSign, zeroDigit, decimalMark, minDecimals, decimalGroups,
                 shift, roundingMode, codes, codeSeparator, codePrefixed);
     }
@@ -298,16 +300,16 @@ public final class MonetaryFormat {
         this.decimalGroups = null;
         this.shift = 0;
         this.roundingMode = RoundingMode.HALF_UP;
-        this.codes = new HashMap<Integer, String>();
-        this.codes.put(0, CODE_BTC);
-        this.codes.put(3, CODE_MBTC);
-        this.codes.put(6, CODE_UBTC);
+        this.codes = new String[MAX_DECIMALS];
+        this.codes[0] = CODE_BTC;
+        this.codes[3] = CODE_MBTC;
+        this.codes[6] = CODE_UBTC;
         this.codeSeparator = ' ';
         this.codePrefixed = true;
     }
 
     private MonetaryFormat(char negativeSign, char positiveSign, char zeroDigit, char decimalMark, int minDecimals,
-            List<Integer> decimalGroups, int shift, RoundingMode roundingMode, Map<Integer, String> codes,
+            List<Integer> decimalGroups, int shift, RoundingMode roundingMode, String[] codes,
             char codeSeparator, boolean codePrefixed) {
         this.negativeSign = negativeSign;
         this.positiveSign = positiveSign;
@@ -443,9 +445,8 @@ public final class MonetaryFormat {
     public String code() {
         if (codes == null)
             return null;
-        String code = codes.get(shift);
-        if (code == null)
+        if (codes[shift] == null)
             throw new NumberFormatException("missing code for shift: " + shift);
-        return code;
+        return codes[shift];
     }
 }

--- a/core/src/test/java/org/bitcoinj/utils/MonetaryFormatTest.java
+++ b/core/src/test/java/org/bitcoinj/utils/MonetaryFormatTest.java
@@ -220,6 +220,16 @@ public class MonetaryFormatTest {
         assertEquals("dBTC 0", MonetaryFormat.UBTC.code(1, "dBTC").shift(1).format(Coin.ZERO).toString());
     }
 
+    /**
+     * Test clearing all codes, and then setting codes after clearing.
+     */
+    @Test
+    public void noCode() throws Exception {
+        assertEquals("0", MonetaryFormat.UBTC.noCode().shift(0).format(Coin.ZERO).toString());
+        // Ensure that inserting a code after codes are wiped, works
+        assertEquals("dBTC 0", MonetaryFormat.UBTC.noCode().code(1, "dBTC").shift(1).format(Coin.ZERO).toString());
+    }
+
     @Test
     public void codeOrientation() throws Exception {
         assertEquals("BTC 0.00", MonetaryFormat.BTC.prefixCode().format(Coin.ZERO).toString());


### PR DESCRIPTION
Add support for replacing all codes in a MonetaryFormat as a single operation, for example for altcoins where the default codes do not apply.
Replace monetary codes map with an array as a simpler data type given that the data storage needs are small and constant.
.