### PR TITLE
Prevent null pointer exception if DNS seeds parameter is null.

### DIFF
--- a/core/src/main/java/org/bitcoinj/net/discovery/DnsDiscovery.java
+++ b/core/src/main/java/org/bitcoinj/net/discovery/DnsDiscovery.java
@@ -56,9 +56,10 @@ public class DnsDiscovery extends MultiplexingDiscovery {
     }
 
     private static List<PeerDiscovery> buildDiscoveries(NetworkParameters params, String[] seeds) {
-        List<PeerDiscovery> discoveries = new ArrayList<PeerDiscovery>(seeds.length);
-        for (String seed : seeds)
-            discoveries.add(new DnsSeedDiscovery(params, seed));
+        List<PeerDiscovery> discoveries = new ArrayList<PeerDiscovery>();
+        if (seeds != null)
+            for (String seed : seeds)
+                discoveries.add(new DnsSeedDiscovery(params, seed));
         return discoveries;
     }
 


### PR DESCRIPTION
I'm working on upgrading BitcoinJ from 0.12 to 0.13 and some of my tests were failing due to a null pointer exception that gets thrown if you instantiate a DnsDiscovery object with the UnitTest NetworkParams.