### PR TITLE
Close increasePaymentFuture when receiving an ERROR from the server.

### DIFF
--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClient.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClient.java
@@ -338,12 +338,14 @@ public class PaymentChannelClient implements IPaymentChannelClient {
                         checkState(msg.hasError());
                         log.error("Server sent ERROR {} with explanation {}", msg.getError().getCode().name(),
                                 msg.getError().hasExplanation() ? msg.getError().getExplanation() : "");
+                        setIncreasePaymentFutureIfNeeded(CloseReason.REMOTE_SENT_ERROR, msg.getError().getCode().name());
                         conn.destroyConnection(CloseReason.REMOTE_SENT_ERROR);
                         return;
                     default:
                         log.error("Got unknown message type or type that doesn't apply to clients.");
                         errorBuilder = Protos.Error.newBuilder()
                                 .setCode(Protos.Error.ErrorCode.SYNTAX_ERROR);
+                        setIncreasePaymentFutureIfNeeded(CloseReason.REMOTE_SENT_INVALID_MESSAGE, "");
                         closeReason = CloseReason.REMOTE_SENT_INVALID_MESSAGE;
                         break;
                 }
@@ -366,6 +368,18 @@ public class PaymentChannelClient implements IPaymentChannelClient {
             conn.destroyConnection(closeReason);
         } finally {
             lock.unlock();
+        }
+    }
+
+    /*
+     * If this is an ongoing payment channel increase we need to call setException() on its future.
+     *
+     * @param reason is the reason for aborting
+     * @param message is the detailed message
+     */
+    private void setIncreasePaymentFutureIfNeeded(PaymentChannelCloseException.CloseReason reason, String message) {
+        if (increasePaymentFuture != null && !increasePaymentFuture.isDone()) {
+            increasePaymentFuture.setException(new PaymentChannelCloseException(message, reason));
         }
     }
 


### PR DESCRIPTION
In PaymentChannelClient we have a future:

   @GuardedBy("lock") SettableFuture<PaymentIncrementAck> increasePaymentFuture;

... and this future is used by incrementPayment(). When PAYMENT_ACK is returned from the serve the increasePaymentFuture is updated correctly. This PR makes sure the increasePaymentFuture is set even if the server returns an error.