### PR TITLE
Wallet-Tool: New action to modify the creation time of wallets.

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
@@ -48,7 +48,7 @@ public class DeterministicSeed implements EncryptableItem {
     @Nullable private final List<String> mnemonicCode; // only one of mnemonicCode/encryptedMnemonicCode will be set
     @Nullable private final EncryptedData encryptedMnemonicCode;
     @Nullable private EncryptedData encryptedSeed;
-    private final long creationTimeSeconds;
+    private long creationTimeSeconds;
 
     public DeterministicSeed(String mnemonicCode, byte[] seed, String passphrase, long creationTimeSeconds) throws UnreadableWalletException {
         this(decodeMnemonicCode(mnemonicCode), seed, passphrase, creationTimeSeconds);
@@ -173,6 +173,10 @@ public class DeterministicSeed implements EncryptableItem {
     @Override
     public long getCreationTimeSeconds() {
         return creationTimeSeconds;
+    }
+
+    public void setCreationTimeSeconds(long creationTimeSeconds) {
+        this.creationTimeSeconds = creationTimeSeconds;
     }
 
     public DeterministicSeed encrypt(KeyCrypter keyCrypter, KeyParameter aesKey) {

--- a/tools/src/main/java/org/bitcoinj/tools/WalletTool.java
+++ b/tools/src/main/java/org/bitcoinj/tools/WalletTool.java
@@ -177,6 +177,7 @@ public class WalletTool {
         DECRYPT,
         MARRY,
         ROTATE,
+        SET_CREATION_TIME,
     }
 
     public enum WaitForEnum {
@@ -369,6 +370,7 @@ public class WalletTool {
             case DECRYPT: decrypt(); break;
             case MARRY: marry(); break;
             case ROTATE: rotate(); break;
+            case SET_CREATION_TIME: setCreationTime(); break;
         }
 
         if (!wallet.isConsistent()) {
@@ -1083,5 +1085,19 @@ public class WalletTool {
         if (chainFileName.exists())
             setup();
         System.out.println(wallet.toString(options.has("dump-privkeys"), true, true, chain));
+    }
+
+    private static void setCreationTime() {
+        DeterministicSeed seed = wallet.getActiveKeyChain().getSeed();
+        if (seed == null) {
+            System.err.println("Active chain does not have a seed.");
+            return;
+        }
+        long creationTime = getCreationTimeSeconds();
+        if (creationTime > 0)
+            System.out.println("Setting creation time to: " + Utils.dateTimeFormat(creationTime * 1000));
+        else
+            System.out.println("Clearing creation time.");
+        seed.setCreationTimeSeconds(creationTime);
     }
 }

--- a/tools/src/main/resources/org/bitcoinj/tools/wallet-tool-help.txt
+++ b/tools/src/main/resources/org/bitcoinj/tools/wallet-tool-help.txt
@@ -56,6 +56,11 @@ Usage: wallet-tool --flags action-name
                        created before this date will be re-spent to a key (from an HD tree) that was created after it.
                        If --date is missing, the current time is assumed. If the time covers all keys, a new HD tree
                        will be created from a new random seed.
+  set-creation-time    Modify the creation time of the active chain of this wallet. Currently, watching wallets are
+                       not supported.
+                       If --date is specified, that's the creation date.
+                       If --unixtime is specified, that's the creation time and it overrides --date.
+                       If you omit both options, the creation time is being cleared (set to 0).
 
 >>> GENERAL OPTIONS
   --debuglog           Enables logging from the core library.


### PR DESCRIPTION
This PR makes DeterministicSeed.creationTimeSeconds mutable. Since the creation time can be recovered by a full scan of the block chain, I don't consider this a risk.