### PR TITLE
Allowing settlement of unused channel

### DIFF
--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerState.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerState.java
@@ -398,7 +398,7 @@ public class PaymentChannelServerState {
             wallet.completeTx(req);  // TODO: Fix things so shuffling is usable.
             feePaidForPayment = req.tx.getFee();
             log.info("Calculated fee is {}", feePaidForPayment);
-            if (feePaidForPayment.compareTo(bestValueToMe) >= 0) {
+            if (feePaidForPayment.compareTo(bestValueToMe) > 0) {
                 final String msg = String.format("Had to pay more in fees (%s) than the channel was worth (%s)",
                         feePaidForPayment, bestValueToMe);
                 throw new InsufficientMoneyException(feePaidForPayment.subtract(bestValueToMe), msg);

--- a/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelStateTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelStateTest.java
@@ -705,8 +705,8 @@ public class PaymentChannelStateTest extends TestWithWallet {
             assertTrue(e.getMessage().contains("more in fees"));
         }
 
-        signature = clientState.incrementPaymentBy(SATOSHI.multiply(2), null).signature.encodeToBitcoin();
-        totalRefund = totalRefund.subtract(SATOSHI.multiply(2));
+        signature = clientState.incrementPaymentBy(SATOSHI, null).signature.encodeToBitcoin();
+        totalRefund = totalRefund.subtract(SATOSHI);
         serverState.incrementPayment(totalRefund, signature);
 
         // And settle the channel.


### PR DESCRIPTION
The client should be able to settle a channel after it has payed the requested minimum payment specified in the Initiate message.