### PR TITLE
Clean up MessageSerializer to simplify subclasses

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
@@ -41,7 +41,7 @@ import static org.bitcoinj.core.Utils.*;
  * <li>Message.bitcoinSerializeToStream() needs to be properly subclassed</li>
  * </ul>
  */
-public class BitcoinSerializer implements MessageSerializer {
+public class BitcoinSerializer extends MessageSerializer {
     private static final Logger log = LoggerFactory.getLogger(BitcoinSerializer.class);
     private static final int COMMAND_LEN = 12;
 
@@ -266,16 +266,7 @@ public class BitcoinSerializer implements MessageSerializer {
      * serialization format support.
      */
     @Override
-    public Block makeBlock(byte[] payloadBytes) throws ProtocolException {
-        return new Block(params, payloadBytes, this, payloadBytes.length);
-    }
-
-    /**
-     * Make a block from the payload. Extension point for alternative
-     * serialization format support.
-     */
-    @Override
-    public Block makeBlock(byte[] payloadBytes, int length) throws ProtocolException {
+    public Block makeBlock(final byte[] payloadBytes, final int length) throws ProtocolException {
         return new Block(params, payloadBytes, this, length);
     }
 
@@ -317,16 +308,6 @@ public class BitcoinSerializer implements MessageSerializer {
         if (hash != null)
             tx.setHash(Sha256Hash.wrapReversed(hash));
         return tx;
-    }
-
-    @Override
-    public Transaction makeTransaction(byte[] payloadBytes) throws ProtocolException {
-        return makeTransaction(payloadBytes, 0, payloadBytes.length, null);
-    }
-
-    @Override
-    public Transaction makeTransaction(byte[] payloadBytes, int offset) throws ProtocolException {
-        return makeTransaction(payloadBytes, offset, payloadBytes.length, null);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -121,8 +121,9 @@ public class Block extends Message {
     }
 
     /**
-     * Contruct a block object from the Bitcoin wire format.
+     * Construct a block object from the Bitcoin wire format.
      * @param params NetworkParameters object.
+     * @param payloadBytes the payload to extract the block from.
      * @param serializer the serializer to use for this message.
      * @param length The length of message if known.  Usually this is provided when deserializing of the wire
      * as the length will be provided as part of the header.  If unknown then set to Message.UNKNOWN_LENGTH
@@ -963,5 +964,15 @@ public class Block extends Message {
     @VisibleForTesting
     boolean isTransactionBytesValid() {
         return transactionBytesValid;
+    }
+
+    /**
+     * Return whether this block contains any transactions.
+     * 
+     * @return  true if the block contains transactions, false otherwise (is
+     * purely a header).
+     */
+    public boolean hasTransactions() {
+        return !this.transactions.isEmpty();
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/DummySerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/DummySerializer.java
@@ -25,7 +25,7 @@ import java.nio.ByteBuffer;
  * Dummy serializer used ONLY for objects which do not have network parameters
  * set.
  */
-class DummySerializer implements MessageSerializer {
+class DummySerializer extends MessageSerializer {
     public static final DummySerializer DEFAULT = new DummySerializer();
 
     private static final String DEFAULT_EXCEPTION_MESSAGE = "Dummy serializer cannot serialize/deserialize objects as it does not know which network they belong to.";
@@ -64,11 +64,6 @@ class DummySerializer implements MessageSerializer {
     }
 
     @Override
-    public Block makeBlock(byte[] payloadBytes) throws UnsupportedOperationException {
-        throw new UnsupportedOperationException(DEFAULT_EXCEPTION_MESSAGE);
-    }
-
-    @Override
     public Block makeBlock(byte[] payloadBytes, int length) throws UnsupportedOperationException {
         throw new UnsupportedOperationException(DEFAULT_EXCEPTION_MESSAGE);
     }
@@ -91,16 +86,6 @@ class DummySerializer implements MessageSerializer {
     @Override
     public Transaction makeTransaction(byte[] payloadBytes, int offset, int length, byte[] hash) throws UnsupportedOperationException {
         throw new UnsupportedOperationException(DEFAULT_EXCEPTION_MESSAGE);
-    }
-
-    @Override
-    public Transaction makeTransaction(byte[] payloadBytes) throws UnsupportedOperationException {
-        return makeTransaction(payloadBytes, 0, payloadBytes.length, null);
-    }
-
-    @Override
-    public Transaction makeTransaction(byte[] payloadBytes, int offset) throws UnsupportedOperationException {
-        return makeTransaction(payloadBytes, offset, payloadBytes.length, null);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/MessageSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/MessageSerializer.java
@@ -27,71 +27,75 @@ import java.nio.ByteBuffer;
  * Generic interface for classes which serialize/deserialize messages. Implementing
  * classes should be immutable.
  */
-public interface MessageSerializer {
+public abstract class MessageSerializer {
 
     /**
      * Reads a message from the given ByteBuffer and returns it.
      */
-    Message deserialize(ByteBuffer in) throws ProtocolException, IOException, UnsupportedOperationException;
+    public abstract Message deserialize(ByteBuffer in) throws ProtocolException, IOException, UnsupportedOperationException;
 
     /**
      * Deserializes only the header in case packet meta data is needed before decoding
      * the payload. This method assumes you have already called seekPastMagicBytes()
      */
-    BitcoinSerializer.BitcoinPacketHeader deserializeHeader(ByteBuffer in) throws ProtocolException, IOException, UnsupportedOperationException;
+    public abstract BitcoinSerializer.BitcoinPacketHeader deserializeHeader(ByteBuffer in) throws ProtocolException, IOException, UnsupportedOperationException;
 
     /**
      * Deserialize payload only.  You must provide a header, typically obtained by calling
      * {@link BitcoinSerializer#deserializeHeader}.
      */
-    Message deserializePayload(BitcoinSerializer.BitcoinPacketHeader header, ByteBuffer in) throws ProtocolException, BufferUnderflowException, UnsupportedOperationException;
+    public abstract Message deserializePayload(BitcoinSerializer.BitcoinPacketHeader header, ByteBuffer in) throws ProtocolException, BufferUnderflowException, UnsupportedOperationException;
 
     /**
      * Whether the serializer will produce cached mode Messages
      */
-    boolean isParseRetainMode();
+    public abstract boolean isParseRetainMode();
 
     /**
      * Make an address message from the payload. Extension point for alternative
      * serialization format support.
      */
-    AddressMessage makeAddressMessage(byte[] payloadBytes, int length) throws ProtocolException, UnsupportedOperationException;
+    public abstract AddressMessage makeAddressMessage(byte[] payloadBytes, int length) throws ProtocolException, UnsupportedOperationException;
 
     /**
      * Make an alert message from the payload. Extension point for alternative
      * serialization format support.
      */
-    Message makeAlertMessage(byte[] payloadBytes) throws ProtocolException, UnsupportedOperationException;
+    public abstract Message makeAlertMessage(byte[] payloadBytes) throws ProtocolException, UnsupportedOperationException;
+
 
     /**
-     * Make a block from the payload. Extension point for alternative
-     * serialization format support.
+     * Make a block from the payload, using an offset of zero and the payload
+     * length as block length.
      */
-    Block makeBlock(byte[] payloadBytes) throws ProtocolException, UnsupportedOperationException;
+    public final Block makeBlock(byte[] payloadBytes) throws ProtocolException {
+        return makeBlock(payloadBytes, payloadBytes.length);
+    }
 
     /**
-     * Make a block from the payload. Extension point for alternative
+     * Make a block from the payload, using an offset of zero and the provided
+     * length as block length. Extension point for alternative
      * serialization format support.
      */
-    Block makeBlock(byte[] payloadBytes, int length) throws ProtocolException, UnsupportedOperationException;
+    public abstract Block makeBlock(byte[] payloadBytes, int length) throws ProtocolException;
 
     /**
      * Make an filter message from the payload. Extension point for alternative
      * serialization format support.
      */
-    Message makeBloomFilter(byte[] payloadBytes) throws ProtocolException, UnsupportedOperationException;
+    public abstract Message makeBloomFilter(byte[] payloadBytes) throws ProtocolException, UnsupportedOperationException;
 
     /**
      * Make a filtered block from the payload. Extension point for alternative
      * serialization format support.
      */
-    FilteredBlock makeFilteredBlock(byte[] payloadBytes) throws ProtocolException, UnsupportedOperationException;
+    public abstract FilteredBlock makeFilteredBlock(byte[] payloadBytes) throws ProtocolException, UnsupportedOperationException;
 
     /**
      * Make an inventory message from the payload. Extension point for alternative
      * serialization format support.
      */
-    InventoryMessage makeInventoryMessage(byte[] payloadBytes, int length) throws ProtocolException, UnsupportedOperationException;
+    public abstract InventoryMessage makeInventoryMessage(byte[] payloadBytes, int length) throws ProtocolException, UnsupportedOperationException;
 
     /**
      * Make a transaction from the payload. Extension point for alternative
@@ -102,7 +106,7 @@ public interface MessageSerializer {
      * serializer (i.e. for messages with no network parameters), or because
      * it does not support deserializing transactions.
      */
-    Transaction makeTransaction(byte[] payloadBytes, int offset, int length, byte[] hash) throws ProtocolException, UnsupportedOperationException;
+    public abstract Transaction makeTransaction(byte[] payloadBytes, int offset, int length, byte[] hash) throws ProtocolException, UnsupportedOperationException;
 
     /**
      * Make a transaction from the payload. Extension point for alternative
@@ -113,7 +117,9 @@ public interface MessageSerializer {
      * serializer (i.e. for messages with no network parameters), or because
      * it does not support deserializing transactions.
      */
-    Transaction makeTransaction(byte[] payloadBytes) throws ProtocolException, UnsupportedOperationException;
+    public final Transaction makeTransaction(byte[] payloadBytes) throws ProtocolException, UnsupportedOperationException {
+        return makeTransaction(payloadBytes, 0);
+    }
 
     /**
      * Make a transaction from the payload. Extension point for alternative
@@ -124,9 +130,11 @@ public interface MessageSerializer {
      * serializer (i.e. for messages with no network parameters), or because
      * it does not support deserializing transactions.
      */
-    Transaction makeTransaction(byte[] payloadBytes, int offset) throws ProtocolException, UnsupportedOperationException;
+    public final Transaction makeTransaction(byte[] payloadBytes, int offset) throws ProtocolException {
+        return makeTransaction(payloadBytes, offset, payloadBytes.length, null);
+    }
 
-    void seekPastMagicBytes(ByteBuffer in) throws BufferUnderflowException;
+    public abstract void seekPastMagicBytes(ByteBuffer in) throws BufferUnderflowException;
 
     /**
      * Writes message to to the output stream.
@@ -136,7 +144,7 @@ public interface MessageSerializer {
      * serializer (i.e. for messages with no network parameters), or because
      * it does not support serializing the given message.
      */
-    void serialize(String name, byte[] message, OutputStream out) throws IOException, UnsupportedOperationException;
+    public abstract void serialize(String name, byte[] message, OutputStream out) throws IOException, UnsupportedOperationException;
 
     /**
      * Writes message to to the output stream.
@@ -146,6 +154,6 @@ public interface MessageSerializer {
      * serializer (i.e. for messages with no network parameters), or because
      * it does not support serializing the given message.
      */
-    void serialize(Message message, OutputStream out) throws IOException, UnsupportedOperationException;
+    public abstract void serialize(Message message, OutputStream out) throws IOException, UnsupportedOperationException;
     
 }


### PR DESCRIPTION
By replacing MessageSerializer with an abstract class, methods which should just call other methods in the same class are now fixed, and subclasses only have to override a single abstract method instead of multiple methods.