### PR TITLE
Refactor Wallet: Move broadcasting code to own class

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/core/Wallet.java
@@ -4811,8 +4811,8 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
      * A wallet app should call this from time to time in order to let the wallet craft and send transactions needed
      * to re-organise coins internally. A good time to call this would be after receiving coins for an unencrypted
      * wallet, or after sending money for an encrypted wallet. If you have an encrypted wallet and just want to know
-     * if some maintenance needs doing, call this method with andSend set to false and look at the returned list of
-     * transactions. Maintenance might also include internal changes that involve some processing or work but
+     * if some maintenance needs doing, call this method with {@code signAndSend} set to false and look at the returned
+     * list of transactions. Maintenance might also include internal changes that involve some processing or work but
      * which don't require making transactions - these will happen automatically unless the password is required
      * in which case an exception will be thrown.
      *

--- a/core/src/main/java/org/bitcoinj/wallet/maintenance/BroadcastTransactionsAndLog.java
+++ b/core/src/main/java/org/bitcoinj/wallet/maintenance/BroadcastTransactionsAndLog.java
@@ -1,0 +1,93 @@
+package org.bitcoinj.wallet.maintenance;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionBroadcaster;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Create futures for broadcasting the given transactions. This class delegates to the provided
+ * {@link org.bitcoinj.core.TransactionBroadcaster} and additionally logs.
+ */
+public class BroadcastTransactionsAndLog {
+    private final TransactionBroadcaster transactionBroadcaster;
+    private String errorMessage = "Failed to broadcast transaction";
+    private String successMessage = "Successfully broadcast transaction: {}";
+    private Logger logger = LoggerFactory.getLogger(BroadcastTransactionsAndLog.class);
+
+    /**
+     * @param transactionBroadcaster the broadcaster to use
+     */
+    public BroadcastTransactionsAndLog(TransactionBroadcaster transactionBroadcaster) {
+        this.transactionBroadcaster = transactionBroadcaster;
+    }
+
+    /**
+     * @param transactions the transactions to broadcast
+     * @return futures generated for broadcasting the given transactions
+     */
+    public ListenableFuture<List<Transaction>> getBroadcastFutures(List<Transaction> transactions) {
+        ArrayList<ListenableFuture<Transaction>> futures = new ArrayList<ListenableFuture<Transaction>>(transactions.size());
+        for (Transaction transaction : transactions) {
+            addBroadcastFuture(futures, transaction);
+        }
+        return Futures.allAsList(futures);
+    }
+
+    private void addBroadcastFuture(ArrayList<ListenableFuture<Transaction>> futures, Transaction transaction) {
+        try {
+            futures.add(createBroadcastFuture(transaction));
+        } catch (Exception exception) {
+            logger.error(errorMessage, exception);
+        }
+    }
+
+    private ListenableFuture<Transaction> createBroadcastFuture(Transaction keyRotationTransaction) {
+        final ListenableFuture<Transaction> future = transactionBroadcaster.broadcastTransaction(keyRotationTransaction).future();
+        addLogCallbacksToFuture(future);
+        return future;
+    }
+
+    private void addLogCallbacksToFuture(ListenableFuture<Transaction> future) {
+        Futures.addCallback(future, new FutureCallback<Transaction>() {
+            @Override
+            public void onSuccess(Transaction transaction) {
+                logger.info(successMessage, transaction);
+            }
+
+            @Override
+            public void onFailure(@Nonnull Throwable throwable) {
+                logger.error(errorMessage, throwable);
+            }
+        });
+    }
+
+    /**
+     * @param successMessage use this success message instead of the default
+     */
+    public void setSuccessMessage(String successMessage) {
+        this.successMessage = successMessage;
+    }
+
+    /**
+     * @param errorMessage use this error message instead of the default
+     */
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    /**
+     * @param logger use this logger instead of the default
+     */
+    public void setLogger(Logger logger) {
+        this.logger = logger;
+    }
+
+}


### PR DESCRIPTION
The class Wallet is way too big. This is my first attempt to find something worth moving out of it. I'm not too happy about the package for the new class, feel free to suggest something else.

Note that this uses its own logger (which could be changed easily).

In the long run I'd like to move all code related purely to wallet maintenance out.

Do you know if broadcasting transactions like this is done elsewhere, too?