### PR TITLE
Add support for block headers of variable length

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
@@ -266,8 +266,8 @@ public class BitcoinSerializer extends MessageSerializer {
      * serialization format support.
      */
     @Override
-    public Block makeBlock(final byte[] payloadBytes, final int length) throws ProtocolException {
-        return new Block(params, payloadBytes, this, length);
+    public Block makeBlock(final byte[] payloadBytes, final int offset, final int length) throws ProtocolException {
+        return new Block(params, payloadBytes, offset, this, length);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -135,6 +135,21 @@ public class Block extends Message {
     }
 
     /**
+     * Construct a block object from the Bitcoin wire format.
+     * @param params NetworkParameters object.
+     * @param payloadBytes the payload to extract the block from.
+     * @param offset The location of the first payload byte within the array.
+     * @param serializer the serializer to use for this message.
+     * @param length The length of message if known.  Usually this is provided when deserializing of the wire
+     * as the length will be provided as part of the header.  If unknown then set to Message.UNKNOWN_LENGTH
+     * @throws ProtocolException
+     */
+    public Block(NetworkParameters params, byte[] payloadBytes, int offset, MessageSerializer serializer, int length)
+            throws ProtocolException {
+        super(params, payloadBytes, offset, serializer, length);
+    }
+
+    /**
      * Construct a block object from the Bitcoin wire format. Used in the case of a block
      * contained within another message (i.e. for AuxPoW header).
      *

--- a/core/src/main/java/org/bitcoinj/core/DummySerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/DummySerializer.java
@@ -64,7 +64,7 @@ class DummySerializer extends MessageSerializer {
     }
 
     @Override
-    public Block makeBlock(byte[] payloadBytes, int length) throws UnsupportedOperationException {
+    public Block makeBlock(byte[] payloadBytes, int offset, int length) throws UnsupportedOperationException {
         throw new UnsupportedOperationException(DEFAULT_EXCEPTION_MESSAGE);
     }
 

--- a/core/src/main/java/org/bitcoinj/core/MessageSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/MessageSerializer.java
@@ -69,7 +69,15 @@ public abstract class MessageSerializer {
      * length as block length.
      */
     public final Block makeBlock(byte[] payloadBytes) throws ProtocolException {
-        return makeBlock(payloadBytes, payloadBytes.length);
+        return makeBlock(payloadBytes, 0, payloadBytes.length);
+    }
+
+    /**
+     * Make a block from the payload, using an offset of zero and the provided
+     * length as block length.
+     */
+    public final Block makeBlock(byte[] payloadBytes, int length) throws ProtocolException {
+        return makeBlock(payloadBytes, 0, length);
     }
 
     /**
@@ -77,7 +85,7 @@ public abstract class MessageSerializer {
      * length as block length. Extension point for alternative
      * serialization format support.
      */
-    public abstract Block makeBlock(byte[] payloadBytes, int length) throws ProtocolException;
+    public abstract Block makeBlock(final byte[] payloadBytes, final int offset, final int length) throws ProtocolException, UnsupportedOperationException;
 
     /**
      * Make an filter message from the payload. Extension point for alternative


### PR DESCRIPTION
Add support for block headers of variable length, when parsing headers messages. Also removes a lot of double-handling of messages (i.e. copying subparts of the message out so they are parsed in isolation rather than within the context of the message)