### PR TITLE
Name change: ProtobufParser -> ProtobufConnection

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -18,6 +18,7 @@ package org.bitcoinj.core;
 
 import com.google.common.base.*;
 import com.google.common.base.Objects;
+import org.bitcoinj.net.StreamConnection;
 import org.bitcoinj.core.listeners.PeerConnectionEventListener;
 import org.bitcoinj.core.listeners.PeerDataEventListener;
 import org.bitcoinj.store.BlockStore;
@@ -162,9 +163,9 @@ public class Peer extends PeerSocketHandler {
      *
      * <p>Note that this does <b>NOT</b> make a connection to the given remoteAddress, it only creates a handler for a
      * connection. If you want to create a one-off connection, create a Peer and pass it to
-     * {@link org.bitcoinj.net.NioClientManager#openConnection(java.net.SocketAddress, org.bitcoinj.net.StreamParser)}
+     * {@link org.bitcoinj.net.NioClientManager#openConnection(java.net.SocketAddress, StreamConnection)}
      * or
-     * {@link org.bitcoinj.net.NioClient#NioClient(java.net.SocketAddress, org.bitcoinj.net.StreamParser, int)}.</p>
+     * {@link org.bitcoinj.net.NioClient#NioClient(java.net.SocketAddress, StreamConnection, int)}.</p>
      *
      * <p>The remoteAddress provided should match the remote address of the peer which is being connected to, and is
      * used to keep track of which peers relayed transactions and offer more descriptive logging.</p>
@@ -180,9 +181,9 @@ public class Peer extends PeerSocketHandler {
      *
      * <p>Note that this does <b>NOT</b> make a connection to the given remoteAddress, it only creates a handler for a
      * connection. If you want to create a one-off connection, create a Peer and pass it to
-     * {@link org.bitcoinj.net.NioClientManager#openConnection(java.net.SocketAddress, org.bitcoinj.net.StreamParser)}
+     * {@link org.bitcoinj.net.NioClientManager#openConnection(java.net.SocketAddress, StreamConnection)}
      * or
-     * {@link org.bitcoinj.net.NioClient#NioClient(java.net.SocketAddress, org.bitcoinj.net.StreamParser, int)}.</p>
+     * {@link org.bitcoinj.net.NioClient#NioClient(java.net.SocketAddress, StreamConnection, int)}.</p>
      *
      * <p>The remoteAddress provided should match the remote address of the peer which is being connected to, and is
      * used to keep track of which peers relayed transactions and offer more descriptive logging.</p>
@@ -199,9 +200,9 @@ public class Peer extends PeerSocketHandler {
      *
      * <p>Note that this does <b>NOT</b> make a connection to the given remoteAddress, it only creates a handler for a
      * connection. If you want to create a one-off connection, create a Peer and pass it to
-     * {@link org.bitcoinj.net.NioClientManager#openConnection(java.net.SocketAddress, org.bitcoinj.net.StreamParser)}
+     * {@link org.bitcoinj.net.NioClientManager#openConnection(java.net.SocketAddress, StreamConnection)}
      * or
-     * {@link org.bitcoinj.net.NioClient#NioClient(java.net.SocketAddress, org.bitcoinj.net.StreamParser, int)}.</p>
+     * {@link org.bitcoinj.net.NioClient#NioClient(java.net.SocketAddress, StreamConnection, int)}.</p>
      *
      * <p>The remoteAddress provided should match the remote address of the peer which is being connected to, and is
      * used to keep track of which peers relayed transactions and offer more descriptive logging.</p>
@@ -232,9 +233,9 @@ public class Peer extends PeerSocketHandler {
      *
      * <p>Note that this does <b>NOT</b> make a connection to the given remoteAddress, it only creates a handler for a
      * connection. If you want to create a one-off connection, create a Peer and pass it to
-     * {@link org.bitcoinj.net.NioClientManager#openConnection(java.net.SocketAddress, org.bitcoinj.net.StreamParser)}
+     * {@link org.bitcoinj.net.NioClientManager#openConnection(java.net.SocketAddress, StreamConnection)}
      * or
-     * {@link org.bitcoinj.net.NioClient#NioClient(java.net.SocketAddress, org.bitcoinj.net.StreamParser, int)}.</p>
+     * {@link org.bitcoinj.net.NioClient#NioClient(java.net.SocketAddress, StreamConnection, int)}.</p>
      *
      * <p>The remoteAddress provided should match the remote address of the peer which is being connected to, and is
      * used to keep track of which peers relayed transactions and offer more descriptive logging.</p>

--- a/core/src/main/java/org/bitcoinj/core/PeerSocketHandler.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerSocketHandler.java
@@ -18,7 +18,7 @@ package org.bitcoinj.core;
 
 import org.bitcoinj.net.AbstractTimeoutHandler;
 import org.bitcoinj.net.MessageWriteTarget;
-import org.bitcoinj.net.StreamParser;
+import org.bitcoinj.net.StreamConnection;
 import org.bitcoinj.utils.Threading;
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
@@ -39,7 +39,7 @@ import static com.google.common.base.Preconditions.*;
  * Handles high-level message (de)serialization for peers, acting as the bridge between the
  * {@link org.bitcoinj.net} classes and {@link Peer}.
  */
-public abstract class PeerSocketHandler extends AbstractTimeoutHandler implements StreamParser {
+public abstract class PeerSocketHandler extends AbstractTimeoutHandler implements StreamConnection {
     private static final Logger log = LoggerFactory.getLogger(PeerSocketHandler.class);
 
     private final MessageSerializer serializer;

--- a/core/src/main/java/org/bitcoinj/net/BlockingClientManager.java
+++ b/core/src/main/java/org/bitcoinj/net/BlockingClientManager.java
@@ -55,11 +55,11 @@ public class BlockingClientManager extends AbstractIdleService implements Client
     }
 
     @Override
-    public ListenableFuture<SocketAddress> openConnection(SocketAddress serverAddress, StreamParser parser) {
+    public ListenableFuture<SocketAddress> openConnection(SocketAddress serverAddress, StreamConnection connection) {
         try {
             if (!isRunning())
                 throw new IllegalStateException();
-            return new BlockingClient(serverAddress, parser, connectTimeoutMillis, socketFactory, clients).getConnectFuture();
+            return new BlockingClient(serverAddress, connection, connectTimeoutMillis, socketFactory, clients).getConnectFuture();
         } catch (IOException e) {
             throw new RuntimeException(e); // This should only happen if we are, eg, out of system resources
         }

--- a/core/src/main/java/org/bitcoinj/net/ClientConnectionManager.java
+++ b/core/src/main/java/org/bitcoinj/net/ClientConnectionManager.java
@@ -30,10 +30,10 @@ import java.net.SocketAddress;
  */
 public interface ClientConnectionManager extends Service {
     /**
-     * Creates a new connection to the given address, with the given parser used to handle incoming data. Any errors
+     * Creates a new connection to the given address, with the given connection used to handle incoming data. Any errors
      * that occur during connection will be returned in the given future, including errors that can occur immediately.
      */
-    ListenableFuture<SocketAddress> openConnection(SocketAddress serverAddress, StreamParser parser);
+    ListenableFuture<SocketAddress> openConnection(SocketAddress serverAddress, StreamConnection connection);
 
     /** Gets the number of connected peers */
     int getConnectedClientCount();

--- a/core/src/main/java/org/bitcoinj/net/ConnectionHandler.java
+++ b/core/src/main/java/org/bitcoinj/net/ConnectionHandler.java
@@ -57,7 +57,7 @@ class ConnectionHandler implements MessageWriteTarget {
     @GuardedBy("lock") private final ByteBuffer readBuff;
     @GuardedBy("lock") private final SocketChannel channel;
     @GuardedBy("lock") private final SelectionKey key;
-    @GuardedBy("lock") StreamParser parser;
+    @GuardedBy("lock") StreamConnection connection;
     @GuardedBy("lock") private boolean closeCalled = false;
 
     @GuardedBy("lock") private long bytesToWriteRemaining = 0;
@@ -65,30 +65,30 @@ class ConnectionHandler implements MessageWriteTarget {
 
     private Set<ConnectionHandler> connectedHandlers;
 
-    public ConnectionHandler(StreamParserFactory parserFactory, SelectionKey key) throws IOException {
-        this(parserFactory.getNewParser(((SocketChannel) key.channel()).socket().getInetAddress(), ((SocketChannel) key.channel()).socket().getPort()), key);
-        if (parser == null)
-            throw new IOException("Parser factory.getNewParser returned null");
+    public ConnectionHandler(StreamConnectionFactory connectionFactory, SelectionKey key) throws IOException {
+        this(connectionFactory.getNewConnection(((SocketChannel) key.channel()).socket().getInetAddress(), ((SocketChannel) key.channel()).socket().getPort()), key);
+        if (connection == null)
+            throw new IOException("Parser factory.getNewConnection returned null");
     }
 
-    private ConnectionHandler(@Nullable StreamParser parser, SelectionKey key) {
+    private ConnectionHandler(@Nullable StreamConnection connection, SelectionKey key) {
         this.key = key;
         this.channel = checkNotNull(((SocketChannel)key.channel()));
-        if (parser == null) {
+        if (connection == null) {
             readBuff = null;
             return;
         }
-        this.parser = parser;
-        readBuff = ByteBuffer.allocateDirect(Math.min(Math.max(parser.getMaxMessageSize(), BUFFER_SIZE_LOWER_BOUND), BUFFER_SIZE_UPPER_BOUND));
-        parser.setWriteTarget(this); // May callback into us (eg closeConnection() now)
+        this.connection = connection;
+        readBuff = ByteBuffer.allocateDirect(Math.min(Math.max(connection.getMaxMessageSize(), BUFFER_SIZE_LOWER_BOUND), BUFFER_SIZE_UPPER_BOUND));
+        connection.setWriteTarget(this); // May callback into us (eg closeConnection() now)
         connectedHandlers = null;
     }
 
-    public ConnectionHandler(StreamParser parser, SelectionKey key, Set<ConnectionHandler> connectedHandlers) {
-        this(checkNotNull(parser), key);
+    public ConnectionHandler(StreamConnection connection, SelectionKey key, Set<ConnectionHandler> connectedHandlers) {
+        this(checkNotNull(connection), key);
 
         // closeConnection() may have already happened because we invoked the other c'tor above, which called
-        // parser.setWriteTarget which might have re-entered already. In this case we shouldn't add ourselves
+        // connection.setWriteTarget which might have re-entered already. In this case we shouldn't add ourselves
         // to the connectedHandlers set.
         lock.lock();
         try {
@@ -191,7 +191,7 @@ class ConnectionHandler implements MessageWriteTarget {
         }
         if (callClosed) {
             checkState(connectedHandlers == null || connectedHandlers.remove(this));
-            parser.connectionClosed();
+            connection.connectionClosed();
         }
     }
 
@@ -208,7 +208,7 @@ class ConnectionHandler implements MessageWriteTarget {
                 return;
             }
             if (key.isReadable()) {
-                // Do a socket read and invoke the parser's receiveBytes message
+                // Do a socket read and invoke the connection's receiveBytes message
                 int read = handler.channel.read(handler.readBuff);
                 if (read == 0)
                     return; // Was probably waiting on a write
@@ -219,8 +219,8 @@ class ConnectionHandler implements MessageWriteTarget {
                 }
                 // "flip" the buffer - setting the limit to the current position and setting position to 0
                 handler.readBuff.flip();
-                // Use parser.receiveBytes's return value as a check that it stopped reading at the right location
-                int bytesConsumed = checkNotNull(handler.parser).receiveBytes(handler.readBuff);
+                // Use connection.receiveBytes's return value as a check that it stopped reading at the right location
+                int bytesConsumed = checkNotNull(handler.connection).receiveBytes(handler.readBuff);
                 checkState(handler.readBuff.position() == bytesConsumed);
                 // Now drop the bytes which were read by compacting readBuff (resetting limit and keeping relative
                 // position)
@@ -230,7 +230,7 @@ class ConnectionHandler implements MessageWriteTarget {
                 handler.tryWriteBytes();
         } catch (Exception e) {
             // This can happen eg if the channel closes while the thread is about to get killed
-            // (ClosedByInterruptException), or if handler.parser.receiveBytes throws something
+            // (ClosedByInterruptException), or if handler.connection.receiveBytes throws something
             Throwable t = Throwables.getRootCause(e);
             log.warn("Error handling SelectionKey: {}", t.getMessage() != null ? t.getMessage() : t.getClass().getName());
             handler.closeConnection();

--- a/core/src/main/java/org/bitcoinj/net/MessageWriteTarget.java
+++ b/core/src/main/java/org/bitcoinj/net/MessageWriteTarget.java
@@ -27,7 +27,7 @@ public interface MessageWriteTarget {
      */
     void writeBytes(byte[] message) throws IOException;
     /**
-     * Closes the connection to the server, triggering the {@link StreamParser#connectionClosed()}
+     * Closes the connection to the server, triggering the {@link StreamConnection#connectionClosed()}
      * event on the network-handling thread where all callbacks occur.
      */
     void closeConnection();

--- a/core/src/main/java/org/bitcoinj/net/NioClient.java
+++ b/core/src/main/java/org/bitcoinj/net/NioClient.java
@@ -26,7 +26,7 @@ import java.net.*;
 import java.nio.*;
 
 /**
- * Creates a simple connection to a server using a {@link StreamParser} to process data.
+ * Creates a simple connection to a server using a {@link StreamConnection} to process data.
  */
 public class NioClient implements MessageWriteTarget {
     private static final Logger log = LoggerFactory.getLogger(NioClient.class);
@@ -34,13 +34,13 @@ public class NioClient implements MessageWriteTarget {
     private final Handler handler;
     private final NioClientManager manager = new NioClientManager();
 
-    class Handler extends AbstractTimeoutHandler implements StreamParser {
-        private final StreamParser upstreamParser;
+    class Handler extends AbstractTimeoutHandler implements StreamConnection {
+        private final StreamConnection upstreamConnection;
         private MessageWriteTarget writeTarget;
         private boolean closeOnOpen = false;
         private boolean closeCalled = false;
-        Handler(StreamParser upstreamParser, int connectTimeoutMillis) {
-            this.upstreamParser = upstreamParser;
+        Handler(StreamConnection upstreamConnection, int connectTimeoutMillis) {
+            this.upstreamConnection = upstreamConnection;
             setSocketTimeout(connectTimeoutMillis);
             setTimeoutEnabled(true);
         }
@@ -56,19 +56,19 @@ public class NioClient implements MessageWriteTarget {
             manager.stopAsync();
             if (!closeCalled) {
                 closeCalled = true;
-                upstreamParser.connectionClosed();
+                upstreamConnection.connectionClosed();
             }
         }
 
         @Override
         public synchronized void connectionOpened() {
             if (!closeOnOpen)
-                upstreamParser.connectionOpened();
+                upstreamConnection.connectionOpened();
         }
 
         @Override
         public int receiveBytes(ByteBuffer buff) throws Exception {
-            return upstreamParser.receiveBytes(buff);
+            return upstreamConnection.receiveBytes(buff);
         }
 
         @Override
@@ -78,26 +78,26 @@ public class NioClient implements MessageWriteTarget {
             else {
                 setTimeoutEnabled(false);
                 this.writeTarget = writeTarget;
-                upstreamParser.setWriteTarget(writeTarget);
+                upstreamConnection.setWriteTarget(writeTarget);
             }
         }
 
         @Override
         public int getMaxMessageSize() {
-            return upstreamParser.getMaxMessageSize();
+            return upstreamConnection.getMaxMessageSize();
         }
     }
 
     /**
-     * <p>Creates a new client to the given server address using the given {@link StreamParser} to decode the data.
-     * The given parser <b>MUST</b> be unique to this object. This does not block while waiting for the connection to
-     * open, but will call either the {@link StreamParser#connectionOpened()} or
-     * {@link StreamParser#connectionClosed()} callback on the created network event processing thread.</p>
+     * <p>Creates a new client to the given server address using the given {@link StreamConnection} to decode the data.
+     * The given connection <b>MUST</b> be unique to this object. This does not block while waiting for the connection to
+     * open, but will call either the {@link StreamConnection#connectionOpened()} or
+     * {@link StreamConnection#connectionClosed()} callback on the created network event processing thread.</p>
      *
      * @param connectTimeoutMillis The connect timeout set on the connection (in milliseconds). 0 is interpreted as no
      *                             timeout.
      */
-    public NioClient(final SocketAddress serverAddress, final StreamParser parser,
+    public NioClient(final SocketAddress serverAddress, final StreamConnection parser,
                      final int connectTimeoutMillis) throws IOException {
         manager.startAsync();
         manager.awaitRunning();

--- a/core/src/main/java/org/bitcoinj/net/StreamConnection.java
+++ b/core/src/main/java/org/bitcoinj/net/StreamConnection.java
@@ -21,8 +21,10 @@ import java.nio.ByteBuffer;
 /**
  * A generic handler which is used in {@link NioServer}, {@link NioClient} and {@link BlockingClient} to handle incoming
  * data streams.
+ *
+ * Used to be callet StreamParser.
  */
-public interface StreamParser {
+public interface StreamConnection {
     /** Called when the connection socket is closed */
     void connectionClosed();
 
@@ -31,7 +33,7 @@ public interface StreamParser {
 
     /**
      * <p>Called when new bytes are available from the remote end. This should only ever be called by the single
-     * writeTarget associated with any given StreamParser, multiple callers will likely confuse implementations.</p>
+     * writeTarget associated with any given StreamConnection, multiple callers will likely confuse implementations.</p>
      *
      * Implementers/callers must follow the following conventions exactly:
      * <ul>
@@ -51,7 +53,7 @@ public interface StreamParser {
     int receiveBytes(ByteBuffer buff) throws Exception;
 
     /**
-     * Called when this parser is attached to an upstream write target (ie a low-level connection handler). This
+     * Called when this connection is attached to an upstream write target (ie a low-level connection handler). This
      * writeTarget should be stored and used to close the connection or write data to the socket.
      */
     void setWriteTarget(MessageWriteTarget writeTarget);

--- a/core/src/main/java/org/bitcoinj/net/StreamConnectionFactory.java
+++ b/core/src/main/java/org/bitcoinj/net/StreamConnectionFactory.java
@@ -20,14 +20,14 @@ import java.net.InetAddress;
 import javax.annotation.Nullable;
 
 /**
- * A factory which generates new {@link StreamParser}s when a new connection is opened.
+ * A factory which generates new {@link StreamConnection}s when a new connection is opened.
  */
-public interface StreamParserFactory {
+public interface StreamConnectionFactory {
     /**
      * Returns a new handler or null to have the connection close.
      * @param inetAddress The client's (IP) address
      * @param port The remote port on the client side
      */
     @Nullable
-    StreamParser getNewParser(InetAddress inetAddress, int port);
+    StreamConnection getNewConnection(InetAddress inetAddress, int port);
 }

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerListener.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerListener.java
@@ -22,8 +22,8 @@ import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.TransactionBroadcaster;
 import org.bitcoinj.core.Wallet;
 import org.bitcoinj.net.NioServer;
-import org.bitcoinj.net.ProtobufParser;
-import org.bitcoinj.net.StreamParserFactory;
+import org.bitcoinj.net.ProtobufConnection;
+import org.bitcoinj.net.StreamConnectionFactory;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
@@ -90,14 +90,14 @@ public class PaymentChannelServerListener {
                 }
             });
 
-            protobufHandlerListener = new ProtobufParser.Listener<Protos.TwoWayChannelMessage>() {
+            protobufHandlerListener = new ProtobufConnection.Listener<Protos.TwoWayChannelMessage>() {
                 @Override
-                public synchronized void messageReceived(ProtobufParser<Protos.TwoWayChannelMessage> handler, Protos.TwoWayChannelMessage msg) {
+                public synchronized void messageReceived(ProtobufConnection<Protos.TwoWayChannelMessage> handler, Protos.TwoWayChannelMessage msg) {
                     paymentChannelManager.receiveMessage(msg);
                 }
 
                 @Override
-                public synchronized void connectionClosed(ProtobufParser<Protos.TwoWayChannelMessage> handler) {
+                public synchronized void connectionClosed(ProtobufConnection<Protos.TwoWayChannelMessage> handler) {
                     paymentChannelManager.connectionClosed();
                     if (closeReason != null)
                         eventHandler.channelClosed(closeReason);
@@ -107,7 +107,7 @@ public class PaymentChannelServerListener {
                 }
 
                 @Override
-                public synchronized void connectionOpen(ProtobufParser<Protos.TwoWayChannelMessage> handler) {
+                public synchronized void connectionOpen(ProtobufConnection<Protos.TwoWayChannelMessage> handler) {
                     ServerConnectionEventHandler eventHandler = eventHandlerFactory.onNewConnection(address);
                     if (eventHandler == null)
                         handler.closeConnection();
@@ -118,7 +118,7 @@ public class PaymentChannelServerListener {
                 }
             };
 
-            socketProtobufHandler = new ProtobufParser<Protos.TwoWayChannelMessage>
+            socketProtobufHandler = new ProtobufConnection<Protos.TwoWayChannelMessage>
                     (protobufHandlerListener, Protos.TwoWayChannelMessage.getDefaultInstance(), Short.MAX_VALUE, timeoutSeconds*1000);
         }
 
@@ -131,10 +131,10 @@ public class PaymentChannelServerListener {
         private final PaymentChannelServer paymentChannelManager;
 
         // The connection handler which puts/gets protobufs from the TCP socket
-        private final ProtobufParser<Protos.TwoWayChannelMessage> socketProtobufHandler;
+        private final ProtobufConnection<Protos.TwoWayChannelMessage> socketProtobufHandler;
 
         // The listener which connects to socketProtobufHandler
-        private final ProtobufParser.Listener<Protos.TwoWayChannelMessage> protobufHandlerListener;
+        private final ProtobufConnection.Listener<Protos.TwoWayChannelMessage> protobufHandlerListener;
     }
 
     /**
@@ -142,9 +142,9 @@ public class PaymentChannelServerListener {
      * @throws Exception If binding to the given port fails (eg SocketException: Permission denied for privileged ports)
      */
     public void bindAndStart(int port) throws Exception {
-        server = new NioServer(new StreamParserFactory() {
+        server = new NioServer(new StreamConnectionFactory() {
             @Override
-            public ProtobufParser<Protos.TwoWayChannelMessage> getNewParser(InetAddress inetAddress, int port) {
+            public ProtobufConnection<Protos.TwoWayChannelMessage> getNewConnection(InetAddress inetAddress, int port) {
                 return new ServerHandler(new InetSocketAddress(inetAddress, port), timeoutSeconds).socketProtobufHandler;
             }
         }, new InetSocketAddress(port));

--- a/core/src/main/java/org/bitcoinj/protocols/channels/ServerConnectionEventHandler.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/ServerConnectionEventHandler.java
@@ -18,7 +18,7 @@ package org.bitcoinj.protocols.channels;
 
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Sha256Hash;
-import org.bitcoinj.net.ProtobufParser;
+import org.bitcoinj.net.ProtobufConnection;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
@@ -31,10 +31,10 @@ import javax.annotation.Nullable;
  * {@link PaymentChannelServerListener}
 */
 public abstract class ServerConnectionEventHandler {
-    private ProtobufParser<Protos.TwoWayChannelMessage> connectionChannel;
+    private ProtobufConnection<Protos.TwoWayChannelMessage> connectionChannel;
     // Called by ServerListener before channelOpen to set connectionChannel when it is ready to received application messages
     // Also called with null to clear connectionChannel after channelClosed()
-    synchronized void setConnectionChannel(@Nullable ProtobufParser<Protos.TwoWayChannelMessage> connectionChannel) { this.connectionChannel = connectionChannel; }
+    synchronized void setConnectionChannel(@Nullable ProtobufConnection<Protos.TwoWayChannelMessage> connectionChannel) { this.connectionChannel = connectionChannel; }
 
     /**
      * <p>Closes the channel with the client (will generate a

--- a/core/src/main/java/org/bitcoinj/testing/TestWithNetworkConnections.java
+++ b/core/src/main/java/org/bitcoinj/testing/TestWithNetworkConnections.java
@@ -111,10 +111,10 @@ public class TestWithNetworkConnections {
     }
 
     protected void startPeerServer(int i) throws IOException {
-        peerServers[i] = new NioServer(new StreamParserFactory() {
+        peerServers[i] = new NioServer(new StreamConnectionFactory() {
             @Nullable
             @Override
-            public StreamParser getNewParser(InetAddress inetAddress, int port) {
+            public StreamConnection getNewConnection(InetAddress inetAddress, int port) {
                 return new InboundMessageQueuer(params) {
                     @Override
                     public void connectionClosed() {


### PR DESCRIPTION
After working with ProtobufParser for 1/2 a year (we use it in the Stroem implementation) I find the name misleading. A name change would be breaking, but I still request it.

The responsibility of PP is to read raw data and chunk it so that complete protobuf messages comes out. The name is probably a twist on its super class: StreamParser, but PP also has a "write()" method, which indicates that it also can send, not only parse. 

When working with payment channels I see PP as the main gateway to the network; when I call "write()" the message will be sent to the server, and I don't have to care much how it is done. The code I write would make more sense if the name is changed to ProtobufConnection. 