### PR TITLE
Fixed behaviour of OP_0 to not NullPointerException

### DIFF
--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -822,8 +822,13 @@ public class Script {
         
         for (ScriptChunk chunk : script.chunks) {
             boolean shouldExecute = !ifStack.contains(false);
-            
-            if (!chunk.isOpCode()) {
+
+            if (chunk.opcode == OP_0) {
+                if (!shouldExecute)
+                    continue;
+
+                stack.add(new byte[] {});
+            } else if (!chunk.isOpCode()) {
                 if (chunk.data.length > MAX_SCRIPT_ELEMENT_SIZE)
                     throw new ScriptException("Attempted to push a data string larger than 520 bytes");
                 

--- a/core/src/test/java/org/bitcoinj/script/ScriptTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptTest.java
@@ -221,6 +221,18 @@ public class ScriptTest {
         }
     }
 
+    @Test
+    public void testOp0() {
+        // Check that OP_0 doesn't NPE and pushes an empty stack frame.
+        Transaction tx = new Transaction(params);
+        tx.addInput(new TransactionInput(params, tx, new byte[] {}));
+        Script script = new ScriptBuilder().smallNum(0).build();
+
+        LinkedList<byte[]> stack = new LinkedList<byte[]>();
+        Script.executeScript(tx, 0, script, stack, Script.ALL_VERIFY_FLAGS);
+        assertEquals("OP_0 push length", 0, stack.get(0).length);
+    }
+
     private Script parseScriptString(String string) throws IOException {
         String[] words = string.split("[ \\t\\n]");
         


### PR DESCRIPTION
`OP_0` was throwing a `NullPointerException` when chunk.data was attempted to access inside the if statement below. Since the behaviour of `OP_0` is to push an empty array to the stack I modified the behaviour as so.