### PR TITLE
Remove lazy parsing of messages.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AlertMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/AlertMessage.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2011 Google Inc.
+ * Copyright 2015 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +62,7 @@ public class AlertMessage extends Message {
     }
 
     @Override
-    void parse() throws ProtocolException {
+    protected void parse() throws ProtocolException {
         // Alerts are formatted in two levels. The top level contains two byte arrays: a signature, and a serialized
         // data structure containing the actual alert data.
         int startPos = cursor;
@@ -113,11 +114,6 @@ public class AlertMessage extends Message {
      */
     public boolean isSignatureValid() {
         return ECKey.verify(Sha256Hash.hashTwice(content), signature, params.getAlertSigningKey());
-    }
-
-    @Override
-    protected void parseLite() throws ProtocolException {
-        // Do nothing, lazy parsing isn't useful for alerts.
     }
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
@@ -46,7 +46,6 @@ public class BitcoinSerializer implements MessageSerializer {
     private static final int COMMAND_LEN = 12;
 
     private final NetworkParameters params;
-    private final boolean parseLazy;
     private final boolean parseRetain;
 
     private static final Map<Class<? extends Message>, String> names = new HashMap<Class<? extends Message>, String>();
@@ -75,31 +74,13 @@ public class BitcoinSerializer implements MessageSerializer {
     }
 
     /**
-     * Constructs a partial BitcoinSerializer with the given behavior. This is
-     * intended for use by messages which do not understand the network they
-     * belong to.
-     * 
-     * @param parseLazy        deserialize messages in lazy mode.
-     * @param parseRetain      retain the backing byte array of a message for fast reserialization.
-     * @deprecated use BitcoinSerializer(NetworkParameters, boolean, boolean) instead.
-     */
-    @Deprecated
-    BitcoinSerializer(boolean parseLazy, boolean parseRetain) {
-        this.params = null;
-        this.parseLazy = parseLazy;
-        this.parseRetain = parseRetain;
-    }
-
-    /**
      * Constructs a BitcoinSerializer with the given behavior.
      *
      * @param params           networkParams used to create Messages instances and termining packetMagic
-     * @param parseLazy        deserialize messages in lazy mode.
      * @param parseRetain      retain the backing byte array of a message for fast reserialization.
      */
-    public BitcoinSerializer(NetworkParameters params, boolean parseLazy, boolean parseRetain) {
+    public BitcoinSerializer(NetworkParameters params, boolean parseRetain) {
         this.params = params;
-        this.parseLazy = parseLazy;
         this.parseRetain = parseRetain;
     }
 
@@ -368,14 +349,6 @@ public class BitcoinSerializer implements MessageSerializer {
                 magicCursor = 3;
             }
         }
-    }
-
-    /**
-     * Whether the serializer will produce lazy parse mode Messages
-     */
-    @Override
-    public boolean isParseLazyMode() {
-        return parseLazy;
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -93,9 +93,6 @@ public class Block extends Message {
     /** Stores the hash of the block. If null, getHash() will recalculate it. */
     private Sha256Hash hash;
 
-    protected boolean headerParsed;
-    protected boolean transactionsParsed;
-
     protected boolean headerBytesValid;
     protected boolean transactionBytesValid;
     
@@ -195,28 +192,6 @@ public class Block extends Message {
         return FIFTY_COINS.shiftRight(height / params.getSubsidyDecreaseBlockCount());
     }
 
-    protected void parseHeader() throws ProtocolException {
-        if (headerParsed)
-            return;
-
-        cursor = offset;
-        version = readUint32();
-        prevBlockHash = readHash();
-        merkleRoot = readHash();
-        time = readUint32();
-        difficultyTarget = readUint32();
-        nonce = readUint32();
-
-        hash = Sha256Hash.wrapReversed(Sha256Hash.hashTwice(payload, offset, cursor));
-
-        headerParsed = true;
-        headerBytesValid = serializer.isParseRetainMode();
-    }
-
-    protected void parseTransactions() throws ProtocolException {
-        parseTransactions(offset + HEADER_SIZE);
-    }
-
     /**
      * Parse transactions from the block.
      * 
@@ -225,14 +200,10 @@ public class Block extends Message {
      * size.
      */
     protected void parseTransactions(final int transactionsOffset) throws ProtocolException {
-        if (transactionsParsed)
-            return;
-
         cursor = transactionsOffset;
         optimalEncodingMessageSize = HEADER_SIZE;
         if (payload.length == cursor) {
             // This message is just a header, it has no transactions.
-            transactionsParsed = true;
             transactionBytesValid = false;
             return;
         }
@@ -248,158 +219,34 @@ public class Block extends Message {
             cursor += tx.getMessageSize();
             optimalEncodingMessageSize += tx.getOptimalEncodingMessageSize();
         }
-        // No need to set length here. If length was not provided then it should be set at the end of parseLight().
-        // If this is a genuine lazy parse then length must have been provided to the constructor.
-        transactionsParsed = true;
         transactionBytesValid = serializer.isParseRetainMode();
     }
 
     @Override
-    void parse() throws ProtocolException {
-        parseHeader();
-        parseTransactions();
+    protected void parse() throws ProtocolException {
+        // header
+        cursor = offset;
+        version = readUint32();
+        prevBlockHash = readHash();
+        merkleRoot = readHash();
+        time = readUint32();
+        difficultyTarget = readUint32();
+        nonce = readUint32();
+        hash = Sha256Hash.wrapReversed(Sha256Hash.hashTwice(payload, offset, cursor));
+        headerBytesValid = serializer.isParseRetainMode();
+
+        // transactions
+        parseTransactions(offset + HEADER_SIZE);
         length = cursor - offset;
     }
     
     public int getOptimalEncodingMessageSize() {
         if (optimalEncodingMessageSize != 0)
             return optimalEncodingMessageSize;
-        maybeParseTransactions();
         if (optimalEncodingMessageSize != 0)
             return optimalEncodingMessageSize;
         optimalEncodingMessageSize = bitcoinSerialize().length;
         return optimalEncodingMessageSize;
-    }
-
-    @Override
-    protected void parseLite() throws ProtocolException {
-        // Ignore the header since it has fixed length. If length is not provided we will have to
-        // invoke a light parse of transactions to calculate the length.
-        if (length == UNKNOWN_LENGTH) {
-            Preconditions.checkState(serializer.isParseLazyMode(),
-                    "Performing lite parse of block transaction as block was initialised from byte array " +
-                    "without providing length.  This should never need to happen.");
-            parseTransactions();
-            length = cursor - offset;
-        } else {
-            transactionBytesValid = !transactionsParsed || serializer.isParseRetainMode() && length > HEADER_SIZE;
-        }
-        headerBytesValid = !headerParsed || serializer.isParseRetainMode() && length >= HEADER_SIZE;
-    }
-
-    /*
-     * Block uses some special handling for lazy parsing and retention of cached bytes. Parsing and serializing the
-     * block header and the transaction list are both non-trivial so there are good efficiency gains to be had by
-     * separating them. There are many cases where a user may need to access or change one or the other but not both.
-     *
-     * With this in mind we ignore the inherited checkParse() and unCache() methods and implement a separate version
-     * of them for both header and transactions.
-     *
-     * Serializing methods are also handled in their own way. Whilst they deal with separate parts of the block structure
-     * there are some interdependencies. For example altering a tx requires invalidating the Merkle root and therefore
-     * the cached header bytes.
-     */
-    private void maybeParseHeader() {
-        if (headerParsed || payload == null)
-            return;
-        try {
-            parseHeader();
-            if (!(headerBytesValid || transactionBytesValid))
-                payload = null;
-        } catch (ProtocolException e) {
-            throw new LazyParseException(
-                    "ProtocolException caught during lazy parse.  For safe access to fields call ensureParsed before attempting read or write access",
-                    e);
-        }
-    }
-
-    private void maybeParseTransactions() {
-        if (transactionsParsed || payload == null)
-            return;
-        try {
-            parseTransactions();
-            if (!serializer.isParseRetainMode()) {
-                transactionBytesValid = false;
-                if (headerParsed)
-                    payload = null;
-            }
-        } catch (ProtocolException e) {
-            throw new LazyParseException(
-                    "ProtocolException caught during lazy parse.  For safe access to fields call ensureParsed before attempting read or write access",
-                    e);
-        }
-    }
-
-    /**
-     * Ensure the object is parsed if needed. This should be called in every getter before returning a value. If the
-     * lazy parse flag is not set this is a method returns immediately.
-     */
-    @Override
-    protected void maybeParse() {
-        throw new LazyParseException(
-                "checkParse() should never be called on a Block.  Instead use checkParseHeader() and checkParseTransactions()");
-    }
-
-    /**
-     * In lazy parsing mode access to getters and setters may throw an unchecked LazyParseException.  If guaranteed
-     * safe access is required this method will force parsing to occur immediately thus ensuring LazyParseExeption will
-     * never be thrown from this Message. If the Message contains child messages (e.g. a Block containing Transaction
-     * messages) this will not force child messages to parse.
-     *
-     * This method ensures parsing of both headers and transactions.
-     *
-     * @throws ProtocolException
-     */
-    @Override
-    public void ensureParsed() throws ProtocolException {
-        try {
-            maybeParseHeader();
-            maybeParseTransactions();
-        } catch (LazyParseException e) {
-            if (e.getCause() instanceof ProtocolException)
-                throw (ProtocolException) e.getCause();
-            throw new ProtocolException(e);
-        }
-    }
-
-    /**
-     * In lazy parsing mode access to getters and setters may throw an unchecked LazyParseException.  If guaranteed
-     * safe access is required this method will force parsing to occur immediately thus ensuring LazyParseExeption
-     * will never be thrown from this Message. If the Message contains child messages (e.g. a Block containing
-     * Transaction messages) this will not force child messages to parse.
-     *
-     * This method ensures parsing of headers only.
-     *
-     * @throws ProtocolException
-     */
-    public void ensureParsedHeader() throws ProtocolException {
-        try {
-            maybeParseHeader();
-        } catch (LazyParseException e) {
-            if (e.getCause() instanceof ProtocolException)
-                throw (ProtocolException) e.getCause();
-            throw new ProtocolException(e);
-        }
-    }
-
-    /**
-     * In lazy parsing mode access to getters and setters may throw an unchecked LazyParseException.  If guaranteed
-     * safe access is required this method will force parsing to occur immediately thus ensuring LazyParseExeption will
-     * never be thrown from this Message. If the Message contains child messages (e.g. a Block containing Transaction
-     * messages) this will not force child messages to parse.
-     *
-     * This method ensures parsing of transactions only.
-     *
-     * @throws ProtocolException
-     */
-    public void ensureParsedTransactions() throws ProtocolException {
-        try {
-            maybeParseTransactions();
-        } catch (LazyParseException e) {
-            if (e.getCause() instanceof ProtocolException)
-                throw (ProtocolException) e.getCause();
-            throw new ProtocolException(e);
-        }
     }
 
     // default for testing
@@ -410,7 +257,6 @@ public class Block extends Message {
             return;
         }
         // fall back to manual write
-        maybeParseHeader();
         Utils.uint32ToByteStreamLE(version, stream);
         stream.write(prevBlockHash.getReversedBytes());
         stream.write(getMerkleRoot().getReversedBytes());
@@ -422,7 +268,7 @@ public class Block extends Message {
     private void writeTransactions(OutputStream stream) throws IOException {
         // check for no transaction conditions first
         // must be a more efficient way to do this but I'm tired atm.
-        if (transactions == null && transactionsParsed) {
+        if (transactions == null) {
             return;
         }
 
@@ -509,7 +355,6 @@ public class Block extends Message {
     }
 
     private void unCacheHeader() {
-        maybeParseHeader();
         headerBytesValid = false;
         if (!transactionBytesValid)
             payload = null;
@@ -517,7 +362,6 @@ public class Block extends Message {
     }
 
     private void unCacheTransactions() {
-        maybeParseTransactions();
         transactionBytesValid = false;
         if (!headerBytesValid)
             payload = null;
@@ -584,7 +428,6 @@ public class Block extends Message {
 
     /** Returns a copy of the block, but without any transactions. */
     public Block cloneAsHeader() {
-        maybeParseHeader();
         Block block = new Block(params, BLOCK_VERSION_GENESIS);
         copyBitcoinHeaderTo(block);
         return block;
@@ -633,7 +476,6 @@ public class Block extends Message {
      * extraNonce.</p>
      */
     public void solve() {
-        maybeParseHeader();
         while (true) {
             try {
                 // Is our proof of work valid yet?
@@ -653,7 +495,6 @@ public class Block extends Message {
      * is thrown.
      */
     public BigInteger getDifficultyTargetAsInteger() throws VerificationException {
-        maybeParseHeader();
         BigInteger target = Utils.decodeCompactBits(difficultyTarget);
         if (target.signum() <= 0 || target.compareTo(params.maxTarget) > 0)
             throw new VerificationException("Difficulty target is bad: " + target.toString());
@@ -685,7 +526,6 @@ public class Block extends Message {
     }
 
     private void checkTimestamp() throws VerificationException {
-        maybeParseHeader();
         // Allow injection of a fake clock to allow unit testing.
         long currentTime = Utils.currentTimeSeconds();
         if (time > currentTime + ALLOWED_TIME_DRIFT)
@@ -747,7 +587,6 @@ public class Block extends Message {
         //    2     3    4  4
         //  / \   / \   / \
         // t1 t2 t3 t4 t5 t5
-        maybeParseTransactions();
         ArrayList<byte[]> tree = new ArrayList<byte[]>();
         // Start by adding all the hashes of the transactions as leaves of the tree.
         for (Transaction t : transactions) {
@@ -796,7 +635,6 @@ public class Block extends Message {
         //
         // Firstly we need to ensure this block does in fact represent real work done. If the difficulty is high
         // enough, it's probably been done by the network.
-        maybeParseHeader();
         checkProofOfWork(true);
         checkTimestamp();
     }
@@ -813,7 +651,6 @@ public class Block extends Message {
         // transactions that reference spent or non-existant inputs.
         if (transactions.isEmpty())
             throw new VerificationException("Block had no transactions");
-        maybeParseTransactions();
         if (this.getOptimalEncodingMessageSize() > MAX_BLOCK_SIZE)
             throw new VerificationException("Block larger than MAX_BLOCK_SIZE");
         checkTransactions();
@@ -847,7 +684,6 @@ public class Block extends Message {
      * Returns the merkle root in big endian form, calculating it from transactions if necessary.
      */
     public Sha256Hash getMerkleRoot() {
-        maybeParseHeader();
         if (merkleRoot == null) {
             //TODO check if this is really necessary.
             unCacheHeader();
@@ -888,7 +724,6 @@ public class Block extends Message {
 
     /** Returns the version of the block data structure as defined by the Bitcoin protocol. */
     public long getVersion() {
-        maybeParseHeader();
         return version;
     }
 
@@ -896,7 +731,6 @@ public class Block extends Message {
      * Returns the hash of the previous block in the chain, as defined by the block header.
      */
     public Sha256Hash getPrevBlockHash() {
-        maybeParseHeader();
         return prevBlockHash;
     }
 
@@ -911,7 +745,6 @@ public class Block extends Message {
      * is measured in seconds since the UNIX epoch (midnight Jan 1st 1970).
      */
     public long getTimeSeconds() {
-        maybeParseHeader();
         return time;
     }
 
@@ -938,7 +771,6 @@ public class Block extends Message {
      * Calculating the difficulty that way is currently unsupported.
      */
     public long getDifficultyTarget() {
-        maybeParseHeader();
         return difficultyTarget;
     }
 
@@ -954,7 +786,6 @@ public class Block extends Message {
      * difficulty target.
      */
     public long getNonce() {
-        maybeParseHeader();
         return nonce;
     }
 
@@ -968,7 +799,6 @@ public class Block extends Message {
     /** Returns an immutable list of transactions held in this block, or null if this object represents just a header. */
     @Nullable
     public List<Transaction> getTransactions() {
-        maybeParseTransactions();
         return transactions == null ? null : ImmutableList.copyOf(transactions);
     }
 
@@ -1085,16 +915,6 @@ public class Block extends Message {
     @VisibleForTesting
     Block createNextBlockWithCoinbase(byte[] pubKey) {
         return createNextBlock(null, 1, null, Utils.currentTimeSeconds(), pubKey, FIFTY_COINS);
-    }
-
-    @VisibleForTesting
-    boolean isParsedHeader() {
-        return headerParsed;
-    }
-
-    @VisibleForTesting
-    boolean isParsedTransactions() {
-        return transactionsParsed;
     }
 
     @VisibleForTesting

--- a/core/src/main/java/org/bitcoinj/core/BloomFilter.java
+++ b/core/src/main/java/org/bitcoinj/core/BloomFilter.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2012 Matt Corallo
+ * Copyright 2015 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,7 +131,7 @@ public class BloomFilter extends Message {
     }
 
     @Override
-    void parse() throws ProtocolException {
+    protected void parse() throws ProtocolException {
         data = readByteArray();
         if (data.length > MAX_FILTER_SIZE)
             throw new ProtocolException ("Bloom filter out of size range.");
@@ -152,11 +153,6 @@ public class BloomFilter extends Message {
         Utils.uint32ToByteStreamLE(hashFuncs, stream);
         Utils.uint32ToByteStreamLE(nTweak, stream);
         stream.write(nFlags);
-    }
-
-    @Override
-    protected void parseLite() throws ProtocolException {
-        // Do nothing, lazy parsing isn't useful for bloom filters.
     }
 
     private static int rotateLeft32(int x, int r) {

--- a/core/src/main/java/org/bitcoinj/core/DummySerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/DummySerializer.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.bitcoinj.core;
 
 import java.io.IOException;
@@ -45,11 +46,6 @@ class DummySerializer implements MessageSerializer {
     @Override
     public Message deserializePayload(BitcoinSerializer.BitcoinPacketHeader header, ByteBuffer in) throws UnsupportedOperationException {
         throw new UnsupportedOperationException(DEFAULT_EXCEPTION_MESSAGE);
-    }
-
-    @Override
-    public boolean isParseLazyMode() {
-        return false;
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/EmptyMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/EmptyMessage.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2011 Steve Coughlan.
+ * Copyright 2015 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.bitcoinj.core;
 
 import java.io.IOException;
@@ -43,31 +45,7 @@ public abstract class EmptyMessage extends Message {
     }
 
     @Override
-    public int getMessageSize() {
-        return 0;
-    }
-
-    /* (non-Javadoc)
-      * @see Message#parse()
-      */
-    @Override
-    void parse() throws ProtocolException {
-    }
-
-    /* (non-Javadoc)
-      * @see Message#parseLite()
-      */
-    @Override
-    protected void parseLite() throws ProtocolException {
-        length = 0;
-    }
-
-    /* (non-Javadoc)
-      * @see Message#ensureParsed()
-      */
-    @Override
-    public void ensureParsed() throws ProtocolException {
-        parsed = true;
+    protected void parse() throws ProtocolException {
     }
 
     /* (non-Javadoc)
@@ -77,6 +55,4 @@ public abstract class EmptyMessage extends Message {
     public byte[] bitcoinSerialize() {
         return new byte[0];
     }
-
-
 }

--- a/core/src/main/java/org/bitcoinj/core/FilteredBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/FilteredBlock.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2012 Matt Corallo
+ * Copyright 2015 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +58,7 @@ public class FilteredBlock extends Message {
     }
 
     @Override
-    void parse() throws ProtocolException {
+    protected void parse() throws ProtocolException {
         byte[] headerBytes = new byte[Block.HEADER_SIZE];
         System.arraycopy(payload, 0, headerBytes, 0, Block.HEADER_SIZE);
         header = params.getDefaultSerializer().makeBlock(headerBytes);
@@ -65,11 +66,6 @@ public class FilteredBlock extends Message {
         merkleTree = new PartialMerkleTree(params, payload, Block.HEADER_SIZE);
         
         length = Block.HEADER_SIZE + merkleTree.getMessageSize();
-    }
-    
-    @Override
-    protected void parseLite() throws ProtocolException {
-
     }
     
     /**

--- a/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2011 Google Inc.
+ * Copyright 2015 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,22 +44,13 @@ public class GetBlocksMessage extends Message {
     }
 
     @Override
-    protected void parseLite() throws ProtocolException {
+    protected void parse() throws ProtocolException {
         cursor = offset;
         version = readUint32();
         int startCount = (int) readVarInt();
         if (startCount > 500)
             throw new ProtocolException("Number of locators cannot be > 500, received: " + startCount);
         length = cursor - offset + ((startCount + 1) * 32);
-    }
-
-    @Override
-    public void parse() throws ProtocolException {
-        cursor = offset;
-        version = readUint32();
-        int startCount = (int) readVarInt();
-        if (startCount > 500)
-            throw new ProtocolException("Number of locators cannot be > 500, received: " + startCount);
         locator = new ArrayList<Sha256Hash>(startCount);
         for (int i = 0; i < startCount; i++) {
             locator.add(readHash());

--- a/core/src/main/java/org/bitcoinj/core/GetUTXOsMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetUTXOsMessage.java
@@ -79,11 +79,6 @@ public class GetUTXOsMessage extends Message {
     }
 
     @Override
-    protected void parseLite() throws ProtocolException {
-        // Not needed.
-    }
-
-    @Override
     void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         stream.write(new byte[]{includeMempool ? (byte) 1 : 0});  // include mempool.
         stream.write(new VarInt(outPoints.size()).encode());

--- a/core/src/main/java/org/bitcoinj/core/HeadersMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/HeadersMessage.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2011 Google Inc.
+ * Copyright 2015 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +63,7 @@ public class HeadersMessage extends Message {
     }
 
     @Override
-    protected void parseLite() throws ProtocolException {
+    protected void parse() throws ProtocolException {
         if (length == UNKNOWN_LENGTH) {
             int saveCursor = cursor;
             long numHeaders = readVarInt();
@@ -71,10 +72,7 @@ public class HeadersMessage extends Message {
             // Each header has 80 bytes and one more byte for transactions number which is 00.
             length = 81 * (int)numHeaders;
         }
-    }
 
-    @Override
-    void parse() throws ProtocolException {
         long numHeaders = readVarInt();
         if (numHeaders > MAX_HEADERS)
             throw new ProtocolException("Too many headers: got " + numHeaders + " which is larger than " +
@@ -88,7 +86,7 @@ public class HeadersMessage extends Message {
             byte[] blockHeader = readBytes(81);
             if (blockHeader[80] != 0)
                 throw new ProtocolException("Block header does not end with a null byte");
-            Block newBlockHeader = this.params.getSerializer(true, true)
+            Block newBlockHeader = this.params.getSerializer(true)
                 .makeBlock(blockHeader, 81);
             blockHeaders.add(newBlockHeader);
         }
@@ -99,7 +97,6 @@ public class HeadersMessage extends Message {
             }
         }
     }
-
 
     public List<Block> getBlockHeaders() {
         return blockHeaders;

--- a/core/src/main/java/org/bitcoinj/core/ListMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/ListMessage.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2011 Google Inc.
+ * Copyright 2015 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +50,6 @@ public abstract class ListMessage extends Message {
     }
 
     public List<InventoryItem> getItems() {
-        maybeParse();
         return Collections.unmodifiableList(items);
     }
 
@@ -68,15 +68,12 @@ public abstract class ListMessage extends Message {
     }
 
     @Override
-    protected void parseLite() throws ProtocolException {
+    protected void parse() throws ProtocolException {
         arrayLen = readVarInt();
         if (arrayLen > MAX_INVENTORY_ITEMS)
             throw new ProtocolException("Too many items in INV message: " + arrayLen);
         length = (int) (cursor - offset + (arrayLen * InventoryItem.MESSAGE_LENGTH));
-    }
 
-    @Override
-    public void parse() throws ProtocolException {
         // An inv is vector<CInv> where CInv is int+hash. The int is either 1 or 2 for tx or block.
         items = new ArrayList<InventoryItem>((int) arrayLen);
         for (int i = 0; i < arrayLen; i++) {

--- a/core/src/main/java/org/bitcoinj/core/MemoryPoolMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/MemoryPoolMessage.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2012 Google Inc.
+ * Copyright 2015 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,10 +29,7 @@ import java.io.OutputStream;
  */
 public class MemoryPoolMessage extends Message {
     @Override
-    void parse() throws ProtocolException {}
-
-    @Override
-    protected void parseLite() throws ProtocolException {}
+    protected void parse() throws ProtocolException {}
 
     @Override
     void bitcoinSerializeToStream(OutputStream stream) throws IOException {}

--- a/core/src/main/java/org/bitcoinj/core/MessageSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/MessageSerializer.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.bitcoinj.core;
 
 import java.io.IOException;
@@ -44,11 +45,6 @@ public interface MessageSerializer {
      * {@link BitcoinSerializer#deserializeHeader}.
      */
     Message deserializePayload(BitcoinSerializer.BitcoinPacketHeader header, ByteBuffer in) throws ProtocolException, BufferUnderflowException, UnsupportedOperationException;
-
-    /**
-     * Whether the serializer will produce lazy parse mode Messages
-     */
-    boolean isParseLazyMode();
 
     /**
      * Whether the serializer will produce cached mode Messages

--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -439,7 +439,7 @@ public abstract class NetworkParameters {
                     // As the serializers are intended to be immutable, creating
                     // two due to a race condition should not be a problem, however
                     // to be safe we ensure only one exists for each network.
-                    this.defaultSerializer = getSerializer(false, false);
+                    this.defaultSerializer = getSerializer(false);
                 }
             }
         }
@@ -449,7 +449,7 @@ public abstract class NetworkParameters {
     /**
      * Construct and return a custom serializer.
      */
-    public abstract BitcoinSerializer getSerializer(boolean parseLazy, boolean parseRetain);
+    public abstract BitcoinSerializer getSerializer(boolean parseRetain);
 
     /**
      * The number of blocks in the last {@link getMajorityWindow()} blocks

--- a/core/src/main/java/org/bitcoinj/core/PartialMerkleTree.java
+++ b/core/src/main/java/org/bitcoinj/core/PartialMerkleTree.java
@@ -1,6 +1,7 @@
 /**
  * Copyright 2012 The Bitcoin Developers
  * Copyright 2012 Matt Corallo
+ * Copyright 2015 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,7 +110,7 @@ public class PartialMerkleTree extends Message {
     }
 
     @Override
-    void parse() throws ProtocolException {
+    protected void parse() throws ProtocolException {
         transactionCount = (int)readUint32();
 
         int nHashes = (int) readVarInt();
@@ -167,11 +168,6 @@ public class PartialMerkleTree extends Message {
         return combineLeftRight(left.getBytes(), right.getBytes());
     }
 
-    @Override
-    protected void parseLite() {
-        
-    }
-    
     // helper function to efficiently calculate the number of nodes at given height in the merkle tree
     private static int getTreeWidth(int transactionCount, int height) {
         return (transactionCount + (1 << height) - 1) >> height;

--- a/core/src/main/java/org/bitcoinj/core/PeerAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerAddress.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2011 Google Inc.
+ * Copyright 2015 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,11 +64,7 @@ public class PeerAddress extends ChildMessage {
      */
     public PeerAddress(NetworkParameters params, byte[] payload, int offset, int protocolVersion, Message parent, MessageSerializer serializer) throws ProtocolException {
         super(params, payload, offset, protocolVersion, parent, serializer, UNKNOWN_LENGTH);
-        // Message length is calculated in parseLite which is guaranteed to be called before it is ever read.
-        // Even though message length is static for a PeerAddress it is safer to leave it there 
-        // as it will be set regardless of which constructor was used.
     }
-
 
     /**
      * Construct a peer address from a memorized or hardcoded address.
@@ -140,11 +137,6 @@ public class PeerAddress extends ChildMessage {
     }
 
     @Override
-    protected void parseLite() {
-        length = protocolVersion > 31402 ? MESSAGE_SIZE : MESSAGE_SIZE - 4;
-    }
-
-    @Override
     protected void parse() throws ProtocolException {
         // Format of a serialized address:
         //   uint32 timestamp
@@ -163,22 +155,15 @@ public class PeerAddress extends ChildMessage {
             throw new RuntimeException(e);  // Cannot happen.
         }
         port = ((0xFF & payload[cursor++]) << 8) | (0xFF & payload[cursor++]);
-    }
-
-    @Override
-    public int getMessageSize() {
         // The 4 byte difference is the uint32 timestamp that was introduced in version 31402 
         length = protocolVersion > 31402 ? MESSAGE_SIZE : MESSAGE_SIZE - 4;
-        return length;
     }
 
     public String getHostname() {
-        maybeParse();
         return hostname;
     }
 
     public InetAddress getAddr() {
-        maybeParse();
         return addr;
     }
 
@@ -191,42 +176,32 @@ public class PeerAddress extends ChildMessage {
         this.addr = addr;
     }
 
-
     public int getPort() {
-        maybeParse();
         return port;
     }
-
 
     public void setPort(int port) {
         unCache();
         this.port = port;
     }
 
-
     public BigInteger getServices() {
-        maybeParse();
         return services;
     }
-
 
     public void setServices(BigInteger services) {
         unCache();
         this.services = services;
     }
 
-
     public long getTime() {
-        maybeParse();
         return time;
     }
-
 
     public void setTime(long time) {
         unCache();
         this.time = time;
     }
-
 
     @Override
     public String toString() {

--- a/core/src/main/java/org/bitcoinj/core/Ping.java
+++ b/core/src/main/java/org/bitcoinj/core/Ping.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2011 Noa Resare
+ * Copyright 2015 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +52,7 @@ public class Ping extends Message {
     }
 
     @Override
-    void parse() throws ProtocolException {
+    protected void parse() throws ProtocolException {
         try {
             nonce = readInt64();
             hasNonce = true;
@@ -59,11 +60,6 @@ public class Ping extends Message {
             hasNonce = false;
         }
         length = hasNonce ? 8 : 0;
-    }
-    
-    @Override
-    protected void parseLite() {
-        
     }
     
     public boolean hasNonce() {

--- a/core/src/main/java/org/bitcoinj/core/Pong.java
+++ b/core/src/main/java/org/bitcoinj/core/Pong.java
@@ -1,5 +1,6 @@
 /**
  * Copyright 2012 Matt Corallo
+ * Copyright 2015 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +39,7 @@ public class Pong extends Message {
     }
     
     @Override
-    void parse() throws ProtocolException {
+    protected void parse() throws ProtocolException {
         nonce = readInt64();
         length = 8;
     }
@@ -48,10 +49,6 @@ public class Pong extends Message {
         Utils.int64ToByteStreamLE(nonce, stream);
     }
     
-    @Override
-    protected void parseLite() {
-    }
-
     /** Returns the nonce sent by the remote peer. */
     public long getNonce() {
         return nonce;

--- a/core/src/main/java/org/bitcoinj/core/RejectMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/RejectMessage.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2013 Matt Corallo
+ * Copyright 2015 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,19 +83,13 @@ public class RejectMessage extends Message {
     }
 
     @Override
-    protected void parseLite() throws ProtocolException {
+    protected void parse() throws ProtocolException {
         message = readStr();
         code = RejectCode.fromCode(readBytes(1)[0]);
         reason = readStr();
         if (message.equals("block") || message.equals("tx"))
             messageHash = readHash();
         length = cursor - offset;
-    }
-
-    @Override
-    public void parse() throws ProtocolException {
-        if (length == UNKNOWN_LENGTH)
-            parseLite();
     }
 
     @Override
@@ -115,7 +110,6 @@ public class RejectMessage extends Message {
      * Note that this is ENTIRELY UNTRUSTED and should be sanity-checked before it is printed or processed.
      */
     public String getRejectedMessage() {
-        ensureParsed();
         return message;
     }
 
@@ -123,7 +117,6 @@ public class RejectMessage extends Message {
      * Provides the hash of the rejected object (if getRejectedMessage() is either "tx" or "block"), otherwise null.
      */
     public Sha256Hash getRejectedObjectHash() {
-        ensureParsed();
         return messageHash;
     }
 

--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -25,7 +25,6 @@ import com.google.common.base.Objects;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.lang.ref.WeakReference;
 import java.util.Arrays;
@@ -126,18 +125,11 @@ public class TransactionInput extends ChildMessage {
     }
 
     @Override
-    protected void parseLite() throws ProtocolException {
-        int curs = cursor;
-        int scriptLen = (int) readVarInt(36);
-        length = cursor - offset + scriptLen + 4;
-        cursor = curs;
-    }
-
-    @Override
-    void parse() throws ProtocolException {
+    protected void parse() throws ProtocolException {
         outpoint = new TransactionOutPoint(params, payload, cursor, this, serializer);
         cursor += outpoint.getMessageSize();
         int scriptLen = (int) readVarInt();
+        length = cursor - offset + scriptLen + 4;
         scriptBytes = readBytes(scriptLen);
         sequence = readUint32();
     }
@@ -154,7 +146,6 @@ public class TransactionInput extends ChildMessage {
      * Coinbase transactions have special inputs with hashes of zero. If this is such an input, returns true.
      */
     public boolean isCoinBase() {
-        maybeParse();
         return outpoint.getHash().equals(Sha256Hash.ZERO_HASH) &&
                 (outpoint.getIndex() & 0xFFFFFFFFL) == 0xFFFFFFFFL;  // -1 but all is serialized to the wire as unsigned int.
     }
@@ -168,7 +159,6 @@ public class TransactionInput extends ChildMessage {
         // parameter is overloaded to be something totally different.
         Script script = scriptSig == null ? null : scriptSig.get();
         if (script == null) {
-            maybeParse();
             script = new Script(scriptBytes);
             scriptSig = new WeakReference<Script>(script);
         }
@@ -204,7 +194,6 @@ public class TransactionInput extends ChildMessage {
      * feature is disabled so sequence numbers are unusable.
      */
     public long getSequenceNumber() {
-        maybeParse();
         return sequence;
     }
 
@@ -225,7 +214,6 @@ public class TransactionInput extends ChildMessage {
      * data needed to connect to the output of the transaction we're gathering coins from.
      */
     public TransactionOutPoint getOutpoint() {
-        maybeParse();
         return outpoint;
     }
 
@@ -236,7 +224,6 @@ public class TransactionInput extends ChildMessage {
      * @return the scriptBytes
      */
     public byte[] getScriptBytes() {
-        maybeParse();
         return scriptBytes;
     }
 

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2011 Google Inc.
+ * Copyright 2015 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,22 +89,10 @@ public class TransactionOutPoint extends ChildMessage {
     }
 
     @Override
-    protected void parseLite() throws ProtocolException {
+    protected void parse() throws ProtocolException {
         length = MESSAGE_LENGTH;
-    }
-
-    @Override
-    void parse() throws ProtocolException {
         hash = readHash();
         index = readUint32();
-    }
-
-    /* (non-Javadoc)
-      * @see Message#getMessageSize()
-      */
-    @Override
-    public int getMessageSize() {
-        return MESSAGE_LENGTH;
     }
 
     @Override
@@ -197,7 +186,6 @@ public class TransactionOutPoint extends ChildMessage {
      */
     @Override
     public Sha256Hash getHash() {
-        maybeParse();
         return hash;
     }
 
@@ -206,7 +194,6 @@ public class TransactionOutPoint extends ChildMessage {
     }
 
     public long getIndex() {
-        maybeParse();
         return index;
     }
     

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -110,7 +110,6 @@ public class TransactionOutput extends ChildMessage {
 
     public Script getScriptPubKey() throws ScriptException {
         if (scriptPubKey == null) {
-            maybeParse();
             scriptPubKey = new Script(scriptBytes);
         }
         return scriptPubKey;
@@ -154,21 +153,16 @@ public class TransactionOutput extends ChildMessage {
     }
 
     @Override
-    protected void parseLite() throws ProtocolException {
+    protected void parse() throws ProtocolException {
         value = readInt64();
         scriptLen = (int) readVarInt();
         length = cursor - offset + scriptLen;
-    }
-
-    @Override
-    void parse() throws ProtocolException {
         scriptBytes = readBytes(scriptLen);
     }
 
     @Override
     protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         checkNotNull(scriptBytes);
-        maybeParse();
         Utils.int64ToByteStreamLE(value, stream);
         // TODO: Move script serialization into the Script class, where it belongs.
         stream.write(new VarInt(scriptBytes.length).encode());
@@ -180,7 +174,6 @@ public class TransactionOutput extends ChildMessage {
      * receives.
      */
     public Coin getValue() {
-        maybeParse();
         try {
             return Coin.valueOf(value);
         } catch (IllegalArgumentException e) {
@@ -286,7 +279,6 @@ public class TransactionOutput extends ChildMessage {
      * @return the scriptBytes
     */
     public byte[] getScriptBytes() {
-        maybeParse();
         return scriptBytes;
     }
 

--- a/core/src/main/java/org/bitcoinj/core/UTXOsMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/UTXOsMessage.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.bitcoinj.core;
 
 import com.google.common.base.Objects;
@@ -90,7 +91,7 @@ public class UTXOsMessage extends Message {
     }
 
     @Override
-    void parse() throws ProtocolException {
+    protected void parse() throws ProtocolException {
         // Format is:
         //   uint32 chainHeight
         //   uint256 chainHeadHash
@@ -121,11 +122,6 @@ public class UTXOsMessage extends Message {
             cursor += output.length;
         }
         length = cursor;
-    }
-
-    @Override
-    protected void parseLite() throws ProtocolException {
-        // Not used.
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/VersionMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionMessage.java
@@ -114,16 +114,7 @@ public class VersionMessage extends Message {
     }
 
     @Override
-    protected void parseLite() throws ProtocolException {
-        // NOP.  VersionMessage is never lazy parsed.
-    }
-
-    @Override
-    public void parse() throws ProtocolException {
-        if (parsed)
-            return;
-        parsed = true;
-
+    protected void parse() throws ProtocolException {
         clientVersion = (int) readUint32();
         localServices = readUint64().longValue();
         time = readUint64().longValue();

--- a/core/src/main/java/org/bitcoinj/params/AbstractBitcoinNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/AbstractBitcoinNetParams.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2013 Google Inc.
+ * Copyright 2015 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +32,6 @@ import org.bitcoinj.store.BlockStoreException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.google.common.base.Preconditions.checkState;
 import org.bitcoinj.core.BitcoinSerializer;
 
 /**
@@ -137,8 +137,8 @@ public abstract class AbstractBitcoinNetParams extends NetworkParameters {
     }
 
     @Override
-    public BitcoinSerializer getSerializer(boolean parseLazy, boolean parseRetain) {
-        return new BitcoinSerializer(this, parseLazy, parseRetain);
+    public BitcoinSerializer getSerializer(boolean parseRetain) {
+        return new BitcoinSerializer(this, parseRetain);
     }
 
     @Override

--- a/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
@@ -30,10 +30,10 @@ import static org.bitcoinj.core.Utils.HEX;
 import static org.junit.Assert.*;
 
 public class BitcoinSerializerTest {
-    private final byte[] addrMessage = HEX.decode("f9beb4d96164647200000000000000001f000000" +
+    private static final byte[] ADDRESS_MESSAGE_BYTES = HEX.decode("f9beb4d96164647200000000000000001f000000" +
             "ed52399b01e215104d010000000000000000000000000000000000ffff0a000001208d");
 
-    private final byte[] txMessage = HEX.withSeparator(" ", 2).decode(
+    private static final byte[] TRANSACTION_MESSAGE_BYTES = HEX.withSeparator(" ", 2).decode(
             "f9 be b4 d9 74 78 00 00  00 00 00 00 00 00 00 00" +
             "02 01 00 00 e2 93 cd be  01 00 00 00 01 6d bd db" +
             "08 5b 1d 8a f7 51 84 f0  bc 01 fa d5 8d 12 66 e9" +
@@ -55,21 +55,21 @@ public class BitcoinSerializerTest {
 
     @Test
     public void testAddr() throws Exception {
-        MessageSerializer bs = MainNetParams.get().getDefaultSerializer();
+        MessageSerializer serializer = MainNetParams.get().getDefaultSerializer();
         // the actual data from https://en.bitcoin.it/wiki/Protocol_specification#addr
-        AddressMessage a = (AddressMessage)bs.deserialize(ByteBuffer.wrap(addrMessage));
-        assertEquals(1, a.getAddresses().size());
-        PeerAddress pa = a.getAddresses().get(0);
-        assertEquals(8333, pa.getPort());
-        assertEquals("10.0.0.1", pa.getAddr().getHostAddress());
-        ByteArrayOutputStream bos = new ByteArrayOutputStream(addrMessage.length);
-        bs.serialize(a, bos);
+        AddressMessage addressMessage = (AddressMessage) serializer.deserialize(ByteBuffer.wrap(ADDRESS_MESSAGE_BYTES));
+        assertEquals(1, addressMessage.getAddresses().size());
+        PeerAddress peerAddress = addressMessage.getAddresses().get(0);
+        assertEquals(8333, peerAddress.getPort());
+        assertEquals("10.0.0.1", peerAddress.getAddr().getHostAddress());
+        ByteArrayOutputStream bos = new ByteArrayOutputStream(ADDRESS_MESSAGE_BYTES.length);
+        serializer.serialize(addressMessage, bos);
 
-        assertEquals(31, a.getMessageSize());
-        a.addAddress(new PeerAddress(InetAddress.getLocalHost()));
-        assertEquals(61, a.getMessageSize());
-        a.removeAddress(0);
-        assertEquals(31, a.getMessageSize());
+        assertEquals(31, addressMessage.getMessageSize());
+        addressMessage.addAddress(new PeerAddress(InetAddress.getLocalHost()));
+        assertEquals(61, addressMessage.getMessageSize());
+        addressMessage.removeAddress(0);
+        assertEquals(31, addressMessage.getMessageSize());
 
         //this wont be true due to dynamic timestamps.
         //assertTrue(LazyParseByteCacheTest.arrayContains(bos.toByteArray(), addrMessage));
@@ -77,56 +77,56 @@ public class BitcoinSerializerTest {
 
     @Test
     public void testCachedParsing() throws Exception {
-        MessageSerializer bs = MainNetParams.get().getSerializer(true);
+        MessageSerializer serializer = MainNetParams.get().getSerializer(true);
         
         // first try writing to a fields to ensure uncaching and children are not affected
-        Transaction tx = (Transaction)bs.deserialize(ByteBuffer.wrap(txMessage));
-        assertNotNull(tx);
-        assertEquals(true, tx.isCached());
+        Transaction transaction = (Transaction) serializer.deserialize(ByteBuffer.wrap(TRANSACTION_MESSAGE_BYTES));
+        assertNotNull(transaction);
+        assertTrue(transaction.isCached());
 
-        tx.setLockTime(1);
+        transaction.setLockTime(1);
         // parent should have been uncached
-        assertEquals(false, tx.isCached());
+        assertFalse(transaction.isCached());
         // child should remain cached.
-        assertEquals(true, tx.getInputs().get(0).isCached());
+        assertTrue(transaction.getInputs().get(0).isCached());
 
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        bs.serialize(tx, bos);
-        assertEquals(true, !Arrays.equals(txMessage, bos.toByteArray()));
+        serializer.serialize(transaction, bos);
+        assertFalse(Arrays.equals(TRANSACTION_MESSAGE_BYTES, bos.toByteArray()));
 
         // now try writing to a child to ensure uncaching is propagated up to parent but not to siblings
-        tx = (Transaction)bs.deserialize(ByteBuffer.wrap(txMessage));
-        assertNotNull(tx);
-        assertEquals(true, tx.isCached());
+        transaction = (Transaction) serializer.deserialize(ByteBuffer.wrap(TRANSACTION_MESSAGE_BYTES));
+        assertNotNull(transaction);
+        assertTrue(transaction.isCached());
 
-        tx.getInputs().get(0).setSequenceNumber(1);
+        transaction.getInputs().get(0).setSequenceNumber(1);
         // parent should have been uncached
-        assertEquals(false, tx.isCached());
+        assertFalse(transaction.isCached());
         // so should child
-        assertEquals(false, tx.getInputs().get(0).isCached());
+        assertFalse(transaction.getInputs().get(0).isCached());
 
         bos = new ByteArrayOutputStream();
-        bs.serialize(tx, bos);
-        assertEquals(true, !Arrays.equals(txMessage, bos.toByteArray()));
+        serializer.serialize(transaction, bos);
+        assertFalse(Arrays.equals(TRANSACTION_MESSAGE_BYTES, bos.toByteArray()));
 
         // deserialize/reserialize to check for equals.
-        tx = (Transaction)bs.deserialize(ByteBuffer.wrap(txMessage));
-        assertNotNull(tx);
-        assertEquals(true, tx.isCached());
+        transaction = (Transaction) serializer.deserialize(ByteBuffer.wrap(TRANSACTION_MESSAGE_BYTES));
+        assertNotNull(transaction);
+        assertTrue(transaction.isCached());
         bos = new ByteArrayOutputStream();
-        bs.serialize(tx, bos);
-        assertEquals(true, Arrays.equals(txMessage, bos.toByteArray()));
+        serializer.serialize(transaction, bos);
+        assertTrue(Arrays.equals(TRANSACTION_MESSAGE_BYTES, bos.toByteArray()));
 
         // deserialize/reserialize to check for equals.  Set a field to it's existing value to trigger uncache
-        tx = (Transaction)bs.deserialize(ByteBuffer.wrap(txMessage));
-        assertNotNull(tx);
-        assertEquals(true, tx.isCached());
+        transaction = (Transaction) serializer.deserialize(ByteBuffer.wrap(TRANSACTION_MESSAGE_BYTES));
+        assertNotNull(transaction);
+        assertTrue(transaction.isCached());
 
-        tx.getInputs().get(0).setSequenceNumber(tx.getInputs().get(0).getSequenceNumber());
+        transaction.getInputs().get(0).setSequenceNumber(transaction.getInputs().get(0).getSequenceNumber());
 
         bos = new ByteArrayOutputStream();
-        bs.serialize(tx, bos);
-        assertEquals(true, Arrays.equals(txMessage, bos.toByteArray()));
+        serializer.serialize(transaction, bos);
+        assertTrue(Arrays.equals(TRANSACTION_MESSAGE_BYTES, bos.toByteArray()));
     }
 
     /**
@@ -134,43 +134,35 @@ public class BitcoinSerializerTest {
      */
     @Test
     public void testHeaders1() throws Exception {
-        MessageSerializer bs = MainNetParams.get().getDefaultSerializer();
+        MessageSerializer serializer = MainNetParams.get().getDefaultSerializer();
 
-        String headersMessageBytesHex = "f9beb4d9686561" +
+        byte[] headersMessageBytes = HEX.decode("f9beb4d9686561" +
                 "646572730000000000520000005d4fab8101010000006fe28c0ab6f1b372c1a6a246ae6" +
                 "3f74f931e8365e15a089c68d6190000000000982051fd1e4ba744bbbe680e1fee14677b" +
-                "a1a3c3540bf7b1cdb606e857233e0e61bc6649ffff001d01e3629900";
-        byte[] headersMessageBytes = HEX.decode(headersMessageBytesHex);
-        HeadersMessage hm = (HeadersMessage) bs.deserialize(ByteBuffer.wrap(headersMessageBytes));
+                "a1a3c3540bf7b1cdb606e857233e0e61bc6649ffff001d01e3629900");
+        HeadersMessage headersMessage = (HeadersMessage) serializer.deserialize(ByteBuffer.wrap(headersMessageBytes));
 
         // The first block after the genesis
         // http://blockexplorer.com/b/1
-        Block block = hm.getBlockHeaders().get(0);
-        String hash = block.getHashAsString();
-        assertEquals(hash, "00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048");
-
+        Block block = headersMessage.getBlockHeaders().get(0);
+        assertEquals("00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048", block.getHashAsString());
         assertNotNull(block.transactions);
-
-        assertEquals(Utils.HEX.encode(block.getMerkleRoot().getBytes()),
-                "0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098");
+        assertEquals("0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098", Utils.HEX.encode(block.getMerkleRoot().getBytes()));
 
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        bs.serialize(hm, byteArrayOutputStream);
+        serializer.serialize(headersMessage, byteArrayOutputStream);
         byte[] serializedBytes = byteArrayOutputStream.toByteArray();
-        String serializedBytesHex = HEX.encode(serializedBytes);
-        assertEquals(headersMessageBytes.length, serializedBytes.length);
-        assertEquals(true, Arrays.equals(headersMessageBytes, serializedBytes));
+        assertArrayEquals(headersMessageBytes, serializedBytes);
     }
 
-
-    @Test
     /**
      * Get 6 headers of blocks 1-6 in the chain
      */
+    @Test
     public void testHeaders2() throws Exception {
-        MessageSerializer bs = MainNetParams.get().getDefaultSerializer();
+        MessageSerializer serializer = MainNetParams.get().getDefaultSerializer();
 
-        String headersMessageBytesHex = "f9beb4d96865616465" +
+        byte[] headersMessageBytes = HEX.decode("f9beb4d96865616465" +
                 "72730000000000e701000085acd4ea06010000006fe28c0ab6f1b372c1a6a246ae63f74f931e" +
                 "8365e15a089c68d6190000000000982051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1c" +
                 "db606e857233e0e61bc6649ffff001d01e3629900010000004860eb18bf1b1620e37e9490fc8a" +
@@ -183,91 +175,63 @@ public class BitcoinSerializerTest {
                 "a88d221c8bd6c059da090e88f8a2c99690ee55dbba4e00000000e11c48fecdd9e72510ca84f023" +
                 "370c9a38bf91ac5cae88019bee94d24528526344c36649ffff001d1d03e4770001000000fc33f5" +
                 "96f822a0a1951ffdbf2a897b095636ad871707bf5d3162729b00000000379dfb96a5ea8c81700ea4" +
-                "ac6b97ae9a9312b2d4301a29580e924ee6761a2520adc46649ffff001d189c4c9700";
-        byte[] headersMessageBytes = HEX.decode(headersMessageBytesHex);
-        HeadersMessage hm = (HeadersMessage) bs.deserialize(ByteBuffer.wrap(headersMessageBytes));
+                "ac6b97ae9a9312b2d4301a29580e924ee6761a2520adc46649ffff001d189c4c9700");
+        HeadersMessage headersMessage = (HeadersMessage) serializer.deserialize(ByteBuffer.wrap(headersMessageBytes));
 
-        int nBlocks = hm.getBlockHeaders().size();
-        assertEquals(nBlocks, 6);
+        assertEquals(6, headersMessage.getBlockHeaders().size());
 
         // index 0 block is the number 1 block in the block chain
         // http://blockexplorer.com/b/1
-        Block zeroBlock = hm.getBlockHeaders().get(0);
-        String zeroBlockHash = zeroBlock.getHashAsString();
-
+        Block zeroBlock = headersMessage.getBlockHeaders().get(0);
         assertEquals("00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048",
-                zeroBlockHash);
-        assertEquals(zeroBlock.getNonce(), 2573394689L);
-
-
-        Block thirdBlock = hm.getBlockHeaders().get(3);
-        String thirdBlockHash = thirdBlock.getHashAsString();
+                zeroBlock.getHashAsString());
+        assertEquals(2573394689L, zeroBlock.getNonce());
 
         // index 3 block is the number 4 block in the block chain
         // http://blockexplorer.com/b/4
+        Block thirdBlock = headersMessage.getBlockHeaders().get(3);
         assertEquals("000000004ebadb55ee9096c9a2f8880e09da59c0d68b1c228da88e48844a1485",
-                thirdBlockHash);
-        assertEquals(thirdBlock.getNonce(), 2850094635L);
+                thirdBlock.getHashAsString());
+        assertEquals(2850094635L, thirdBlock.getNonce());
 
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        bs.serialize(hm, byteArrayOutputStream);
+        serializer.serialize(headersMessage, byteArrayOutputStream);
         byte[] serializedBytes = byteArrayOutputStream.toByteArray();
-        assertEquals(headersMessageBytes.length, serializedBytes.length);
-        assertEquals(true, Arrays.equals(headersMessageBytes, serializedBytes));
+        assertArrayEquals(headersMessageBytes, serializedBytes);
     }
 
-    @Test
-    public void testBitcoinPacketHeader() {
-        try {
-            new BitcoinSerializer.BitcoinPacketHeader(ByteBuffer.wrap(new byte[]{0}));
-            fail();
-        } catch (BufferUnderflowException e) {
-        }
+    @Test(expected = BufferUnderflowException.class)
+    public void testBitcoinPacketHeaderTooShort() {
+        new BitcoinSerializer.BitcoinPacketHeader(ByteBuffer.wrap(new byte[] { 0 }));
+    }
 
+    @Test(expected = ProtocolException.class)
+    public void testBitcoinPacketHeaderTooLong() {
         // Message with a Message size which is 1 too big, in little endian format.
         byte[] wrongMessageLength = HEX.decode("000000000000000000000000010000020000000000");
-        try {
-            new BitcoinSerializer.BitcoinPacketHeader(ByteBuffer.wrap(wrongMessageLength));
-            fail();
-        } catch (ProtocolException e) {
-            // expected
-        }
+        new BitcoinSerializer.BitcoinPacketHeader(ByteBuffer.wrap(wrongMessageLength));
     }
 
-    @Test
+    @Test(expected = BufferUnderflowException.class)
     public void testSeekPastMagicBytes() {
         // Fail in another way, there is data in the stream but no magic bytes.
         byte[] brokenMessage = HEX.decode("000000");
-        try {
-            MainNetParams.get().getDefaultSerializer().seekPastMagicBytes(ByteBuffer.wrap(brokenMessage));
-            fail();
-        } catch (BufferUnderflowException e) {
-            // expected
-        }
+        MainNetParams.get().getDefaultSerializer().seekPastMagicBytes(ByteBuffer.wrap(brokenMessage));
     }
 
-    @Test
     /**
      * Tests serialization of an unknown message.
      */
-    public void testSerializeUnknownMessage() {
-        MessageSerializer bs = MainNetParams.get().getDefaultSerializer();
+    @Test(expected = Error.class)
+    public void testSerializeUnknownMessage() throws Exception {
+        MessageSerializer serializer = MainNetParams.get().getDefaultSerializer();
 
-        UnknownMessage a = new UnknownMessage();
-        ByteArrayOutputStream bos = new ByteArrayOutputStream(addrMessage.length);
-        try {
-            bs.serialize(a, bos);
-            fail();
-        } catch (Throwable e) {
-        }
-    }
-
-    /**
-     * Unknown message for testSerializeUnknownMessage.
-     */
-    class UnknownMessage extends Message {
-        @Override
-        protected void parse() throws ProtocolException {
-        }
+        Message unknownMessage = new Message() {
+            @Override
+            protected void parse() throws ProtocolException {
+            }
+        };
+        ByteArrayOutputStream bos = new ByteArrayOutputStream(ADDRESS_MESSAGE_BYTES.length);
+        serializer.serialize(unknownMessage, bos);
     }
 }

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -1218,7 +1218,7 @@ public class FullBlockTestGenerator {
 
             for (Transaction transaction : b64Original.block.getTransactions())
                 transaction.bitcoinSerialize(stream);
-            b64 = params.getSerializer(false, true).makeBlock(stream.toByteArray(), stream.size());
+            b64 = params.getSerializer(true).makeBlock(stream.toByteArray(), stream.size());
 
             // The following checks are checking to ensure block serialization functions in the way needed for this test
             // If they fail, it is likely not an indication of error, but an indication that this test needs rewritten

--- a/core/src/test/java/org/bitcoinj/core/MessageTest.java
+++ b/core/src/test/java/org/bitcoinj/core/MessageTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2014 Piotr Włodarek
+ * Copyright 2015 Andreas Schildbach
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,12 +37,9 @@ public class MessageTest {
         }
 
         @Override
-        void parse() throws ProtocolException {
+        protected void parse() throws ProtocolException {
             readStr();
         }
-
-        @Override
-        protected void parseLite() throws ProtocolException {}
     }
 
     // If readBytes() is vulnerable this causes OutOfMemory
@@ -59,12 +57,8 @@ public class MessageTest {
         }
 
         @Override
-        void parse() throws ProtocolException {
+        protected void parse() throws ProtocolException {
             readByteArray();
         }
-
-        @Override
-        protected void parseLite() throws ProtocolException {}
     }
-
 }


### PR DESCRIPTION
In particular:

* Message.parsed: removed
* Message.parseLite(): folded into Message.parse()
* Message.maybeParse(): removed
* Message.ensureParsed(): removed
* Message.isParsed(): removed
* Block.parseHeader(): folded into Block.parse()
* Block.parseTransactions(): folded into Block.parse()
* Block.maybeParseHeader(): removed
* Block.maybeParseTransactions(): removed
* Block.ensureParsedHeader(): removed
* Block.ensureParsedTransactions(): removed
* Block.isParsedHeader(): removed
* Block.isParsedTransasctions(): removed
* MessageSerializer.isParseLazyMode(): removed
* BitcoinSerializer.parseLazy: removed
* BitcoinSerializer.getSerializer(): parseLazy parameter removed
* LazyParseException: removed
* LazyParseByteCacheTest: renamed to ParseByteCacheTest