### PR TITLE
Use FixedPointCombMultiplier for mul by G

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -88,7 +88,7 @@ public class DeterministicKey extends ECKey {
                             byte[] chainCode,
                             BigInteger priv,
                             @Nullable DeterministicKey parent) {
-        super(priv, compressPoint(ECKey.CURVE.getG().multiply(priv)));
+        super(priv, compressPoint(ECKey.publicPointFromPrivate(priv)));
         checkArgument(chainCode.length == 32);
         this.parent = parent;
         this.childNumberPath = checkNotNull(childNumberPath);
@@ -156,7 +156,7 @@ public class DeterministicKey extends ECKey {
                             @Nullable DeterministicKey parent,
                             int depth,
                             int parentFingerprint) {
-        super(priv, compressPoint(ECKey.CURVE.getG().multiply(priv)));
+        super(priv, compressPoint(ECKey.publicPointFromPrivate(priv)));
         checkArgument(chainCode.length == 32);
         this.parent = parent;
         this.childNumberPath = checkNotNull(childNumberPath);

--- a/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
@@ -194,21 +194,20 @@ public final class HDKeyDerivation {
         BigInteger ilInt = new BigInteger(1, il);
         assertLessThanN(ilInt, "Illegal derived key: I_L >= n");
 
-        final ECPoint G = ECKey.CURVE.getG();
         final BigInteger N = ECKey.CURVE.getN();
         ECPoint Ki;
         switch (mode) {
             case NORMAL:
-                Ki = G.multiply(ilInt).add(parent.getPubKeyPoint());
+                Ki = ECKey.publicPointFromPrivate(ilInt).add(parent.getPubKeyPoint());
                 break;
             case WITH_INVERSION:
                 // This trick comes from Gregory Maxwell. Check the homomorphic properties of our curve hold. The
                 // below calculations should be redundant and give the same result as NORMAL but if the precalculated
                 // tables have taken a bit flip will yield a different answer. This mode is used when vending a key
                 // to perform a last-ditch sanity check trying to catch bad RAM.
-                Ki = G.multiply(ilInt.add(RAND_INT));
+                Ki = ECKey.publicPointFromPrivate(ilInt.add(RAND_INT).mod(N));
                 BigInteger additiveInverse = RAND_INT.negate().mod(N);
-                Ki = Ki.add(G.multiply(additiveInverse));
+                Ki = Ki.add(ECKey.publicPointFromPrivate(additiveInverse));
                 Ki = Ki.add(parent.getPubKeyPoint());
                 break;
             default: throw new AssertionError();


### PR DESCRIPTION
I noticed a few places where CURVE.getG() is being multiplied by some scalar directly, which won't actually use the fixed-point multiplication for which you have the nice precomputed tables. These changes fix that (ECDSA and other high-level primitives already do this internally of course).