### PR TITLE
Don't gitignore wallet files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ target
 *.iml
 *.chain
 *.spvchain
-*.wallet


### PR DESCRIPTION
If we ignore them, it's easy to accidently remove them.