### PR TITLE
Make Travis not run any tests that involve accessing the network.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ language: java
 jdk: oraclejdk8
 install: true # remove default
 script:
-  - mvn -q clean install
+  - mvn -q clean install -Pno-network
   - jdk_switcher use openjdk6
   - cd orchid
   - mvn -q clean package
   - cd ../core
-  - mvn -q clean package
+  - mvn -q clean package -Pno-network
 
 after_success:
   - cd ../core

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -91,6 +91,23 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>no-network</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/core/PeerTest.java</exclude>
+                                <exclude>**/core/TransactionBroadcastTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>


### PR DESCRIPTION
Travis builds have been failing excessively in the past weeks. The problem was enhanced by moving to the new Travis build infrastructure, but even before tests failed too often.