### PR TITLE
READY FOR REVIEW - Fix #1078. Add ability to load Wallet without loading its transactions. ...

### DIFF
--- a/tools/src/main/java/org/bitcoinj/tools/WalletTool.java
+++ b/tools/src/main/java/org/bitcoinj/tools/WalletTool.java
@@ -311,11 +311,14 @@ public class WalletTool {
 
         InputStream walletInputStream = null;
         try {
+            boolean forceReset = action == ActionEnum.RESET
+                || (action == ActionEnum.SYNC
+                    && options.has("force"));
             WalletProtobufSerializer loader = new WalletProtobufSerializer();
             if (options.has("ignore-mandatory-extensions"))
                 loader.setRequireMandatoryExtensions(false);
             walletInputStream = new BufferedInputStream(new FileInputStream(walletFile));
-            wallet = loader.readWallet(walletInputStream);
+            wallet = loader.readWallet(walletInputStream, forceReset, (WalletExtension[])(null));
             if (!wallet.getParams().equals(params)) {
                 System.err.println("Wallet does not match requested network parameters: " +
                         wallet.getParams().getId() + " vs " + params.getId());
@@ -372,7 +375,7 @@ public class WalletTool {
             System.err.println("************** WALLET IS INCONSISTENT *****************");
             return;
         }
-        
+
         saveWallet(walletFile);
 
         if (options.has(waitForFlag)) {

--- a/tools/src/main/resources/org/bitcoinj/tools/wallet-tool-help.txt
+++ b/tools/src/main/resources/org/bitcoinj/tools/wallet-tool-help.txt
@@ -24,7 +24,7 @@ Usage: wallet-tool --flags action-name
   current-receive-addr Prints the current receive address, deriving one if needed. Addresses derived with this action are
                        independent of addresses derived with the add-key action.
   sync                 Sync the wallet with the latest block chain (download new transactions).
-                       If the chain file does not exist this will RESET the wallet.
+                       If the chain file does not exist or if --force is present, this will RESET the wallet.
   reset                Deletes all transactions from the wallet, for if you want to replay the chain.
   send                 Creates and broadcasts a transaction from the given wallet.
                        Requires either --output or --payment-request to be specified.


### PR DESCRIPTION
… Use new methods with `wallet-tool reset` (where transactions are deleted anyway) and with `wallet-tool sync` (if the `--force` option is provided).