### PR TITLE
DKC toString() fix

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -1340,13 +1340,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
                     Utils.dateTimeFormat(seed.getCreationTimeSeconds() * 1000)));
         }
         final DeterministicKey watchingKey = getWatchingKey();
-        // Don't show if it's been imported from a watching wallet already, because it'd result in a weird/
-        // unintuitive result where the watching key in a watching wallet is not the one it was created with
-        // due to the parent fingerprint being missing/not stored. In future we could store the parent fingerprint
-        // optionally as well to fix this, but it seems unimportant for now.
-        if (watchingKey.getParent() != null) {
-            builder2.append(String.format("Key to watch:  %s%n", watchingKey.serializePubB58(params)));
-        }
+        builder2.append(String.format("Key to watch:  %s%n", watchingKey.serializePubB58(params)));
         formatAddresses(includePrivateKeys, params, builder2);
         return builder2.toString();
     }


### PR DESCRIPTION
Removed "if" because I could not find a use case where the parent fingerprint is missing.
Parent key may be missing, but that does screwes up the xpub.

The "if" was making MarriedKeyChain.toString() to display the following keychains xpubs but not the  followed keychain xpub

Bellow is a piece of code that shows my point

```
public class WalletToStringTest {

    public static void main(String[] args) {
        Context context = Context.getOrCreate(MainNetParams.get()); 
        Wallet wallet = new Wallet(context);
        System.out.println(wallet.toString());
        
        Wallet w2 = getWalletMultisig(context.getParams());
        System.out.println(w2.toString());

        Wallet w3 = getWalletWatchonly(context.getParams());
        System.out.println(w3.toString());

        Wallet w4 = getWalletWatchonly2(context.getParams());
        System.out.println(w4.toString());
        
    }
    
    private static String getNewRandomXpub(NetworkParameters params) {
        DeterministicKeyChain keyChain = new DeterministicKeyChain(new SecureRandom());
        return keyChain.getWatchingKey().serializePubB58(params);
    }
    
    private static Wallet getWalletMultisig(NetworkParameters params) {
        DeterministicKey key = DeterministicKey.deserializeB58(null, getNewRandomXpub(params), params);
        DeterministicKeyChain keyChain; 
        List<DeterministicKey> followingAccountKeys = new ArrayList<DeterministicKey>();
        DeterministicKey followingAccountKey = DeterministicKey.deserializeB58(null, getNewRandomXpub(params), params);
        followingAccountKeys.add(followingAccountKey);
        MarriedKeyChain marriedKeyChain = MarriedKeyChain.builder()
                 .seedCreationTimeSecs(new Date().getTime() / 1000)
                 .watchingKey(key)
                 .followingKeys(followingAccountKeys)
                 .threshold(2).build();
        keyChain = marriedKeyChain;
        KeyChainGroup kcg = new KeyChainGroup(params);
        kcg.addAndActivateHDChain(keyChain);        
        Wallet wallet = new Wallet(params, kcg);
        return wallet;
    }

    private static Wallet getWalletWatchonly(NetworkParameters params) {
        DeterministicKey key = DeterministicKey.deserializeB58(null, getNewRandomXpub(params), params);
        Wallet wallet = Wallet.fromWatchingKey(params, key);
        return wallet;
    }

    private static Wallet getWalletWatchonly2(NetworkParameters params) {
        DeterministicKey key = DeterministicKey.deserializeB58(null, getNewRandomXpub(params), params);
        DeterministicKeyChain keyChain = DeterministicKeyChain.watch(key);
        KeyChainGroup kcg = new KeyChainGroup(params);
        kcg.addAndActivateHDChain(keyChain);        
        Wallet wallet = new Wallet(params, kcg);
        return wallet;
    }
    
}
```