### PR TITLE
Enforce v4 block switchover

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
@@ -544,12 +544,13 @@ public abstract class AbstractBlockChain {
             if (expensiveChecks && block.getTimeSeconds() <= getMedianTimestampOfRecentBlocks(head, blockStore))
                 throw new VerificationException("Block's timestamp is too early");
 
-            // BIP 66: Enforce block version 3 once it's a supermajority of blocks
+            // BIP 66 & 65: Enforce block version 3/4 once they are a supermajority of blocks
             // NOTE: This requires 1,000 blocks since the last checkpoint (on main
             // net, less on test) in order to be applied. It is also limited to
-            // stopping addition of new v2 blocks to the tip of the chain.
-            if (block.getVersion() == Block.BLOCK_VERSION_BIP34) {
-                final Integer count = versionTally.getCountAtOrAbove(Block.BLOCK_VERSION_BIP66);
+            // stopping addition of new v2/3 blocks to the tip of the chain.
+            if (block.getVersion() == Block.BLOCK_VERSION_BIP34
+                || block.getVersion() == Block.BLOCK_VERSION_BIP66) {
+                final Integer count = versionTally.getCountAtOrAbove(block.getVersion() + 1);
                 if (count != null
                     && count >= params.getMajorityRejectBlockOutdated()) {
                     throw new VerificationException.BlockVersionOutOfDate(block.getVersion());

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -84,6 +84,8 @@ public class Block extends Message {
     public static final long BLOCK_VERSION_BIP34 = 2;
     /** Block version introduced in BIP 66: Strict DER signatures */
     public static final long BLOCK_VERSION_BIP66 = 3;
+    /** Block version introduced in BIP 65: OP_CHECKLOCKTIMEVERIFY */
+    public static final long BLOCK_VERSION_BIP65 = 4;
 
     // Fields defined as part of the protocol format.
     private long version;


### PR DESCRIPTION
This enforces the switch over to block v4 once a supermajority is met, as per BIP65. Does not add any handling of OP_CHECKLOCKTIMEVERIFY yet.
