### PR TITLE
Fix how key depth is determined.

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -71,7 +71,7 @@ public class DeterministicKey extends ECKey {
         this.parent = parent;
         this.childNumberPath = checkNotNull(childNumberPath);
         this.chainCode = Arrays.copyOf(chainCode, chainCode.length);
-        this.depth = this.childNumberPath.size();
+        this.depth = parent == null ? 0 : parent.depth + 1;
         this.parentFingerprint = (parent != null) ? parent.getFingerprint() : 0;
     }
 
@@ -93,7 +93,7 @@ public class DeterministicKey extends ECKey {
         this.parent = parent;
         this.childNumberPath = checkNotNull(childNumberPath);
         this.chainCode = Arrays.copyOf(chainCode, chainCode.length);
-        this.depth = this.childNumberPath.size();
+        this.depth = parent == null ? 0 : parent.depth + 1;
         this.parentFingerprint = (parent != null) ? parent.getFingerprint() : 0;
     }
 


### PR DESCRIPTION
The way it was previously done before did not allow to properly derive keys which had their position concealed in the hierarchy.

For example:
When I load a DeterministicKey from `xpub6DCBiTDDPiK6JxAW3b7J1UZBYK5nibVBwnxUeyqwmvo6yqe4otZanXSX3D6wrSg1k3wXaxzD7fyjoWLDhqdtmVkFtWvpi32f55oibMttRQB`, BitcoinJ successfully determines that it's a key of depth 3. It assigns it a path of `M/0H` because it has no way of determining it's position in the hierarchy.

Previously, if I tried to derive the first child extended key from this one, I would get a DeterministicKey of depth 2. It said so because it was determined by the path length. I believe it should say depth 4 because it's information we have available and because the extended key will differ from the one we expect.

Results:

Erroneous (before):  `xpub6BJPFHLff3Uvzt8EioPeAoAsHiovWgqEiND323t6rzcsfcQToUvQRX9izevwV5yejKs6Mm3eZScFY6G57Tr5KDQtqMyWfQhtSntqwunhAhX` (depth 2)
Expected (now): `xpub6F4exrNi5epviRPAnnKAo4hYtAdov948rATqmmdSCsLgXSJ5t3w5ztJvVoUcxxnacijPdty55X2Nu3EgrBNfS3ckzfdN45JJ6FZk3wQLcb6` (depth 4)

Never the derivation of a depth 3 key should indicate depth 2. The path in this case should be considered as relative. 

Signed-off-by: Marc-André Tremblay <marcandre.tr@gmail.com>