### PR TITLE
Remove BlockChainListener.isTransactionRelevant.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AbstractBlockChainListener.java
+++ b/core/src/main/java/org/bitcoinj/core/AbstractBlockChainListener.java
@@ -31,11 +31,6 @@ public class AbstractBlockChainListener implements BlockChainListener {
     }
 
     @Override
-    public boolean isTransactionRelevant(Transaction tx) throws ScriptException {
-        return false;
-    }
-
-    @Override
     public void receiveFromBlock(Transaction tx, StoredBlock block, BlockChain.NewBlockType blockType,
                                  int relativityOffset) throws VerificationException {
     }

--- a/core/src/main/java/org/bitcoinj/core/BlockChainListener.java
+++ b/core/src/main/java/org/bitcoinj/core/BlockChainListener.java
@@ -46,15 +46,6 @@ public interface BlockChainListener {
                     List<StoredBlock> newBlocks) throws VerificationException;
 
     /**
-     * Returns true if the given transaction is interesting to the listener. If yes, then the transaction will
-     * be provided via the receiveFromBlock method. This method is essentially an optimization that lets BlockChain
-     * bypass verification of a blocks merkle tree if no listeners are interested, which can save time when processing
-     * full blocks on mobile phones. It's likely the method will be removed in future and replaced with an alternative
-     * mechanism that involves listeners providing all keys that are interesting.
-     */
-    boolean isTransactionRelevant(Transaction tx) throws ScriptException;
-
-    /**
      * <p>Called by the {@link BlockChain} when we receive a new block that contains a relevant transaction.</p>
      *
      * <p>A transaction may be received multiple times if is included into blocks in parallel chains. The blockType

--- a/core/src/main/java/org/bitcoinj/core/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/core/Wallet.java
@@ -1701,7 +1701,6 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
      * <p>Note that if the tx has inputs containing one of our keys, but the connected transaction is not in the wallet,
      * it will not be considered relevant.</p>
      */
-    @Override
     public boolean isTransactionRelevant(Transaction tx) throws ScriptException {
         lock.lock();
         try {
@@ -1768,6 +1767,8 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
                                  int relativityOffset) throws VerificationException {
         lock.lock();
         try {
+            if (!isTransactionRelevant(tx))
+                return;
             receive(tx, block, blockType, relativityOffset);
         } finally {
             lock.unlock();
@@ -1778,6 +1779,7 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
                          int relativityOffset) throws VerificationException {
         // Runs in a peer thread.
         checkState(lock.isHeldByCurrentThread());
+
         Coin prevBalance = getBalance();
         Sha256Hash txHash = tx.getHash();
         boolean bestChain = blockType == BlockChain.NewBlockType.BEST_CHAIN;

--- a/core/src/main/java/org/bitcoinj/jni/NativeBlockChainListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeBlockChainListener.java
@@ -35,9 +35,6 @@ public class NativeBlockChainListener implements BlockChainListener {
     public native void reorganize(StoredBlock splitPoint, List<StoredBlock> oldBlocks, List<StoredBlock> newBlocks) throws VerificationException;
 
     @Override
-    public native boolean isTransactionRelevant(Transaction tx) throws ScriptException;
-
-    @Override
     public native void receiveFromBlock(Transaction tx, StoredBlock block, BlockChain.NewBlockType blockType,
                                         int relativityOffset) throws VerificationException;
 

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -275,6 +275,7 @@ public class TransactionTest {
         assertEquals(iterator.hasNext(), false);
     }
 
+
     @Test(expected = ScriptException.class)
     public void testAddSignedInputThrowsExceptionWhenScriptIsNotToRawPubKeyAndIsNotToAddress() {
         ECKey key = new ECKey();


### PR DESCRIPTION
The optimisation this was meant to support ceased to be relevant a long time ago.