### PR TITLE
remove some calls to BigDecimal#setScale where returned objects are not used

### DIFF
--- a/core/src/main/java/org/bitcoinj/utils/BtcAutoFormat.java
+++ b/core/src/main/java/org/bitcoinj/utils/BtcAutoFormat.java
@@ -142,17 +142,14 @@ public final class BtcAutoFormat extends BtcFormat {
         int coinOffset = Math.max(SMALLEST_UNIT_EXPONENT - fractionPlaces, 0);
         BigDecimal inCoins = new BigDecimal(satoshis).movePointLeft(coinOffset);
         if (inCoins.remainder(ONE).compareTo(ZERO) == 0) {
-            inCoins.setScale(0);
             places = COIN_SCALE;
         } else {
             BigDecimal inMillis = inCoins.movePointRight(MILLICOIN_SCALE);
             if (inMillis.remainder(ONE).compareTo(ZERO) == 0) {
-                inMillis.setScale(0);
                 places = MILLICOIN_SCALE;
             } else {
                 BigDecimal inMicros = inCoins.movePointRight(MICROCOIN_SCALE);
                 if (inMicros.remainder(ONE).compareTo(ZERO) == 0) {
-                    inMicros.setScale(0);
                     places = MICROCOIN_SCALE;
                 } else {
                     // no way to avoid rounding: so what denomination gives smallest error?


### PR DESCRIPTION
Hi

I found this code with no effect while using FindBugs:
- setScale is called on immutable BigDecimal
- the returned new BigDecimal is not assigned

I'm not yet sure if there's more to it.