### PR TITLE
Fix consistency issues with equals/hashCode in LazyECPoint

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
+++ b/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
@@ -168,20 +168,16 @@ public class LazyECPoint {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        LazyECPoint point1 = (LazyECPoint) o;
-        if (bits != null && point1.bits != null)
-            return Arrays.equals(bits, point1.bits);
-        else
-            return get().equals(point1.get());
+        return this == o || o != null && getClass() == o.getClass()
+            && Arrays.equals(getCanonicalEncoding(), ((LazyECPoint)o).getCanonicalEncoding());
     }
 
     @Override
     public int hashCode() {
-        if (bits != null)
-            return Arrays.hashCode(bits);
-        else
-            return get().hashCode();
+        return Arrays.hashCode(getCanonicalEncoding());
+    }
+
+    private byte[] getCanonicalEncoding() {
+        return getEncoded(true);
     }
 }


### PR DESCRIPTION
The existing implementation could give inconsistent results, potentially returning differing hashcodes for, or inequality between, points with the same logical value. I wasn't able to see any problems actually happening during unit testing, but clearly there's room for serious (and subtle) problems.

This PR changes equals and hashCode to both be based on a "canonical encoding", which is chosen as the compressed encoding, mainly because it can still be generated cheaply if the original encoding is uncompressed (the reverse is not true). Also that encoding is an external standard and not BC-specific.

I've made no attempt at cacheing the canonical encoding or the hashcode, but that's obviously a possibility if performance becomes an issue.