### PR TITLE
Add hooks to override protocol version numbers

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/FilteredBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/FilteredBlock.java
@@ -27,8 +27,6 @@ import java.util.*;
  * of the block header and a {@link PartialMerkleTree} which contains the transactions which matched the filter.</p>
  */
 public class FilteredBlock extends Message {
-    /** The protocol version at which Bloom filtering started to be supported. */
-    public static final int MIN_PROTOCOL_VERSION = 70000;
     private Block header;
 
     private PartialMerkleTree merkleTree;

--- a/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
@@ -74,7 +74,7 @@ public class GetBlocksMessage extends Message {
     @Override
     protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         // Version, for some reason.
-        Utils.uint32ToByteStreamLE(NetworkParameters.PROTOCOL_VERSION, stream);
+        Utils.uint32ToByteStreamLE(params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.CURRENT), stream);
         // Then a vector of block hashes. This is actually a "block locator", a set of block
         // identifiers that spans the entire chain with exponentially increasing gaps between
         // them, until we end up at the genesis block. See CBlockLocator::Set()

--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -118,11 +118,13 @@ public abstract class Message {
     }
 
     Message(NetworkParameters params, byte[] payload, int offset) throws ProtocolException {
-        this(params, payload, offset, NetworkParameters.PROTOCOL_VERSION, params.getDefaultSerializer(), UNKNOWN_LENGTH);
+        this(params, payload, offset, params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.CURRENT),
+             params.getDefaultSerializer(), UNKNOWN_LENGTH);
     }
 
     Message(NetworkParameters params, byte[] payload, int offset, MessageSerializer serializer, int length) throws ProtocolException {
-        this(params, payload, offset, NetworkParameters.PROTOCOL_VERSION, serializer, length);
+        this(params, payload, offset, params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.CURRENT),
+             serializer, length);
     }
 
     // These methods handle the serialization/deserialization using the custom Bitcoin protocol.

--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -47,11 +47,6 @@ import org.bitcoinj.utils.VersionTally;
  */
 public abstract class NetworkParameters {
     /**
-     * The protocol version this library implements.
-     */
-    public static final int PROTOCOL_VERSION = 70001;
-
-    /**
      * The alert signing key originally owned by Satoshi, and now passed on to Gavin along with a few others.
      */
     public static final byte[] SATOSHI_KEY = Utils.HEX.decode("04fc9702847840aaf195de8442ebecedf5b095cdbb9bc716bda9110971b28a49e0ead8564ff0db22209e0374782c093bb899692d524e9d6a6956e7c5ecbcd68284");
@@ -516,5 +511,24 @@ public abstract class NetworkParameters {
         if (block.getTimeSeconds() >= NetworkParameters.BIP16_ENFORCE_TIME)
             verifyFlags.add(Script.VerifyFlag.P2SH);
         return verifyFlags;
+    }
+
+    public abstract int getProtocolVersionNum(final ProtocolVersion version);
+
+    public static enum ProtocolVersion {
+        MINIMUM(70000),
+        PONG(60001),
+        BLOOM_FILTER(70000),
+        CURRENT(70001);
+
+        private final int bitcoinProtocol;
+
+        ProtocolVersion(final int bitcoinProtocol) {
+            this.bitcoinProtocol = bitcoinProtocol;
+        }
+
+        public int getBitcoinProtocolVersion() {
+            return bitcoinProtocol;
+        }
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -133,7 +133,7 @@ public class Peer extends PeerSocketHandler {
     @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
     private final HashSet<TransactionConfidence> pendingTxDownloads = new HashSet<TransactionConfidence>();
     // The lowest version number we're willing to accept. Lower than this will result in an immediate disconnect.
-    private volatile int vMinProtocolVersion = Pong.MIN_PROTOCOL_VERSION;
+    private volatile int vMinProtocolVersion;
     // When an API user explicitly requests a block or transaction from a peer, the InventoryItem is put here
     // whilst waiting for the response. Is not used for downloads Peer generates itself.
     private static class GetDataRequest {
@@ -223,6 +223,7 @@ public class Peer extends PeerSocketHandler {
         this.fastCatchupTimeSecs = params.getGenesisBlock().getTimeSeconds();
         this.isAcked = false;
         this.pendingPings = new CopyOnWriteArrayList<PendingPing>();
+        this.vMinProtocolVersion = params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.PONG);
         this.wallets = new CopyOnWriteArrayList<Wallet>();
         this.context = Context.get();
     }

--- a/core/src/main/java/org/bitcoinj/core/PeerAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerAddress.java
@@ -78,39 +78,78 @@ public class PeerAddress extends ChildMessage {
     }
 
     /**
-     * Constructs a peer address from the given IP address and port. Protocol version is the default.
+     * Constructs a peer address from the given IP address and port. Protocol version is the default
+     * for Bitcoin.
      */
     public PeerAddress(InetAddress addr, int port) {
-        this(addr, port, NetworkParameters.PROTOCOL_VERSION);
+        this(addr, port, NetworkParameters.ProtocolVersion.CURRENT.getBitcoinProtocolVersion());
     }
 
     /**
-     * Constructs a peer address from the given IP address. Port and protocol version are default for the mainnet.
+     * Constructs a peer address from the given IP address and port.
+     */
+    public PeerAddress(NetworkParameters params, InetAddress addr, int port) {
+        this(addr, port, params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.CURRENT));
+    }
+
+    /**
+     * Constructs a peer address from the given IP address. Port and version number
+     * are default for Bitcoin mainnet.
      */
     public PeerAddress(InetAddress addr) {
         this(addr, MainNetParams.get().getPort());
     }
 
     /**
+     * Constructs a peer address from the given IP address. Port is default for
+     * Bitcoin mainnet, version number is default for the given parameters.
+     */
+    public PeerAddress(NetworkParameters params, InetAddress addr) {
+        this(params, addr, MainNetParams.get().getPort());
+    }
+
+    /**
+     * Constructs a peer address from an {@link InetSocketAddress}. An InetSocketAddress can take in as parameters an
+     * InetAddress or a String hostname. If you want to connect to a .onion, set the hostname to the .onion address.
+     * Protocol version is the default.  Protocol version is the default
+     * for Bitcoin.
+     */
+    public PeerAddress(InetSocketAddress addr) {
+        this(addr.getAddress(), addr.getPort(), NetworkParameters.ProtocolVersion.CURRENT.getBitcoinProtocolVersion());
+    }
+
+    /**
      * Constructs a peer address from an {@link InetSocketAddress}. An InetSocketAddress can take in as parameters an
      * InetAddress or a String hostname. If you want to connect to a .onion, set the hostname to the .onion address.
      */
-    public PeerAddress(InetSocketAddress addr) {
-        this(addr.getAddress(), addr.getPort());
+    public PeerAddress(NetworkParameters params, InetSocketAddress addr) {
+        this(params, addr.getAddress(), addr.getPort());
+    }
+
+    /**
+     * Constructs a peer address from a stringified hostname+port. Use this if you want to connect to a Tor .onion address.
+     * Protocol version is the default for Bitcoin.
+     */
+    public PeerAddress(String hostname, int port) {
+        this.hostname = hostname;
+        this.port = port;
+        this.protocolVersion = NetworkParameters.ProtocolVersion.CURRENT.getBitcoinProtocolVersion();
+        this.services = BigInteger.ZERO;
     }
 
     /**
      * Constructs a peer address from a stringified hostname+port. Use this if you want to connect to a Tor .onion address.
      */
-    public PeerAddress(String hostname, int port) {
+    public PeerAddress(NetworkParameters params, String hostname, int port) {
+        super(params);
         this.hostname = hostname;
         this.port = port;
-        this.protocolVersion = NetworkParameters.PROTOCOL_VERSION;
+        this.protocolVersion = params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.CURRENT);
         this.services = BigInteger.ZERO;
     }
 
     public static PeerAddress localhost(NetworkParameters params) {
-        return new PeerAddress(InetAddresses.forString("127.0.0.1"), params.getPort());
+        return new PeerAddress(params, InetAddresses.forString("127.0.0.1"), params.getPort());
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/PeerSocketHandler.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerSocketHandler.java
@@ -61,7 +61,7 @@ public abstract class PeerSocketHandler extends AbstractTimeoutHandler implement
     public PeerSocketHandler(NetworkParameters params, InetSocketAddress remoteIp) {
         checkNotNull(params);
         serializer = params.getDefaultSerializer();
-        this.peerAddress = new PeerAddress(remoteIp);
+        this.peerAddress = new PeerAddress(params, remoteIp);
     }
 
     public PeerSocketHandler(NetworkParameters params, PeerAddress peerAddress) {

--- a/core/src/main/java/org/bitcoinj/core/Pong.java
+++ b/core/src/main/java/org/bitcoinj/core/Pong.java
@@ -21,9 +21,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 public class Pong extends Message {
-    /** The smallest protocol version that supports the pong response (BIP 31). Anything beyond version 60000. */
-    public static final int MIN_PROTOCOL_VERSION = 60001;
-
     private long nonce;
 
     public Pong(NetworkParameters params, byte[] payloadBytes) throws ProtocolException {

--- a/core/src/main/java/org/bitcoinj/core/VersionMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionMessage.java
@@ -89,7 +89,7 @@ public class VersionMessage extends Message {
     
     public VersionMessage(NetworkParameters params, int newBestHeight) {
         super(params);
-        clientVersion = NetworkParameters.PROTOCOL_VERSION;
+        clientVersion = params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.CURRENT);
         localServices = 0;
         time = System.currentTimeMillis() / 1000;
         // Note that the official client doesn't do anything with these, and finding out your own external IP address
@@ -274,7 +274,7 @@ public class VersionMessage extends Message {
      * Returns true if the clientVersion field is >= Pong.MIN_PROTOCOL_VERSION. If it is then ping() is usable.
      */
     public boolean isPingPongSupported() {
-        return clientVersion >= Pong.MIN_PROTOCOL_VERSION;
+        return clientVersion >= params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.PONG);
     }
 
     /**
@@ -282,7 +282,7 @@ public class VersionMessage extends Message {
      * is available and the memory pool of the remote peer will be queried when the downloadData property is true.
      */
     public boolean isBloomFilteringSupported() {
-        return clientVersion >= FilteredBlock.MIN_PROTOCOL_VERSION;
+        return clientVersion >= params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.BLOOM_FILTER);
     }
 
     /** Returns true if the protocol version and service bits both indicate support for the getutxos message. */

--- a/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
+++ b/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
@@ -116,7 +116,7 @@ public class WalletAppKit extends AbstractIdleService {
     public WalletAppKit connectToLocalHost() {
         try {
             final InetAddress localHost = InetAddress.getLocalHost();
-            return setPeerNodes(new PeerAddress(localHost, params.getPort()));
+            return setPeerNodes(new PeerAddress(params, localHost, params.getPort()));
         } catch (UnknownHostException e) {
             // Borked machine with no loopback adapter configured properly.
             throw new RuntimeException(e);

--- a/core/src/main/java/org/bitcoinj/params/AbstractBitcoinNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/AbstractBitcoinNetParams.java
@@ -137,6 +137,11 @@ public abstract class AbstractBitcoinNetParams extends NetworkParameters {
     }
 
     @Override
+    public int getProtocolVersionNum(final ProtocolVersion version) {
+        return version.getBitcoinProtocolVersion();
+    }
+
+    @Override
     public BitcoinSerializer getSerializer(boolean parseRetain) {
         return new BitcoinSerializer(this, parseRetain);
     }

--- a/core/src/main/java/org/bitcoinj/store/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/store/WalletProtobufSerializer.java
@@ -506,7 +506,7 @@ public class WalletProtobufSerializer {
 
             // Update transaction outputs to point to inputs that spend them
             for (Protos.Transaction txProto : walletProto.getTransactionList()) {
-                WalletTransaction wtx = connectTransactionOutputs(txProto);
+                WalletTransaction wtx = connectTransactionOutputs(params, txProto);
                 wallet.addWalletTransaction(wtx);
             }
 
@@ -672,7 +672,8 @@ public class WalletProtobufSerializer {
         txMap.put(txProto.getHash(), tx);
     }
 
-    private WalletTransaction connectTransactionOutputs(org.bitcoinj.wallet.Protos.Transaction txProto) throws UnreadableWalletException {
+    private WalletTransaction connectTransactionOutputs(final NetworkParameters params,
+                                                        final org.bitcoinj.wallet.Protos.Transaction txProto) throws UnreadableWalletException {
         Transaction tx = txMap.get(txProto.getHash());
         final WalletTransaction.Pool pool;
         switch (txProto.getPool()) {
@@ -710,14 +711,15 @@ public class WalletProtobufSerializer {
         if (txProto.hasConfidence()) {
             Protos.TransactionConfidence confidenceProto = txProto.getConfidence();
             TransactionConfidence confidence = tx.getConfidence();
-            readConfidence(tx, confidenceProto, confidence);
+            readConfidence(params, tx, confidenceProto, confidence);
         }
 
         return new WalletTransaction(pool, tx);
     }
 
-    private void readConfidence(Transaction tx, Protos.TransactionConfidence confidenceProto,
-                                TransactionConfidence confidence) throws UnreadableWalletException {
+    private void readConfidence(final NetworkParameters params, final Transaction tx,
+                                final Protos.TransactionConfidence confidenceProto,
+                                final TransactionConfidence confidence) throws UnreadableWalletException {
         // We are lenient here because tx confidence is not an essential part of the wallet.
         // If the tx has an unknown type of confidence, ignore.
         if (!confidenceProto.hasType()) {
@@ -772,7 +774,7 @@ public class WalletProtobufSerializer {
                 throw new UnreadableWalletException("Peer IP address does not have the right length", e);
             }
             int port = proto.getPort();
-            PeerAddress address = new PeerAddress(ip, port);
+            PeerAddress address = new PeerAddress(params, ip, port);
             address.setServices(BigInteger.valueOf(proto.getServices()));
             confidence.markBroadcastBy(address);
         }

--- a/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
@@ -55,7 +55,8 @@ public class BitcoinSerializerTest {
 
     @Test
     public void testAddr() throws Exception {
-        MessageSerializer serializer = MainNetParams.get().getDefaultSerializer();
+        final NetworkParameters params = MainNetParams.get();
+        MessageSerializer serializer = params.getDefaultSerializer();
         // the actual data from https://en.bitcoin.it/wiki/Protocol_specification#addr
         AddressMessage addressMessage = (AddressMessage) serializer.deserialize(ByteBuffer.wrap(ADDRESS_MESSAGE_BYTES));
         assertEquals(1, addressMessage.getAddresses().size());
@@ -66,7 +67,7 @@ public class BitcoinSerializerTest {
         serializer.serialize(addressMessage, bos);
 
         assertEquals(31, addressMessage.getMessageSize());
-        addressMessage.addAddress(new PeerAddress(InetAddress.getLocalHost()));
+        addressMessage.addAddress(new PeerAddress(params, InetAddress.getLocalHost()));
         assertEquals(61, addressMessage.getMessageSize());
         addressMessage.removeAddress(0);
         assertEquals(31, addressMessage.getMessageSize());

--- a/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
@@ -78,7 +78,7 @@ public class BitcoindComparisonTool {
         VersionMessage ver = new VersionMessage(params, 42);
         ver.appendToSubVer("BlockAcceptanceComparisonTool", "1.1", null);
         ver.localServices = VersionMessage.NODE_NETWORK;
-        final Peer bitcoind = new Peer(params, ver, new BlockChain(params, new MemoryBlockStore(params)), new PeerAddress(InetAddress.getLocalHost()));
+        final Peer bitcoind = new Peer(params, ver, new BlockChain(params, new MemoryBlockStore(params)), new PeerAddress(params, InetAddress.getLocalHost()));
         Preconditions.checkState(bitcoind.getVersionMessage().hasBlockChain());
 
         final BlockWrapper currentBlock = new BlockWrapper();

--- a/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
@@ -188,8 +188,8 @@ public class ChainSplitTest {
         wallet.commitTx(spend);
         // Waiting for confirmation ... make it eligible for selection.
         assertEquals(Coin.ZERO, wallet.getBalance());
-        spend.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByAddress(new byte[]{1, 2, 3, 4})));
-        spend.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByAddress(new byte[]{5,6,7,8})));
+        spend.getConfidence().markBroadcastBy(new PeerAddress(unitTestParams, InetAddress.getByAddress(new byte[]{1, 2, 3, 4})));
+        spend.getConfidence().markBroadcastBy(new PeerAddress(unitTestParams, InetAddress.getByAddress(new byte[]{5,6,7,8})));
         assertEquals(ConfidenceType.PENDING, spend.getConfidence().getConfidenceType());
         assertEquals(valueOf(40, 0), wallet.getBalance());
         Block b2 = b1.createNextBlock(someOtherGuy);

--- a/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -429,7 +429,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         peerGroup.start();
         peerGroup.setPingIntervalMsec(0);
         VersionMessage versionMessage = new VersionMessage(params, 2);
-        versionMessage.clientVersion = FilteredBlock.MIN_PROTOCOL_VERSION;
+        versionMessage.clientVersion = NetworkParameters.ProtocolVersion.BLOOM_FILTER.getBitcoinProtocolVersion();
         versionMessage.localServices = VersionMessage.NODE_NETWORK;
         connectPeer(1, versionMessage);
         peerGroup.waitForPeers(1).get();
@@ -441,7 +441,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         peerGroup.start();
         peerGroup.setPingIntervalMsec(100);
         VersionMessage versionMessage = new VersionMessage(params, 2);
-        versionMessage.clientVersion = FilteredBlock.MIN_PROTOCOL_VERSION;
+        versionMessage.clientVersion = NetworkParameters.ProtocolVersion.BLOOM_FILTER.getBitcoinProtocolVersion();
         versionMessage.localServices = VersionMessage.NODE_NETWORK;
         InboundMessageQueuer p1 = connectPeer(1, versionMessage);
         Ping ping = (Ping) waitForOutbound(p1);
@@ -458,10 +458,10 @@ public class PeerGroupTest extends TestWithPeerGroup {
     public void downloadPeerSelection() throws Exception {
         peerGroup.start();
         VersionMessage versionMessage2 = new VersionMessage(params, 2);
-        versionMessage2.clientVersion = FilteredBlock.MIN_PROTOCOL_VERSION;
+        versionMessage2.clientVersion = NetworkParameters.ProtocolVersion.BLOOM_FILTER.getBitcoinProtocolVersion();
         versionMessage2.localServices = VersionMessage.NODE_NETWORK;
         VersionMessage versionMessage3 = new VersionMessage(params, 3);
-        versionMessage3.clientVersion = FilteredBlock.MIN_PROTOCOL_VERSION;
+        versionMessage3.clientVersion = NetworkParameters.ProtocolVersion.BLOOM_FILTER.getBitcoinProtocolVersion();
         versionMessage3.localServices = VersionMessage.NODE_NETWORK;
         assertNull(peerGroup.getDownloadPeer());
         Peer a = connectPeer(1, versionMessage2).peer;

--- a/core/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -79,7 +79,7 @@ public class PeerTest extends TestWithNetworkConnections {
         super.setUp();
         VersionMessage ver = new VersionMessage(params, 100);
         InetSocketAddress address = new InetSocketAddress("127.0.0.1", 4000);
-        peer = new Peer(params, ver, new PeerAddress(address), blockChain);
+        peer = new Peer(params, ver, new PeerAddress(params, address), blockChain);
         peer.addWallet(wallet);
     }
 
@@ -269,7 +269,7 @@ public class PeerTest extends TestWithNetworkConnections {
         // Check co-ordination of which peer to download via the memory pool.
         VersionMessage ver = new VersionMessage(params, 100);
         InetSocketAddress address = new InetSocketAddress("127.0.0.1", 4242);
-        Peer peer2 = new Peer(params, ver, new PeerAddress(address), blockChain);
+        Peer peer2 = new Peer(params, ver, new PeerAddress(params, address), blockChain);
         peer2.addWallet(wallet);
         VersionMessage peerVersion = new VersionMessage(params, OTHER_PEER_CHAIN_HEIGHT);
         peerVersion.clientVersion = 70001;

--- a/core/src/test/java/org/bitcoinj/core/TxConfidenceTableTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TxConfidenceTableTest.java
@@ -45,9 +45,9 @@ public class TxConfidenceTableTest {
         tx2 = FakeTxBuilder.createFakeTxWithChangeAddress(params, COIN, to, change);
         assertEquals(tx1.getHash(), tx2.getHash());
 
-        address1 = new PeerAddress(InetAddress.getByAddress(new byte[] { 127, 0, 0, 1 }));
-        address2 = new PeerAddress(InetAddress.getByAddress(new byte[] { 127, 0, 0, 2 }));
-        address3 = new PeerAddress(InetAddress.getByAddress(new byte[] { 127, 0, 0, 3 }));
+        address1 = new PeerAddress(params, InetAddress.getByAddress(new byte[] { 127, 0, 0, 1 }));
+        address2 = new PeerAddress(params, InetAddress.getByAddress(new byte[] { 127, 0, 0, 2 }));
+        address3 = new PeerAddress(params, InetAddress.getByAddress(new byte[] { 127, 0, 0, 3 }));
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/core/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/core/WalletTest.java
@@ -423,8 +423,8 @@ public class WalletTest extends TestWithWallet {
             }
         });
 
-        t.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByAddress(new byte[]{1,2,3,4})));
-        t.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByAddress(new byte[]{10,2,3,4})));
+        t.getConfidence().markBroadcastBy(new PeerAddress(params, InetAddress.getByAddress(new byte[]{1,2,3,4})));
+        t.getConfidence().markBroadcastBy(new PeerAddress(params, InetAddress.getByAddress(new byte[]{10,2,3,4})));
         wallet.commitTx(t);
         Threading.waitForUserCode();
         assertEquals(1, wallet.getPoolSize(WalletTransaction.Pool.PENDING));

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -104,8 +104,8 @@ public class WalletProtobufSerializerTest {
         // Check basic tx serialization.
         Coin v1 = COIN;
         Transaction t1 = createFakeTx(params, v1, myAddress);
-        t1.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByName("1.2.3.4")));
-        t1.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByName("5.6.7.8")));
+        t1.getConfidence().markBroadcastBy(new PeerAddress(params, InetAddress.getByName("1.2.3.4")));
+        t1.getConfidence().markBroadcastBy(new PeerAddress(params, InetAddress.getByName("5.6.7.8")));
         t1.getConfidence().setSource(TransactionConfidence.Source.NETWORK);
         myWallet.receivePending(t1, null);
         Wallet wallet1 = roundTrip(myWallet);

--- a/core/src/test/java/org/bitcoinj/wallet/DefaultCoinSelectorTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DefaultCoinSelectorTest.java
@@ -52,9 +52,9 @@ public class DefaultCoinSelectorTest extends TestWithWallet {
         assertFalse(DefaultCoinSelector.isSelectable(t));
         t.getConfidence().setSource(TransactionConfidence.Source.SELF);
         assertFalse(DefaultCoinSelector.isSelectable(t));
-        t.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByName("1.2.3.4")));
+        t.getConfidence().markBroadcastBy(new PeerAddress(params, InetAddress.getByName("1.2.3.4")));
         assertFalse(DefaultCoinSelector.isSelectable(t));
-        t.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByName("5.6.7.8")));
+        t.getConfidence().markBroadcastBy(new PeerAddress(params, InetAddress.getByName("5.6.7.8")));
         assertTrue(DefaultCoinSelector.isSelectable(t));
         t = new Transaction(params);
         t.getConfidence().setConfidenceType(TransactionConfidence.ConfidenceType.BUILDING);


### PR DESCRIPTION
Enables altcoin networks which may have out of sync protocol numbers, and also moves version numbers into a single enum rather than having them scattered through the code.
