### PR TITLE
Don't add Maven descriptor to build artifacts.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,15 @@
       </plugin>
 
       <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <addMavenDescriptor>false</addMavenDescriptor>
+          </archive>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
         <version>1.6.5</version>


### PR DESCRIPTION
It's pretty useless and it stands in the way of reproducible builds.