### PR TITLE
Equals-hashCode-copmareTo fixes

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -809,8 +809,7 @@ public class Block extends Message {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        Block other = (Block) o;
-        return getHash().equals(other.getHash());
+        return getHash().equals(((Block)o).getHash());
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/BloomFilter.java
+++ b/core/src/main/java/org/bitcoinj/core/BloomFilter.java
@@ -357,9 +357,7 @@ public class BloomFilter extends Message {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         BloomFilter other = (BloomFilter) o;
-        return hashFuncs == other.hashFuncs &&
-               nTweak == other.nTweak &&
-               Arrays.equals(data, other.data);
+        return hashFuncs == other.hashFuncs && nTweak == other.nTweak && Arrays.equals(data, other.data);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/Coin.java
+++ b/core/src/main/java/org/bitcoinj/core/Coin.java
@@ -18,6 +18,7 @@ package org.bitcoinj.core;
 
 import org.bitcoinj.utils.MonetaryFormat;
 import com.google.common.math.LongMath;
+import com.google.common.primitives.Longs;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -256,14 +257,9 @@ public final class Coin implements Monetary, Comparable<Coin>, Serializable {
 
     @Override
     public boolean equals(final Object o) {
-        if (o == this)
-            return true;
-        if (o == null || o.getClass() != getClass())
-            return false;
-        final Coin other = (Coin) o;
-        if (this.value != other.value)
-            return false;
-        return true;
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        return this.value == ((Coin)o).value;
     }
 
     @Override
@@ -273,8 +269,6 @@ public final class Coin implements Monetary, Comparable<Coin>, Serializable {
 
     @Override
     public int compareTo(final Coin other) {
-        if (this.value == other.value)
-            return 0;
-        return this.value > other.value ? 1 : -1;
+        return Longs.compare(this.value, other.value);
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/DumpedPrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/core/DumpedPrivateKey.java
@@ -90,6 +90,6 @@ public class DumpedPrivateKey extends VersionedChecksummedBytes {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(bytes, version, compressed);
+        return Objects.hashCode(version, compressed, Arrays.hashCode(bytes));
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/DumpedPrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/core/DumpedPrivateKey.java
@@ -83,9 +83,7 @@ public class DumpedPrivateKey extends VersionedChecksummedBytes {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         DumpedPrivateKey other = (DumpedPrivateKey) o;
-        return Arrays.equals(bytes, other.bytes) &&
-               version == other.version &&
-               compressed == other.compressed;
+        return version == other.version && compressed == other.compressed && Arrays.equals(bytes, other.bytes);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/core/ECKey.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.common.base.Objects.ToStringHelper;
 import com.google.common.base.Preconditions;
+import com.google.common.primitives.Ints;
 import com.google.common.primitives.UnsignedBytes;
 import org.bitcoin.NativeSecp256k1;
 import org.bitcoinj.wallet.Protos;
@@ -612,15 +613,12 @@ public class ECKey implements EncryptableItem, Serializable {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             ECDSASignature other = (ECDSASignature) o;
-            return r.equals(other.r) &&
-                   s.equals(other.s);
+            return r.equals(other.r) && s.equals(other.s);
         }
 
         @Override
         public int hashCode() {
-            int result = r.hashCode();
-            result = 31 * result + s.hashCode();
-            return result;
+            return Objects.hashCode(r, s);
         }
     }
 
@@ -1187,9 +1185,7 @@ public class ECKey implements EncryptableItem, Serializable {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || !(o instanceof ECKey)) return false;
-
         ECKey other = (ECKey) o;
-
         return Objects.equal(this.priv, other.priv)
                 && Objects.equal(this.pub, other.pub)
                 && Objects.equal(this.creationTimeSeconds, other.creationTimeSeconds)
@@ -1202,7 +1198,7 @@ public class ECKey implements EncryptableItem, Serializable {
         // Public keys are random already so we can just use a part of them as the hashcode. Read from the start to
         // avoid picking up the type code (compressed vs uncompressed) which is tacked on the end.
         byte[] bits = getPubKey();
-        return (bits[0] & 0xFF) | ((bits[1] & 0xFF) << 8) | ((bits[2] & 0xFF) << 16) | ((bits[3] & 0xFF) << 24);
+        return Ints.fromBytes(bits[0], bits[1], bits[2], bits[3]);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/FilteredBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/FilteredBlock.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.core;
 
+import com.google.common.base.Objects;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.*;
@@ -132,22 +133,14 @@ public class FilteredBlock extends Message {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
-        FilteredBlock block = (FilteredBlock) o;
-
-        if (!associatedTransactions.equals(block.associatedTransactions)) return false;
-        if (!header.equals(block.header)) return false;
-        if (!merkleTree.equals(block.merkleTree)) return false;
-
-        return true;
+        FilteredBlock other = (FilteredBlock) o;
+        return associatedTransactions.equals(other.associatedTransactions)
+            && header.equals(other.header) && merkleTree.equals(other.merkleTree);
     }
 
     @Override
     public int hashCode() {
-        int result = header.hashCode();
-        result = 31 * result + merkleTree.hashCode();
-        result = 31 * result + associatedTransactions.hashCode();
-        return result;
+        return Objects.hashCode(associatedTransactions, header, merkleTree);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
@@ -100,17 +100,14 @@ public class GetBlocksMessage extends Message {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         GetBlocksMessage other = (GetBlocksMessage) o;
-        return version == other.version &&
-               locator.size() == other.locator.size() &&
-               locator.containsAll(other.locator) && // ignores locator ordering
-               stopHash.equals(other.stopHash);
+        return version == other.version && stopHash.equals(other.stopHash) &&
+            locator.size() == other.locator.size() && locator.containsAll(other.locator); // ignores locator ordering
     }
 
     @Override
     public int hashCode() {
-        int hashCode = (int) version ^ "getblocks".hashCode();
+        int hashCode = (int)version ^ "getblocks".hashCode() ^ stopHash.hashCode();
         for (Sha256Hash aLocator : locator) hashCode ^= aLocator.hashCode(); // ignores locator ordering
-        hashCode ^= stopHash.hashCode();
         return hashCode;
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
@@ -102,14 +102,14 @@ public class GetBlocksMessage extends Message {
         GetBlocksMessage other = (GetBlocksMessage) o;
         return version == other.version &&
                locator.size() == other.locator.size() &&
-               locator.containsAll(other.locator) &&
+               locator.containsAll(other.locator) && // ignores locator ordering
                stopHash.equals(other.stopHash);
     }
 
     @Override
     public int hashCode() {
         int hashCode = (int) version ^ "getblocks".hashCode();
-        for (Sha256Hash aLocator : locator) hashCode ^= aLocator.hashCode();
+        for (Sha256Hash aLocator : locator) hashCode ^= aLocator.hashCode(); // ignores locator ordering
         hashCode ^= stopHash.hashCode();
         return hashCode;
     }

--- a/core/src/main/java/org/bitcoinj/core/GetHeadersMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetHeadersMessage.java
@@ -49,14 +49,14 @@ public class GetHeadersMessage extends GetBlocksMessage {
         GetHeadersMessage other = (GetHeadersMessage) o;
         return version == other.version &&
                locator.size() == other.locator.size() &&
-               locator.containsAll(other.locator) &&
+               locator.containsAll(other.locator) && // ignores locator ordering
                stopHash.equals(other.stopHash);
     }
 
     @Override
     public int hashCode() {
         int hashCode = (int) version ^ "getheaders".hashCode();
-        for (Sha256Hash aLocator : locator) hashCode ^= aLocator.hashCode();
+        for (Sha256Hash aLocator : locator) hashCode ^= aLocator.hashCode(); // ignores locator ordering
         hashCode ^= stopHash.hashCode();
         return hashCode;
     }

--- a/core/src/main/java/org/bitcoinj/core/GetHeadersMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetHeadersMessage.java
@@ -47,17 +47,14 @@ public class GetHeadersMessage extends GetBlocksMessage {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         GetHeadersMessage other = (GetHeadersMessage) o;
-        return version == other.version &&
-               locator.size() == other.locator.size() &&
-               locator.containsAll(other.locator) && // ignores locator ordering
-               stopHash.equals(other.stopHash);
+        return version == other.version && stopHash.equals(other.stopHash) &&
+            locator.size() == other.locator.size() && locator.containsAll(other.locator);  // ignores locator ordering
     }
 
     @Override
     public int hashCode() {
-        int hashCode = (int) version ^ "getheaders".hashCode();
+        int hashCode = (int)version ^ "getheaders".hashCode() ^ stopHash.hashCode();
         for (Sha256Hash aLocator : locator) hashCode ^= aLocator.hashCode(); // ignores locator ordering
-        hashCode ^= stopHash.hashCode();
         return hashCode;
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/GetUTXOsMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetUTXOsMessage.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.core;
 
+import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
@@ -95,19 +96,12 @@ public class GetUTXOsMessage extends Message {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
-        GetUTXOsMessage that = (GetUTXOsMessage) o;
-
-        if (includeMempool != that.includeMempool) return false;
-        if (!outPoints.equals(that.outPoints)) return false;
-
-        return true;
+        GetUTXOsMessage other = (GetUTXOsMessage) o;
+        return includeMempool == other.includeMempool && outPoints.equals(other.outPoints);
     }
 
     @Override
     public int hashCode() {
-        int result = (includeMempool ? 1 : 0);
-        result = 31 * result + outPoints.hashCode();
-        return result;
+        return Objects.hashCode(includeMempool, outPoints);
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/InventoryItem.java
+++ b/core/src/main/java/org/bitcoinj/core/InventoryItem.java
@@ -16,6 +16,8 @@
 
 package org.bitcoinj.core;
 
+import com.google.common.base.Objects;
+
 public class InventoryItem {
     
     /**
@@ -48,12 +50,11 @@ public class InventoryItem {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         InventoryItem other = (InventoryItem) o;
-        return type == other.type &&
-               hash.equals(other.hash);
+        return type == other.type && hash.equals(other.hash);
     }
 
     @Override
     public int hashCode() {
-        return hash.hashCode() + type.ordinal();
+        return Objects.hashCode(type, hash);
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/ListMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/ListMessage.java
@@ -124,8 +124,7 @@ public abstract class ListMessage extends Message {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        ListMessage other = (ListMessage) o;
-        return items.equals(other.items);
+        return items.equals(((ListMessage)o).items);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -203,8 +203,7 @@ public abstract class NetworkParameters implements Serializable {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        NetworkParameters other = (NetworkParameters) o;
-        return getId().equals(other.getId());
+        return getId().equals(((NetworkParameters)o).getId());
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/PartialMerkleTree.java
+++ b/core/src/main/java/org/bitcoinj/core/PartialMerkleTree.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.bitcoinj.core.Utils.*;
+import com.google.common.base.Objects;
 
 /**
  * <p>A data structure that contains proofs of block inclusion for one or more transactions, in an efficient manner.</p>
@@ -269,22 +270,14 @@ public class PartialMerkleTree extends Message {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
-        PartialMerkleTree tree = (PartialMerkleTree) o;
-
-        if (transactionCount != tree.transactionCount) return false;
-        if (!hashes.equals(tree.hashes)) return false;
-        if (!Arrays.equals(matchedChildBits, tree.matchedChildBits)) return false;
-
-        return true;
+        PartialMerkleTree other = (PartialMerkleTree) o;
+        return transactionCount == other.transactionCount && hashes.equals(other.hashes)
+            && Arrays.equals(matchedChildBits, other.matchedChildBits);
     }
 
     @Override
     public int hashCode() {
-        int result = transactionCount;
-        result = 31 * result + Arrays.hashCode(matchedChildBits);
-        result = 31 * result + hashes.hashCode();
-        return result;
+        return Objects.hashCode(transactionCount, hashes, Arrays.hashCode(matchedChildBits));
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/PeerAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerAddress.java
@@ -17,6 +17,7 @@
 package org.bitcoinj.core;
 
 import org.bitcoinj.params.MainNetParams;
+import com.google.common.base.Objects;
 import com.google.common.net.InetAddresses;
 
 import java.io.IOException;
@@ -223,16 +224,13 @@ public class PeerAddress extends ChildMessage {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         PeerAddress other = (PeerAddress) o;
-        return other.addr.equals(addr) &&
-                other.port == port &&
-                other.services.equals(services) &&
-                other.time == time;
+        return other.addr.equals(addr) && other.port == port && other.time == time && other.services.equals(services);
         //TODO: including services and time could cause same peer to be added multiple times in collections
     }
 
     @Override
     public int hashCode() {
-        return addr.hashCode() ^ port ^ (int) time ^ services.hashCode();
+        return Objects.hashCode(addr, port, time, services);
     }
     
     public InetSocketAddress toSocketAddress() {

--- a/core/src/main/java/org/bitcoinj/core/RejectMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/RejectMessage.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.core;
 
+import com.google.common.base.Objects;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -161,18 +162,12 @@ public class RejectMessage extends Message {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         RejectMessage other = (RejectMessage) o;
-        return message.equals(other.message) &&
-               code.equals(other.code) &&
-               reason.equals(other.reason) &&
-               messageHash.equals(other.messageHash);
+        return message.equals(other.message) && code.equals(other.code)
+            && reason.equals(other.reason) && messageHash.equals(other.messageHash);
     }
 
     @Override
     public int hashCode() {
-        int result = message.hashCode();
-        result = 31 * result + reason.hashCode();
-        result = 31 * result + code.hashCode();
-        result = 31 * result + messageHash.hashCode();
-        return result;
+        return Objects.hashCode(message, code, reason, messageHash);
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/Sha256Hash.java
+++ b/core/src/main/java/org/bitcoinj/core/Sha256Hash.java
@@ -265,6 +265,7 @@ public class Sha256Hash implements Serializable, Comparable<Sha256Hash> {
 
     @Override
     public int compareTo(Sha256Hash o) {
-        return this.hashCode() - o.hashCode();
+        // note that in this implementation compareTo() is not consistent with equals()
+        return this.hashCode() - o.hashCode(); // arbitrary but consistent
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/Sha256Hash.java
+++ b/core/src/main/java/org/bitcoinj/core/Sha256Hash.java
@@ -223,7 +223,9 @@ public class Sha256Hash implements Serializable, Comparable<Sha256Hash> {
 
     @Override
     public boolean equals(Object o) {
-        return this == o || o != null && getClass() == o.getClass() && Arrays.equals(bytes, ((Sha256Hash)o).bytes);
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        return Arrays.equals(bytes, ((Sha256Hash)o).bytes);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/StoredBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/StoredBlock.java
@@ -18,6 +18,7 @@ package org.bitcoinj.core;
 
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.BlockStoreException;
+import com.google.common.base.Objects;
 
 import java.io.*;
 import java.math.BigInteger;
@@ -86,15 +87,12 @@ public class StoredBlock implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         StoredBlock other = (StoredBlock) o;
-        return header.equals(other.header) &&
-               chainWork.equals(other.chainWork) &&
-               height == other.height;
+        return header.equals(other.header) && chainWork.equals(other.chainWork) && height == other.height;
     }
 
     @Override
     public int hashCode() {
-        // A better hashCode is possible, but this works for now.
-        return header.hashCode() ^ chainWork.hashCode() ^ height;
+        return Objects.hashCode(header, chainWork, height);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/StoredUndoableBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/StoredUndoableBlock.java
@@ -80,8 +80,7 @@ public class StoredUndoableBlock implements Serializable {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        StoredUndoableBlock other = (StoredUndoableBlock) o;
-        return getHash().equals(other.getHash());
+        return getHash().equals(((StoredUndoableBlock)o).getHash());
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -1165,8 +1165,7 @@ public class Transaction extends ChildMessage implements Serializable {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        Transaction other = (Transaction) o;
-        return getHash().equals(other.getHash());
+        return getHash().equals(((Transaction)o).getHash());
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -479,7 +479,6 @@ public class TransactionInput extends ChildMessage implements Serializable {
         if (sequence != input.sequence) return false;
         if (!outpoint.equals(input.outpoint)) return false;
         if (!Arrays.equals(scriptBytes, input.scriptBytes)) return false;
-        if (scriptSig != null ? !scriptSig.equals(input.scriptSig) : input.scriptSig != null) return false;
         if (parent != input.parent) return false;
 
         return true;
@@ -490,7 +489,6 @@ public class TransactionInput extends ChildMessage implements Serializable {
         int result = (int) (sequence ^ (sequence >>> 32));
         result = 31 * result + outpoint.hashCode();
         result = 31 * result + (scriptBytes != null ? Arrays.hashCode(scriptBytes) : 0);
-        result = 31 * result + (scriptSig != null ? scriptSig.hashCode() : 0);
         return result;
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -21,6 +21,7 @@ import org.bitcoinj.script.Script;
 import org.bitcoinj.wallet.DefaultRiskAnalysis;
 import org.bitcoinj.wallet.KeyBag;
 import org.bitcoinj.wallet.RedeemData;
+import com.google.common.base.Objects;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -473,22 +474,13 @@ public class TransactionInput extends ChildMessage implements Serializable {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
-        TransactionInput input = (TransactionInput) o;
-
-        if (sequence != input.sequence) return false;
-        if (!outpoint.equals(input.outpoint)) return false;
-        if (!Arrays.equals(scriptBytes, input.scriptBytes)) return false;
-        if (parent != input.parent) return false;
-
-        return true;
+        TransactionInput other = (TransactionInput) o;
+        return sequence == other.sequence && parent == other.parent
+            && outpoint.equals(other.outpoint) && Arrays.equals(scriptBytes, other.scriptBytes);
     }
 
     @Override
     public int hashCode() {
-        int result = (int) (sequence ^ (sequence >>> 32));
-        result = 31 * result + outpoint.hashCode();
-        result = 31 * result + (scriptBytes != null ? Arrays.hashCode(scriptBytes) : 0);
-        return result;
+        return Objects.hashCode(sequence, outpoint, Arrays.hashCode(scriptBytes));
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -239,6 +239,6 @@ public class TransactionOutPoint extends ChildMessage implements Serializable {
 
     @Override
     public int hashCode() {
-        return 31 * hash.hashCode() + (int) (index ^ (index >>> 32));
+        return 31 * getHash().hashCode() + (int) (getIndex() ^ (getIndex() >>> 32));
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.core;
 
+import com.google.common.base.Objects;
 import org.bitcoinj.script.*;
 import org.bitcoinj.wallet.*;
 
@@ -233,12 +234,11 @@ public class TransactionOutPoint extends ChildMessage implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         TransactionOutPoint other = (TransactionOutPoint) o;
-        return getIndex() == other.getIndex() &&
-               getHash().equals(other.getHash());
+        return getIndex() == other.getIndex() && getHash().equals(other.getHash());
     }
 
     @Override
     public int hashCode() {
-        return 31 * getHash().hashCode() + (int) (getIndex() ^ (getIndex() >>> 32));
+        return Objects.hashCode(getIndex(), getHash());
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -17,6 +17,7 @@
 
 package org.bitcoinj.core;
 
+import com.google.common.base.Objects;
 import org.bitcoinj.script.*;
 import org.slf4j.*;
 
@@ -429,22 +430,13 @@ public class TransactionOutput extends ChildMessage implements Serializable {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         TransactionOutput other = (TransactionOutput) o;
-
-        if (!Arrays.equals(scriptBytes, other.scriptBytes)) return false;
-        if (value != other.value) return false;
-        if (parent != null && parent != other.parent) return false;
-
-        return true;
+        return value == other.value && (parent == null || parent == other.parent)
+            && Arrays.equals(scriptBytes, other.scriptBytes);
     }
 
     @Override
     public int hashCode() {
-        int result = (int) (value ^ (value >>> 32));
-        result = 31 * result + Arrays.hashCode(scriptBytes);
-        if (parent != null)
-            result *= parent.getHash().hashCode();
-        return result;
+        return Objects.hashCode(value, parent, Arrays.hashCode(scriptBytes));
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -444,7 +444,7 @@ public class TransactionOutput extends ChildMessage implements Serializable {
         int result = (int) (value ^ (value >>> 32));
         result = 31 * result + Arrays.hashCode(scriptBytes);
         if (parent != null)
-            result *= parent.getHash().hashCode() + getIndex();
+            result *= parent.getHash().hashCode();
         return result;
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/UTXO.java
+++ b/core/src/main/java/org/bitcoinj/core/UTXO.java
@@ -17,6 +17,7 @@
 package org.bitcoinj.core;
 
 import org.bitcoinj.script.*;
+import com.google.common.base.Objects;
 
 import java.io.*;
 import java.math.*;
@@ -161,7 +162,7 @@ public class UTXO implements Serializable {
 
     @Override
     public int hashCode() {
-        return hash.hashCode() + (int) index;
+        return Objects.hashCode(getIndex(), getHash());
     }
 
     @Override
@@ -169,8 +170,7 @@ public class UTXO implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         UTXO other = (UTXO) o;
-        return getHash().equals(other.getHash()) &&
-                getIndex() == other.getIndex();
+        return getIndex() == other.getIndex() && getHash().equals(other.getHash());
     }
 
     public void serializeToStream(OutputStream bos) throws IOException {

--- a/core/src/main/java/org/bitcoinj/core/UTXOsMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/UTXOsMessage.java
@@ -15,6 +15,7 @@
  */
 package org.bitcoinj.core;
 
+import com.google.common.base.Objects;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -157,25 +158,14 @@ public class UTXOsMessage extends Message {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
-        UTXOsMessage message = (UTXOsMessage) o;
-
-        if (height != message.height) return false;
-        if (!chainHead.equals(message.chainHead)) return false;
-        if (!Arrays.equals(heights, message.heights)) return false;
-        if (!Arrays.equals(hits, message.hits)) return false;
-        if (!outputs.equals(message.outputs)) return false;
-
-        return true;
+        UTXOsMessage other = (UTXOsMessage) o;
+        return height == other.height && chainHead.equals(other.chainHead)
+            && Arrays.equals(heights, other.heights) && Arrays.equals(hits, other.hits)
+            && outputs.equals(other.outputs);
     }
 
     @Override
     public int hashCode() {
-        int result = (int) (height ^ (height >>> 32));
-        result = 31 * result + chainHead.hashCode();
-        result = 31 * result + Arrays.hashCode(hits);
-        result = 31 * result + outputs.hashCode();
-        result = 31 * result + Arrays.hashCode(heights);
-        return result;
+        return Objects.hashCode(height, chainHead, Arrays.hashCode(heights), Arrays.hashCode(hits), outputs);
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/Utils.java
+++ b/core/src/main/java/org/bitcoinj/core/Utils.java
@@ -578,6 +578,7 @@ public class Utils {
     private static class Pair implements Comparable<Pair> {
         int item, count;
         public Pair(int item, int count) { this.count = count; this.item = item; }
+        // note that in this implementation compareTo() is not consistent with equals()
         @Override public int compareTo(Pair o) { return -Ints.compare(count, o.count); }
     }
 

--- a/core/src/main/java/org/bitcoinj/core/VersionMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionMessage.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.core;
 
+import com.google.common.base.Objects;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -212,8 +213,8 @@ public class VersionMessage extends Message {
 
     @Override
     public int hashCode() {
-        return (int) bestHeight ^ clientVersion ^ (int) localServices ^ (int) time ^ subVer.hashCode() ^ myAddr.hashCode()
-            ^ theirAddr.hashCode() * (relayTxesBeforeFilter ? 1 : 2);
+        return Objects.hashCode(bestHeight, clientVersion, localServices,
+            time, subVer, myAddr, theirAddr, relayTxesBeforeFilter);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/VersionedChecksummedBytes.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionedChecksummedBytes.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 
 import com.google.common.base.Objects;
+import com.google.common.primitives.Ints;
 import com.google.common.primitives.UnsignedBytes;
 
 /**
@@ -76,8 +77,7 @@ public class VersionedChecksummedBytes implements Serializable, Cloneable, Compa
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         VersionedChecksummedBytes other = (VersionedChecksummedBytes) o;
-        return this.version == other.version
-                && Arrays.equals(this.bytes, other.bytes);
+        return this.version == other.version && Arrays.equals(this.bytes, other.bytes);
     }
 
     /**
@@ -99,13 +99,8 @@ public class VersionedChecksummedBytes implements Serializable, Cloneable, Compa
      */
     @Override
     public int compareTo(VersionedChecksummedBytes o) {
-        int versionCompare = Integer.valueOf(this.version).compareTo(Integer.valueOf(o.version));  // JDK 6 way
-        if (versionCompare == 0) {
-            // Would there be a performance benefit to caching the comparator?
-            return UnsignedBytes.lexicographicalComparator().compare(this.bytes, o.bytes);
-        } else {
-            return versionCompare;
-        }
+        int result = Ints.compare(this.version, o.version);
+        return result != 0 ? result : UnsignedBytes.lexicographicalComparator().compare(this.bytes, o.bytes);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/core/Wallet.java
@@ -4050,6 +4050,7 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
         }
 
         @Override public int compareTo(TxOffsetPair o) {
+            // note that in this implementation compareTo() is not consistent with equals()
             return Ints.compare(offset, o.offset);
         }
     }

--- a/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
@@ -166,9 +166,7 @@ public class BIP38PrivateKey extends VersionedChecksummedBytes {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         BIP38PrivateKey other = (BIP38PrivateKey) o;
-
-        return super.equals(other)
-                && Objects.equal(this.params, other.params);
+        return super.equals(other) && Objects.equal(this.params, other.params);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/crypto/ChildNumber.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ChildNumber.java
@@ -91,6 +91,7 @@ public class ChildNumber implements Comparable<ChildNumber> {
 
     @Override
     public int compareTo(ChildNumber other) {
+        // note that in this implementation compareTo() is not consistent with equals()
         return Ints.compare(this.num(), other.num());
     }
 }

--- a/core/src/main/java/org/bitcoinj/crypto/ChildNumber.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ChildNumber.java
@@ -80,8 +80,7 @@ public class ChildNumber implements Comparable<ChildNumber> {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        ChildNumber other = (ChildNumber) o;
-        return i == other.i;
+        return i == ((ChildNumber)o).i;
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -585,9 +585,7 @@ public class DeterministicKey extends ECKey {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         DeterministicKey other = (DeterministicKey) o;
-
         return super.equals(other)
                 && Arrays.equals(this.chainCode, other.chainCode)
                 && Objects.equal(this.childNumberPath, other.childNumberPath);
@@ -595,10 +593,7 @@ public class DeterministicKey extends ECKey {
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + childNumberPath.hashCode();
-        result = 31 * result + Arrays.hashCode(chainCode);
-        return result;
+        return Objects.hashCode(super.hashCode(), Arrays.hashCode(chainCode), childNumberPath);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/crypto/EncryptedData.java
+++ b/core/src/main/java/org/bitcoinj/crypto/EncryptedData.java
@@ -15,6 +15,7 @@
  */
 package org.bitcoinj.crypto;
 
+import com.google.common.base.Objects;
 import java.util.Arrays;
 
 /**
@@ -37,16 +38,13 @@ public final class EncryptedData {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        EncryptedData that = (EncryptedData) o;
-        return Arrays.equals(encryptedBytes, that.encryptedBytes) && Arrays.equals(initialisationVector, that.initialisationVector);
-
+        EncryptedData other = (EncryptedData) o;
+        return Arrays.equals(encryptedBytes, other.encryptedBytes) && Arrays.equals(initialisationVector, other.initialisationVector);
     }
 
     @Override
     public int hashCode() {
-        int result = Arrays.hashCode(initialisationVector);
-        result = 31 * result + Arrays.hashCode(encryptedBytes);
-        return result;
+        return Objects.hashCode(Arrays.hashCode(encryptedBytes), Arrays.hashCode(initialisationVector));
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/crypto/KeyCrypterScrypt.java
+++ b/core/src/main/java/org/bitcoinj/crypto/KeyCrypterScrypt.java
@@ -263,14 +263,13 @@ public class KeyCrypterScrypt implements KeyCrypter, Serializable {
 
     @Override
     public int hashCode() {
-        return com.google.common.base.Objects.hashCode(scryptParameters);
+        return Objects.hashCode(scryptParameters);
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        KeyCrypterScrypt other = (KeyCrypterScrypt) o;
-        return Objects.equal(scryptParameters, other.scryptParameters);
+        return Objects.equal(scryptParameters, ((KeyCrypterScrypt)o).scryptParameters);
     }
 }

--- a/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
+++ b/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
@@ -168,8 +168,9 @@ public class LazyECPoint {
 
     @Override
     public boolean equals(Object o) {
-        return this == o || o != null && getClass() == o.getClass()
-            && Arrays.equals(getCanonicalEncoding(), ((LazyECPoint)o).getCanonicalEncoding());
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        return Arrays.equals(getCanonicalEncoding(), ((LazyECPoint)o).getCanonicalEncoding());
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -1492,13 +1492,11 @@ public class Script {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        Script other = (Script) o;
-        return Arrays.equals(getQuickProgram(), other.getQuickProgram());
+        return Arrays.equals(getQuickProgram(), ((Script)o).getQuickProgram());
     }
 
     @Override
     public int hashCode() {
-        byte[] bytes = getQuickProgram();
-        return Arrays.hashCode(bytes);
+        return Arrays.hashCode(getQuickProgram());
     }
 }

--- a/core/src/main/java/org/bitcoinj/script/ScriptChunk.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptChunk.java
@@ -18,6 +18,7 @@
 package org.bitcoinj.script;
 
 import org.bitcoinj.core.Utils;
+import com.google.common.base.Objects;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -151,21 +152,13 @@ public class ScriptChunk {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         ScriptChunk other = (ScriptChunk) o;
-
-        if (opcode != other.opcode) return false;
-        if (startLocationInProgram != other.startLocationInProgram) return false;
-        if (!Arrays.equals(data, other.data)) return false;
-
-        return true;
+        return opcode == other.opcode && startLocationInProgram == other.startLocationInProgram
+            && Arrays.equals(data, other.data);
     }
 
     @Override
     public int hashCode() {
-        int result = opcode;
-        result = 31 * result + (data != null ? Arrays.hashCode(data) : 0);
-        result = 31 * result + startLocationInProgram;
-        return result;
+        return Objects.hashCode(opcode, startLocationInProgram, Arrays.hashCode(data));
     }
 }

--- a/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
@@ -63,7 +63,7 @@ class StoredTransactionOutPoint implements Serializable {
 
     @Override
     public int hashCode() {
-        return this.hash.hashCode() + (int)index;
+        return Objects.hashCode(getIndex(), getHash());
     }
     
     @Override
@@ -76,8 +76,7 @@ class StoredTransactionOutPoint implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         StoredTransactionOutPoint other = (StoredTransactionOutPoint) o;
-        return getIndex() == other.getIndex() &&
-               Objects.equal(getHash(), other.getHash());
+        return getIndex() == other.getIndex() && Objects.equal(getHash(), other.getHash());
     }
 }
 

--- a/core/src/main/java/org/bitcoinj/utils/BtcAutoFormat.java
+++ b/core/src/main/java/org/bitcoinj/utils/BtcAutoFormat.java
@@ -186,9 +186,9 @@ public final class BtcAutoFormat extends BtcFormat {
       * Formatters for different locales will never be equal, even
       * if they behave identically. */
     @Override public boolean equals(Object o) {
-        if (o == this) return true;
+        if (this == o) return true;
         if (!(o instanceof BtcAutoFormat)) return false;
-        return super.equals((BtcAutoFormat)o);
+        return super.equals(o);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/utils/BtcFixedFormat.java
+++ b/core/src/main/java/org/bitcoinj/utils/BtcFixedFormat.java
@@ -18,6 +18,7 @@ package org.bitcoinj.utils;
 
 import static org.bitcoinj.core.Coin.SMALLEST_UNIT_EXPONENT;
 import static com.google.common.base.Preconditions.checkArgument;
+import com.google.common.base.Objects;
 import java.math.BigInteger;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
@@ -134,18 +135,14 @@ public final class BtcFixedFormat extends BtcFormat {
         if (o == this) return true;
         if (!(o instanceof BtcFixedFormat)) return false;
         BtcFixedFormat other = (BtcFixedFormat)o;
-        return other.scale() == scale() &&
-            other.decimalGroups.equals(decimalGroups) &&
-            super.equals(other);
+        return super.equals(other) && other.scale() == scale() && other.decimalGroups.equals(decimalGroups);
     }
 
     /** Return a hash code value for this instance.
      *  @see java.lang.Object#hashCode
      */
     @Override public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + scale;
-        return result;
+        return Objects.hashCode(super.hashCode(), scale);
     }
 
     private static String prefixLabel(int scale) {

--- a/core/src/main/java/org/bitcoinj/utils/BtcFormat.java
+++ b/core/src/main/java/org/bitcoinj/utils/BtcFormat.java
@@ -20,6 +20,7 @@ import org.bitcoinj.utils.BtcAutoFormat.Style;
 import static org.bitcoinj.utils.BtcAutoFormat.Style.*;
 
 import org.bitcoinj.core.Coin;
+import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.base.Strings;
@@ -1587,12 +1588,7 @@ public abstract class BtcFormat extends Format {
      *  @see java.lang.Object#hashCode
      */
     @Override public int hashCode() {
-        int result = 17;
-        result = 31 * result + pattern().hashCode();
-        result = 31 * result + symbols().hashCode();
-        result = 31 * result + minimumFractionDigits;
-        result = 31 * result + decimalGroups.hashCode();
-        return result;
+        return Objects.hashCode(pattern(), symbols(), minimumFractionDigits, decimalGroups);
     }
 
 }

--- a/core/src/main/java/org/bitcoinj/utils/ExponentialBackoff.java
+++ b/core/src/main/java/org/bitcoinj/utils/ExponentialBackoff.java
@@ -17,6 +17,7 @@
 package org.bitcoinj.utils;
 
 import org.bitcoinj.core.Utils;
+import com.google.common.primitives.Longs;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -91,11 +92,7 @@ public class ExponentialBackoff implements Comparable<ExponentialBackoff> {
     @Override
     public int compareTo(ExponentialBackoff other) {
         // note that in this implementation compareTo() is not consistent with equals()
-        if (retryTime < other.retryTime)
-            return -1;
-        if (retryTime > other.retryTime)
-            return 1;
-        return 0;
+        return Longs.compare(retryTime, other.retryTime);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/utils/ExponentialBackoff.java
+++ b/core/src/main/java/org/bitcoinj/utils/ExponentialBackoff.java
@@ -90,6 +90,7 @@ public class ExponentialBackoff implements Comparable<ExponentialBackoff> {
 
     @Override
     public int compareTo(ExponentialBackoff other) {
+        // note that in this implementation compareTo() is not consistent with equals()
         if (retryTime < other.retryTime)
             return -1;
         if (retryTime > other.retryTime)

--- a/core/src/main/java/org/bitcoinj/utils/Fiat.java
+++ b/core/src/main/java/org/bitcoinj/utils/Fiat.java
@@ -22,7 +22,9 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 
 import org.bitcoinj.core.Monetary;
+import com.google.common.base.Objects;
 import com.google.common.math.LongMath;
+import com.google.common.primitives.Longs;
 
 /**
  * Represents a monetary fiat value. It was decided to not fold this into {@link org.bitcoinj.core.Coin} because of type
@@ -202,29 +204,21 @@ public final class Fiat implements Monetary, Comparable<Fiat>, Serializable {
 
     @Override
     public boolean equals(final Object o) {
-        if (o == this)
-            return true;
-        if (o == null || o.getClass() != getClass())
-            return false;
+        if (o == this) return true;
+        if (o == null || o.getClass() != getClass()) return false;
         final Fiat other = (Fiat) o;
-        if (this.value != other.value)
-            return false;
-        if (!this.currencyCode.equals(other.currencyCode))
-            return false;
-        return true;
+        return this.value == other.value && this.currencyCode.equals(other.currencyCode);
     }
 
     @Override
     public int hashCode() {
-        return (int) this.value + 37 * this.currencyCode.hashCode();
+        return Objects.hashCode(value, currencyCode);
     }
 
     @Override
     public int compareTo(final Fiat other) {
         if (!this.currencyCode.equals(other.currencyCode))
             return this.currencyCode.compareTo(other.currencyCode);
-        if (this.value != other.value)
-            return this.value > other.value ? 1 : -1;
-        return 0;
+        return Longs.compare(this.value, other.value);
     }
 }

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
@@ -21,6 +21,7 @@ import org.bitcoinj.core.Utils;
 import org.bitcoinj.crypto.*;
 import org.bitcoinj.store.UnreadableWalletException;
 import com.google.common.base.Charsets;
+import com.google.common.base.Objects;
 import com.google.common.base.Splitter;
 import org.spongycastle.crypto.params.KeyParameter;
 
@@ -198,25 +199,15 @@ public class DeterministicSeed implements EncryptableItem {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
-        DeterministicSeed seed = (DeterministicSeed) o;
-
-        if (creationTimeSeconds != seed.creationTimeSeconds) return false;
-        if (encryptedMnemonicCode != null) {
-            if (seed.encryptedMnemonicCode == null) return false;
-            if (!encryptedMnemonicCode.equals(seed.encryptedMnemonicCode)) return false;
-        } else {
-            if (!mnemonicCode.equals(seed.mnemonicCode)) return false;
-        }
-
-        return true;
+        DeterministicSeed other = (DeterministicSeed) o;
+        return creationTimeSeconds == other.creationTimeSeconds
+            && Objects.equal(encryptedMnemonicCode, other.encryptedMnemonicCode)
+            && Objects.equal(mnemonicCode, other.mnemonicCode);
     }
 
     @Override
     public int hashCode() {
-        int result = encryptedMnemonicCode != null ? encryptedMnemonicCode.hashCode() : mnemonicCode.hashCode();
-        result = 31 * result + (int) (creationTimeSeconds ^ (creationTimeSeconds >>> 32));
-        return result;
+        return Objects.hashCode(creationTimeSeconds, encryptedMnemonicCode, mnemonicCode);
     }
 
     /**

--- a/core/src/test/java/org/bitcoinj/protocols/channels/ChannelTestUtils.java
+++ b/core/src/test/java/org/bitcoinj/protocols/channels/ChannelTestUtils.java
@@ -5,6 +5,7 @@ import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.TransactionBroadcaster;
 import org.bitcoinj.core.Wallet;
 
+import com.google.common.base.Objects;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
@@ -145,20 +146,13 @@ public class ChannelTestUtils {
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-
-            UpdatePair that = (UpdatePair) o;
-
-            if (amount != null ? !amount.equals(that.amount) : that.amount != null) return false;
-            if (info != null ? !info.equals(that.info) : that.info != null) return false;
-
-            return true;
+            UpdatePair other = (UpdatePair) o;
+            return Objects.equal(amount, other.amount) && Objects.equal(info, other.info);
         }
 
         @Override
         public int hashCode() {
-            int result = amount != null ? amount.hashCode() : 0;
-            result = 31 * result + (info != null ? info.hashCode() : 0);
-            return result;
+            return Objects.hashCode(amount, info);
         }
 
         public void assertPair(Coin amount, ByteString info) {


### PR DESCRIPTION
The law of bug clustering strikes again! Following the bug reported in https://github.com/bitcoinj/bitcoinj/pull/1002, I had a look at other equals/hashCode/compareTo implementations, and indeed found several issues:

- DumpedPrivateKey incorrectly uses byte array reference rather than its content in hashCode
- GetBlockMessage/GetHeadersMessage equals/hashCode ignore list ordering - it's undocumented, but I assume that explains the current implementation. I added a comment, but perhaps the correct fix is to use Sets instead of Lists, if that's how they are to be treated?
- TransactionInput hashCode/equals include scriptSig which is a WeakReference (and scriptBytes already contains the same data anyway)
- TransactionOutPoint hashCode does not call getIndex/getHash accessors, so they are not parsed properly
- TransactionOutput null checks on parent cause equals to not be reflexive and hashCode to break the equals contract (what is the desired behavior here regarding parent?)
- Sha256Hash,Utils.Pair,Wallet.TxOffsetPair,ChildNumber,ExponentialBackoff implement compareTo that is not consistent with equals. I just added a comment documenting this for now, since some of these are privately used in only one or two methods and I assume they work correctly, but if necessary I can add equals/hashCode so that the contracts are respected.

I fixed the ones that were obvious, but for the others I don't know what the intent or use-case was for the original code or what the desired behavior should be. If you let me know, I'll update the code.

I also added a second commit which is supposed to contain only code cleanup rather than fixing anything. Behavior might be slightly changed (e.g. actual hashCode values) but not in a meaningful way.
