### PR TITLE
MySQL data type fixed. Changed binary to varbinary.

### DIFF
--- a/core/src/main/java/org/bitcoinj/store/MySQLFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MySQLFullPrunedBlockStore.java
@@ -39,16 +39,16 @@ public class MySQLFullPrunedBlockStore extends DatabaseFullPrunedBlockStore {
             ")\n";
 
     private static final String CREATE_HEADERS_TABLE = "CREATE TABLE headers (\n" +
-            "    hash binary(28) NOT NULL,\n" +
-            "    chainwork binary(12) NOT NULL,\n" +
+            "    hash varbinary(28) NOT NULL,\n" +
+            "    chainwork varbinary(12) NOT NULL,\n" +
             "    height integer NOT NULL,\n" +
-            "    header binary(80) NOT NULL,\n" +
+            "    header varbinary(80) NOT NULL,\n" +
             "    wasundoable tinyint(1) NOT NULL,\n" +
             "    CONSTRAINT headers_pk PRIMARY KEY (hash) USING BTREE \n" +
             ")";
 
     private static final String CREATE_UNDOABLE_TABLE = "CREATE TABLE undoableblocks (\n" +
-            "    hash binary(28) NOT NULL,\n" +
+            "    hash varbinary(28) NOT NULL,\n" +
             "    height integer NOT NULL,\n" +
             "    txoutchanges mediumblob,\n" +
             "    transactions mediumblob,\n" +
@@ -56,7 +56,7 @@ public class MySQLFullPrunedBlockStore extends DatabaseFullPrunedBlockStore {
             ")\n";
 
     private static final String CREATE_OPEN_OUTPUT_TABLE = "CREATE TABLE openoutputs (\n" +
-            "    hash binary(32) NOT NULL,\n" +
+            "    hash varbinary(32) NOT NULL,\n" +
             "    `index` integer NOT NULL,\n" +
             "    height integer NOT NULL,\n" +
             "    value bigint NOT NULL,\n" +


### PR DESCRIPTION
I received an email from Daniel Yin for a bug in the MySQL store. This was a change that happened recently if you remember (not sure why the unit test didn't flag this then- maybe it wasn't run I guess).

The problem is to do with padding of the values that we really shouldn't need to worry about so hence this correction- it's now equivalent to the blob that was used previously. 

(I've also informed Daniel that he shouldn't email me directly. I only realised when I sent the reply. Create an issue or post on the forum for obvious reasons - the funniest being me and a big red bus :-)