### PR TITLE
Set minimum fee to 5000 satoshis, matching Bitcoin Core 0.11.1.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -91,16 +91,15 @@ public class Transaction extends ChildMessage {
 
     /**
      * If fee is lower than this value (in satoshis), Bitcoin Core will treat it as if there were no fee.
-     * Currently this is 1000 satoshis.
      */
-    public static final Coin REFERENCE_DEFAULT_MIN_TX_FEE = Coin.valueOf(1000);
+    public static final Coin REFERENCE_DEFAULT_MIN_TX_FEE = Coin.valueOf(5000); // satoshis
 
     /**
      * Any standard (ie pay-to-address) output smaller than this value (in satoshis) will most likely be rejected by the network.
      * This is calculated by assuming a standard output will be 34 bytes, and then using the formula used in
-     * {@link TransactionOutput#getMinNonDustValue(Coin)}. Currently it's 546 satoshis.
+     * {@link TransactionOutput#getMinNonDustValue(Coin)}.
      */
-    public static final Coin MIN_NONDUST_OUTPUT = Coin.valueOf(546);
+    public static final Coin MIN_NONDUST_OUTPUT = Coin.valueOf(2730); // satoshis
 
     // These are bitcoin serialized.
     private long version;


### PR DESCRIPTION
However, I'm not entirely convinced we need this. There will always be a certain percentage of nodes that use the old relay rules, e.g. Bitcoin XT. What do others think?