### PR TITLE
a transaction output may have multiple OP_RETURNs

### DIFF
--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -750,7 +750,7 @@ public class Script {
     }
 
     public boolean isOpReturn() {
-        return chunks.size() == 2 && chunks.get(0).equalsOpCode(OP_RETURN);
+        return chunks.size() > 0 && chunks.get(0).equalsOpCode(OP_RETURN);
     }
 
     /**


### PR DESCRIPTION
E.g. see this:

https://testnet3.toshi.io/api/v0/transactions/f18045a1b7395a4b793bfd48d919c62d4a88ed5a0e3b7fbe0b12572b6696698a

Bitcoinj should recognize this TransactionOutput as OP_RETURN
