### PR TITLE
Cleanup MAX_SATOSHIS pseudo-constant

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Coin.java
+++ b/core/src/main/java/org/bitcoinj/core/Coin.java
@@ -82,10 +82,9 @@ public final class Coin implements Monetary, Comparable<Coin>, Serializable {
      */
     public final long value;
 
-    private final long MAX_SATOSHIS = COIN_VALUE * NetworkParameters.MAX_COINS;
-
     private Coin(final long satoshis) {
-        checkArgument(-MAX_SATOSHIS <= satoshis && satoshis <= MAX_SATOSHIS,
+        long maxSatoshis = COIN_VALUE * NetworkParameters.MAX_COINS;
+        checkArgument(-maxSatoshis <= satoshis && satoshis <= maxSatoshis,
             "%s satoshis exceeds maximum possible quantity of Bitcoin.", satoshis);
         this.value = satoshis;
     }


### PR DESCRIPTION
This commit inlines the pseudo constant to the only method using it.

Due to cyclic dependencies (NetworkParameters vs. Coin) MAX_SATOSHIS
cannot be made a true constant.