### PR TITLE
Cleanup HDUtilsTest

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/ChildNumber.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ChildNumber.java
@@ -50,6 +50,14 @@ public class ChildNumber implements Comparable<ChildNumber> {
         this.i = i;
     }
 
+    public static ChildNumber createHardened(int childNumber) {
+        return new ChildNumber(childNumber, true);
+    }
+
+    public static ChildNumber createNonHardened(int childNumber) {
+        return new ChildNumber(childNumber, false);
+    }
+
     /** Returns the uint32 encoded form of the path element, including the most significant bit. */
     public int getI() {
         return i;


### PR DESCRIPTION
Introduce indirection with the benefit of readability.
Use less (unsafe) type casts.
Use speaking names for variables and methods.
Use Hamcrest's assertThat instead of assertEquals (with possibly wrong argument order).