### PR TITLE
MySQL Column types and a name change

### DIFF
--- a/core/src/main/java/org/bitcoinj/store/DatabaseFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/DatabaseFullPrunedBlockStore.java
@@ -74,7 +74,7 @@ import java.util.*;
  * <table>
  *     <tr><th>Field Name</th><th>Type (generic)</th></tr>
  *     <tr><td>hash</td><td>binary</td></tr>
- *     <tr><td>index</td><td>integer</td></tr>
+ *     <tr><td>output_index</td><td>integer</td></tr>
  *     <tr><td>height</td><td>integer</td></tr>
  *     <tr><td>value</td><td>integer</td></tr>
  *     <tr><td>scriptbytes</td><td>binary</td></tr>
@@ -112,10 +112,10 @@ public abstract class DatabaseFullPrunedBlockStore implements FullPrunedBlockSto
     private static final String UPDATE_UNDOABLEBLOCKS_SQL                       = "UPDATE undoableBlocks SET txOutChanges=?, transactions=? WHERE hash = ?";
     private static final String DELETE_UNDOABLEBLOCKS_SQL                       = "DELETE FROM undoableBlocks WHERE height <= ?";
 
-    private static final String SELECT_OPENOUTPUTS_SQL                          = "SELECT height, value, scriptBytes, coinbase, toaddress, addresstargetable FROM openOutputs WHERE hash = ? AND index = ?";
+    private static final String SELECT_OPENOUTPUTS_SQL                          = "SELECT height, value, scriptBytes, coinbase, toaddress, addresstargetable FROM openOutputs WHERE hash = ? AND output_index = ?";
     private static final String SELECT_OPENOUTPUTS_COUNT_SQL                    = "SELECT COUNT(*) FROM openOutputs WHERE hash = ?";
-    private static final String INSERT_OPENOUTPUTS_SQL                          = "INSERT INTO openOutputs (hash, index, height, value, scriptBytes, toAddress, addressTargetable, coinbase) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
-    private static final String DELETE_OPENOUTPUTS_SQL                          = "DELETE FROM openOutputs WHERE hash = ? AND index = ?";
+    private static final String INSERT_OPENOUTPUTS_SQL                          = "INSERT INTO openOutputs (hash, output_index, height, value, scriptBytes, toAddress, addressTargetable, coinbase) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+    private static final String DELETE_OPENOUTPUTS_SQL                          = "DELETE FROM openOutputs WHERE hash = ? AND output_index = ?";
 
     // Dump table SQL (this is just for data sizing statistics).
     private static final String SELECT_DUMP_SETTINGS_SQL                        = "SELECT name, value FROM settings";
@@ -123,10 +123,10 @@ public abstract class DatabaseFullPrunedBlockStore implements FullPrunedBlockSto
     private static final String SELECT_DUMP_UNDOABLEBLOCKS_SQL                  = "SELECT txOutChanges, transactions FROM undoableBlocks";
     private static final String SELECT_DUMP_OPENOUTPUTS_SQL                     = "SELECT value, scriptBytes FROM openOutputs";
 
-    private static final String SELECT_TRANSACTION_OUTPUTS_SQL                  = "SELECT hash, value, scriptBytes, height, index, coinbase, toaddress, addresstargetable FROM openOutputs where toaddress = ?";
+    private static final String SELECT_TRANSACTION_OUTPUTS_SQL                  = "SELECT hash, value, scriptBytes, height, output_index, coinbase, toaddress, addresstargetable FROM openOutputs WHERE toaddress = ?";
 
     // Select the balance of an address SQL.
-    private static final String SELECT_BALANCE_SQL                              = "select sum(value) from openoutputs where toaddress = ?";
+    private static final String SELECT_BALANCE_SQL                              = "select sum(value) FROM openoutputs WHERE toaddress = ?";
 
     // Tables exist SQL.
     private static final String SELECT_CHECK_TABLES_EXIST_SQL                   = "SELECT * FROM settings WHERE 1 = 2";

--- a/core/src/main/java/org/bitcoinj/store/H2FullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/H2FullPrunedBlockStore.java
@@ -66,18 +66,18 @@ public class H2FullPrunedBlockStore extends DatabaseFullPrunedBlockStore {
 
     private static final String CREATE_OPEN_OUTPUT_TABLE = "CREATE TABLE openOutputs ("
             + "hash BINARY(32) NOT NULL,"
-            + "index INT NOT NULL,"
+            + "output_index INT NOT NULL,"
             + "height INT NOT NULL,"
             + "value BIGINT NOT NULL,"
             + "scriptBytes BLOB NOT NULL,"
             + "toaddress VARCHAR(35),"
             + "addresstargetable TINYINT,"
             + "coinbase BOOLEAN,"
-            + "PRIMARY KEY (hash, index),"
+            + "PRIMARY KEY (hash, output_index),"
             + ")";
 
     // Some indexes to speed up inserts
-    private static final String CREATE_OUTPUTS_ADDRESS_MULTI_INDEX      = "CREATE INDEX openoutputs_hash_index_height_toaddress_idx ON openoutputs (hash, index, height, toaddress)";
+    private static final String CREATE_OUTPUTS_ADDRESS_MULTI_INDEX      = "CREATE INDEX openoutputs_hash_index_height_toaddress_idx ON openoutputs (hash, output_index, height, toaddress)";
     private static final String CREATE_OUTPUTS_TOADDRESS_INDEX          = "CREATE INDEX openoutputs_toaddress_idx ON openoutputs (toaddress)";
     private static final String CREATE_OUTPUTS_ADDRESSTARGETABLE_INDEX  = "CREATE INDEX openoutputs_addresstargetable_idx ON openoutputs (addresstargetable)";
     private static final String CREATE_OUTPUTS_HASH_INDEX               = "CREATE INDEX openoutputs_hash_idx ON openoutputs (hash)";

--- a/core/src/main/java/org/bitcoinj/store/MySQLFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MySQLFullPrunedBlockStore.java
@@ -39,51 +39,51 @@ public class MySQLFullPrunedBlockStore extends DatabaseFullPrunedBlockStore {
     private static final String CREATE_SETTINGS_TABLE = "CREATE TABLE settings (\n" +
             "    name varchar(32) NOT NULL,\n" +
             "    value blob,\n" +
-            "    CONSTRAINT `setting_pk` PRIMARY KEY (name)\n" +
+            "    CONSTRAINT `setting_pk` PRIMARY KEY (name)  \n" +
             ")\n";
 
     private static final String CREATE_HEADERS_TABLE = "CREATE TABLE headers (\n" +
-            "    hash blob NOT NULL,\n" +
-            "    chainwork mediumblob NOT NULL,\n" +
+            "    hash binary(28) NOT NULL,\n" +
+            "    chainwork binary(12) NOT NULL,\n" +
             "    height integer NOT NULL,\n" +
-            "    header blob NOT NULL,\n" +
+            "    header binary(80) NOT NULL,\n" +
             "    wasundoable tinyint(1) NOT NULL,\n" +
-            "    CONSTRAINT `headers_pk` PRIMARY KEY (hash(28)) USING btree\n" +
+            "    CONSTRAINT `headers_pk` PRIMARY KEY (hash) USING BTREE \n" +
             ")";
 
     private static final String CREATE_UNDOABLE_TABLE = "CREATE TABLE undoableblocks (\n" +
-            "    hash blob NOT NULL,\n" +
+            "    hash binary(28) NOT NULL,\n" +
             "    height integer NOT NULL,\n" +
-            "    txoutchanges mediumblob,\n" +
-            "    transactions mediumblob,\n" +
-            "    CONSTRAINT `undoableblocks_pk` PRIMARY KEY (hash(28)) USING btree\n" +
+            "    txoutchanges blob,\n" +
+            "    transactions blob,\n" +
+            "    CONSTRAINT `undoableblocks_pk` PRIMARY KEY (hash) USING BTREE \n" +
             ")\n";
 
     private static final String CREATE_OPEN_OUTPUT_TABLE = "CREATE TABLE openoutputs (\n" +
-            "    hash blob NOT NULL,\n" +
-            "    `index` integer NOT NULL,\n" +
+            "    hash binary(32) NOT NULL,\n" +
+            "    output_index integer NOT NULL,\n" +
             "    height integer NOT NULL,\n" +
             "    value bigint NOT NULL,\n" +
             "    scriptbytes mediumblob NOT NULL,\n" +
             "    toaddress varchar(35),\n" +
             "    addresstargetable tinyint(1),\n" +
             "    coinbase boolean,\n" +
-            "    CONSTRAINT `openoutputs_pk` PRIMARY KEY (hash(32),`index`) USING btree\n" +
+            "    CONSTRAINT `openoutputs_pk` PRIMARY KEY (hash, output_index) USING BTREE \n" +
             ")\n";
 
     // Some indexes to speed up inserts
-    private static final String CREATE_OUTPUTS_ADDRESS_MULTI_INDEX              = "CREATE INDEX openoutputs_hash_index_height_toaddress_idx ON openoutputs (hash(32), `index`, height, toaddress) USING btree";
+    private static final String CREATE_OUTPUTS_ADDRESS_MULTI_INDEX              = "CREATE INDEX openoutputs_hash_index_height_toaddress_idx ON openoutputs (hash(32), output_index, height, toaddress) USING btree";
     private static final String CREATE_OUTPUTS_TOADDRESS_INDEX                  = "CREATE INDEX openoutputs_toaddress_idx ON openoutputs (toaddress) USING btree";
     private static final String CREATE_OUTPUTS_ADDRESSTARGETABLE_INDEX          = "CREATE INDEX openoutputs_addresstargetable_idx ON openoutputs (addresstargetable) USING btree";
     private static final String CREATE_OUTPUTS_HASH_INDEX                       = "CREATE INDEX openoutputs_hash_idx ON openoutputs (hash(32)) USING btree";
     private static final String CREATE_UNDOABLE_TABLE_INDEX                     = "CREATE INDEX undoableblocks_height_idx ON undoableBlocks (height) USING btree";
 
-    // SQL involving index column (table openOutputs) overridden as it is a reserved word and must be back ticked in MySQL.
-    private static final String SELECT_OPENOUTPUTS_SQL                          = "SELECT height, value, scriptBytes, coinbase, toaddress, addresstargetable FROM openOutputs WHERE hash = ? AND `index` = ?";
-    private static final String INSERT_OPENOUTPUTS_SQL                          = "INSERT INTO openOutputs (hash, `index`, height, value, scriptBytes, toAddress, addressTargetable, coinbase) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
-    private static final String DELETE_OPENOUTPUTS_SQL                          = "DELETE FROM openOutputs WHERE hash = ? AND `index` = ?";
+    // SQL involving output_index column (table openOutputs) overridden as it is a reserved word and must be back ticked in MySQL.
+    private static final String SELECT_OPENOUTPUTS_SQL                          = "SELECT height, value, scriptBytes, coinbase, toaddress, addresstargetable FROM openOutputs WHERE hash = ? AND output_index = ?";
+    private static final String INSERT_OPENOUTPUTS_SQL                          = "INSERT INTO openOutputs (hash, output_index, height, value, scriptBytes, toAddress, addressTargetable, coinbase) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+    private static final String DELETE_OPENOUTPUTS_SQL                          = "DELETE FROM openOutputs WHERE hash = ? AND output_index = ?";
 
-    private static final String SELECT_TRANSACTION_OUTPUTS_SQL                  = "SELECT hash, value, scriptBytes, height, `index`, coinbase, toaddress, addresstargetable FROM openOutputs where toaddress = ?";
+    private static final String SELECT_TRANSACTION_OUTPUTS_SQL                  = "SELECT hash, value, scriptBytes, height, output_index, coinbase, toaddress, addresstargetable FROM openOutputs where toaddress = ?";
 
     /**
      * Creates a new MySQLFullPrunedBlockStore.

--- a/core/src/main/java/org/bitcoinj/store/PostgresFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/PostgresFullPrunedBlockStore.java
@@ -69,18 +69,18 @@ public class PostgresFullPrunedBlockStore extends DatabaseFullPrunedBlockStore {
 
     private static final String CREATE_OPEN_OUTPUT_TABLE = "CREATE TABLE openoutputs (\n" +
             "    hash bytea NOT NULL,\n" +
-            "    index integer NOT NULL,\n" +
+            "    output_index integer NOT NULL,\n" +
             "    height integer NOT NULL,\n" +
             "    value bigint NOT NULL,\n" +
             "    scriptbytes bytea NOT NULL,\n" +
             "    toaddress character varying(35),\n" +
             "    addresstargetable smallint,\n" +
             "    coinbase boolean,\n" +
-            "    CONSTRAINT openoutputs_pk PRIMARY KEY (hash,index)\n" +
+            "    CONSTRAINT openoutputs_pk PRIMARY KEY (hash,output_index)\n" +
             ")\n";
 
     // Some indexes to speed up inserts
-    private static final String CREATE_OUTPUTS_ADDRESS_MULTI_INDEX      = "CREATE INDEX openoutputs_hash_index_num_height_toaddress_idx ON openoutputs USING btree (hash, index, height, toaddress)";
+    private static final String CREATE_OUTPUTS_ADDRESS_MULTI_INDEX      = "CREATE INDEX openoutputs_hash_index_num_height_toaddress_idx ON openoutputs USING btree (hash, output_index, height, toaddress)";
     private static final String CREATE_OUTPUTS_TOADDRESS_INDEX          = "CREATE INDEX openoutputs_toaddress_idx ON openoutputs USING btree (toaddress)";
     private static final String CREATE_OUTPUTS_ADDRESSTARGETABLE_INDEX  = "CREATE INDEX openoutputs_addresstargetable_idx ON openoutputs USING btree (addresstargetable)";
     private static final String CREATE_OUTPUTS_HASH_INDEX               = "CREATE INDEX openoutputs_hash_idx ON openoutputs USING btree (hash)";


### PR DESCRIPTION
Change a few column types so that MySQL can perform faster, and hints to the reader the actual size of the binary data. 

Also, the column "index" should be renamed since it is a keyword in some DBs. Hard to predict the effects of using keywords as column names.