### PR TITLE
Address: Fix Java serialization and add serialization test case.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Address.java
+++ b/core/src/main/java/org/bitcoinj/core/Address.java
@@ -1,6 +1,7 @@
 /**
  * Copyright 2011 Google Inc.
  * Copyright 2014 Giannis Dzegoutanis
+ * Copyright 2015 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +17,10 @@
  */
 
 package org.bitcoinj.core;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 
 import org.bitcoinj.params.Networks;
 import org.bitcoinj.script.Script;
@@ -42,7 +47,7 @@ public class Address extends VersionedChecksummedBytes {
      */
     public static final int LENGTH = 20;
 
-    private final NetworkParameters params;
+    private transient NetworkParameters params;
 
     /**
      * Construct an address from parameters, the address version, and the hash160 form. Example:<p>
@@ -175,5 +180,17 @@ public class Address extends VersionedChecksummedBytes {
     @Override
     public Address clone() throws CloneNotSupportedException {
         return (Address) super.clone();
+    }
+
+    // Java serialization
+
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        out.defaultWriteObject();
+        out.writeUTF(params.id);
+    }
+
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        params = NetworkParameters.fromID(in.readUTF());
     }
 }

--- a/core/src/test/java/org/bitcoinj/core/AddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AddressTest.java
@@ -24,6 +24,10 @@ import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.List;
 
@@ -33,6 +37,23 @@ import static org.junit.Assert.*;
 public class AddressTest {
     static final NetworkParameters testParams = TestNet3Params.get();
     static final NetworkParameters mainParams = MainNetParams.get();
+
+    @Test
+    public void testJavaSerialization() throws Exception {
+        Address testAddress = new Address(testParams, "n4eA2nbYqErp7H6jebchxAN59DmNpksexv");
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        new ObjectOutputStream(os).writeObject(testAddress);
+        VersionedChecksummedBytes testAddressCopy = (VersionedChecksummedBytes) new ObjectInputStream(
+                new ByteArrayInputStream(os.toByteArray())).readObject();
+        assertEquals(testAddress, testAddressCopy);
+
+        Address mainAddress = new Address(mainParams, "17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL");
+        os = new ByteArrayOutputStream();
+        new ObjectOutputStream(os).writeObject(mainAddress);
+        VersionedChecksummedBytes mainAddressCopy = (VersionedChecksummedBytes) new ObjectInputStream(
+                new ByteArrayInputStream(os.toByteArray())).readObject();
+        assertEquals(mainAddress, mainAddressCopy);
+    }
 
     @Test
     public void stringification() throws Exception {


### PR DESCRIPTION
The issue became uncovered because the newly-for-0.13 introduced HttpDiscovery.Details member into MainNetParams broke the serialization chain for all mainnet addresses.