### PR TITLE
Hash-related code cleanup

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AlertMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/AlertMessage.java
@@ -114,7 +114,7 @@ public class AlertMessage extends Message {
      * doesn't verify, because that would allow arbitrary attackers to spam your users.
      */
     public boolean isSignatureValid() {
-        return ECKey.verify(Utils.doubleDigest(content), signature, params.getAlertSigningKey());
+        return ECKey.verify(Sha256Hash.calcDoubleHashBytes(content), signature, params.getAlertSigningKey());
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/AlertMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/AlertMessage.java
@@ -114,7 +114,7 @@ public class AlertMessage extends Message {
      * doesn't verify, because that would allow arbitrary attackers to spam your users.
      */
     public boolean isSignatureValid() {
-        return ECKey.verify(Sha256Hash.calcDoubleHashBytes(content), signature, params.getAlertSigningKey());
+        return ECKey.verify(Sha256Hash.hashTwice(content), signature, params.getAlertSigningKey());
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/Base58.java
+++ b/core/src/main/java/org/bitcoinj/core/Base58.java
@@ -153,7 +153,7 @@ public class Base58 {
         byte[] bytes = copyOfRange(tmp, 0, tmp.length - 4);
         byte[] checksum = copyOfRange(tmp, tmp.length - 4, tmp.length);
         
-        tmp = Utils.doubleDigest(bytes);
+        tmp = Sha256Hash.calcDoubleHashBytes(bytes);
         byte[] hash = copyOfRange(tmp, 0, 4);
         if (!Arrays.equals(checksum, hash)) 
             throw new AddressFormatException("Checksum does not validate");

--- a/core/src/main/java/org/bitcoinj/core/Base58.java
+++ b/core/src/main/java/org/bitcoinj/core/Base58.java
@@ -153,7 +153,7 @@ public class Base58 {
         byte[] bytes = copyOfRange(tmp, 0, tmp.length - 4);
         byte[] checksum = copyOfRange(tmp, tmp.length - 4, tmp.length);
         
-        tmp = Sha256Hash.calcDoubleHashBytes(bytes);
+        tmp = Sha256Hash.hashTwice(bytes);
         byte[] hash = copyOfRange(tmp, 0, 4);
         if (!Arrays.equals(checksum, hash)) 
             throw new AddressFormatException("Checksum does not validate");

--- a/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
@@ -112,7 +112,7 @@ public class BitcoinSerializer {
 
         Utils.uint32ToByteArrayLE(message.length, header, 4 + COMMAND_LEN);
 
-        byte[] hash = Sha256Hash.calcDoubleHashBytes(message);
+        byte[] hash = Sha256Hash.hashTwice(message);
         System.arraycopy(hash, 0, header, 4 + COMMAND_LEN + 4, 4);
         out.write(header);
         out.write(message);
@@ -174,7 +174,7 @@ public class BitcoinSerializer {
 
         // Verify the checksum.
         byte[] hash;
-        hash = Sha256Hash.calcDoubleHashBytes(payloadBytes);
+        hash = Sha256Hash.hashTwice(payloadBytes);
         if (header.checksum[0] != hash[0] || header.checksum[1] != hash[1] ||
                 header.checksum[2] != hash[2] || header.checksum[3] != hash[3]) {
             throw new ProtocolException("Checksum failed to verify, actual " +
@@ -214,7 +214,7 @@ public class BitcoinSerializer {
         } else if (command.equals("tx")) {
             Transaction tx = new Transaction(params, payloadBytes, null, parseLazy, parseRetain, length);
             if (hash != null)
-                tx.setHash(new Sha256Hash(Utils.reverseBytes(hash)));
+                tx.setHash(Sha256Hash.wrap(Utils.reverseBytes(hash)));
             message = tx;
         } else if (command.equals("addr")) {
             message = new AddressMessage(params, payloadBytes, parseLazy, parseRetain, length);

--- a/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
@@ -112,7 +112,7 @@ public class BitcoinSerializer {
 
         Utils.uint32ToByteArrayLE(message.length, header, 4 + COMMAND_LEN);
 
-        byte[] hash = doubleDigest(message);
+        byte[] hash = Sha256Hash.calcDoubleHashBytes(message);
         System.arraycopy(hash, 0, header, 4 + COMMAND_LEN + 4, 4);
         out.write(header);
         out.write(message);
@@ -174,7 +174,7 @@ public class BitcoinSerializer {
 
         // Verify the checksum.
         byte[] hash;
-        hash = doubleDigest(payloadBytes);
+        hash = Sha256Hash.calcDoubleHashBytes(payloadBytes);
         if (header.checksum[0] != hash[0] || header.checksum[1] != hash[1] ||
                 header.checksum[2] != hash[2] || header.checksum[3] != hash[3]) {
             throw new ProtocolException("Checksum failed to verify, actual " +

--- a/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
@@ -214,7 +214,7 @@ public class BitcoinSerializer {
         } else if (command.equals("tx")) {
             Transaction tx = new Transaction(params, payloadBytes, null, parseLazy, parseRetain, length);
             if (hash != null)
-                tx.setHash(Sha256Hash.wrap(Utils.reverseBytes(hash)));
+                tx.setHash(Sha256Hash.wrapReversed(hash));
             message = tx;
         } else if (command.equals("addr")) {
             message = new AddressMessage(params, payloadBytes, parseLazy, parseRetain, length);

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -191,7 +191,7 @@ public class Block extends Message {
         difficultyTarget = readUint32();
         nonce = readUint32();
 
-        hash = Sha256Hash.wrap(Utils.reverseBytes(Sha256Hash.hashTwice(payload, offset, cursor)));
+        hash = Sha256Hash.wrapReversed(Sha256Hash.hashTwice(payload, offset, cursor));
 
         headerParsed = true;
         headerBytesValid = parseRetain;
@@ -385,8 +385,8 @@ public class Block extends Message {
         // fall back to manual write
         maybeParseHeader();
         Utils.uint32ToByteStreamLE(version, stream);
-        stream.write(Utils.reverseBytes(prevBlockHash.getBytes()));
-        stream.write(Utils.reverseBytes(getMerkleRoot().getBytes()));
+        stream.write(prevBlockHash.getReversedBytes());
+        stream.write(getMerkleRoot().getReversedBytes());
         Utils.uint32ToByteStreamLE(time, stream);
         Utils.uint32ToByteStreamLE(difficultyTarget, stream);
         Utils.uint32ToByteStreamLE(nonce, stream);
@@ -511,7 +511,7 @@ public class Block extends Message {
         try {
             ByteArrayOutputStream bos = new UnsafeByteArrayOutputStream(HEADER_SIZE);
             writeHeader(bos);
-            return Sha256Hash.wrap(Utils.reverseBytes(Sha256Hash.hashTwice(bos.toByteArray())));
+            return Sha256Hash.wrapReversed(Sha256Hash.hashTwice(bos.toByteArray()));
         } catch (IOException e) {
             throw new RuntimeException(e); // Cannot happen.
         }

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -37,7 +37,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import static org.bitcoinj.core.Coin.FIFTY_COINS;
-import static org.bitcoinj.core.Sha256Hash.calcDoubleHashBytes;
+import static org.bitcoinj.core.Sha256Hash.hashTwice;
 
 /**
  * <p>A block is a group of transactions, and is one of the fundamental data structures of the Bitcoin system.
@@ -191,7 +191,7 @@ public class Block extends Message {
         difficultyTarget = readUint32();
         nonce = readUint32();
 
-        hash = new Sha256Hash(Utils.reverseBytes(Sha256Hash.calcDoubleHashBytes(payload, offset, cursor)));
+        hash = Sha256Hash.wrap(Utils.reverseBytes(Sha256Hash.hashTwice(payload, offset, cursor)));
 
         headerParsed = true;
         headerBytesValid = parseRetain;
@@ -511,7 +511,7 @@ public class Block extends Message {
         try {
             ByteArrayOutputStream bos = new UnsafeByteArrayOutputStream(HEADER_SIZE);
             writeHeader(bos);
-            return new Sha256Hash(Utils.reverseBytes(Sha256Hash.calcDoubleHashBytes(bos.toByteArray())));
+            return Sha256Hash.wrap(Utils.reverseBytes(Sha256Hash.hashTwice(bos.toByteArray())));
         } catch (IOException e) {
             throw new RuntimeException(e); // Cannot happen.
         }
@@ -699,7 +699,7 @@ public class Block extends Message {
 
     private Sha256Hash calculateMerkleRoot() {
         List<byte[]> tree = buildMerkleTree();
-        return new Sha256Hash(tree.get(tree.size() - 1));
+        return Sha256Hash.wrap(tree.get(tree.size() - 1));
     }
 
     private List<byte[]> buildMerkleTree() {
@@ -749,7 +749,7 @@ public class Block extends Message {
                 int right = Math.min(left + 1, levelSize - 1);
                 byte[] leftBytes = Utils.reverseBytes(tree.get(levelOffset + left));
                 byte[] rightBytes = Utils.reverseBytes(tree.get(levelOffset + right));
-                tree.add(Utils.reverseBytes(calcDoubleHashBytes(leftBytes, 0, 32, rightBytes, 0, 32)));
+                tree.add(Utils.reverseBytes(hashTwice(leftBytes, 0, 32, rightBytes, 0, 32)));
             }
             // Move to the next level.
             levelOffset += levelSize;
@@ -1026,7 +1026,7 @@ public class Block extends Message {
                 byte[] counter = new byte[32];
                 counter[0] = (byte) txCounter;
                 counter[1] = (byte) (txCounter++ >> 8);
-                input.getOutpoint().setHash(new Sha256Hash(counter));
+                input.getOutpoint().setHash(Sha256Hash.wrap(counter));
             } else {
                 input = new TransactionInput(params, t, Script.createInputScript(EMPTY_BYTES, EMPTY_BYTES), prevOut);
             }

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -37,8 +37,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import static org.bitcoinj.core.Coin.FIFTY_COINS;
-import static org.bitcoinj.core.Utils.doubleDigest;
-import static org.bitcoinj.core.Utils.doubleDigestTwoBuffers;
+import static org.bitcoinj.core.Sha256Hash.calcDoubleHashBytes;
 
 /**
  * <p>A block is a group of transactions, and is one of the fundamental data structures of the Bitcoin system.
@@ -192,7 +191,7 @@ public class Block extends Message {
         difficultyTarget = readUint32();
         nonce = readUint32();
 
-        hash = new Sha256Hash(Utils.reverseBytes(Utils.doubleDigest(payload, offset, cursor)));
+        hash = new Sha256Hash(Utils.reverseBytes(Sha256Hash.calcDoubleHashBytes(payload, offset, cursor)));
 
         headerParsed = true;
         headerBytesValid = parseRetain;
@@ -512,7 +511,7 @@ public class Block extends Message {
         try {
             ByteArrayOutputStream bos = new UnsafeByteArrayOutputStream(HEADER_SIZE);
             writeHeader(bos);
-            return new Sha256Hash(Utils.reverseBytes(doubleDigest(bos.toByteArray())));
+            return new Sha256Hash(Utils.reverseBytes(Sha256Hash.calcDoubleHashBytes(bos.toByteArray())));
         } catch (IOException e) {
             throw new RuntimeException(e); // Cannot happen.
         }
@@ -750,7 +749,7 @@ public class Block extends Message {
                 int right = Math.min(left + 1, levelSize - 1);
                 byte[] leftBytes = Utils.reverseBytes(tree.get(levelOffset + left));
                 byte[] rightBytes = Utils.reverseBytes(tree.get(levelOffset + right));
-                tree.add(Utils.reverseBytes(doubleDigestTwoBuffers(leftBytes, 0, 32, rightBytes, 0, 32)));
+                tree.add(Utils.reverseBytes(calcDoubleHashBytes(leftBytes, 0, 32, rightBytes, 0, 32)));
             }
             // Move to the next level.
             levelOffset += levelSize;

--- a/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
+++ b/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
@@ -100,7 +100,7 @@ public class CheckpointManager {
     private Sha256Hash readBinary(InputStream inputStream) throws IOException {
         DataInputStream dis = null;
         try {
-            MessageDigest digest = Utils.newSha256Digest();
+            MessageDigest digest = Sha256Hash.newDigest();
             DigestInputStream digestInputStream = new DigestInputStream(inputStream, digest);
             dis = new DataInputStream(digestInputStream);
             digestInputStream.on(false);

--- a/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
+++ b/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
@@ -38,7 +38,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.TreeMap;
@@ -101,7 +100,7 @@ public class CheckpointManager {
     private Sha256Hash readBinary(InputStream inputStream) throws IOException {
         DataInputStream dis = null;
         try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            MessageDigest digest = Utils.newSha256Digest();
             DigestInputStream digestInputStream = new DigestInputStream(inputStream, digest);
             dis = new DataInputStream(digestInputStream);
             digestInputStream.on(false);
@@ -130,8 +129,6 @@ public class CheckpointManager {
             Sha256Hash dataHash = new Sha256Hash(digest.digest());
             log.info("Read {} checkpoints, hash is {}", checkpoints.size(), dataHash);
             return dataHash;
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);  // Cannot happen.
         } catch (ProtocolException e) {
             throw new IOException(e);
         } finally {

--- a/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
+++ b/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
@@ -126,7 +126,7 @@ public class CheckpointManager {
                 buffer.position(0);
                 checkpoints.put(block.getHeader().getTimeSeconds(), block);
             }
-            Sha256Hash dataHash = new Sha256Hash(digest.digest());
+            Sha256Hash dataHash = Sha256Hash.wrap(digest.digest());
             log.info("Read {} checkpoints, hash is {}", checkpoints.size(), dataHash);
             return dataHash;
         } catch (ProtocolException e) {
@@ -165,7 +165,7 @@ public class CheckpointManager {
             }
             HashCode hash = hasher.hash();
             log.info("Read {} checkpoints, hash is {}", checkpoints.size(), hash);
-            return new Sha256Hash(hash.asBytes());
+            return Sha256Hash.wrap(hash.asBytes());
         } finally {
             if (reader != null) reader.close();
         }

--- a/core/src/main/java/org/bitcoinj/core/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/core/ECKey.java
@@ -834,7 +834,7 @@ public class ECKey implements EncryptableItem, Serializable {
      */
     public String signMessage(String message, @Nullable KeyParameter aesKey) throws KeyCrypterException {
         byte[] data = Utils.formatMessageForSigning(message);
-        Sha256Hash hash = Sha256Hash.hashTwice(data);
+        Sha256Hash hash = Sha256Hash.twiceOf(data);
         ECDSASignature sig = sign(hash, aesKey);
         // Now we have to work backwards to figure out the recId needed to recover the signature.
         int recId = -1;
@@ -888,7 +888,7 @@ public class ECKey implements EncryptableItem, Serializable {
         byte[] messageBytes = Utils.formatMessageForSigning(message);
         // Note that the C++ code doesn't actually seem to specify any character encoding. Presumably it's whatever
         // JSON-SPIRIT hands back. Assume UTF-8 for now.
-        Sha256Hash messageHash = Sha256Hash.hashTwice(messageBytes);
+        Sha256Hash messageHash = Sha256Hash.twiceOf(messageBytes);
         boolean compressed = false;
         if (header >= 31) {
             compressed = true;

--- a/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
@@ -95,10 +95,10 @@ public class GetBlocksMessage extends Message {
         stream.write(new VarInt(locator.size()).encode());
         for (Sha256Hash hash : locator) {
             // Have to reverse as wire format is little endian.
-            stream.write(Utils.reverseBytes(hash.getBytes()));
+            stream.write(hash.getReversedBytes());
         }
         // Next, a block ID to stop at.
-        stream.write(Utils.reverseBytes(stopHash.getBytes()));
+        stream.write(stopHash.getReversedBytes());
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/ListMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/ListMessage.java
@@ -116,7 +116,7 @@ public abstract class ListMessage extends Message {
             // Write out the type code.
             Utils.uint32ToByteStreamLE(i.type.ordinal(), stream);
             // And now the hash.
-            stream.write(Utils.reverseBytes(i.hash.getBytes()));
+            stream.write(i.hash.getReversedBytes());
         }
     }
 

--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -415,7 +415,7 @@ public abstract class Message implements Serializable {
             // Not the most efficient way to do this but the clearest.
             hash = Utils.reverseBytes(hash);
             cursor += 32;
-            return new Sha256Hash(hash);
+            return Sha256Hash.wrap(hash);
         } catch (IndexOutOfBoundsException e) {
             throw new ProtocolException(e);
         }

--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -411,11 +411,10 @@ public abstract class Message implements Serializable {
         try {
             byte[] hash = new byte[32];
             System.arraycopy(payload, cursor, hash, 0, 32);
+            cursor += 32;
             // We have to flip it around, as it's been read off the wire in little endian.
             // Not the most efficient way to do this but the clearest.
-            hash = Utils.reverseBytes(hash);
-            cursor += 32;
-            return Sha256Hash.wrap(hash);
+            return Sha256Hash.wrapReversed(hash);
         } catch (IndexOutOfBoundsException e) {
             throw new ProtocolException(e);
         }

--- a/core/src/main/java/org/bitcoinj/core/PartialMerkleTree.java
+++ b/core/src/main/java/org/bitcoinj/core/PartialMerkleTree.java
@@ -214,7 +214,7 @@ public class PartialMerkleTree extends Message {
     }
 
     private static Sha256Hash combineLeftRight(byte[] left, byte[] right) {
-        return new Sha256Hash(reverseBytes(Sha256Hash.calcDoubleHashBytes(
+        return Sha256Hash.wrap(reverseBytes(Sha256Hash.hashTwice(
             reverseBytes(left), 0, 32,
             reverseBytes(right), 0, 32)));
     }

--- a/core/src/main/java/org/bitcoinj/core/PartialMerkleTree.java
+++ b/core/src/main/java/org/bitcoinj/core/PartialMerkleTree.java
@@ -214,9 +214,9 @@ public class PartialMerkleTree extends Message {
     }
 
     private static Sha256Hash combineLeftRight(byte[] left, byte[] right) {
-        return new Sha256Hash(reverseBytes(doubleDigestTwoBuffers(
-                reverseBytes(left), 0, 32,
-                reverseBytes(right), 0, 32)));
+        return new Sha256Hash(reverseBytes(Sha256Hash.calcDoubleHashBytes(
+            reverseBytes(left), 0, 32,
+            reverseBytes(right), 0, 32)));
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/PartialMerkleTree.java
+++ b/core/src/main/java/org/bitcoinj/core/PartialMerkleTree.java
@@ -101,7 +101,7 @@ public class PartialMerkleTree extends Message {
 
         stream.write(new VarInt(hashes.size()).encode());
         for (Sha256Hash hash : hashes)
-            stream.write(reverseBytes(hash.getBytes()));
+            stream.write(hash.getReversedBytes());
 
         stream.write(new VarInt(matchedChildBits.length).encode());
         stream.write(matchedChildBits);
@@ -214,9 +214,9 @@ public class PartialMerkleTree extends Message {
     }
 
     private static Sha256Hash combineLeftRight(byte[] left, byte[] right) {
-        return Sha256Hash.wrap(reverseBytes(Sha256Hash.hashTwice(
+        return Sha256Hash.wrapReversed(Sha256Hash.hashTwice(
             reverseBytes(left), 0, 32,
-            reverseBytes(right), 0, 32)));
+            reverseBytes(right), 0, 32));
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/RejectMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/RejectMessage.java
@@ -107,7 +107,7 @@ public class RejectMessage extends Message {
         stream.write(new VarInt(reasonBytes.length).encode());
         stream.write(reasonBytes);
         if (message.equals("block") || message.equals("tx"))
-            stream.write(Utils.reverseBytes(messageHash.getBytes()));
+            stream.write(messageHash.getReversedBytes());
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/Sha256Hash.java
+++ b/core/src/main/java/org/bitcoinj/core/Sha256Hash.java
@@ -81,6 +81,18 @@ public class Sha256Hash implements Serializable, Comparable<Sha256Hash> {
         return wrap(Utils.HEX.decode(hexString));
     }
 
+    /**
+     * Creates a new instance that wraps the given hash value, but with byte order reversed.
+     *
+     * @param rawHashBytes the raw hash bytes to wrap
+     * @return a new instance
+     * @throws IllegalArgumentException if the given array length is not exactly 32
+     */
+    @SuppressWarnings("deprecation") // the constructor will be made private in the future
+    public static Sha256Hash wrapReversed(byte[] rawHashBytes) {
+        return wrap(Utils.reverseBytes(rawHashBytes));
+    }
+
     /** Use {@link #of(byte[])} instead: this old name is ambiguous. */
     @Deprecated
     public static Sha256Hash create(byte[] contents) {
@@ -242,6 +254,13 @@ public class Sha256Hash implements Serializable, Comparable<Sha256Hash> {
      */
     public byte[] getBytes() {
         return bytes;
+    }
+
+    /**
+     * Returns a reversed copy of the internal byte array.
+     */
+    public byte[] getReversedBytes() {
+        return Utils.reverseBytes(bytes);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/Sha256Hash.java
+++ b/core/src/main/java/org/bitcoinj/core/Sha256Hash.java
@@ -36,7 +36,6 @@ import static com.google.common.base.Preconditions.checkArgument;
  * map. It also checks that the length is correct and provides a bit more type safety.
  */
 public class Sha256Hash implements Serializable, Comparable<Sha256Hash> {
-    private static final MessageDigest digest = newDigest();
     private final byte[] bytes;
     public static final Sha256Hash ZERO_HASH = new Sha256Hash(new byte[32]);
 
@@ -157,12 +156,9 @@ public class Sha256Hash implements Serializable, Comparable<Sha256Hash> {
      * @return the double-hash (in big-endian order)
      */
     public static byte[] calcDoubleHashBytes(byte[] input, int offset, int length) {
-        synchronized (digest) {
-            digest.reset();
-            digest.update(input, offset, length);
-            byte[] first = digest.digest();
-            return digest.digest(first);
-        }
+        MessageDigest digest = newDigest();
+        digest.update(input, offset, length);
+        return digest.digest(digest.digest());
     }
 
     /**
@@ -170,13 +166,10 @@ public class Sha256Hash implements Serializable, Comparable<Sha256Hash> {
      */
     public static byte[] calcDoubleHashBytes(byte[] input1, int offset1, int length1,
                                              byte[] input2, int offset2, int length2) {
-        synchronized (digest) {
-            digest.reset();
-            digest.update(input1, offset1, length1);
-            digest.update(input2, offset2, length2);
-            byte[] first = digest.digest();
-            return digest.digest(first);
-        }
+        MessageDigest digest = newDigest();
+        digest.update(input1, offset1, length1);
+        digest.update(input2, offset2, length2);
+        return digest.digest(digest.digest());
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/Sha256Hash.java
+++ b/core/src/main/java/org/bitcoinj/core/Sha256Hash.java
@@ -65,12 +65,7 @@ public class Sha256Hash implements Serializable, Comparable<Sha256Hash> {
      * Calculates the (one-time) hash of contents and returns it.
      */
     public static Sha256Hash hash(byte[] contents) {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            return new Sha256Hash(digest.digest(contents));
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);  // Cannot happen.
-        }
+        return new Sha256Hash(Utils.newSha256Digest().digest(contents));
     }
 
     /** Use hashTwice(byte[]) instead: this old name is ambiguous. */

--- a/core/src/main/java/org/bitcoinj/core/Sha256Hash.java
+++ b/core/src/main/java/org/bitcoinj/core/Sha256Hash.java
@@ -65,7 +65,7 @@ public class Sha256Hash implements Serializable, Comparable<Sha256Hash> {
      * Calculates the (one-time) hash of contents and returns it.
      */
     public static Sha256Hash hash(byte[] contents) {
-        return new Sha256Hash(Utils.newSha256Digest().digest(contents));
+        return new Sha256Hash(Utils.singleDigest(contents));
     }
 
     /** Use hashTwice(byte[]) instead: this old name is ambiguous. */

--- a/core/src/main/java/org/bitcoinj/core/Sha256Hash.java
+++ b/core/src/main/java/org/bitcoinj/core/Sha256Hash.java
@@ -97,10 +97,7 @@ public class Sha256Hash implements Serializable, Comparable<Sha256Hash> {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Sha256Hash other = (Sha256Hash) o;
-        return Arrays.equals(bytes, other.bytes);
+        return this == o || o != null && getClass() == o.getClass() && Arrays.equals(bytes, ((Sha256Hash)o).bytes);
     }
 
     /**
@@ -135,8 +132,6 @@ public class Sha256Hash implements Serializable, Comparable<Sha256Hash> {
 
     @Override
     public int compareTo(Sha256Hash o) {
-        int thisCode = this.hashCode();
-        int oCode = ((Sha256Hash)o).hashCode();
-        return thisCode > oCode ? 1 : (thisCode == oCode ? 0 : -1);
+        return this.hashCode() - o.hashCode();
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/Sha256Hash.java
+++ b/core/src/main/java/org/bitcoinj/core/Sha256Hash.java
@@ -36,6 +36,7 @@ import static com.google.common.base.Preconditions.checkArgument;
  * map. It also checks that the length is correct and provides a bit more type safety.
  */
 public class Sha256Hash implements Serializable, Comparable<Sha256Hash> {
+    private static final MessageDigest digest = newDigest();
     private final byte[] bytes;
     public static final Sha256Hash ZERO_HASH = new Sha256Hash(new byte[32]);
 
@@ -65,7 +66,7 @@ public class Sha256Hash implements Serializable, Comparable<Sha256Hash> {
      * Calculates the (one-time) hash of contents and returns it.
      */
     public static Sha256Hash hash(byte[] contents) {
-        return new Sha256Hash(Utils.singleDigest(contents));
+        return new Sha256Hash(calcHashBytes(contents));
     }
 
     /** Use hashTwice(byte[]) instead: this old name is ambiguous. */
@@ -78,7 +79,7 @@ public class Sha256Hash implements Serializable, Comparable<Sha256Hash> {
      * Calculates the hash of the hash of the contents. This is a standard operation in Bitcoin.
      */
     public static Sha256Hash hashTwice(byte[] contents) {
-        return new Sha256Hash(Utils.doubleDigest(contents));
+        return new Sha256Hash(calcDoubleHashBytes(contents));
     }
 
     /**
@@ -92,6 +93,89 @@ public class Sha256Hash implements Serializable, Comparable<Sha256Hash> {
             return hash(ByteStreams.toByteArray(in));
         } finally {
             in.close();
+        }
+    }
+
+    /**
+     * Returns a new SHA-256 MessageDigest instance.
+     *
+     * This is a convenience method which wraps the checked
+     * exception that can never occur with a RuntimeException.
+     *
+     * @return a new SHA-256 MessageDigest instance
+     */
+    public static MessageDigest newDigest() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);  // Can't happen.
+        }
+    }
+
+    /**
+     * Calculates the SHA-256 hash of the given bytes.
+     *
+     * @param input the bytes to hash
+     * @return the hash (in big-endian order)
+     */
+    public static byte[] calcHashBytes(byte[] input) {
+        return calcHashBytes(input, 0, input.length);
+    }
+
+    /**
+     * Calculates the SHA-256 hash of the given byte range.
+     *
+     * @param input the array containing the bytes to hash
+     * @param offset the offset within the array of the bytes to hash
+     * @param length the number of bytes to hash
+     * @return the hash (in big-endian order)
+     */
+    public static byte[] calcHashBytes(byte[] input, int offset, int length) {
+        MessageDigest digest = newDigest();
+        digest.update(input, offset, length);
+        return digest.digest();
+    }
+
+    /**
+     * Calculates the SHA-256 hash of the given bytes,
+     * and then hashes the resulting hash again.
+     *
+     * @param input the bytes to hash
+     * @return the double-hash (in big-endian order)
+     */
+    public static byte[] calcDoubleHashBytes(byte[] input) {
+        return calcDoubleHashBytes(input, 0, input.length);
+    }
+
+    /**
+     * Calculates the SHA-256 hash of the given byte range,
+     * and then hashes the resulting hash again.
+     *
+     * @param input the array containing the bytes to hash
+     * @param offset the offset within the array of the bytes to hash
+     * @param length the number of bytes to hash
+     * @return the double-hash (in big-endian order)
+     */
+    public static byte[] calcDoubleHashBytes(byte[] input, int offset, int length) {
+        synchronized (digest) {
+            digest.reset();
+            digest.update(input, offset, length);
+            byte[] first = digest.digest();
+            return digest.digest(first);
+        }
+    }
+
+    /**
+     * Calculates SHA256(SHA256(byte range 1 + byte range 2)).
+     */
+    public static byte[] calcDoubleHashBytes(byte[] input1, int offset1, int length1,
+                                             byte[] input2, int offset2, int length2) {
+        synchronized (digest) {
+            digest.reset();
+            digest.update(input1, offset1, length1);
+            digest.update(input2, offset2, length2);
+            byte[] first = digest.digest();
+            return digest.digest(first);
         }
     }
 

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -226,7 +226,7 @@ public class Transaction extends ChildMessage implements Serializable {
     public Sha256Hash getHash() {
         if (hash == null) {
             byte[] bits = bitcoinSerialize();
-            hash = Sha256Hash.wrap(reverseBytes(Sha256Hash.hashTwice(bits)));
+            hash = Sha256Hash.wrapReversed(Sha256Hash.hashTwice(bits));
         }
         return hash;
     }

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -226,7 +226,7 @@ public class Transaction extends ChildMessage implements Serializable {
     public Sha256Hash getHash() {
         if (hash == null) {
             byte[] bits = bitcoinSerialize();
-            hash = new Sha256Hash(reverseBytes(Sha256Hash.calcDoubleHashBytes(bits)));
+            hash = Sha256Hash.wrap(reverseBytes(Sha256Hash.hashTwice(bits)));
         }
         return hash;
     }
@@ -983,7 +983,7 @@ public class Transaction extends ChildMessage implements Serializable {
                     this.outputs = outputs;
                     // Satoshis bug is that SignatureHash was supposed to return a hash and on this codepath it
                     // actually returns the constant "1" to indicate an error, which is never checked for. Oops.
-                    return new Sha256Hash("0100000000000000000000000000000000000000000000000000000000000000");
+                    return Sha256Hash.wrap("0100000000000000000000000000000000000000000000000000000000000000");
                 }
                 // In SIGHASH_SINGLE the outputs after the matching input index are deleted, and the outputs before
                 // that position are "nulled out". Unintuitively, the value in a "null" transaction is set to -1.
@@ -1010,7 +1010,7 @@ public class Transaction extends ChildMessage implements Serializable {
             uint32ToByteStreamLE(0x000000ff & sigHashType, bos);
             // Note that this is NOT reversed to ensure it will be signed correctly. If it were to be printed out
             // however then we would expect that it is IS reversed.
-            Sha256Hash hash = new Sha256Hash(Sha256Hash.calcDoubleHashBytes(bos.toByteArray()));
+            Sha256Hash hash = Sha256Hash.twiceOf(bos.toByteArray());
             bos.close();
 
             // Put the transaction back to how we found it.

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -226,7 +226,7 @@ public class Transaction extends ChildMessage implements Serializable {
     public Sha256Hash getHash() {
         if (hash == null) {
             byte[] bits = bitcoinSerialize();
-            hash = new Sha256Hash(reverseBytes(doubleDigest(bits)));
+            hash = new Sha256Hash(reverseBytes(Sha256Hash.calcDoubleHashBytes(bits)));
         }
         return hash;
     }
@@ -1010,7 +1010,7 @@ public class Transaction extends ChildMessage implements Serializable {
             uint32ToByteStreamLE(0x000000ff & sigHashType, bos);
             // Note that this is NOT reversed to ensure it will be signed correctly. If it were to be printed out
             // however then we would expect that it is IS reversed.
-            Sha256Hash hash = new Sha256Hash(doubleDigest(bos.toByteArray()));
+            Sha256Hash hash = new Sha256Hash(Sha256Hash.calcDoubleHashBytes(bos.toByteArray()));
             bos.close();
 
             // Put the transaction back to how we found it.

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -112,7 +112,7 @@ public class TransactionOutPoint extends ChildMessage implements Serializable {
 
     @Override
     protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
-        stream.write(Utils.reverseBytes(hash.getBytes()));
+        stream.write(hash.getReversedBytes());
         Utils.uint32ToByteStreamLE(index, stream);
     }
 

--- a/core/src/main/java/org/bitcoinj/core/UTXO.java
+++ b/core/src/main/java/org/bitcoinj/core/UTXO.java
@@ -102,7 +102,7 @@ public class UTXO implements Serializable {
         byte[] hashBytes = new byte[32];
         if (in.read(hashBytes) != 32)
             throw new EOFException();
-        hash = new Sha256Hash(hashBytes);
+        hash = Sha256Hash.wrap(hashBytes);
 
         byte[] indexBytes = new byte[4];
         if (in.read(indexBytes) != 4)

--- a/core/src/main/java/org/bitcoinj/core/Utils.java
+++ b/core/src/main/java/org/bitcoinj/core/Utils.java
@@ -216,7 +216,7 @@ public class Utils {
      * Calculates RIPEMD160(SHA256(input)). This is used in Address calculations.
      */
     public static byte[] sha256hash160(byte[] input) {
-        byte[] sha256 = Sha256Hash.calcHashBytes(input);
+        byte[] sha256 = Sha256Hash.hash(input);
         RIPEMD160Digest digest = new RIPEMD160Digest();
         digest.update(sha256, 0, sha256.length);
         byte[] out = new byte[20];

--- a/core/src/main/java/org/bitcoinj/core/Utils.java
+++ b/core/src/main/java/org/bitcoinj/core/Utils.java
@@ -50,20 +50,29 @@ import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterrup
  * To enable debug logging from the library, run with -Dbitcoinj.logging=true on your command line.
  */
 public class Utils {
-    private static final MessageDigest digest;
-    static {
-        try {
-            digest = MessageDigest.getInstance("SHA-256");
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);  // Can't happen.
-        }
-    }
+    private static final MessageDigest digest = newSha256Digest();
 
     /** The string that prefixes all text messages signed using Bitcoin keys. */
     public static final String BITCOIN_SIGNED_MESSAGE_HEADER = "Bitcoin Signed Message:\n";
     public static final byte[] BITCOIN_SIGNED_MESSAGE_HEADER_BYTES = BITCOIN_SIGNED_MESSAGE_HEADER.getBytes(Charsets.UTF_8);
 
     private static BlockingQueue<Boolean> mockSleepQueue;
+
+    /**
+     * Returns a new SHA-256 MessageDigest instance.
+     *
+     * This is a convenience method which wraps the checked
+     * exception that can never occur with a RuntimeException.
+     *
+     * @return a new SHA-256 MessageDigest instance
+     */
+    public static MessageDigest newSha256Digest() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);  // Can't happen.
+        }
+    }
 
     /**
      * The regular {@link java.math.BigInteger#toByteArray()} method isn't quite what we often need: it appends a
@@ -268,16 +277,12 @@ public class Utils {
      * Calculates RIPEMD160(SHA256(input)). This is used in Address calculations.
      */
     public static byte[] sha256hash160(byte[] input) {
-        try {
-            byte[] sha256 = MessageDigest.getInstance("SHA-256").digest(input);
-            RIPEMD160Digest digest = new RIPEMD160Digest();
-            digest.update(sha256, 0, sha256.length);
-            byte[] out = new byte[20];
-            digest.doFinal(out, 0);
-            return out;
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);  // Cannot happen.
-        }
+        byte[] sha256 = newSha256Digest().digest(input);
+        RIPEMD160Digest digest = new RIPEMD160Digest();
+        digest.update(sha256, 0, sha256.length);
+        byte[] out = new byte[20];
+        digest.doFinal(out, 0);
+        return out;
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/Utils.java
+++ b/core/src/main/java/org/bitcoinj/core/Utils.java
@@ -151,15 +151,24 @@ public class Utils {
     }
 
     /**
-     * See {@link Utils#doubleDigest(byte[], int, int)}.
+     * Calculates the SHA-256 hash of the given bytes,
+     * and then hashes the resulting hash again.
+     *
+     * @param input the bytes to hash
+     * @return the double-hash (in big-endian order)
      */
     public static byte[] doubleDigest(byte[] input) {
         return doubleDigest(input, 0, input.length);
     }
 
     /**
-     * Calculates the SHA-256 hash of the given byte range, and then hashes the resulting hash again. This is
-     * standard procedure in Bitcoin. The resulting hash is in big endian form.
+     * Calculates the SHA-256 hash of the given byte range,
+     * and then hashes the resulting hash again.
+     *
+     * @param input the array containing the bytes to hash
+     * @param offset the offset within the array of the bytes to hash
+     * @param length the number of bytes to hash
+     * @return the double-hash (in big-endian order)
      */
     public static byte[] doubleDigest(byte[] input, int offset, int length) {
         synchronized (digest) {
@@ -170,12 +179,28 @@ public class Utils {
         }
     }
 
+    /**
+     * Calculates the SHA-256 hash of the given bytes.
+     *
+     * @param input the bytes to hash
+     * @return the hash (in big-endian order)
+     */
+    public static byte[] singleDigest(byte[] input) {
+        return singleDigest(input, 0, input.length);
+    }
+
+    /**
+     * Calculates the SHA-256 hash of the given byte range.
+     *
+     * @param input the array containing the bytes to hash
+     * @param offset the offset within the array of the bytes to hash
+     * @param length the number of bytes to hash
+     * @return the hash (in big-endian order)
+     */
     public static byte[] singleDigest(byte[] input, int offset, int length) {
-        synchronized (digest) {
-            digest.reset();
-            digest.update(input, offset, length);
-            return digest.digest();
-        }
+        MessageDigest digest = newSha256Digest();
+        digest.update(input, offset, length);
+        return digest.digest();
     }
 
     /**
@@ -277,7 +302,7 @@ public class Utils {
      * Calculates RIPEMD160(SHA256(input)). This is used in Address calculations.
      */
     public static byte[] sha256hash160(byte[] input) {
-        byte[] sha256 = newSha256Digest().digest(input);
+        byte[] sha256 = singleDigest(input);
         RIPEMD160Digest digest = new RIPEMD160Digest();
         digest.update(sha256, 0, sha256.length);
         byte[] out = new byte[20];

--- a/core/src/main/java/org/bitcoinj/core/VersionedChecksummedBytes.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionedChecksummedBytes.java
@@ -61,7 +61,7 @@ public class VersionedChecksummedBytes implements Serializable, Cloneable, Compa
         byte[] addressBytes = new byte[1 + bytes.length + 4];
         addressBytes[0] = (byte) version;
         System.arraycopy(bytes, 0, addressBytes, 1, bytes.length);
-        byte[] checksum = Sha256Hash.calcDoubleHashBytes(addressBytes, 0, bytes.length + 1);
+        byte[] checksum = Sha256Hash.hashTwice(addressBytes, 0, bytes.length + 1);
         System.arraycopy(checksum, 0, addressBytes, bytes.length + 1, 4);
         return Base58.encode(addressBytes);
     }

--- a/core/src/main/java/org/bitcoinj/core/VersionedChecksummedBytes.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionedChecksummedBytes.java
@@ -61,7 +61,7 @@ public class VersionedChecksummedBytes implements Serializable, Cloneable, Compa
         byte[] addressBytes = new byte[1 + bytes.length + 4];
         addressBytes[0] = (byte) version;
         System.arraycopy(bytes, 0, addressBytes, 1, bytes.length);
-        byte[] checksum = Utils.doubleDigest(addressBytes, 0, bytes.length + 1);
+        byte[] checksum = Sha256Hash.calcDoubleHashBytes(addressBytes, 0, bytes.length + 1);
         System.arraycopy(checksum, 0, addressBytes, bytes.length + 1, 4);
         return Base58.encode(addressBytes);
     }

--- a/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
@@ -122,7 +122,7 @@ public class BIP38PrivateKey extends VersionedChecksummedBytes {
             if (hasLotAndSequence) {
                 byte[] hashBytes = Bytes.concat(passFactorBytes, ownerEntropy);
                 checkState(hashBytes.length == 40);
-                passFactorBytes = Sha256Hash.hashTwice(hashBytes).getBytes();
+                passFactorBytes = Utils.doubleDigest(hashBytes);
             }
             BigInteger passFactor = new BigInteger(1, passFactorBytes);
             ECKey k = ECKey.fromPrivate(passFactor, true);
@@ -150,7 +150,7 @@ public class BIP38PrivateKey extends VersionedChecksummedBytes {
 
             byte[] seed = Bytes.concat(decrypted1, Arrays.copyOfRange(decrypted2, 8, 16));
             checkState(seed.length == 24);
-            BigInteger seedFactor = new BigInteger(1, Sha256Hash.hashTwice(seed).getBytes());
+            BigInteger seedFactor = new BigInteger(1, Utils.doubleDigest(seed));
             checkState(passFactor.signum() >= 0);
             checkState(seedFactor.signum() >= 0);
             BigInteger priv = passFactor.multiply(seedFactor).mod(ECKey.CURVE.getN());

--- a/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
@@ -87,7 +87,7 @@ public class BIP38PrivateKey extends VersionedChecksummedBytes {
     public ECKey decrypt(String passphrase) throws BadPassphraseException {
         String normalizedPassphrase = Normalizer.normalize(passphrase, Normalizer.Form.NFC);
         ECKey key = ecMultiply ? decryptEC(normalizedPassphrase) : decryptNoEC(normalizedPassphrase);
-        Sha256Hash hash = Sha256Hash.hashTwice(key.toAddress(params).toString().getBytes(Charsets.US_ASCII));
+        Sha256Hash hash = Sha256Hash.twiceOf(key.toAddress(params).toString().getBytes(Charsets.US_ASCII));
         byte[] actualAddressHash = Arrays.copyOfRange(hash.getBytes(), 0, 4);
         if (!Arrays.equals(actualAddressHash, addressHash))
             throw new BadPassphraseException();
@@ -122,7 +122,7 @@ public class BIP38PrivateKey extends VersionedChecksummedBytes {
             if (hasLotAndSequence) {
                 byte[] hashBytes = Bytes.concat(passFactorBytes, ownerEntropy);
                 checkState(hashBytes.length == 40);
-                passFactorBytes = Sha256Hash.calcDoubleHashBytes(hashBytes);
+                passFactorBytes = Sha256Hash.hashTwice(hashBytes);
             }
             BigInteger passFactor = new BigInteger(1, passFactorBytes);
             ECKey k = ECKey.fromPrivate(passFactor, true);
@@ -150,7 +150,7 @@ public class BIP38PrivateKey extends VersionedChecksummedBytes {
 
             byte[] seed = Bytes.concat(decrypted1, Arrays.copyOfRange(decrypted2, 8, 16));
             checkState(seed.length == 24);
-            BigInteger seedFactor = new BigInteger(1, Sha256Hash.calcDoubleHashBytes(seed));
+            BigInteger seedFactor = new BigInteger(1, Sha256Hash.hashTwice(seed));
             checkState(passFactor.signum() >= 0);
             checkState(seedFactor.signum() >= 0);
             BigInteger priv = passFactor.multiply(seedFactor).mod(ECKey.CURVE.getN());

--- a/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
@@ -122,7 +122,7 @@ public class BIP38PrivateKey extends VersionedChecksummedBytes {
             if (hasLotAndSequence) {
                 byte[] hashBytes = Bytes.concat(passFactorBytes, ownerEntropy);
                 checkState(hashBytes.length == 40);
-                passFactorBytes = Utils.doubleDigest(hashBytes);
+                passFactorBytes = Sha256Hash.calcDoubleHashBytes(hashBytes);
             }
             BigInteger passFactor = new BigInteger(1, passFactorBytes);
             ECKey k = ECKey.fromPrivate(passFactor, true);
@@ -150,7 +150,7 @@ public class BIP38PrivateKey extends VersionedChecksummedBytes {
 
             byte[] seed = Bytes.concat(decrypted1, Arrays.copyOfRange(decrypted2, 8, 16));
             checkState(seed.length == 24);
-            BigInteger seedFactor = new BigInteger(1, Utils.doubleDigest(seed));
+            BigInteger seedFactor = new BigInteger(1, Sha256Hash.calcDoubleHashBytes(seed));
             checkState(passFactor.signum() >= 0);
             checkState(seedFactor.signum() >= 0);
             BigInteger priv = passFactor.multiply(seedFactor).mod(ECKey.CURVE.getN());

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -283,7 +283,7 @@ public class DeterministicKey extends ECKey {
         int inputLength = input.length;
         byte[] checksummed = new byte[inputLength + 4];
         System.arraycopy(input, 0, checksummed, 0, inputLength);
-        byte[] checksum = Sha256Hash.calcDoubleHashBytes(input);
+        byte[] checksum = Sha256Hash.hashTwice(input);
         System.arraycopy(checksum, 0, checksummed, inputLength, 4);
         return checksummed;
     }

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -283,7 +283,7 @@ public class DeterministicKey extends ECKey {
         int inputLength = input.length;
         byte[] checksummed = new byte[inputLength + 4];
         System.arraycopy(input, 0, checksummed, 0, inputLength);
-        byte[] checksum = Utils.doubleDigest(input);
+        byte[] checksum = Sha256Hash.calcDoubleHashBytes(input);
         System.arraycopy(checksum, 0, checksummed, inputLength, 4);
         return checksummed;
     }

--- a/core/src/main/java/org/bitcoinj/crypto/MnemonicCode.java
+++ b/core/src/main/java/org/bitcoinj/crypto/MnemonicCode.java
@@ -17,6 +17,7 @@
 
 package org.bitcoinj.crypto;
 
+import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.Utils;
 import com.google.common.base.Joiner;
 import org.slf4j.Logger;
@@ -86,7 +87,7 @@ public class MnemonicCode {
     public MnemonicCode(InputStream wordstream, String wordListDigest) throws IOException, IllegalArgumentException {
         BufferedReader br = new BufferedReader(new InputStreamReader(wordstream, "UTF-8"));
         this.wordList = new ArrayList<String>(2048);
-        MessageDigest md = Utils.newSha256Digest();
+        MessageDigest md = Sha256Hash.newDigest();
         String word;
         while ((word = br.readLine()) != null) {
             md.update(word.getBytes());
@@ -173,7 +174,7 @@ public class MnemonicCode {
                     entropy[ii] |= 1 << (7 - jj);
 
         // Take the digest of the entropy.
-        byte[] hash = Utils.singleDigest(entropy);
+        byte[] hash = Sha256Hash.calcHashBytes(entropy);
         boolean[] hashBits = bytesToBits(hash);
 
         // Check all the checksum bits.
@@ -197,7 +198,7 @@ public class MnemonicCode {
         // We take initial entropy of ENT bits and compute its
         // checksum by taking first ENT / 32 bits of its SHA256 hash.
 
-        byte[] hash = Utils.singleDigest(entropy);
+        byte[] hash = Sha256Hash.calcHashBytes(entropy);
         boolean[] hashBits = bytesToBits(hash);
         
         boolean[] entropyBits = bytesToBits(entropy);

--- a/core/src/main/java/org/bitcoinj/crypto/MnemonicCode.java
+++ b/core/src/main/java/org/bitcoinj/crypto/MnemonicCode.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -88,12 +87,7 @@ public class MnemonicCode {
     public MnemonicCode(InputStream wordstream, String wordListDigest) throws IOException, IllegalArgumentException {
         BufferedReader br = new BufferedReader(new InputStreamReader(wordstream, "UTF-8"));
         this.wordList = new ArrayList<String>(2048);
-        MessageDigest md;
-        try {
-            md = MessageDigest.getInstance("SHA-256");
-        } catch (NoSuchAlgorithmException ex) {
-            throw new RuntimeException(ex);		// Can't happen.
-        }
+        MessageDigest md = Utils.newSha256Digest();
         String word;
         while ((word = br.readLine()) != null) {
             md.update(word.getBytes());

--- a/core/src/main/java/org/bitcoinj/crypto/MnemonicCode.java
+++ b/core/src/main/java/org/bitcoinj/crypto/MnemonicCode.java
@@ -17,7 +17,6 @@
 
 package org.bitcoinj.crypto;
 
-import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.Utils;
 import com.google.common.base.Joiner;
 import org.slf4j.Logger;
@@ -174,7 +173,7 @@ public class MnemonicCode {
                     entropy[ii] |= 1 << (7 - jj);
 
         // Take the digest of the entropy.
-        byte[] hash = Sha256Hash.hash(entropy).getBytes();
+        byte[] hash = Utils.singleDigest(entropy);
         boolean[] hashBits = bytesToBits(hash);
 
         // Check all the checksum bits.
@@ -198,7 +197,7 @@ public class MnemonicCode {
         // We take initial entropy of ENT bits and compute its
         // checksum by taking first ENT / 32 bits of its SHA256 hash.
 
-        byte[] hash = Sha256Hash.hash(entropy).getBytes();
+        byte[] hash = Utils.singleDigest(entropy);
         boolean[] hashBits = bytesToBits(hash);
         
         boolean[] entropyBits = bytesToBits(entropy);

--- a/core/src/main/java/org/bitcoinj/crypto/MnemonicCode.java
+++ b/core/src/main/java/org/bitcoinj/crypto/MnemonicCode.java
@@ -174,7 +174,7 @@ public class MnemonicCode {
                     entropy[ii] |= 1 << (7 - jj);
 
         // Take the digest of the entropy.
-        byte[] hash = Sha256Hash.calcHashBytes(entropy);
+        byte[] hash = Sha256Hash.hash(entropy);
         boolean[] hashBits = bytesToBits(hash);
 
         // Check all the checksum bits.
@@ -198,7 +198,7 @@ public class MnemonicCode {
         // We take initial entropy of ENT bits and compute its
         // checksum by taking first ENT / 32 bits of its SHA256 hash.
 
-        byte[] hash = Sha256Hash.calcHashBytes(entropy);
+        byte[] hash = Sha256Hash.hash(entropy);
         boolean[] hashBits = bytesToBits(hash);
         
         boolean[] entropyBits = bytesToBits(entropy);

--- a/core/src/main/java/org/bitcoinj/net/discovery/HttpDiscovery.java
+++ b/core/src/main/java/org/bitcoinj/net/discovery/HttpDiscovery.java
@@ -101,8 +101,8 @@ public class HttpDiscovery implements PeerDiscovery {
         if (details.pubkey != null) {
             if (!Arrays.equals(proto.getPubkey().toByteArray(), details.pubkey.getPubKey()))
                 throw new PeerDiscoveryException("Public key mismatch");
-            Sha256Hash hash = Sha256Hash.hash(proto.getPeerSeeds().toByteArray());
-            details.pubkey.verifyOrThrow(hash.getBytes(), proto.getSignature().toByteArray());
+            byte[] hash = Utils.singleDigest(proto.getPeerSeeds().toByteArray());
+            details.pubkey.verifyOrThrow(hash, proto.getSignature().toByteArray());
         }
         PeerSeedProtos.PeerSeeds seeds = PeerSeedProtos.PeerSeeds.parseFrom(proto.getPeerSeeds());
         if (seeds.getTimestamp() < Utils.currentTimeSeconds() - (60 * 60 * 24))

--- a/core/src/main/java/org/bitcoinj/net/discovery/HttpDiscovery.java
+++ b/core/src/main/java/org/bitcoinj/net/discovery/HttpDiscovery.java
@@ -101,7 +101,7 @@ public class HttpDiscovery implements PeerDiscovery {
         if (details.pubkey != null) {
             if (!Arrays.equals(proto.getPubkey().toByteArray(), details.pubkey.getPubKey()))
                 throw new PeerDiscoveryException("Public key mismatch");
-            byte[] hash = Utils.singleDigest(proto.getPeerSeeds().toByteArray());
+            byte[] hash = Sha256Hash.calcHashBytes(proto.getPeerSeeds().toByteArray());
             details.pubkey.verifyOrThrow(hash, proto.getSignature().toByteArray());
         }
         PeerSeedProtos.PeerSeeds seeds = PeerSeedProtos.PeerSeeds.parseFrom(proto.getPeerSeeds());

--- a/core/src/main/java/org/bitcoinj/net/discovery/HttpDiscovery.java
+++ b/core/src/main/java/org/bitcoinj/net/discovery/HttpDiscovery.java
@@ -101,7 +101,7 @@ public class HttpDiscovery implements PeerDiscovery {
         if (details.pubkey != null) {
             if (!Arrays.equals(proto.getPubkey().toByteArray(), details.pubkey.getPubKey()))
                 throw new PeerDiscoveryException("Public key mismatch");
-            byte[] hash = Sha256Hash.calcHashBytes(proto.getPeerSeeds().toByteArray());
+            byte[] hash = Sha256Hash.hash(proto.getPeerSeeds().toByteArray());
             details.pubkey.verifyOrThrow(hash, proto.getSignature().toByteArray());
         }
         PeerSeedProtos.PeerSeeds seeds = PeerSeedProtos.PeerSeeds.parseFrom(proto.getPeerSeeds());

--- a/core/src/main/java/org/bitcoinj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/MainNetParams.java
@@ -56,11 +56,11 @@ public class MainNetParams extends AbstractBitcoinNetParams {
         // transactions are handled. Duplicated transactions could occur in the case where a coinbase had the same
         // extraNonce and the same outputs but appeared at different heights, and greatly complicated re-org handling.
         // Having these here simplifies block connection logic considerably.
-        checkpoints.put(91722, new Sha256Hash("00000000000271a2dc26e7667f8419f2e15416dc6955e5a6c6cdf3f2574dd08e"));
-        checkpoints.put(91812, new Sha256Hash("00000000000af0aed4792b1acee3d966af36cf5def14935db8de83d6f9306f2f"));
-        checkpoints.put(91842, new Sha256Hash("00000000000a4d0a398161ffc163c503763b1f4360639393e0e4c8e300e0caec"));
-        checkpoints.put(91880, new Sha256Hash("00000000000743f190a18c5577a3c2d2a1f610ae9601ac046a38084ccb7cd721"));
-        checkpoints.put(200000, new Sha256Hash("000000000000034a7dedef4a161fa058a2d67a173a90155f3a2fe6fc132e0ebf"));
+        checkpoints.put(91722, Sha256Hash.wrap("00000000000271a2dc26e7667f8419f2e15416dc6955e5a6c6cdf3f2574dd08e"));
+        checkpoints.put(91812, Sha256Hash.wrap("00000000000af0aed4792b1acee3d966af36cf5def14935db8de83d6f9306f2f"));
+        checkpoints.put(91842, Sha256Hash.wrap("00000000000a4d0a398161ffc163c503763b1f4360639393e0e4c8e300e0caec"));
+        checkpoints.put(91880, Sha256Hash.wrap("00000000000743f190a18c5577a3c2d2a1f610ae9601ac046a38084ccb7cd721"));
+        checkpoints.put(200000, Sha256Hash.wrap("000000000000034a7dedef4a161fa058a2d67a173a90155f3a2fe6fc132e0ebf"));
 
         dnsSeeds = new String[] {
                 "seed.bitcoin.sipa.be",        // Pieter Wuille

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClientConnection.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClientConnection.java
@@ -101,7 +101,7 @@ public class PaymentChannelClientConnection {
             throws IOException, ValueOutOfRangeException {
         // Glue the object which vends/ingests protobuf messages in order to manage state to the network object which
         // reads/writes them to the wire in length prefixed form.
-        channelClient = new PaymentChannelClient(wallet, myKey, maxValue, Sha256Hash.hash(serverId.getBytes()), timeWindow,
+        channelClient = new PaymentChannelClient(wallet, myKey, maxValue, Sha256Hash.of(serverId.getBytes()), timeWindow,
                 userKeySetup, new PaymentChannelClient.ClientConnection() {
             @Override
             public void sendToServer(Protos.TwoWayChannelMessage msg) {

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServer.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServer.java
@@ -226,7 +226,7 @@ public class PaymentChannelServer {
                 .build());
         ByteString reopenChannelContractHash = clientVersion.getPreviousChannelContractHash();
         if (reopenChannelContractHash != null && reopenChannelContractHash.size() == 32) {
-            Sha256Hash contractHash = new Sha256Hash(reopenChannelContractHash.toByteArray());
+            Sha256Hash contractHash = Sha256Hash.wrap(reopenChannelContractHash.toByteArray());
             log.info("New client that wants to resume {}", contractHash);
             StoredPaymentChannelServerStates channels = (StoredPaymentChannelServerStates)
                     wallet.getExtensions().get(StoredPaymentChannelServerStates.EXTENSION_ID);

--- a/core/src/main/java/org/bitcoinj/protocols/channels/StoredPaymentChannelClientStates.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/StoredPaymentChannelClientStates.java
@@ -298,14 +298,14 @@ public class StoredPaymentChannelClientStates implements WalletExtension {
                 ECKey myKey = (storedState.getMyKey().isEmpty()) ?
                         containingWallet.findKeyFromPubKey(storedState.getMyPublicKey().toByteArray()) :
                         ECKey.fromPrivate(storedState.getMyKey().toByteArray());
-                StoredClientChannel channel = new StoredClientChannel(new Sha256Hash(storedState.getId().toByteArray()),
+                StoredClientChannel channel = new StoredClientChannel(Sha256Hash.wrap(storedState.getId().toByteArray()),
                         new Transaction(params, storedState.getContractTransaction().toByteArray()),
                         refundTransaction,
                         myKey,
                         Coin.valueOf(storedState.getValueToMe()),
                         Coin.valueOf(storedState.getRefundFees()), false);
                 if (storedState.hasCloseTransactionHash()) {
-                    Sha256Hash closeTxHash = new Sha256Hash(storedState.getCloseTransactionHash().toByteArray());
+                    Sha256Hash closeTxHash = Sha256Hash.wrap(storedState.getCloseTransactionHash().toByteArray());
                     channel.close = containingWallet.getTransaction(closeTxHash);
                 }
                 putChannel(channel, false);

--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -1223,11 +1223,7 @@ public class Script {
                 case OP_SHA256:
                     if (stack.size() < 1)
                         throw new ScriptException("Attempted OP_SHA256 on an empty stack");
-                    try {
-                        stack.add(MessageDigest.getInstance("SHA-256").digest(stack.pollLast()));
-                    } catch (NoSuchAlgorithmException e) {
-                        throw new RuntimeException(e);  // Cannot happen.
-                    }
+                    stack.add(Utils.newSha256Digest().digest(stack.pollLast()));
                     break;
                 case OP_HASH160:
                     if (stack.size() < 1)

--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -1223,7 +1223,7 @@ public class Script {
                 case OP_SHA256:
                     if (stack.size() < 1)
                         throw new ScriptException("Attempted OP_SHA256 on an empty stack");
-                    stack.add(Utils.newSha256Digest().digest(stack.pollLast()));
+                    stack.add(Utils.singleDigest(stack.pollLast()));
                     break;
                 case OP_HASH160:
                     if (stack.size() < 1)

--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -1223,7 +1223,7 @@ public class Script {
                 case OP_SHA256:
                     if (stack.size() < 1)
                         throw new ScriptException("Attempted OP_SHA256 on an empty stack");
-                    stack.add(Sha256Hash.calcHashBytes(stack.pollLast()));
+                    stack.add(Sha256Hash.hash(stack.pollLast()));
                     break;
                 case OP_HASH160:
                     if (stack.size() < 1)
@@ -1233,7 +1233,7 @@ public class Script {
                 case OP_HASH256:
                     if (stack.size() < 1)
                         throw new ScriptException("Attempted OP_SHA256 on an empty stack");
-                    stack.add(Sha256Hash.calcDoubleHashBytes(stack.pollLast()));
+                    stack.add(Sha256Hash.hashTwice(stack.pollLast()));
                     break;
                 case OP_CODESEPARATOR:
                     lastCodeSepLocation = chunk.getStartLocationInProgram() + 1;

--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -1223,7 +1223,7 @@ public class Script {
                 case OP_SHA256:
                     if (stack.size() < 1)
                         throw new ScriptException("Attempted OP_SHA256 on an empty stack");
-                    stack.add(Utils.singleDigest(stack.pollLast()));
+                    stack.add(Sha256Hash.calcHashBytes(stack.pollLast()));
                     break;
                 case OP_HASH160:
                     if (stack.size() < 1)
@@ -1233,7 +1233,7 @@ public class Script {
                 case OP_HASH256:
                     if (stack.size() < 1)
                         throw new ScriptException("Attempted OP_SHA256 on an empty stack");
-                    stack.add(Utils.doubleDigest(stack.pollLast()));
+                    stack.add(Sha256Hash.calcDoubleHashBytes(stack.pollLast()));
                     break;
                 case OP_CODESEPARATOR:
                     lastCodeSepLocation = chunk.getStartLocationInProgram() + 1;

--- a/core/src/main/java/org/bitcoinj/store/DatabaseFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/DatabaseFullPrunedBlockStore.java
@@ -587,7 +587,7 @@ public abstract class DatabaseFullPrunedBlockStore implements FullPrunedBlockSto
         if (!rs.next()) {
             throw new BlockStoreException("corrupt database block store - no chain head pointer");
         }
-        Sha256Hash hash = new Sha256Hash(rs.getBytes(1));
+        Sha256Hash hash = Sha256Hash.wrap(rs.getBytes(1));
         rs.close();
         this.chainHeadBlock = get(hash);
         this.chainHeadHash = hash;
@@ -599,7 +599,7 @@ public abstract class DatabaseFullPrunedBlockStore implements FullPrunedBlockSto
         if (!rs.next()) {
             throw new BlockStoreException("corrupt database block store - no verified chain head pointer");
         }
-        hash = new Sha256Hash(rs.getBytes(1));
+        hash = Sha256Hash.wrap(rs.getBytes(1));
         rs.close();
         ps.close();
         this.verifiedChainHeadBlock = get(hash);
@@ -1165,7 +1165,7 @@ public abstract class DatabaseFullPrunedBlockStore implements FullPrunedBlockSto
                 s.setString(1, address.toString());
                 ResultSet rs = s.executeQuery();
                 while (rs.next()) {
-                    Sha256Hash hash = new Sha256Hash(rs.getBytes(1));
+                    Sha256Hash hash = Sha256Hash.wrap(rs.getBytes(1));
                     Coin amount = Coin.valueOf(rs.getLong(2));
                     byte[] scriptBytes = rs.getBytes(3);
                     int height = rs.getInt(4);

--- a/core/src/main/java/org/bitcoinj/store/LevelDBBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/LevelDBBlockStore.java
@@ -77,7 +77,7 @@ public class LevelDBBlockStore implements BlockStore {
 
     @Override
     public synchronized StoredBlock getChainHead() throws BlockStoreException {
-        return get(new Sha256Hash(db.get(CHAIN_HEAD_KEY)));
+        return get(Sha256Hash.wrap(db.get(CHAIN_HEAD_KEY)));
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
@@ -234,7 +234,7 @@ public class SPVBlockStore implements BlockStore {
                 byte[] headHash = new byte[32];
                 buffer.position(8);
                 buffer.get(headHash);
-                Sha256Hash hash = new Sha256Hash(headHash);
+                Sha256Hash hash = Sha256Hash.wrap(headHash);
                 StoredBlock block = get(hash);
                 if (block == null)
                     throw new BlockStoreException("Corrupted block store: could not find chain head: " + hash);

--- a/core/src/main/java/org/bitcoinj/store/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/store/WalletProtobufSerializer.java
@@ -373,7 +373,7 @@ public class WalletProtobufSerializer {
     }
 
     public static Sha256Hash byteStringToHash(ByteString bs) {
-        return new Sha256Hash(bs.toByteArray());
+        return Sha256Hash.wrap(bs.toByteArray());
     }
 
     /**

--- a/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
@@ -216,7 +216,7 @@ public class BitcoindComparisonTool {
 
         ArrayList<Sha256Hash> locator = new ArrayList<Sha256Hash>(1);
         locator.add(params.getGenesisBlock().getHash());
-        Sha256Hash hashTo = new Sha256Hash("0000000000000000000000000000000000000000000000000000000000000000");
+        Sha256Hash hashTo = Sha256Hash.wrap("0000000000000000000000000000000000000000000000000000000000000000");
                 
         int rulesSinceFirstFail = 0;
         for (Rule rule : blockList.list) {

--- a/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
@@ -214,7 +214,7 @@ public class BlockChainTest {
         assertTrue(testNetChain.add(b2));
         Block bad = new Block(testNet);
         // Merkle root can be anything here, doesn't matter.
-        bad.setMerkleRoot(new Sha256Hash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+        bad.setMerkleRoot(Sha256Hash.wrap("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
         // Nonce was just some number that made the hash < difficulty limit set below, it can be anything.
         bad.setNonce(140548933);
         bad.setTime(1279242649);
@@ -373,10 +373,10 @@ public class BlockChainTest {
     // Some blocks from the test net.
     private static Block getBlock2() throws Exception {
         Block b2 = new Block(testNet);
-        b2.setMerkleRoot(new Sha256Hash("addc858a17e21e68350f968ccd384d6439b64aafa6c193c8b9dd66320470838b"));
+        b2.setMerkleRoot(Sha256Hash.wrap("addc858a17e21e68350f968ccd384d6439b64aafa6c193c8b9dd66320470838b"));
         b2.setNonce(2642058077L);
         b2.setTime(1296734343L);
-        b2.setPrevBlockHash(new Sha256Hash("000000033cc282bc1fa9dcae7a533263fd7fe66490f550d80076433340831604"));
+        b2.setPrevBlockHash(Sha256Hash.wrap("000000033cc282bc1fa9dcae7a533263fd7fe66490f550d80076433340831604"));
         assertEquals("000000037b21cac5d30fc6fda2581cf7b2612908aed2abbcc429c45b0557a15f", b2.getHashAsString());
         b2.verifyHeader();
         return b2;
@@ -384,10 +384,10 @@ public class BlockChainTest {
 
     private static Block getBlock1() throws Exception {
         Block b1 = new Block(testNet);
-        b1.setMerkleRoot(new Sha256Hash("0e8e58ecdacaa7b3c6304a35ae4ffff964816d2b80b62b58558866ce4e648c10"));
+        b1.setMerkleRoot(Sha256Hash.wrap("0e8e58ecdacaa7b3c6304a35ae4ffff964816d2b80b62b58558866ce4e648c10"));
         b1.setNonce(236038445);
         b1.setTime(1296734340);
-        b1.setPrevBlockHash(new Sha256Hash("00000007199508e34a9ff81e6ec0c477a4cccff2a4767a8eee39c11db367b008"));
+        b1.setPrevBlockHash(Sha256Hash.wrap("00000007199508e34a9ff81e6ec0c477a4cccff2a4767a8eee39c11db367b008"));
         assertEquals("000000033cc282bc1fa9dcae7a533263fd7fe66490f550d80076433340831604", b1.getHashAsString());
         b1.verifyHeader();
         return b1;

--- a/core/src/test/java/org/bitcoinj/core/BlockTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockTest.java
@@ -173,7 +173,7 @@ public class BlockTest {
         Arrays.fill(outputScript, (byte) ScriptOpCodes.OP_FALSE);
         tx.addOutput(new TransactionOutput(params, null, Coin.SATOSHI, outputScript));
         tx.addInput(new TransactionInput(params, null, new byte[] {(byte) ScriptOpCodes.OP_FALSE},
-                new TransactionOutPoint(params, 0, Sha256Hash.hash(new byte[]{1}))));
+                new TransactionOutPoint(params, 0, Sha256Hash.of(new byte[] { 1 }))));
         int origTxLength = 8 + 2 + 8 + 1 + 10 + 40 + 1 + 1;
         assertEquals(tx.bitcoinSerialize().length, tx.length);
         assertEquals(origTxLength, tx.length);
@@ -188,7 +188,7 @@ public class BlockTest {
         assertEquals(block.length, origBlockLen + tx.length);
         assertEquals(tx.length, origTxLength - 1);
         block.getTransactions().get(1).addInput(new TransactionInput(params, null, new byte[] {(byte) ScriptOpCodes.OP_FALSE},
-                new TransactionOutPoint(params, 0, Sha256Hash.hash(new byte[]{1}))));
+                new TransactionOutPoint(params, 0, Sha256Hash.of(new byte[] { 1 }))));
         assertEquals(block.length, origBlockLen + tx.length);
         assertEquals(tx.length, origTxLength + 41); // - 1 + 40 + 1 + 1
     }

--- a/core/src/test/java/org/bitcoinj/core/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ECKeyTest.java
@@ -87,7 +87,7 @@ public class ECKeyTest {
         List<ListenableFuture<ECKey.ECDSASignature>> sigFutures = Lists.newArrayList();
         final ECKey key = new ECKey();
         for (byte i = 0; i < ITERATIONS; i++) {
-            final Sha256Hash hash = Sha256Hash.hash(new byte[]{i});
+            final Sha256Hash hash = Sha256Hash.of(new byte[]{i});
             sigFutures.add(executor.submit(new Callable<ECKey.ECDSASignature>() {
                 @Override
                 public ECKey.ECDSASignature call() throws Exception {
@@ -138,7 +138,7 @@ public class ECKeyTest {
         for (ECKey key : new ECKey[] {decodedKey, roundtripKey}) {
             byte[] message = reverseBytes(HEX.decode(
                     "11da3761e86431e4a54c176789e41f1651b324d240d599a7067bee23d328ec2a"));
-            byte[] output = key.sign(new Sha256Hash(message)).encodeToDER();
+            byte[] output = key.sign(Sha256Hash.wrap(message)).encodeToDER();
             assertTrue(key.verify(message, output));
 
             output = HEX.decode(
@@ -149,8 +149,8 @@ public class ECKeyTest {
         // Try to sign with one key and verify with the other.
         byte[] message = reverseBytes(HEX.decode(
             "11da3761e86431e4a54c176789e41f1651b324d240d599a7067bee23d328ec2a"));
-        assertTrue(roundtripKey.verify(message, decodedKey.sign(new Sha256Hash(message)).encodeToDER()));
-        assertTrue(decodedKey.verify(message, roundtripKey.sign(new Sha256Hash(message)).encodeToDER()));
+        assertTrue(roundtripKey.verify(message, decodedKey.sign(Sha256Hash.wrap(message)).encodeToDER()));
+        assertTrue(decodedKey.verify(message, roundtripKey.sign(Sha256Hash.wrap(message)).encodeToDER()));
     }
 
     @Test
@@ -167,7 +167,7 @@ public class ECKeyTest {
         for (ECKey key : new ECKey[] {decodedKey, roundtripKey}) {
             byte[] message = reverseBytes(HEX.decode(
                     "11da3761e86431e4a54c176789e41f1651b324d240d599a7067bee23d328ec2a"));
-            byte[] output = key.sign(new Sha256Hash(message)).encodeToDER();
+            byte[] output = key.sign(Sha256Hash.wrap(message)).encodeToDER();
             assertTrue(key.verify(message, output));
 
             output = HEX.decode(
@@ -178,8 +178,8 @@ public class ECKeyTest {
         // Try to sign with one key and verify with the other.
         byte[] message = reverseBytes(HEX.decode(
             "11da3761e86431e4a54c176789e41f1651b324d240d599a7067bee23d328ec2a"));
-        assertTrue(roundtripKey.verify(message, decodedKey.sign(new Sha256Hash(message)).encodeToDER()));
-        assertTrue(decodedKey.verify(message, roundtripKey.sign(new Sha256Hash(message)).encodeToDER()));
+        assertTrue(roundtripKey.verify(message, decodedKey.sign(Sha256Hash.wrap(message)).encodeToDER()));
+        assertTrue(decodedKey.verify(message, roundtripKey.sign(Sha256Hash.wrap(message)).encodeToDER()));
 
         // Verify bytewise equivalence of public keys (i.e. compression state is preserved)
         ECKey key = new ECKey();
@@ -247,7 +247,7 @@ public class ECKeyTest {
     public void keyRecovery() throws Exception {
         ECKey key = new ECKey();
         String message = "Hello World!";
-        Sha256Hash hash = Sha256Hash.hash(message.getBytes());
+        Sha256Hash hash = Sha256Hash.of(message.getBytes());
         ECKey.ECDSASignature sig = key.sign(hash);
         key = ECKey.fromPublicOnly(key.getPubKeyPoint());
         boolean found = false;
@@ -346,7 +346,7 @@ public class ECKeyTest {
         ECKey encryptedKey = unencryptedKey.encrypt(keyCrypter, aesKey);
 
         String message = "Goodbye Jupiter!";
-        Sha256Hash hash = Sha256Hash.hash(message.getBytes());
+        Sha256Hash hash = Sha256Hash.of(message.getBytes());
         ECKey.ECDSASignature sig = encryptedKey.sign(hash, aesKey);
         unencryptedKey = ECKey.fromPublicOnly(unencryptedKey.getPubKeyPoint());
         boolean found = false;
@@ -447,7 +447,7 @@ public class ECKeyTest {
 
         byte[] hash = new byte[32];
         new Random().nextBytes(hash);
-        byte[] sigBytes = key.sign(new Sha256Hash(hash)).encodeToDER();
+        byte[] sigBytes = key.sign(Sha256Hash.wrap(hash)).encodeToDER();
         byte[] encodedSig = Arrays.copyOf(sigBytes, sigBytes.length + 1);
         encodedSig[sigBytes.length] = (byte) (Transaction.SigHash.ALL.ordinal() + 1);
         if (!TransactionSignature.isEncodingCanonical(encodedSig)) {

--- a/core/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTests.java
+++ b/core/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTests.java
@@ -52,7 +52,7 @@ public class FilteredBlockAndPartialMerkleTreeTests extends TestWithPeerGroup {
         // Cheat and place the previous block (block 100000) at the head of the block store without supporting blocks
         store.put(new StoredBlock(new Block(params, HEX.decode("0100000050120119172a610421a6c3011dd330d9df07b63616c2cc1f1cd00200000000006657a9252aacd5c0b2940996ecff952228c3067cc38d4885efb5a4ac4247e9f337221b4d4c86041b0f2b5710")),
                 BigInteger.valueOf(1), 100000));
-        store.setChainHead(store.get(new Sha256Hash("000000000003ba27aa200b1cecaad478d2b00432346c3f1f3986da1afd33e506")));
+        store.setChainHead(store.get(Sha256Hash.wrap("000000000003ba27aa200b1cecaad478d2b00432346c3f1f3986da1afd33e506")));
 
         KeyChainGroup group = new KeyChainGroup(params);
         group.importKeys(ECKey.fromPublicOnly(HEX.decode("04b27f7e9475ccf5d9a431cb86d665b8302c140144ec2397fce792f4a4e7765fecf8128534eaa71df04f93c74676ae8279195128a1506ebf7379d23dab8fca0f63")),
@@ -76,12 +76,12 @@ public class FilteredBlockAndPartialMerkleTreeTests extends TestWithPeerGroup {
         FilteredBlock block = new FilteredBlock(params, HEX.decode("0100000079cda856b143d9db2c1caff01d1aecc8630d30625d10e8b4b8b0000000000000b50cc069d6a3e33e3ff84a5c41d9d3febe7c770fdcc96b2c3ff60abe184f196367291b4d4c86041b8fa45d630100000001b50cc069d6a3e33e3ff84a5c41d9d3febe7c770fdcc96b2c3ff60abe184f19630101"));
         
         // Check that the header was properly deserialized
-        assertTrue(block.getBlockHeader().getHash().equals(new Sha256Hash("000000000000dab0130bbcc991d3d7ae6b81aa6f50a798888dfe62337458dc45")));
+        assertTrue(block.getBlockHeader().getHash().equals(Sha256Hash.wrap("000000000000dab0130bbcc991d3d7ae6b81aa6f50a798888dfe62337458dc45")));
         
         // Check that the partial merkle tree is correct
         List<Sha256Hash> txesMatched = block.getTransactionHashes();
         assertTrue(txesMatched.size() == 1);
-        assertTrue(txesMatched.contains(new Sha256Hash("63194f18be0af63f2c6bc9dc0f777cbefed3d9415c4af83f3ee3a3d669c00cb5")));
+        assertTrue(txesMatched.contains(Sha256Hash.wrap("63194f18be0af63f2c6bc9dc0f777cbefed3d9415c4af83f3ee3a3d669c00cb5")));
 
         // Check round tripping.
         assertEquals(block, new FilteredBlock(params, block.bitcoinSerialize()));
@@ -108,7 +108,7 @@ public class FilteredBlockAndPartialMerkleTreeTests extends TestWithPeerGroup {
     private Sha256Hash numAsHash(int num) {
         byte[] bits = new byte[32];
         bits[0] = (byte) num;
-        return new Sha256Hash(bits);
+        return Sha256Hash.wrap(bits);
     }
 
     @Test(expected = VerificationException.class)
@@ -133,27 +133,27 @@ public class FilteredBlockAndPartialMerkleTreeTests extends TestWithPeerGroup {
         FilteredBlock filteredBlock = new FilteredBlock(params, HEX.decode("0100000006e533fd1ada86391f3f6c343204b0d278d4aaec1c0b20aa27ba0300000000006abbb3eb3d733a9fe18967fd7d4c117e4ccbbac5bec4d910d900b3ae0793e77f54241b4d4c86041b4089cc9b0c000000084c30b63cfcdc2d35e3329421b9805ef0c6565d35381ca857762ea0b3a5a128bbca5065ff9617cbcba45eb23726df6498a9b9cafed4f54cbab9d227b0035ddefbbb15ac1d57d0182aaee61c74743a9c4f785895e563909bafec45c9a2b0ff3181d77706be8b1dcc91112eada86d424e2d0a8907c3488b6e44fda5a74a25cbc7d6bb4fa04245f4ac8a1a571d5537eac24adca1454d65eda446055479af6c6d4dd3c9ab658448c10b6921b7a4ce3021eb22ed6bb6a7fde1e5bcc4b1db6615c6abc5ca042127bfaf9f44ebce29cb29c6df9d05b47f35b2edff4f0064b578ab741fa78276222651209fe1a2c4c0fa1c58510aec8b090dd1eb1f82f9d261b8273b525b02ff1a"));
         
         // Block 100001
-        assertTrue(block.getHash().equals(new Sha256Hash("00000000000080b66c911bd5ba14a74260057311eaeb1982802f7010f1a9f090")));
+        assertTrue(block.getHash().equals(Sha256Hash.wrap("00000000000080b66c911bd5ba14a74260057311eaeb1982802f7010f1a9f090")));
         assertTrue(filteredBlock.getHash().equals(block.getHash()));
         
         List<Sha256Hash> txHashList = filteredBlock.getTransactionHashes();
         assertTrue(txHashList.size() == 4);
         // Four transactions (0, 1, 2, 6) from block 100001
         Transaction tx0 = new Transaction(params, HEX.decode("01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff07044c86041b010dffffffff0100f2052a01000000434104b27f7e9475ccf5d9a431cb86d665b8302c140144ec2397fce792f4a4e7765fecf8128534eaa71df04f93c74676ae8279195128a1506ebf7379d23dab8fca0f63ac00000000"));
-        assertTrue(tx0.getHash().equals(new Sha256Hash("bb28a1a5b3a02e7657a81c38355d56c6f05e80b9219432e3352ddcfc3cb6304c")));
+        assertTrue(tx0.getHash().equals(Sha256Hash.wrap("bb28a1a5b3a02e7657a81c38355d56c6f05e80b9219432e3352ddcfc3cb6304c")));
         assertEquals(tx0.getHash(), txHashList.get(0));
         
         Transaction tx1 = new Transaction(params, HEX.decode("0100000001d992e5a888a86d4c7a6a69167a4728ee69497509740fc5f456a24528c340219a000000008b483045022100f0519bdc9282ff476da1323b8ef7ffe33f495c1a8d52cc522b437022d83f6a230220159b61d197fbae01b4a66622a23bc3f1def65d5fa24efd5c26fa872f3a246b8e014104839f9023296a1fabb133140128ca2709f6818c7d099491690bd8ac0fd55279def6a2ceb6ab7b5e4a71889b6e739f09509565eec789e86886f6f936fa42097adeffffffff02000fe208010000001976a914948c765a6914d43f2a7ac177da2c2f6b52de3d7c88ac00e32321000000001976a9140c34f4e29ab5a615d5ea28d4817f12b137d62ed588ac00000000"));
-        assertTrue(tx1.getHash().equals(new Sha256Hash("fbde5d03b027d2b9ba4cf5d4fecab9a99864df2637b25ea4cbcb1796ff6550ca")));
+        assertTrue(tx1.getHash().equals(Sha256Hash.wrap("fbde5d03b027d2b9ba4cf5d4fecab9a99864df2637b25ea4cbcb1796ff6550ca")));
         assertEquals(tx1.getHash(), txHashList.get(1));
 
         Transaction tx2 = new Transaction(params, HEX.decode("01000000059daf0abe7a92618546a9dbcfd65869b6178c66ec21ccfda878c1175979cfd9ef000000004a493046022100c2f7f25be5de6ce88ac3c1a519514379e91f39b31ddff279a3db0b1a229b708b022100b29efbdbd9837cc6a6c7318aa4900ed7e4d65662c34d1622a2035a3a5534a99a01ffffffffd516330ebdf075948da56db13d22632a4fb941122df2884397dda45d451acefb0000000048473044022051243debe6d4f2b433bee0cee78c5c4073ead0e3bde54296dbed6176e128659c022044417bfe16f44eb7b6eb0cdf077b9ce972a332e15395c09ca5e4f602958d266101ffffffffe1f5aa33961227b3c344e57179417ce01b7ccd421117fe2336289b70489883f900000000484730440220593252bb992ce3c85baf28d6e3aa32065816271d2c822398fe7ee28a856bc943022066d429dd5025d3c86fd8fd8a58e183a844bd94aa312cefe00388f57c85b0ca3201ffffffffe207e83718129505e6a7484831442f668164ae659fddb82e9e5421a081fb90d50000000049483045022067cf27eb733e5bcae412a586b25a74417c237161a084167c2a0b439abfebdcb2022100efcc6baa6824b4c5205aa967e0b76d31abf89e738d4b6b014e788c9a8cccaf0c01ffffffffe23b8d9d80a9e9d977fab3c94dbe37befee63822443c3ec5ae5a713ede66c3940000000049483045022020f2eb35036666b1debe0d1d2e77a36d5d9c4e96c1dba23f5100f193dbf524790221008ce79bc1321fb4357c6daee818038d41544749127751726e46b2b320c8b565a201ffffffff0200ba1dd2050000001976a914366a27645806e817a6cd40bc869bdad92fe5509188ac40420f00000000001976a914ee8bd501094a7d5ca318da2506de35e1cb025ddc88ac00000000"));
-        assertTrue(tx2.getHash().equals(new Sha256Hash("8131ffb0a2c945ecaf9b9063e59558784f9c3a74741ce6ae2a18d0571dac15bb")));
+        assertTrue(tx2.getHash().equals(Sha256Hash.wrap("8131ffb0a2c945ecaf9b9063e59558784f9c3a74741ce6ae2a18d0571dac15bb")));
         assertEquals(tx2.getHash(), txHashList.get(2));
 
 
         Transaction tx3 = new Transaction(params, HEX.decode("01000000011b56cf3aab3286d582c055a42af3a911ee08423f276da702bb67f1222ac1a5b6000000008c4930460221009e9fba682e162c9627b96b7df272006a727988680b956c61baff869f0907b8fb022100a9c19adc7c36144bafe526630783845e5cb9554d30d3edfb56f0740274d507f30141046e0efbfac7b1615ad553a6f097615bc63b7cdb3b8e1cb3263b619ba63740012f51c7c5b09390e3577e377b7537e61226e315f95f926444fc5e5f2978c112e448ffffffff02c0072b11010000001976a914b73e9e01933351ca076faf8e0d94dd58079d0b1f88ac80b63908000000001976a9141aca0bdf0d2cee63db19aa4a484f45a4e26a880c88ac00000000"));
-        assertTrue(tx3.getHash().equals(new Sha256Hash("c5abc61566dbb1c4bce5e1fda7b66bed22eb2130cea4b721690bc1488465abc9")));
+        assertTrue(tx3.getHash().equals(Sha256Hash.wrap("c5abc61566dbb1c4bce5e1fda7b66bed22eb2130cea4b721690bc1488465abc9")));
         assertEquals(tx3.getHash(),txHashList.get(3));
 
         BloomFilter filter = wallet.getBloomFilter(wallet.getKeychainSize()*2, 0.001, 0xDEADBEEF);

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -981,7 +981,7 @@ public class FullBlockTestGenerator {
         NewBlock b49 = createNextBlock(b44, chainHeadHeight + 16, out15, null);
         byte[] b49MerkleHash = Sha256Hash.ZERO_HASH.getBytes().clone();
         b49MerkleHash[1] = (byte) 0xDE;
-        b49.block.setMerkleRoot(Sha256Hash.hash(b49MerkleHash));
+        b49.block.setMerkleRoot(Sha256Hash.of(b49MerkleHash));
         b49.solve();
         blocks.add(new BlockAndValidity(b49, false, true, b44.getHash(), chainHeadHeight + 15, "b49"));
 
@@ -1326,7 +1326,7 @@ public class FullBlockTestGenerator {
         {
             Transaction tx = new Transaction(params);
             tx.addOutput(ZERO, OP_TRUE_SCRIPT);
-            tx.addInput(new Sha256Hash("23c70ed7c0506e9178fc1a987f40a33946d4ad4c962b5ae3a52546da53af0c5c"), 0,
+            tx.addInput(Sha256Hash.wrap("23c70ed7c0506e9178fc1a987f40a33946d4ad4c962b5ae3a52546da53af0c5c"), 0,
                     OP_NOP_SCRIPT);
             b70.addTransaction(tx);
         }

--- a/core/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -568,9 +568,9 @@ public class PeerTest extends TestWithNetworkConnections {
         Transaction t1 = new Transaction(params);
         t1.addInput(t2.getOutput(0));
         t1.addInput(t3.getOutput(0));
-        Sha256Hash someHash = new Sha256Hash("2b801dd82f01d17bbde881687bf72bc62e2faa8ab8133d36fcb8c3abe7459da6");
+        Sha256Hash someHash = Sha256Hash.wrap("2b801dd82f01d17bbde881687bf72bc62e2faa8ab8133d36fcb8c3abe7459da6");
         t1.addInput(new TransactionInput(params, t1, new byte[]{}, new TransactionOutPoint(params, 0, someHash)));
-        Sha256Hash anotherHash = new Sha256Hash("3b801dd82f01d17bbde881687bf72bc62e2faa8ab8133d36fcb8c3abe7459da6");
+        Sha256Hash anotherHash = Sha256Hash.wrap("3b801dd82f01d17bbde881687bf72bc62e2faa8ab8133d36fcb8c3abe7459da6");
         t1.addInput(new TransactionInput(params, t1, new byte[]{}, new TransactionOutPoint(params, 1, anotherHash)));
         t1.addOutput(COIN, to);
         t1 = FakeTxBuilder.roundTripTransaction(params, t1);
@@ -704,7 +704,7 @@ public class PeerTest extends TestWithNetworkConnections {
         Transaction t2 = new Transaction(params);
         t2.setLockTime(999999);
         // Add a fake input to t3 that goes nowhere.
-        Sha256Hash t3 = Sha256Hash.hash("abc".getBytes(Charset.forName("UTF-8")));
+        Sha256Hash t3 = Sha256Hash.of("abc".getBytes(Charset.forName("UTF-8")));
         t2.addInput(new TransactionInput(params, t2, new byte[]{}, new TransactionOutPoint(params, 0, t3)));
         t2.getInput(0).setSequenceNumber(0xDEADBEEF);
         t2.addOutput(COIN, new ECKey());
@@ -817,8 +817,8 @@ public class PeerTest extends TestWithNetworkConnections {
         // Basic test of support for BIP 64: getutxos support. The Lighthouse unit tests exercise this stuff more
         // thoroughly.
         connectWithVersion(GetUTXOsMessage.MIN_PROTOCOL_VERSION, VersionMessage.NODE_NETWORK | VersionMessage.NODE_GETUTXOS);
-        TransactionOutPoint op1 = new TransactionOutPoint(params, 1, Sha256Hash.hash("foo".getBytes()));
-        TransactionOutPoint op2 = new TransactionOutPoint(params, 2, Sha256Hash.hash("bar".getBytes()));
+        TransactionOutPoint op1 = new TransactionOutPoint(params, 1, Sha256Hash.of("foo".getBytes()));
+        TransactionOutPoint op2 = new TransactionOutPoint(params, 2, Sha256Hash.of("bar".getBytes()));
 
         ListenableFuture<UTXOsMessage> future1 = peer.getUTXOs(ImmutableList.of(op1));
         ListenableFuture<UTXOsMessage> future2 = peer.getUTXOs(ImmutableList.of(op2));
@@ -870,9 +870,9 @@ public class PeerTest extends TestWithNetworkConnections {
             @Override
             public void bitcoinSerializeToStream(OutputStream stream) throws IOException {
                 // Add some hashes.
-                addItem(new InventoryItem(InventoryItem.Type.Transaction, Sha256Hash.hash(new byte[]{1})));
-                addItem(new InventoryItem(InventoryItem.Type.Transaction, Sha256Hash.hash(new byte[]{2})));
-                addItem(new InventoryItem(InventoryItem.Type.Transaction, Sha256Hash.hash(new byte[]{3})));
+                addItem(new InventoryItem(InventoryItem.Type.Transaction, Sha256Hash.of(new byte[]{1})));
+                addItem(new InventoryItem(InventoryItem.Type.Transaction, Sha256Hash.of(new byte[]{2})));
+                addItem(new InventoryItem(InventoryItem.Type.Transaction, Sha256Hash.of(new byte[]{3})));
 
                 // Write out a copy that's truncated in the middle.
                 ByteArrayOutputStream bos = new ByteArrayOutputStream();

--- a/core/src/test/java/org/bitcoinj/core/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/core/WalletTest.java
@@ -1360,17 +1360,17 @@ public class WalletTest extends TestWithWallet {
     public void autosaveImmediate() throws Exception {
         // Test that the wallet will save itself automatically when it changes.
         File f = File.createTempFile("bitcoinj-unit-test", null);
-        Sha256Hash hash1 = Sha256Hash.hashFileContents(f);
+        Sha256Hash hash1 = Sha256Hash.of(f);
         // Start with zero delay and ensure the wallet file changes after adding a key.
         wallet.autosaveToFile(f, 0, TimeUnit.SECONDS, null);
         ECKey key = wallet.freshReceiveKey();
-        Sha256Hash hash2 = Sha256Hash.hashFileContents(f);
+        Sha256Hash hash2 = Sha256Hash.of(f);
         assertFalse("Wallet not saved after generating fresh key", hash1.equals(hash2));  // File has changed.
 
         Transaction t1 = createFakeTx(params, valueOf(5, 0), key);
         if (wallet.isPendingTransactionRelevant(t1))
             wallet.receivePending(t1, null);
-        Sha256Hash hash3 = Sha256Hash.hashFileContents(f);
+        Sha256Hash hash3 = Sha256Hash.of(f);
         assertFalse("Wallet not saved after receivePending", hash2.equals(hash3));  // File has changed again.
     }
 
@@ -1382,7 +1382,7 @@ public class WalletTest extends TestWithWallet {
         final File[] results = new File[2];
         final CountDownLatch latch = new CountDownLatch(3);
         File f = File.createTempFile("bitcoinj-unit-test", null);
-        Sha256Hash hash1 = Sha256Hash.hashFileContents(f);
+        Sha256Hash hash1 = Sha256Hash.of(f);
         wallet.autosaveToFile(f, 1, TimeUnit.SECONDS,
                 new WalletFiles.Listener() {
                     @Override
@@ -1398,7 +1398,7 @@ public class WalletTest extends TestWithWallet {
                 }
         );
         ECKey key = wallet.freshReceiveKey();
-        Sha256Hash hash2 = Sha256Hash.hashFileContents(f);
+        Sha256Hash hash2 = Sha256Hash.of(f);
         assertFalse(hash1.equals(hash2));  // File has changed immediately despite the delay, as keys are important.
         assertNotNull(results[0]);
         assertEquals(f, results[1]);
@@ -1406,7 +1406,7 @@ public class WalletTest extends TestWithWallet {
 
         Block b0 = createFakeBlock(blockStore).block;
         chain.add(b0);
-        Sha256Hash hash3 = Sha256Hash.hashFileContents(f);
+        Sha256Hash hash3 = Sha256Hash.of(f);
         assertEquals(hash2, hash3);  // File has NOT changed yet. Just new blocks with no txns - delayed.
         assertNull(results[0]);
         assertNull(results[1]);
@@ -1414,20 +1414,20 @@ public class WalletTest extends TestWithWallet {
         Transaction t1 = createFakeTx(params, valueOf(5, 0), key);
         Block b1 = createFakeBlock(blockStore, t1).block;
         chain.add(b1);
-        Sha256Hash hash4 = Sha256Hash.hashFileContents(f);
+        Sha256Hash hash4 = Sha256Hash.of(f);
         assertFalse(hash3.equals(hash4));  // File HAS changed.
         results[0] = results[1] = null;
 
         // A block that contains some random tx we don't care about.
         Block b2 = b1.createNextBlock(new ECKey().toAddress(params));
         chain.add(b2);
-        assertEquals(hash4, Sha256Hash.hashFileContents(f));  // File has NOT changed.
+        assertEquals(hash4, Sha256Hash.of(f));  // File has NOT changed.
         assertNull(results[0]);
         assertNull(results[1]);
 
         // Wait for an auto-save to occur.
         latch.await();
-        Sha256Hash hash5 = Sha256Hash.hashFileContents(f);
+        Sha256Hash hash5 = Sha256Hash.of(f);
         assertFalse(hash4.equals(hash5));  // File has now changed.
         assertNotNull(results[0]);
         assertEquals(f, results[1]);
@@ -1437,12 +1437,12 @@ public class WalletTest extends TestWithWallet {
         results[0] = results[1] = null;
         ECKey key2 = new ECKey();
         wallet.importKey(key2);
-        assertEquals(hash5, Sha256Hash.hashFileContents(f)); // File has NOT changed.
+        assertEquals(hash5, Sha256Hash.of(f)); // File has NOT changed.
         Transaction t2 = createFakeTx(params, valueOf(5, 0), key2);
         Block b3 = createFakeBlock(blockStore, t2).block;
         chain.add(b3);
         Thread.sleep(2000); // Wait longer than autosave delay. TODO Fix the racyness.
-        assertEquals(hash5, Sha256Hash.hashFileContents(f)); // File has still NOT changed.
+        assertEquals(hash5, Sha256Hash.of(f)); // File has still NOT changed.
         assertNull(results[0]);
         assertNull(results[1]);
     }

--- a/core/src/test/java/org/bitcoinj/crypto/ChildKeyDerivationTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ChildKeyDerivationTest.java
@@ -153,7 +153,7 @@ public class ChildKeyDerivationTest {
         assertFalse(decryptedKey2.isEncrypted());
         assertEquals(key2, decryptedKey2);
 
-        Sha256Hash hash = Sha256Hash.hash("the mainstream media won't cover it. why is that?".getBytes());
+        Sha256Hash hash = Sha256Hash.of("the mainstream media won't cover it. why is that?".getBytes());
         try {
             derivedKey2.sign(hash);
             fail();

--- a/core/src/test/java/org/bitcoinj/protocols/channels/ChannelConnectionTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/channels/ChannelConnectionTest.java
@@ -291,7 +291,7 @@ public class ChannelConnectionTest extends TestWithWallet {
         // Tests various aspects of channel resuming.
         Utils.setMockClock();
 
-        final Sha256Hash someServerId = Sha256Hash.hash(new byte[]{});
+        final Sha256Hash someServerId = Sha256Hash.of(new byte[]{});
 
         // Open up a normal channel.
         ChannelTestUtils.RecordingPair pair = ChannelTestUtils.makeRecorders(serverWallet, mockBroadcaster);
@@ -341,7 +341,7 @@ public class ChannelConnectionTest extends TestWithWallet {
         pair.server.receiveMessage(Protos.TwoWayChannelMessage.newBuilder()
             .setType(MessageType.CLIENT_VERSION)
             .setClientVersion(Protos.ClientVersion.newBuilder()
-                .setPreviousChannelContractHash(ByteString.copyFrom(Sha256Hash.calcHashBytes(new byte[] { 0x03 })))
+                .setPreviousChannelContractHash(ByteString.copyFrom(Sha256Hash.hash(new byte[] { 0x03 })))
                 .setMajor(CLIENT_MAJOR_VERSION).setMinor(42))
             .build());
         pair.serverRecorder.checkNextMsg(MessageType.SERVER_VERSION);
@@ -361,7 +361,7 @@ public class ChannelConnectionTest extends TestWithWallet {
         // Check the contract hash is sent on the wire correctly.
         final Protos.TwoWayChannelMessage clientVersionMsg = pair.clientRecorder.checkNextMsg(MessageType.CLIENT_VERSION);
         assertTrue(clientVersionMsg.getClientVersion().hasPreviousChannelContractHash());
-        assertEquals(contractHash, new Sha256Hash(clientVersionMsg.getClientVersion().getPreviousChannelContractHash().toByteArray()));
+        assertEquals(contractHash, Sha256Hash.wrap(clientVersionMsg.getClientVersion().getPreviousChannelContractHash().toByteArray()));
         server.receiveMessage(clientVersionMsg);
         client.receiveMessage(pair.serverRecorder.checkNextMsg(MessageType.SERVER_VERSION));
         client.receiveMessage(pair.serverRecorder.checkNextMsg(MessageType.CHANNEL_OPEN));

--- a/core/src/test/java/org/bitcoinj/protocols/channels/ChannelConnectionTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/channels/ChannelConnectionTest.java
@@ -339,11 +339,11 @@ public class ChannelConnectionTest extends TestWithWallet {
         pair = ChannelTestUtils.makeRecorders(serverWallet, mockBroadcaster);
         pair.server.connectionOpen();
         pair.server.receiveMessage(Protos.TwoWayChannelMessage.newBuilder()
-                .setType(MessageType.CLIENT_VERSION)
-                .setClientVersion(Protos.ClientVersion.newBuilder()
-                        .setPreviousChannelContractHash(ByteString.copyFrom(Utils.singleDigest(new byte[]{0x03})))
-                        .setMajor(CLIENT_MAJOR_VERSION).setMinor(42))
-                .build());
+            .setType(MessageType.CLIENT_VERSION)
+            .setClientVersion(Protos.ClientVersion.newBuilder()
+                .setPreviousChannelContractHash(ByteString.copyFrom(Sha256Hash.calcHashBytes(new byte[] { 0x03 })))
+                .setMajor(CLIENT_MAJOR_VERSION).setMinor(42))
+            .build());
         pair.serverRecorder.checkNextMsg(MessageType.SERVER_VERSION);
         pair.serverRecorder.checkNextMsg(MessageType.INITIATE);
 

--- a/core/src/test/java/org/bitcoinj/protocols/channels/ChannelConnectionTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/channels/ChannelConnectionTest.java
@@ -341,7 +341,7 @@ public class ChannelConnectionTest extends TestWithWallet {
         pair.server.receiveMessage(Protos.TwoWayChannelMessage.newBuilder()
                 .setType(MessageType.CLIENT_VERSION)
                 .setClientVersion(Protos.ClientVersion.newBuilder()
-                        .setPreviousChannelContractHash(ByteString.copyFrom(Sha256Hash.hash(new byte[]{0x03}).getBytes()))
+                        .setPreviousChannelContractHash(ByteString.copyFrom(Utils.singleDigest(new byte[]{0x03})))
                         .setMajor(CLIENT_MAJOR_VERSION).setMinor(42))
                 .build());
         pair.serverRecorder.checkNextMsg(MessageType.SERVER_VERSION);

--- a/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelClientTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelClientTest.java
@@ -33,7 +33,7 @@ public class PaymentChannelClientTest {
         wallet = createMock(Wallet.class);
         ecKey = createMock(ECKey.class);
         maxValue = Coin.COIN;
-        serverHash = Sha256Hash.hash("serverId".getBytes());
+        serverHash = Sha256Hash.of("serverId".getBytes());
         connection = createMock(IPaymentChannelClient.ClientConnection.class);
         clientVersionCapture = new Capture<TwoWayChannelMessage>();
     }

--- a/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelStateTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelStateTest.java
@@ -292,7 +292,7 @@ public class PaymentChannelStateTest extends TestWithWallet {
         Utils.rollMockClock(60 * 60 * 2 + 60 * 5);
 
         // Now store the client state in a stored state object which handles the rebroadcasting
-        clientState.doStoreChannelInWallet(Sha256Hash.hash(new byte[]{}));
+        clientState.doStoreChannelInWallet(Sha256Hash.of(new byte[]{}));
         TxFuturePair clientBroadcastedMultiSig = broadcasts.take();
         TxFuturePair broadcastRefund = broadcasts.take();
         assertEquals(clientBroadcastedMultiSig.tx.getHash(), multisigContract.getHash());

--- a/core/src/test/java/org/bitcoinj/script/ScriptTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptTest.java
@@ -308,7 +308,7 @@ public class ScriptTest {
             String hash = input.get(0).asText();
             int index = input.get(1).asInt();
             String script = input.get(2).asText();
-            Sha256Hash sha256Hash = new Sha256Hash(HEX.decode(hash));
+            Sha256Hash sha256Hash = Sha256Hash.wrap(HEX.decode(hash));
             scriptPubKeys.put(new TransactionOutPoint(params, index, sha256Hash), parseScriptString(script));
         }
         return scriptPubKeys;

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.*;
 
 public class DeterministicKeyChainTest {
     private DeterministicKeyChain chain;
-    private final byte[] ENTROPY = Sha256Hash.calcHashBytes("don't use a string seed like this in real life".getBytes());
+    private final byte[] ENTROPY = Sha256Hash.hash("don't use a string seed like this in real life".getBytes());
 
     @Before
     public void setup() {

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.*;
 
 public class DeterministicKeyChainTest {
     private DeterministicKeyChain chain;
-    private final byte[] ENTROPY = Utils.singleDigest("don't use a string seed like this in real life".getBytes());
+    private final byte[] ENTROPY = Sha256Hash.calcHashBytes("don't use a string seed like this in real life".getBytes());
 
     @Before
     public void setup() {

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.*;
 
 public class DeterministicKeyChainTest {
     private DeterministicKeyChain chain;
-    private final byte[] ENTROPY = Sha256Hash.hash("don't use a string seed like this in real life".getBytes()).getBytes();
+    private final byte[] ENTROPY = Utils.singleDigest("don't use a string seed like this in real life".getBytes());
 
     @Before
     public void setup() {

--- a/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
@@ -64,7 +64,7 @@ public class KeyChainGroupTest {
     }
 
     private MarriedKeyChain createMarriedKeyChain() {
-        byte[] entropy = Sha256Hash.calcHashBytes("don't use a seed like this in real life".getBytes());
+        byte[] entropy = Sha256Hash.hash("don't use a seed like this in real life".getBytes());
         DeterministicSeed seed = new DeterministicSeed(entropy, "", MnemonicCode.BIP39_STANDARDISATION_TIME_SECS);
         MarriedKeyChain chain = MarriedKeyChain.builder()
                 .seed(seed)

--- a/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
@@ -64,7 +64,7 @@ public class KeyChainGroupTest {
     }
 
     private MarriedKeyChain createMarriedKeyChain() {
-        byte[] entropy = Utils.singleDigest("don't use a seed like this in real life".getBytes());
+        byte[] entropy = Sha256Hash.calcHashBytes("don't use a seed like this in real life".getBytes());
         DeterministicSeed seed = new DeterministicSeed(entropy, "", MnemonicCode.BIP39_STANDARDISATION_TIME_SECS);
         MarriedKeyChain chain = MarriedKeyChain.builder()
                 .seed(seed)

--- a/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
@@ -64,7 +64,7 @@ public class KeyChainGroupTest {
     }
 
     private MarriedKeyChain createMarriedKeyChain() {
-        byte[] entropy = Sha256Hash.hash("don't use a seed like this in real life".getBytes()).getBytes();
+        byte[] entropy = Utils.singleDigest("don't use a seed like this in real life".getBytes());
         DeterministicSeed seed = new DeterministicSeed(entropy, "", MnemonicCode.BIP39_STANDARDISATION_TIME_SECS);
         MarriedKeyChain chain = MarriedKeyChain.builder()
                 .seed(seed)

--- a/examples/src/main/java/org/bitcoinj/examples/FetchBlock.java
+++ b/examples/src/main/java/org/bitcoinj/examples/FetchBlock.java
@@ -44,7 +44,7 @@ public class FetchBlock {
         peerGroup.waitForPeers(1).get();
         Peer peer = peerGroup.getConnectedPeers().get(0);
 
-        Sha256Hash blockHash = new Sha256Hash(args[0]);
+        Sha256Hash blockHash = Sha256Hash.wrap(args[0]);
         Future<Block> future = peer.getBlock(blockHash);
         System.out.println("Waiting for node to send us the requested block: " + blockHash);
         Block block = future.get();

--- a/examples/src/main/java/org/bitcoinj/examples/FetchTransactions.java
+++ b/examples/src/main/java/org/bitcoinj/examples/FetchTransactions.java
@@ -44,7 +44,7 @@ public class FetchTransactions {
         peerGroup.waitForPeers(1).get();
         Peer peer = peerGroup.getConnectedPeers().get(0);
 
-        Sha256Hash txHash = new Sha256Hash(args[0]);
+        Sha256Hash txHash = Sha256Hash.wrap(args[0]);
         ListenableFuture<Transaction> future = peer.getPeerMempoolTransaction(txHash);
         System.out.println("Waiting for node to send us the requested transaction: " + txHash);
         Transaction tx = future.get();

--- a/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
@@ -101,7 +101,7 @@ public class BuildCheckpoints {
 
     private static void writeBinaryCheckpoints(TreeMap<Integer, StoredBlock> checkpoints, File file) throws Exception {
         final FileOutputStream fileOutputStream = new FileOutputStream(file, false);
-        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        MessageDigest digest = Utils.newSha256Digest();
         final DigestOutputStream digestOutputStream = new DigestOutputStream(fileOutputStream, digest);
         digestOutputStream.on(false);
         final DataOutputStream dataOutputStream = new DataOutputStream(digestOutputStream);

--- a/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
@@ -116,7 +116,7 @@ public class BuildCheckpoints {
             buffer.position(0);
         }
         dataOutputStream.close();
-        Sha256Hash checkpointsHash = new Sha256Hash(digest.digest());
+        Sha256Hash checkpointsHash = Sha256Hash.wrap(digest.digest());
         System.out.println("Hash of checkpoints data is " + checkpointsHash);
         digestOutputStream.close();
         fileOutputStream.close();

--- a/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
@@ -101,7 +101,7 @@ public class BuildCheckpoints {
 
     private static void writeBinaryCheckpoints(TreeMap<Integer, StoredBlock> checkpoints, File file) throws Exception {
         final FileOutputStream fileOutputStream = new FileOutputStream(file, false);
-        MessageDigest digest = Utils.newSha256Digest();
+        MessageDigest digest = Sha256Hash.newDigest();
         final DigestOutputStream digestOutputStream = new DigestOutputStream(fileOutputStream, digest);
         digestOutputStream.on(false);
         final DataOutputStream dataOutputStream = new DataOutputStream(digestOutputStream);


### PR DESCRIPTION
Here are a bunch of refactoring ideas around the Utils/Sha256Hash classes.

Mainly what bothered me were:

- inconsistent use of synchronized MessageDigest singleton vs creating them on the fly - it looks arbitrary which is used when, and it it unclear that a synchronized singleton has better performance than creating instances. If there really is any performance issue here, a ThreadLocal would probably be best. The current code refactoring would make that change easy (encapsulated) as well. This one is more than just refactoring.

- separation between Utils and Sha256Hash methods which seem somewhat arbitrary as well.

- a few other simplifications I came across in this code.

I've split up the refactoring into a few steps so it's easier to follow and modify if necessary.

Let me know which parts you like and which not so much...

Method names are open to improvement as well :-)
