### PR TITLE
Remove lots of Java serialization.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AddressMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressMessage.java
@@ -12,7 +12,7 @@ import java.util.List;
  * using addr messages is not presently implemented.
  */
 public class AddressMessage extends Message {
-    private static final long serialVersionUID = 8058283864924679460L;
+
     private static final long MAX_ADDRESSES = 1024;
     private List<PeerAddress> addresses;
 

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 Google Inc.
  * Copyright 2014 Andreas Schildbach
  *
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.io.OutputStream;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -51,7 +50,6 @@ import static org.bitcoinj.core.Sha256Hash.hashTwice;
  */
 public class Block extends Message {
     private static final Logger log = LoggerFactory.getLogger(Block.class);
-    private static final long serialVersionUID = 2738848929966035281L;
 
     /** How many bytes are required to represent a block header WITHOUT the trailing 00 length byte. */
     public static final int HEADER_SIZE = 80;
@@ -87,18 +85,18 @@ public class Block extends Message {
     @Nullable List<Transaction> transactions;
 
     /** Stores the hash of the block. If null, getHash() will recalculate it. */
-    private transient Sha256Hash hash;
+    private Sha256Hash hash;
 
-    private transient boolean headerParsed;
-    private transient boolean transactionsParsed;
+    private boolean headerParsed;
+    private boolean transactionsParsed;
 
-    private transient boolean headerBytesValid;
-    private transient boolean transactionBytesValid;
+    private boolean headerBytesValid;
+    private boolean transactionBytesValid;
     
     // Blocks can be encoded in a way that will use more bytes than is optimal (due to VarInts having multiple encodings)
     // MAX_BLOCK_SIZE must be compared to the optimal encoding, not the actual encoding, so when parsing, we keep track
     // of the size of the ideal encoding in addition to the actual message size (which Message needs)
-    private transient int optimalEncodingMessageSize;
+    private int optimalEncodingMessageSize;
 
     /** Special case constructor, used for the genesis node, cloneAsHeader and unit tests. */
     Block(NetworkParameters params) {
@@ -170,13 +168,6 @@ public class Block extends Message {
      */
     public Coin getBlockInflation(int height) {
         return FIFTY_COINS.shiftRight(height / params.getSubsidyDecreaseBlockCount());
-    }
-
-    private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {
-        ois.defaultReadObject();
-        // This code is not actually necessary, as transient fields are initialized to the default value which is in
-        // this case null. However it clears out a FindBugs warning and makes it explicit what we're doing.
-        hash = null;
     }
 
     protected void parseHeader() throws ProtocolException {

--- a/core/src/main/java/org/bitcoinj/core/ChildMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/ChildMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 Steve Coughlan.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,6 @@ import javax.annotation.Nullable;
  * backing byte array need to invalidate their parent's caches as well as their own if they are modified.
  */
 public abstract class ChildMessage extends Message {
-    private static final long serialVersionUID = -7657113383624517931L;
 
     @Nullable protected Message parent;
 

--- a/core/src/main/java/org/bitcoinj/core/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/core/ECKey.java
@@ -154,8 +154,7 @@ public class ECKey implements EncryptableItem {
     protected KeyCrypter keyCrypter;
     protected EncryptedData encryptedPrivateKey;
 
-    // Transient because it's calculated on demand/cached.
-    private transient byte[] pubKeyHash;
+    private byte[] pubKeyHash;
 
     /**
      * Generates an entirely new keypair. Point compression is used so the resulting public key will be 33 bytes

--- a/core/src/main/java/org/bitcoinj/core/EmptyMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/EmptyMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 Steve Coughlan.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,6 @@ import java.io.OutputStream;
  * Currently this includes getaddr, verack and special bitcoinj class UnknownMessage.
  */
 public abstract class EmptyMessage extends Message {
-    private static final long serialVersionUID = 8240801253854151802L;
 
     public EmptyMessage() {
         length = 0;

--- a/core/src/main/java/org/bitcoinj/core/GetAddrMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetAddrMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,10 +21,8 @@ package org.bitcoinj.core;
  * be confused with {@link Address} which is sort of like an account number.
  */
 public class GetAddrMessage extends EmptyMessage {
-    private static final long serialVersionUID = 6204437624599661503L;
 
     public GetAddrMessage(NetworkParameters params) {
         super(params);
     }
-
 }

--- a/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +26,7 @@ import java.util.List;
  * missing. Those blocks can then be downloaded with a {@link GetDataMessage}.
  */
 public class GetBlocksMessage extends Message {
-    private static final long serialVersionUID = 3479412877853645644L;
+
     protected long version;
     protected List<Sha256Hash> locator;
     protected Sha256Hash stopHash;

--- a/core/src/main/java/org/bitcoinj/core/GetDataMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetDataMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +21,6 @@ package org.bitcoinj.core;
  * hashes.
  */
 public class GetDataMessage extends ListMessage {
-    private static final long serialVersionUID = 2754681589501709887L;
 
     public GetDataMessage(NetworkParameters params, byte[] payloadBytes) throws ProtocolException {
         super(params, payloadBytes);

--- a/core/src/main/java/org/bitcoinj/core/InventoryMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/InventoryMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,6 @@ import static com.google.common.base.Preconditions.checkArgument;
  * {@link GetDataMessage}.</p>
  */
 public class InventoryMessage extends ListMessage {
-    private static final long serialVersionUID = -7050246551646107066L;
 
     /** A hard coded constant in the protocol. */
     public static final int MAX_INV_SIZE = 50000;

--- a/core/src/main/java/org/bitcoinj/core/ListMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/ListMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +26,6 @@ import java.util.List;
  * Abstract superclass of classes with list based payload, ie InventoryMessage and GetDataMessage.
  */
 public abstract class ListMessage extends Message {
-    private static final long serialVersionUID = -4275896329391143643L;
 
     private long arrayLen;
     // For some reason the compiler complains if this is inside InventoryItem

--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 Google Inc.
  * Copyright 2014 Andreas Schildbach
  *
@@ -27,13 +27,12 @@ import java.util.Arrays;
 import static com.google.common.base.Preconditions.checkState;
 
 /**
- * <p>A Message is a data structure that can be serialized/deserialized using both the Bitcoin proprietary serialization
- * format and built-in Java object serialization. Specific types of messages that are used both in the block chain,
- * and on the wire, are derived from this class.</p>
+ * <p>A Message is a data structure that can be serialized/deserialized using the Bitcoin serialization format.
+ * Specific types of messages that are used both in the block chain, and on the wire, are derived from this
+ * class.</p>
  */
-public abstract class Message implements Serializable {
+public abstract class Message {
     private static final Logger log = LoggerFactory.getLogger(Message.class);
-    private static final long serialVersionUID = -3561053461717079135L;
 
     public static final int MAX_SIZE = 0x02000000; // 32MB
 
@@ -43,31 +42,27 @@ public abstract class Message implements Serializable {
     private static final boolean SELF_CHECK = false;
 
     // The offset is how many bytes into the provided byte array this message payload starts at.
-    protected transient int offset;
+    protected int offset;
     // The cursor keeps track of where we are in the byte array as we parse it.
     // Note that it's relative to the start of the array NOT the start of the message payload.
-    protected transient int cursor;
+    protected int cursor;
 
-    protected transient int length = UNKNOWN_LENGTH;
+    protected int length = UNKNOWN_LENGTH;
 
     // The raw message payload bytes themselves.
-    protected transient byte[] payload;
+    protected byte[] payload;
 
-    protected transient boolean parsed = false;
-    protected transient boolean recached = false;
-    protected final transient boolean parseLazy;
-    protected final transient boolean parseRetain;
+    protected boolean parsed = false;
+    protected boolean recached = false;
+    protected final boolean parseLazy;
+    protected final boolean parseRetain;
 
-    protected transient int protocolVersion;
+    protected int protocolVersion;
 
-    protected transient byte[] checksum;
+    protected byte[] checksum;
 
-    // This will be saved by subclasses that implement Serializable.
     protected NetworkParameters params;
 
-    /**
-     * This exists for the Java serialization framework to use only.
-     */
     protected Message() {
         parsed = true;
         parseLazy = false;
@@ -151,9 +146,7 @@ public abstract class Message implements Serializable {
     }
 
     // These methods handle the serialization/deserialization using the custom Bitcoin protocol.
-    // It's somewhat painful to work with in Java, so some of these objects support a second
-    // serialization mechanism - the standard Java serialization system. This is used when things
-    // are serialized to the wallet.
+
     abstract void parse() throws ProtocolException;
 
     /**
@@ -476,7 +469,6 @@ public abstract class Message implements Serializable {
     }
 
     public static class LazyParseException extends RuntimeException {
-        private static final long serialVersionUID = 6971943053112975594L;
 
         public LazyParseException(String message, Throwable cause) {
             super(message, cause);

--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 Google Inc.
  * Copyright 2014 Andreas Schildbach
  *
@@ -44,7 +44,7 @@ import static org.bitcoinj.core.Coin.*;
  * intended for unit testing and local app development purposes. Although this class contains some aliases for
  * them, you are encouraged to call the static get() methods on each specific params class directly.</p>
  */
-public abstract class NetworkParameters implements Serializable {
+public abstract class NetworkParameters {
     /**
      * The protocol version this library implements.
      */

--- a/core/src/main/java/org/bitcoinj/core/PeerAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerAddress.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,7 +36,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * a peer in the Bitcoin P2P network. It exists primarily for serialization purposes.
  */
 public class PeerAddress extends ChildMessage {
-    private static final long serialVersionUID = 7501293709324197411L;
+
     static final int MESSAGE_SIZE = 30;
 
     private InetAddress addr;

--- a/core/src/main/java/org/bitcoinj/core/RejectMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/RejectMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 Matt Corallo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,6 @@ import java.io.OutputStream;
  * A message sent by nodes when a message we sent was rejected (ie a transaction had too little fee/was invalid/etc)
  */
 public class RejectMessage extends Message {
-    private static final long serialVersionUID = -5246995579800334336L;
 
     private String message, reason;
     public enum RejectCode {

--- a/core/src/main/java/org/bitcoinj/core/StoredBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/StoredBlock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,6 @@ import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.BlockStoreException;
 import com.google.common.base.Objects;
 
-import java.io.*;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 
@@ -35,8 +34,7 @@ import static com.google.common.base.Preconditions.checkState;
  *
  * StoredBlocks are put inside a {@link BlockStore} which saves them to memory or disk.
  */
-public class StoredBlock implements Serializable {
-    private static final long serialVersionUID = -6097565241243701771L;
+public class StoredBlock {
 
     // A BigInteger representing the total amount of work done so far on this chain. As of May 2011 it takes 8
     // bytes to represent this field, so 12 bytes should be plenty for now.

--- a/core/src/main/java/org/bitcoinj/core/StoredUndoableBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/StoredUndoableBlock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 Google Inc.
  * Copyright 2012 Matt Corallo.
  *
@@ -17,7 +17,6 @@
 
 package org.bitcoinj.core;
 
-import java.io.Serializable;
 import java.util.List;
 
 /**
@@ -27,8 +26,7 @@ import java.util.List;
  * or the set of transaction outputs created/destroyed when the block is
  * connected.
  */
-public class StoredUndoableBlock implements Serializable {
-    private static final long serialVersionUID = 5127353027086786117L;
+public class StoredUndoableBlock {
     
     Sha256Hash blockHash;
     

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 Google Inc.
  * Copyright 2014 Andreas Schildbach
  *
@@ -51,7 +51,7 @@ import static com.google.common.base.Preconditions.checkState;
  * sense for selling MP3s might not make sense for selling cars, or accepting payments from a family member. If you
  * are building a wallet, how to present confidence to your users is something to consider carefully.</p>
  */
-public class Transaction extends ChildMessage implements Serializable {
+public class Transaction extends ChildMessage {
     /**
      * A comparator that can be used to sort transactions by their updateTime field. The ordering goes from most recent
      * into the past.
@@ -78,7 +78,6 @@ public class Transaction extends ChildMessage implements Serializable {
         }
     };
     private static final Logger log = LoggerFactory.getLogger(Transaction.class);
-    private static final long serialVersionUID = -8567546957352643140L;
 
     /** Threshold for lockTime: below this value it is interpreted as block number, otherwise as timestamp. **/
     public static final int LOCKTIME_THRESHOLD = 500000000; // Tue Nov  5 00:53:20 1985 UTC
@@ -99,7 +98,7 @@ public class Transaction extends ChildMessage implements Serializable {
      */
     public static final Coin MIN_NONDUST_OUTPUT = Coin.valueOf(546);
 
-    // These are serialized in both bitcoin and java serialization.
+    // These are bitcoin serialized.
     private long version;
     private ArrayList<TransactionInput> inputs;
     private ArrayList<TransactionOutput> outputs;
@@ -113,7 +112,7 @@ public class Transaction extends ChildMessage implements Serializable {
     private Date updatedAt;
 
     // This is an in memory helper only.
-    private transient Sha256Hash hash;
+    private Sha256Hash hash;
 
     // Data about how confirmed this tx is. Serialized, may be null.
     @Nullable private TransactionConfidence confidence;
@@ -132,7 +131,7 @@ public class Transaction extends ChildMessage implements Serializable {
     // MAX_BLOCK_SIZE must be compared to the optimal encoding, not the actual encoding, so when parsing, we keep track
     // of the size of the ideal encoding in addition to the actual message size (which Message needs) so that Blocks
     // can properly keep track of optimal encoded size
-    private transient int optimalEncodingMessageSize;
+    private int optimalEncodingMessageSize;
 
     /**
      * This enum describes the underlying reason the transaction was created. It's useful for rendering wallet GUIs
@@ -1192,16 +1191,6 @@ public class Transaction extends ChildMessage implements Serializable {
     @Override
     public int hashCode() {
         return getHash().hashCode();
-    }
-
-    /**
-     * Ensure object is fully parsed before invoking java serialization.  The backing byte array
-     * is transient so if the object has parseLazy = true and hasn't invoked checkParse yet
-     * then data will be lost during serialization.
-     */
-    private void writeObject(ObjectOutputStream out) throws IOException {
-        maybeParse();
-        out.defaultWriteObject();
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
@@ -58,8 +58,7 @@ import static com.google.common.base.Preconditions.*;
  * method to ensure the block depth is up to date.</p>
  * To make a copy that won't be changed, use {@link org.bitcoinj.core.TransactionConfidence#duplicate()}.
  */
-public class TransactionConfidence implements Serializable {
-    private static final long serialVersionUID = 4577920141400556444L;
+public class TransactionConfidence {
 
     /**
      * The peers that have announced the transaction to us. Network nodes don't have stable identities, so we use
@@ -70,7 +69,7 @@ public class TransactionConfidence implements Serializable {
     /** The Transaction that this confidence object is associated with. */
     private final Sha256Hash hash;
     // Lazily created listeners array.
-    private transient CopyOnWriteArrayList<ListenerRegistration<Listener>> listeners;
+    private CopyOnWriteArrayList<ListenerRegistration<Listener>> listeners;
 
     // The depth of the transaction on the best chain in blocks. An unconfirmed block has depth 0.
     private int depth;
@@ -138,15 +137,6 @@ public class TransactionConfidence implements Serializable {
         broadcastBy = new CopyOnWriteArrayList<PeerAddress>();
         listeners = new CopyOnWriteArrayList<ListenerRegistration<Listener>>();
         this.hash = hash;
-    }
-
-    /**
-     * In case the class gets created from a serialised version, we need to recreate the listeners object as it is set 
-     * as transient and only created in the constructor.
-     */
-    private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
-        in.defaultReadObject();
-        listeners = new CopyOnWriteArrayList<ListenerRegistration<Listener>>();
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 Google Inc.
  * Copyright 2014 Andreas Schildbach
  *
@@ -27,7 +27,6 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
-import java.io.Serializable;
 import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.Map;
@@ -41,9 +40,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * transaction as being a module which is wired up to others, the inputs of one have to be wired
  * to the outputs of another. The exceptions are coinbase transactions, which create new coins.
  */
-public class TransactionInput extends ChildMessage implements Serializable {
+public class TransactionInput extends ChildMessage {
     public static final long NO_SEQUENCE = 0xFFFFFFFFL;
-    private static final long serialVersionUID = 2;
     public static final byte[] EMPTY_ARRAY = new byte[0];
 
     // Allows for altering transactions after they were broadcast. Tx replacement is currently disabled in the C++
@@ -58,7 +56,7 @@ public class TransactionInput extends ChildMessage implements Serializable {
     private byte[] scriptBytes;
     // The Script object obtained from parsing scriptBytes. Only filled in on demand and if the transaction is not
     // coinbase.
-    private transient WeakReference<Script> scriptSig;
+    private WeakReference<Script> scriptSig;
     /** Value of the output connected to the input, if known. This field does not participate in equals()/hashCode(). */
     @Nullable
     private Coin value;
@@ -392,16 +390,6 @@ public class TransactionInput extends ChildMessage implements Serializable {
         } else {
             return false;
         }
-    }
-
-    /**
-     * Ensure object is fully parsed before invoking java serialization.  The backing byte array
-     * is transient so if the object has parseLazy = true and hasn't invoked checkParse yet
-     * then data will be lost during serialization.
-     */
-    private void writeObject(ObjectOutputStream out) throws IOException {
-        maybeParse();
-        out.defaultWriteObject();
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,8 +28,7 @@ import static com.google.common.base.Preconditions.*;
 /**
  * This message is a reference or pointer to an output of a different transaction.
  */
-public class TransactionOutPoint extends ChildMessage implements Serializable {
-    private static final long serialVersionUID = -6320880638344662579L;
+public class TransactionOutPoint extends ChildMessage {
 
     static final int MESSAGE_LENGTH = 36;
 
@@ -38,8 +37,7 @@ public class TransactionOutPoint extends ChildMessage implements Serializable {
     /** Which output of that transaction we are talking about. */
     private long index;
 
-    // This is not part of Bitcoin serialization. It's included in Java serialization.
-    // It points to the connected transaction.
+    // This is not part of bitcoin serialization. It points to the connected transaction.
     Transaction fromTx;
 
     // The connected output.
@@ -217,16 +215,6 @@ public class TransactionOutPoint extends ChildMessage implements Serializable {
     
     public void setIndex(long index) {
         this.index = index;
-    }
-
-    /**
-     * Ensure object is fully parsed before invoking java serialization.  The backing byte array
-     * is transient so if the object has parseLazy = true and hasn't invoked checkParse yet
-     * then data will be lost during serialization.
-     */
-    private void writeObject(ObjectOutputStream out) throws IOException {
-        maybeParse();
-        out.defaultWriteObject();
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 Google Inc.
  * Copyright 2014 Andreas Schildbach
  *
@@ -31,9 +31,8 @@ import static com.google.common.base.Preconditions.*;
  * A TransactionOutput message contains a scriptPubKey that controls who is able to spend its value. It is a sub-part
  * of the Transaction message.
  */
-public class TransactionOutput extends ChildMessage implements Serializable {
+public class TransactionOutput extends ChildMessage {
     private static final Logger log = LoggerFactory.getLogger(TransactionOutput.class);
-    private static final long serialVersionUID = -590332479859256824L;
 
     // The output's value is kept as a native type in order to save class instances.
     private long value;
@@ -43,16 +42,16 @@ public class TransactionOutput extends ChildMessage implements Serializable {
     private byte[] scriptBytes;
 
     // The script bytes are parsed and turned into a Script on demand.
-    private transient Script scriptPubKey;
+    private Script scriptPubKey;
 
-    // These fields are Java serialized but not Bitcoin serialized. They are used for tracking purposes in our wallet
+    // These fields are not Bitcoin serialized. They are used for tracking purposes in our wallet
     // only. If set to true, this output is counted towards our balance. If false and spentBy is null the tx output
     // was owned by us and was sent to somebody else. If false and spentBy is set it means this output was owned by
     // us and used in one of our own transactions (eg, because it is a change output).
     private boolean availableForSpending;
     @Nullable private TransactionInput spentBy;
 
-    private transient int scriptLen;
+    private int scriptLen;
 
     /**
      * Deserializes a transaction output message. This is usually part of a transaction message.
@@ -401,16 +400,6 @@ public class TransactionOutput extends ChildMessage implements Serializable {
             }
         }
         return -1;
-    }
-
-    /**
-     * Ensure object is fully parsed before invoking java serialization.  The backing byte array
-     * is transient so if the object has parseLazy = true and hasn't invoked checkParse yet
-     * then data will be lost during serialization.
-     */
-    private void writeObject(ObjectOutputStream out) throws IOException {
-        maybeParse();
-        out.defaultWriteObject();
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/UTXO.java
+++ b/core/src/main/java/org/bitcoinj/core/UTXO.java
@@ -29,8 +29,7 @@ import java.math.*;
  * It avoids having to store the entire parentTransaction just to get the hash and index.
  * Useful when working with free standing outputs.
  */
-public class UTXO implements Serializable {
-    private static final long serialVersionUID = -8744924157056340509L;
+public class UTXO {
 
     private Coin value;
     private Script script;

--- a/core/src/main/java/org/bitcoinj/core/UnknownMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/UnknownMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 Google Inc.
  * Copyright 2014 Andreas Schildbach
  *
@@ -18,7 +18,7 @@
 package org.bitcoinj.core;
 
 public class UnknownMessage extends EmptyMessage {
-    private static final long serialVersionUID = 3614705938207918775L;
+
     private String name;
 
     public UnknownMessage(NetworkParameters params, String name, byte[] payloadBytes) throws ProtocolException {

--- a/core/src/main/java/org/bitcoinj/core/VersionMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,7 +33,6 @@ import java.net.UnknownHostException;
  * to ensure it will be used for each new connection.
  */
 public class VersionMessage extends Message {
-    private static final long serialVersionUID = 7313594258967483180L;
 
     /** A services flag that denotes whether the peer has a copy of the block chain or not. */
     public static final int NODE_NETWORK = 1;

--- a/core/src/main/java/org/bitcoinj/core/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/core/Wallet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 Google Inc.
  * Copyright 2014 Andreas Schildbach
  *
@@ -78,17 +78,15 @@ import static com.google.common.base.Preconditions.*;
  * other objects, see the <a href="https://bitcoinj.github.io/getting-started">Getting started</a> tutorial
  * on the website to learn more about how to set everything up.</p>
  *
- * <p>Wallets can be serialized using either Java serialization - this is not compatible across versions of bitcoinj,
- * or protocol buffer serialization. You need to save the wallet whenever it changes, there is an auto-save feature
- * that simplifies this for you although you're still responsible for manually triggering a save when your app is about
- * to quit because the auto-save feature waits a moment before actually committing to disk to avoid IO thrashing when
- * the wallet is changing very fast (eg due to a block chain sync). See
+ * <p>Wallets can be serialized using protocol buffers. You need to save the wallet whenever it changes, there is an
+ * auto-save feature that simplifies this for you although you're still responsible for manually triggering a save when
+ * your app is about to quit because the auto-save feature waits a moment before actually committing to disk to avoid IO
+ * thrashing when the wallet is changing very fast (eg due to a block chain sync). See
  * {@link Wallet#autosaveToFile(java.io.File, long, java.util.concurrent.TimeUnit, org.bitcoinj.wallet.WalletFiles.Listener)}
  * for more information about this.</p>
  */
-public class Wallet extends BaseTaggableObject implements Serializable, BlockChainListener, PeerFilterProvider, KeyBag, TransactionBag {
+public class Wallet extends BaseTaggableObject implements BlockChainListener, PeerFilterProvider, KeyBag, TransactionBag {
     private static final Logger log = LoggerFactory.getLogger(Wallet.class);
-    private static final long serialVersionUID = 2L;
     private static final int MINIMUM_BLOOM_DATA_LENGTH = 8;
 
     // Ordering: lock > keychainLock. Keychain is protected separately to allow fast querying of current receive address
@@ -155,16 +153,16 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
     private int lastBlockSeenHeight;
     private long lastBlockSeenTimeSecs;
 
-    private transient CopyOnWriteArrayList<ListenerRegistration<WalletEventListener>> eventListeners;
+    private CopyOnWriteArrayList<ListenerRegistration<WalletEventListener>> eventListeners;
 
     // A listener that relays confidence changes from the transaction confidence object to the wallet event listener,
     // as a convenience to API users so they don't have to register on every transaction themselves.
-    private transient TransactionConfidence.Listener txConfidenceListener;
+    private TransactionConfidence.Listener txConfidenceListener;
 
     // If a TX hash appears in this set then notifyNewBestBlock will ignore it, as its confidence was already set up
     // in receive() via Transaction.setBlockAppearance(). As the BlockChain always calls notifyNewBestBlock even if
     // it sent transactions to the wallet, without this we'd double count.
-    private transient HashSet<Sha256Hash> ignoreNextNewBlock;
+    private HashSet<Sha256Hash> ignoreNextNewBlock;
     // Whether or not to ignore nLockTime > 0 transactions that are received to the mempool.
     private boolean acceptRiskyTransactions;
 
@@ -181,7 +179,7 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
     // that was created after it. Useful when you believe some keys have been compromised.
     private volatile long vKeyRotationTimestamp;
 
-    protected transient CoinSelector coinSelector = new DefaultCoinSelector();
+    protected CoinSelector coinSelector = new DefaultCoinSelector();
 
     // The wallet version. This is an int that can be used to track breaking changes in the wallet format.
     // You can also use it to detect wallets that come from the future (ie they contain features you
@@ -1512,11 +1510,6 @@ public class Wallet extends BaseTaggableObject implements Serializable, BlockCha
             log.error("Loaded an inconsistent wallet");
         }
         return wallet;
-    }
-
-    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
-        in.defaultReadObject();
-        createTransientState();
     }
 
     //endregion

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicHierarchy.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicHierarchy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 Matija Mazi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,6 @@ package org.bitcoinj.crypto;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
@@ -40,7 +39,7 @@ import static com.google.common.base.Preconditions.checkArgument;
  * <p>The hierarchy is started from a single root key, and a location in the tree is given by a path which
  * is a list of {@link ChildNumber}s.</p>
  */
-public class DeterministicHierarchy implements Serializable {
+public class DeterministicHierarchy {
     private final Map<ImmutableList<ChildNumber>, DeterministicKey> keys = Maps.newHashMap();
     private final ImmutableList<ChildNumber> rootPath;
     // Keep track of how many child keys each node has. This is kind of weak.

--- a/core/src/main/java/org/bitcoinj/crypto/KeyCrypterScrypt.java
+++ b/core/src/main/java/org/bitcoinj/crypto/KeyCrypterScrypt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2013 Jim Burton.
  * Copyright 2014 Andreas Schildbach
  *
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.bitcoinj.crypto;
 
 import com.google.common.base.Objects;
@@ -32,7 +33,6 @@ import org.spongycastle.crypto.paddings.PaddedBufferedBlockCipher;
 import org.spongycastle.crypto.params.KeyParameter;
 import org.spongycastle.crypto.params.ParametersWithIV;
 
-import java.io.Serializable;
 import java.security.SecureRandom;
 import java.util.Arrays;
 
@@ -52,10 +52,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * <p>2) Using the AES Key generated above, you then can encrypt and decrypt any bytes using
  * the AES symmetric cipher. Eight bytes of salt is used to prevent dictionary attacks.</p>
  */
-public class KeyCrypterScrypt implements KeyCrypter, Serializable {
+public class KeyCrypterScrypt implements KeyCrypter {
 
     private static final Logger log = LoggerFactory.getLogger(KeyCrypterScrypt.class);
-    private static final long serialVersionUID = 949662512049152670L;
 
     /**
      * Key length in bytes.
@@ -81,7 +80,7 @@ public class KeyCrypterScrypt implements KeyCrypter, Serializable {
         secureRandom = new SecureRandom();
     }
 
-    private static final transient SecureRandom secureRandom;
+    private static final SecureRandom secureRandom;
 
     /** Returns SALT_LENGTH (8) bytes of random data */
     public static byte[] randomSalt() {
@@ -91,7 +90,7 @@ public class KeyCrypterScrypt implements KeyCrypter, Serializable {
     }
 
     // Scrypt parameters.
-    private final transient ScryptParameters scryptParameters;
+    private final ScryptParameters scryptParameters;
 
     /**
      * Encryption/Decryption using default parameters and a random salt.

--- a/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
@@ -22,15 +22,13 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
 import javax.annotation.Nullable;
-import java.io.Serializable;
 import java.util.*;
 
 /**
  * Used as a key for memory map (to avoid having to think about NetworkParameters,
  * which is required for {@link TransactionOutPoint}
  */
-class StoredTransactionOutPoint implements Serializable {
-    private static final long serialVersionUID = -4064230006297064377L;
+class StoredTransactionOutPoint {
 
     /** Hash of the transaction to which we refer. */
     Sha256Hash hash;

--- a/core/src/test/java/org/bitcoinj/core/BlockTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2011 Google Inc.
  * Copyright 2014 Andreas Schildbach
  *
@@ -23,10 +23,6 @@ import org.bitcoinj.script.ScriptOpCodes;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.math.BigInteger;
 import java.util.Arrays;
 
@@ -132,32 +128,9 @@ public class BlockTest {
         // We have to be able to reserialize everything exactly as we found it for hashing to work. This test also
         // proves that transaction serialization works, along with all its subobjects like scripts and in/outpoints.
         //
-        // NB: This tests the BITCOIN proprietary serialization protocol. A different test checks Java serialization
-        // of transactions.
+        // NB: This tests the bitcoin serialization protocol.
         Block block = new Block(params, blockBytes);
         assertTrue(Arrays.equals(blockBytes, block.bitcoinSerialize()));
-    }
-
-    @Test
-    public void testJavaSerialiazation() throws Exception {
-        Block block = new Block(params, blockBytes);
-        Transaction tx = block.transactions.get(1);
-
-        // Serialize using Java.
-        ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        ObjectOutputStream oos = new ObjectOutputStream(bos);
-        oos.writeObject(tx);
-        oos.close();
-        byte[] javaBits = bos.toByteArray();
-        // Deserialize again.
-        ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(javaBits));
-        Transaction tx2 = (Transaction) ois.readObject();
-        ois.close();
-
-        // Note that this will actually check the transactions are equal by doing bitcoin serialization and checking
-        // the bytestreams are the same! A true "deep equals" is not implemented for Transaction. The primary purpose
-        // of this test is to ensure no errors occur during the Java serialization/deserialization process.
-        assertEquals(tx, tx2);
     }
     
     @Test


### PR DESCRIPTION
Remove Java serialization from

* NetworkParameters,
* the entire Message hierarchy,
* Block,
* StoredBlock,
* StoredUndoableBlock,
* TransactionConfidence,
* UTXO,
* DeterministicHierarchy,
* MemoryFullPrunedBlockStore and
* Wallet

It was largely untested, in many cases not working any more and we don't see a reason for supporting it.