### PR TITLE
Improve the way compression is handled

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
@@ -154,7 +154,7 @@ public final class HDKeyDerivation {
     public static RawKeyBytes deriveChildKeyBytesFromPrivate(DeterministicKey parent,
                                                               ChildNumber childNumber) throws HDDerivationException {
         checkArgument(parent.hasPrivKey(), "Parent key must have private key bytes for this method.");
-        byte[] parentPublicKey = ECKey.compressPoint(parent.getPubKeyPoint()).getEncoded();
+        byte[] parentPublicKey = parent.getPubKeyPoint().getEncoded(true);
         assert parentPublicKey.length == 33 : parentPublicKey.length;
         ByteBuffer data = ByteBuffer.allocate(37);
         if (childNumber.isHardened()) {
@@ -182,7 +182,7 @@ public final class HDKeyDerivation {
 
     public static RawKeyBytes deriveChildKeyBytesFromPublic(DeterministicKey parent, ChildNumber childNumber, PublicDeriveMode mode) throws HDDerivationException {
         checkArgument(!childNumber.isHardened(), "Can't use private derivation with public keys only.");
-        byte[] parentPublicKey = ECKey.compressPoint(parent.getPubKeyPoint()).getEncoded();
+        byte[] parentPublicKey = parent.getPubKeyPoint().getEncoded(true);
         assert parentPublicKey.length == 33 : parentPublicKey.length;
         ByteBuffer data = ByteBuffer.allocate(37);
         data.put(parentPublicKey);


### PR DESCRIPTION
The main change here is the getPointWithCompression method, which swaps the "compression" flag in an ECPoint, as necessary. For going from uncompressed to compressed, this should be much faster, for the reverse direction about the same as before.

It uses the deprecated ECCurve.createPoint, but that's fine since you'll need to change over to "self-managed" compression at some point in any case, as the TODO in ECKey quite rightly points out:

    // TODO: Move this class to tracking compression state itself.
    // The Bouncy Castle guys are deprecating their own tracking of the compression state.
