### PR TITLE
Payment channel fixes

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/core/Wallet.java
@@ -4465,6 +4465,7 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
      */
     public void deserializeExtension(WalletExtension extension, byte[] data) throws Exception {
         lock.lock();
+        keychainLock.lock();
         try {
             // This method exists partly to establish a lock ordering of wallet > extension.
             extension.deserializeWalletExtension(this, data);
@@ -4474,6 +4475,7 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
             extensions.remove(extension.getWalletExtensionID());
             Throwables.propagate(throwable);
         } finally {
+            keychainLock.unlock();
             lock.unlock();
         }
     }

--- a/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
+++ b/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
@@ -369,7 +369,12 @@ public class WalletAppKit extends AbstractIdleService {
             for (WalletExtension e : provideWalletExtensions()) {
                 wallet.addExtension(e);
             }
+
+            // Currently the only way we can be sure that an extension is aware of its containing wallet is by
+            // deserializing the extension (see WalletExtension#deserializeWalletExtension(Wallet, byte[]))
+            // Hence, we first save and then load wallet to ensure any extensions are correctly initialized.
             wallet.saveToFile(vWalletFile);
+            wallet = loadWallet(false);
         }
 
         if (useAutoSave) wallet.autosaveToFile(vWalletFile, 5, TimeUnit.SECONDS, null);

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClientState.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClientState.java
@@ -216,7 +216,6 @@ public class PaymentChannelClientState {
         StoredPaymentChannelClientStates channels = (StoredPaymentChannelClientStates)
                 wallet.getExtensions().get(StoredPaymentChannelClientStates.EXTENSION_ID);
         channels.removeChannel(storedChannel);
-        wallet.addOrUpdateExtension(channels);
         storedChannel = null;
     }
 
@@ -450,7 +449,7 @@ public class PaymentChannelClientState {
         storedChannel.valueToMe = valueToMe;
         StoredPaymentChannelClientStates channels = (StoredPaymentChannelClientStates)
                 wallet.getExtensions().get(StoredPaymentChannelClientStates.EXTENSION_ID);
-        wallet.addOrUpdateExtension(channels);
+        channels.updatedChannel(storedChannel);
     }
 
     /**
@@ -486,7 +485,6 @@ public class PaymentChannelClientState {
         checkState(channels.getChannel(id, multisigContract.getHash()) == null);
         storedChannel = new StoredClientChannel(id, multisigContract, refundTx, myKey, valueToMe, refundFees, true);
         channels.putChannel(storedChannel);
-        wallet.addOrUpdateExtension(channels);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerState.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerState.java
@@ -473,7 +473,7 @@ public class PaymentChannelServerState {
             storedServerChannel.updateValueToMe(bestValueToMe, bestValueSignature);
             StoredPaymentChannelServerStates channels = (StoredPaymentChannelServerStates)
                     wallet.getExtensions().get(StoredPaymentChannelServerStates.EXTENSION_ID);
-            wallet.addOrUpdateExtension(channels);
+            channels.updatedChannel(storedServerChannel);
         }
     }
 
@@ -500,6 +500,5 @@ public class PaymentChannelServerState {
         if (connectedHandler != null)
             checkState(storedServerChannel.setConnectedHandler(connectedHandler, false) == connectedHandler);
         channels.putChannel(storedServerChannel);
-        wallet.addOrUpdateExtension(channels);
     }
 }

--- a/core/src/main/java/org/bitcoinj/protocols/channels/StoredPaymentChannelClientStates.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/StoredPaymentChannelClientStates.java
@@ -180,6 +180,15 @@ public class StoredPaymentChannelClientStates implements WalletExtension {
     }
 
     /**
+     * Notifies the set of stored states that a channel has been updated. Use to notify the wallet of an update to this
+     * wallet extension.
+     */
+    void updatedChannel(final StoredClientChannel channel) {
+        log.info("Stored client channel {} was updated", channel.hashCode());
+        containingWallet.addOrUpdateExtension(this);
+    }
+
+    /**
      * Adds the given channel to this set of stored states, broadcasting the contract and refund transactions when the
      * channel expires and notifies the wallet of an update to this wallet extension
      */
@@ -206,7 +215,7 @@ public class StoredPaymentChannelClientStates implements WalletExtension {
             lock.unlock();
         }
         if (updateWallet)
-            containingWallet.addOrUpdateExtension(this);
+            updatedChannel(channel);
     }
 
     /**
@@ -242,7 +251,7 @@ public class StoredPaymentChannelClientStates implements WalletExtension {
         } finally {
             lock.unlock();
         }
-        containingWallet.addOrUpdateExtension(this);
+        updatedChannel(channel);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/protocols/channels/StoredPaymentChannelServerStates.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/StoredPaymentChannelServerStates.java
@@ -116,7 +116,7 @@ public class StoredPaymentChannelServerStates implements WalletExtension {
             }
             channel.state = null;
         }
-        wallet.addOrUpdateExtension(this);
+        updatedChannel(channel);
     }
 
     /**
@@ -150,6 +150,15 @@ public class StoredPaymentChannelServerStates implements WalletExtension {
     }
 
     /**
+     * Notifies the set of stored states that a channel has been updated. Use to notify the wallet of an update to this
+     * wallet extension.
+     */
+    public void updatedChannel(final StoredServerChannel channel) {
+        log.info("Stored server channel {} was updated", channel.hashCode());
+        wallet.addOrUpdateExtension(this);
+    }
+
+    /**
      * <p>Puts the given channel in the channels map and automatically closes it 2 hours before its refund transaction
      * becomes spendable.</p>
      *
@@ -174,6 +183,7 @@ public class StoredPaymentChannelServerStates implements WalletExtension {
         } finally {
             lock.unlock();
         }
+        updatedChannel(channel);
     }
 
     @Override

--- a/examples/src/main/java/org/bitcoinj/examples/ExamplePaymentChannelServer.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ExamplePaymentChannelServer.java
@@ -42,7 +42,6 @@ import java.util.List;
 public class ExamplePaymentChannelServer implements PaymentChannelServerListener.HandlerFactory {
     private static final org.slf4j.Logger log = LoggerFactory.getLogger(ExamplePaymentChannelServer.class);
 
-    private StoredPaymentChannelServerStates storedStates;
     private WalletAppKit appKit;
 
     public static void main(String[] args) throws Exception {
@@ -88,6 +87,8 @@ public class ExamplePaymentChannelServer implements PaymentChannelServerListener
                 // Try to get the state object from the stored state set in our wallet
                 PaymentChannelServerState state = null;
                 try {
+                    StoredPaymentChannelServerStates storedStates = (StoredPaymentChannelServerStates)
+                            appKit.wallet().getExtensions().get(StoredPaymentChannelServerStates.class.getName());
                     state = storedStates.getChannel(channelId).getOrCreateState(appKit.wallet(), appKit.peerGroup());
                 } catch (VerificationException e) {
                     // This indicates corrupted data, and since the channel was just opened, cannot happen


### PR DESCRIPTION
Some fixes and tidying up of the payment channels code, with the intention of getting the examples working.

The current design of the StoredPaymentChannels{Client|Server}States requires them to have knowledge of the containing wallet. Currently the containing wallet is only passed to these states via deserialization. There are other cases when this is not possible, such as when a wallet file does not exist.

I have split out the loading of wallet extensions from the main wallet to make it easier to pass the wallet to newly created extensions that need it and changed the WalletAppKit to do this. I've tried to do this without changing too much of the existing design to prevent breaking existing code.