### PR TITLE
Don't derive private keys just to check if they exist

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -320,7 +320,7 @@ public class DeterministicKey extends ECKey {
     /** {@inheritDoc} */
     @Override
     public boolean hasPrivKey() {
-        return findOrDerivePrivateKey() != null;
+        return findParentWithPrivKey() != null;
     }
 
     @Nullable
@@ -407,13 +407,18 @@ public class DeterministicKey extends ECKey {
         return derivePrivateKeyDownwards(cursor, parentalPrivateKeyBytes);
     }
 
-    @Nullable
-    private BigInteger findOrDerivePrivateKey() {
+    private DeterministicKey findParentWithPrivKey() {
         DeterministicKey cursor = this;
         while (cursor != null) {
             if (cursor.priv != null) break;
             cursor = cursor.parent;
         }
+        return cursor;
+    }
+
+    @Nullable
+    private BigInteger findOrDerivePrivateKey() {
+        DeterministicKey cursor = findParentWithPrivKey();
         if (cursor == null)
             return null;
         return derivePrivateKeyDownwards(cursor, cursor.priv.toByteArray());


### PR DESCRIPTION
This speeds up `calculateAllSpendCandidates` and `getBalance` by a couple of orders of magnitude, which is especially noticeable on Android.