### PR TITLE
Added core support for BIP65 micropayment channels, added test tools for checking functionality

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/core/Wallet.java
@@ -33,7 +33,6 @@ import org.bitcoinj.core.listeners.WalletChangeEventListener;
 import org.bitcoinj.core.listeners.WalletCoinEventListener;
 import org.bitcoinj.core.TransactionConfidence.*;
 import org.bitcoinj.crypto.*;
-import org.bitcoinj.params.*;
 import org.bitcoinj.script.*;
 import org.bitcoinj.signers.*;
 import org.bitcoinj.store.*;
@@ -3643,20 +3642,19 @@ public class Wallet extends BaseTaggableObject
             return req;
         }
 
-        public static SendRequest toLockTimeVerify(NetworkParameters params, Date releaseTime, ECKey from, ECKey to, Coin value) {
+        public static SendRequest toCLTVPaymentChannel(NetworkParameters params, Date releaseTime, ECKey from, ECKey to, Coin value) {
             long time = releaseTime.getTime() / 1000L;
             checkArgument(time >= Transaction.LOCKTIME_THRESHOLD, "Release time was too small");
-            return toLockTimeVerify(params, BigInteger.valueOf(time), from, to, value);
+            return toCLTVPaymentChannel(params, BigInteger.valueOf(time), from, to, value);
         }
 
-        public static SendRequest toLockTimeVerify(NetworkParameters params, int releaseBlock, ECKey from, ECKey to, Coin value) {
-            checkArgument(0 <= releaseBlock && releaseBlock < Transaction.LOCKTIME_THRESHOLD, "Block number was too large");
-            return toLockTimeVerify(params, BigInteger.valueOf(releaseBlock), from, to, value);
+        public static SendRequest toCLTVPaymentChannel(NetworkParameters params, long lockTime, ECKey from, ECKey to, Coin value) {
+            return toCLTVPaymentChannel(params, BigInteger.valueOf(lockTime), from, to, value);
         }
 
-        private static SendRequest toLockTimeVerify(NetworkParameters params, BigInteger time, ECKey from, ECKey to, Coin value) {
+        private static SendRequest toCLTVPaymentChannel(NetworkParameters params, BigInteger time, ECKey from, ECKey to, Coin value) {
             SendRequest req = new SendRequest();
-            Script output = ScriptBuilder.createLockTimeVerifyOutput(time, from, to);
+            Script output = ScriptBuilder.createCLTVPaymentChannelOutput(time, from, to);
             req.tx = new Transaction(params);
             req.tx.addOutput(value, output);
             return req;
@@ -4139,14 +4137,14 @@ public class Wallet extends BaseTaggableObject
                 if (key != null && (key.isEncrypted() || key.hasPrivKey()))
                     return true;
             }
-        } else if (script.isSentToLockTimeVerify()) {
+        } else if (script.isSentToCLTVPaymentChannel()) {
             // Any script for which we are the recipient or sender counts.
-            byte[] sender = script.getLockTimeVerifySenderPubKey();
+            byte[] sender = script.getCLTVPaymentChannelSenderPubKey();
             ECKey senderKey = findKeyFromPubKey(sender);
             if (senderKey != null && (senderKey.isEncrypted() || senderKey.hasPrivKey())) {
                 return true;
             }
-            byte[] recipient = script.getLockTimeVerifyRecipientPubKey();
+            byte[] recipient = script.getCLTVPaymentChannelRecipientPubKey();
             ECKey recipientKey = findKeyFromPubKey(sender);
             if (recipientKey != null && (recipientKey.isEncrypted() || recipientKey.hasPrivKey())) {
                 return true;

--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -307,8 +307,8 @@ public class Script {
      * @return
      * @throws ScriptException
      */
-    public byte[] getLockTimeVerifySenderPubKey() throws ScriptException {
-        if (!isSentToLockTimeVerify()) {
+    public byte[] getCLTVPaymentChannelSenderPubKey() throws ScriptException {
+        if (!isSentToCLTVPaymentChannel()) {
             throw new ScriptException("Script not a standard CHECKLOCKTIMVERIFY transaction: " + this);
         }
         return chunks.get(8).data;
@@ -319,11 +319,18 @@ public class Script {
      * @return
      * @throws ScriptException
      */
-    public byte[] getLockTimeVerifyRecipientPubKey() throws ScriptException {
-        if (!isSentToLockTimeVerify()) {
+    public byte[] getCLTVPaymentChannelRecipientPubKey() throws ScriptException {
+        if (!isSentToCLTVPaymentChannel()) {
             throw new ScriptException("Script not a standard CHECKLOCKTIMVERIFY transaction: " + this);
         }
         return chunks.get(1).data;
+    }
+
+    public BigInteger getCLTVPaymentChannelExpiry() {
+        if (!isSentToCLTVPaymentChannel()) {
+            throw new ScriptException("Script not a standard CHECKLOCKTIMEVERIFY transaction: " + this);
+        }
+        return castToBigInteger(chunks.get(4).data, 5);
     }
 
     /**
@@ -710,13 +717,14 @@ public class Script {
         return true;
     }
 
-    public boolean isSentToLockTimeVerify() {
+    public boolean isSentToCLTVPaymentChannel() {
         if (chunks.size() != 10) return false;
         // Check that opcodes match the pre-determined format.
         if (!chunks.get(0).equalsOpCode(OP_IF)) return false;
         // chunk[1] = recipient pubkey
         if (!chunks.get(2).equalsOpCode(OP_CHECKSIGVERIFY)) return false;
         if (!chunks.get(3).equalsOpCode(OP_ELSE)) return false;
+        // chunk[4] = locktime
         if (!chunks.get(5).equalsOpCode(OP_CHECKLOCKTIMEVERIFY)) return false;
         if (!chunks.get(6).equalsOpCode(OP_DROP)) return false;
         if (!chunks.get(7).equalsOpCode(OP_ENDIF)) return false;

--- a/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
@@ -23,6 +23,7 @@ import org.bitcoinj.core.Utils;
 import org.bitcoinj.crypto.TransactionSignature;
 
 import javax.annotation.Nullable;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -434,5 +435,33 @@ public class ScriptBuilder {
     public static Script createOpReturnScript(byte[] data) {
         checkArgument(data.length <= 40);
         return new ScriptBuilder().op(OP_RETURN).data(data).build();
+    }
+
+    public static Script createLockTimeVerifyOutput(BigInteger time, ECKey from, ECKey to) {
+        byte[] timeBytes = Utils.reverseBytes(Utils.encodeMPI(time, false));
+        if (timeBytes.length > 5) {
+            throw new RuntimeException("Time too large to encode as 5-byte int");
+        }
+        return new ScriptBuilder().op(OP_IF)
+                .data(to.getPubKey()).op(OP_CHECKSIGVERIFY)
+                .op(OP_ELSE)
+                .data(timeBytes).op(OP_CHECKLOCKTIMEVERIFY).op(OP_DROP)
+                .op(OP_ENDIF)
+                .data(from.getPubKey()).op(OP_CHECKSIG).build();
+    }
+
+    public static Script createLockTimeVerifyRefund(TransactionSignature signature) {
+        ScriptBuilder builder = new ScriptBuilder();
+        builder.data(signature.encodeToBitcoin());
+        builder.data(new byte[] { 0 }); // Use the CHECKLOCKTIMEVERIFY if branch
+        return builder.build();
+    }
+
+    public static Script createLockTimeVerifyInput(TransactionSignature from, TransactionSignature to) {
+        ScriptBuilder builder = new ScriptBuilder();
+        builder.data(from.encodeToBitcoin());
+        builder.data(to.encodeToBitcoin());
+        builder.smallNum(1); // Use the CHECKLOCKTIMEVERIFY if branch
+        return builder.build();
     }
 }

--- a/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
@@ -437,7 +437,7 @@ public class ScriptBuilder {
         return new ScriptBuilder().op(OP_RETURN).data(data).build();
     }
 
-    public static Script createLockTimeVerifyOutput(BigInteger time, ECKey from, ECKey to) {
+    public static Script createCLTVPaymentChannelOutput(BigInteger time, ECKey from, ECKey to) {
         byte[] timeBytes = Utils.reverseBytes(Utils.encodeMPI(time, false));
         if (timeBytes.length > 5) {
             throw new RuntimeException("Time too large to encode as 5-byte int");
@@ -450,14 +450,14 @@ public class ScriptBuilder {
                 .data(from.getPubKey()).op(OP_CHECKSIG).build();
     }
 
-    public static Script createLockTimeVerifyRefund(TransactionSignature signature) {
+    public static Script createCLTVPaymentChannelRefund(TransactionSignature signature) {
         ScriptBuilder builder = new ScriptBuilder();
         builder.data(signature.encodeToBitcoin());
         builder.data(new byte[] { 0 }); // Use the CHECKLOCKTIMEVERIFY if branch
         return builder.build();
     }
 
-    public static Script createLockTimeVerifyInput(TransactionSignature from, TransactionSignature to) {
+    public static Script createCLTVPaymentChannelInput(TransactionSignature from, TransactionSignature to) {
         ScriptBuilder builder = new ScriptBuilder();
         builder.data(from.encodeToBitcoin());
         builder.data(to.encodeToBitcoin());

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -1,12 +1,14 @@
 package org.bitcoinj.core;
 
 import org.bitcoinj.core.TransactionConfidence.*;
+import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.params.*;
 import org.bitcoinj.script.*;
 import org.bitcoinj.testing.*;
 import org.easymock.*;
 import org.junit.*;
 
+import java.math.BigInteger;
 import java.util.*;
 import static org.bitcoinj.core.BlockTest.params;
 import static org.bitcoinj.core.Utils.HEX;
@@ -203,6 +205,86 @@ public class TransactionTest {
 
         tx.getConfidence().setConfidenceType(ConfidenceType.DEAD);
         assertEquals(tx.isMature(), false);
+    }
+
+    @Test
+    public void testLockTimeVerifyTransactionSpending() {
+        BigInteger time = BigInteger.valueOf(20);
+
+        ECKey from = new ECKey(), to = new ECKey(), incorrect = new ECKey();
+        Script outputScript = ScriptBuilder.createLockTimeVerifyOutput(time, from, to);
+
+        Transaction tx = new Transaction(PARAMS);
+        tx.addInput(new TransactionInput(PARAMS, tx, new byte[] {}));
+        tx.getInput(0).setSequenceNumber(0);
+        tx.setLockTime(time.subtract(BigInteger.ONE).longValue());
+        TransactionSignature fromSig =
+                tx.calculateSignature(0, from, outputScript, Transaction.SigHash.ALL, false);
+        TransactionSignature toSig =
+                tx.calculateSignature(0, to, outputScript, Transaction.SigHash.ALL, false);
+        TransactionSignature incorrectSig =
+                tx.calculateSignature(0, incorrect, outputScript, Transaction.SigHash.ALL, false);
+        Script scriptSig =
+                ScriptBuilder.createLockTimeVerifyInput(fromSig, toSig);
+        Script refundSig =
+                ScriptBuilder.createLockTimeVerifyRefund(fromSig);
+        Script invalidScriptSig1 =
+                ScriptBuilder.createLockTimeVerifyInput(fromSig, incorrectSig);
+        Script invalidScriptSig2 =
+                ScriptBuilder.createLockTimeVerifyInput(incorrectSig, toSig);
+
+        try {
+            scriptSig.correctlySpends(tx, 0, outputScript, Script.ALL_VERIFY_FLAGS);
+        } catch (ScriptException e) {
+            e.printStackTrace();
+            fail("Spend before script failed to correctly spend");
+        }
+
+        try {
+            refundSig.correctlySpends(tx, 0, outputScript, Script.ALL_VERIFY_FLAGS);
+            fail("Refund passed before expiry");
+        } catch (ScriptException e) { }
+        try {
+            invalidScriptSig1.correctlySpends(tx, 0, outputScript, Script.ALL_VERIFY_FLAGS);
+            fail("Invalid sig 1 passed");
+        } catch (ScriptException e) { }
+        try {
+            invalidScriptSig2.correctlySpends(tx, 0, outputScript, Script.ALL_VERIFY_FLAGS);
+            fail("Invalid sig 2 passed");
+        } catch (ScriptException e) { }
+    }
+
+    @Test
+    public void testLockTimeVerifyTransactionRefund() {
+        BigInteger time = BigInteger.valueOf(20);
+
+        ECKey from = new ECKey(), to = new ECKey(), incorrect = new ECKey();
+        Script outputScript = ScriptBuilder.createLockTimeVerifyOutput(time, from, to);
+
+        Transaction tx = new Transaction(PARAMS);
+        tx.addInput(new TransactionInput(PARAMS, tx, new byte[] {}));
+        tx.getInput(0).setSequenceNumber(0);
+        tx.setLockTime(time.add(BigInteger.ONE).longValue());
+        TransactionSignature fromSig =
+                tx.calculateSignature(0, from, outputScript, Transaction.SigHash.ALL, false);
+        TransactionSignature incorrectSig =
+                tx.calculateSignature(0, incorrect, outputScript, Transaction.SigHash.ALL, false);
+        Script scriptSig =
+                ScriptBuilder.createLockTimeVerifyRefund(fromSig);
+        Script invalidScriptSig =
+                ScriptBuilder.createLockTimeVerifyRefund(incorrectSig);
+
+        try {
+            scriptSig.correctlySpends(tx, 0, outputScript, Script.ALL_VERIFY_FLAGS);
+        } catch (ScriptException e) {
+            e.printStackTrace();
+            fail("Spend before script failed to correctly spend");
+        }
+
+        try {
+            invalidScriptSig.correctlySpends(tx, 0, outputScript, Script.ALL_VERIFY_FLAGS);
+            fail("Invalid sig passed");
+        } catch (ScriptException e) { }
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -208,36 +208,36 @@ public class TransactionTest {
     }
 
     @Test
-    public void testLockTimeVerifyTransactionSpending() {
+    public void testCLTVPaymentChannelTransactionSpending() {
         BigInteger time = BigInteger.valueOf(20);
 
         ECKey from = new ECKey(), to = new ECKey(), incorrect = new ECKey();
-        Script outputScript = ScriptBuilder.createLockTimeVerifyOutput(time, from, to);
+        Script outputScript = ScriptBuilder.createCLTVPaymentChannelOutput(time, from, to);
 
         Transaction tx = new Transaction(PARAMS);
         tx.addInput(new TransactionInput(PARAMS, tx, new byte[] {}));
         tx.getInput(0).setSequenceNumber(0);
         tx.setLockTime(time.subtract(BigInteger.ONE).longValue());
         TransactionSignature fromSig =
-                tx.calculateSignature(0, from, outputScript, Transaction.SigHash.ALL, false);
+                tx.calculateSignature(0, from, outputScript, Transaction.SigHash.SINGLE, false);
         TransactionSignature toSig =
-                tx.calculateSignature(0, to, outputScript, Transaction.SigHash.ALL, false);
+                tx.calculateSignature(0, to, outputScript, Transaction.SigHash.SINGLE, false);
         TransactionSignature incorrectSig =
-                tx.calculateSignature(0, incorrect, outputScript, Transaction.SigHash.ALL, false);
+                tx.calculateSignature(0, incorrect, outputScript, Transaction.SigHash.SINGLE, false);
         Script scriptSig =
-                ScriptBuilder.createLockTimeVerifyInput(fromSig, toSig);
+                ScriptBuilder.createCLTVPaymentChannelInput(fromSig, toSig);
         Script refundSig =
-                ScriptBuilder.createLockTimeVerifyRefund(fromSig);
+                ScriptBuilder.createCLTVPaymentChannelRefund(fromSig);
         Script invalidScriptSig1 =
-                ScriptBuilder.createLockTimeVerifyInput(fromSig, incorrectSig);
+                ScriptBuilder.createCLTVPaymentChannelInput(fromSig, incorrectSig);
         Script invalidScriptSig2 =
-                ScriptBuilder.createLockTimeVerifyInput(incorrectSig, toSig);
+                ScriptBuilder.createCLTVPaymentChannelInput(incorrectSig, toSig);
 
         try {
             scriptSig.correctlySpends(tx, 0, outputScript, Script.ALL_VERIFY_FLAGS);
         } catch (ScriptException e) {
             e.printStackTrace();
-            fail("Spend before script failed to correctly spend");
+            fail("Settle transaction failed to correctly spend the payment channel");
         }
 
         try {
@@ -255,30 +255,30 @@ public class TransactionTest {
     }
 
     @Test
-    public void testLockTimeVerifyTransactionRefund() {
+    public void testCLTVPaymentChannelTransactionRefund() {
         BigInteger time = BigInteger.valueOf(20);
 
         ECKey from = new ECKey(), to = new ECKey(), incorrect = new ECKey();
-        Script outputScript = ScriptBuilder.createLockTimeVerifyOutput(time, from, to);
+        Script outputScript = ScriptBuilder.createCLTVPaymentChannelOutput(time, from, to);
 
         Transaction tx = new Transaction(PARAMS);
         tx.addInput(new TransactionInput(PARAMS, tx, new byte[] {}));
         tx.getInput(0).setSequenceNumber(0);
         tx.setLockTime(time.add(BigInteger.ONE).longValue());
         TransactionSignature fromSig =
-                tx.calculateSignature(0, from, outputScript, Transaction.SigHash.ALL, false);
+                tx.calculateSignature(0, from, outputScript, Transaction.SigHash.SINGLE, false);
         TransactionSignature incorrectSig =
-                tx.calculateSignature(0, incorrect, outputScript, Transaction.SigHash.ALL, false);
+                tx.calculateSignature(0, incorrect, outputScript, Transaction.SigHash.SINGLE, false);
         Script scriptSig =
-                ScriptBuilder.createLockTimeVerifyRefund(fromSig);
+                ScriptBuilder.createCLTVPaymentChannelRefund(fromSig);
         Script invalidScriptSig =
-                ScriptBuilder.createLockTimeVerifyRefund(incorrectSig);
+                ScriptBuilder.createCLTVPaymentChannelRefund(incorrectSig);
 
         try {
             scriptSig.correctlySpends(tx, 0, outputScript, Script.ALL_VERIFY_FLAGS);
         } catch (ScriptException e) {
             e.printStackTrace();
-            fail("Spend before script failed to correctly spend");
+            fail("Refund failed to correctly spend the payment channel");
         }
 
         try {

--- a/core/src/test/java/org/bitcoinj/script/ScriptTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptTest.java
@@ -407,9 +407,9 @@ public class ScriptTest {
     }
 
     @Test
-    public void testLockTimeVerifyOutput() {
-        Script script = ScriptBuilder.createLockTimeVerifyOutput(BigInteger.valueOf(20), new ECKey(), new ECKey());
-        assertTrue("script is locktime-verify", script.isSentToLockTimeVerify());
+    public void testCLTVPaymentChannelOutput() {
+        Script script = ScriptBuilder.createCLTVPaymentChannelOutput(BigInteger.valueOf(20), new ECKey(), new ECKey());
+        assertTrue("script is locktime-verify", script.isSentToCLTVPaymentChannel());
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/script/ScriptTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptTest.java
@@ -407,6 +407,12 @@ public class ScriptTest {
     }
 
     @Test
+    public void testLockTimeVerifyOutput() {
+        Script script = ScriptBuilder.createLockTimeVerifyOutput(BigInteger.valueOf(20), new ECKey(), new ECKey());
+        assertTrue("script is locktime-verify", script.isSentToLockTimeVerify());
+    }
+
+    @Test
     public void getToAddress() throws Exception {
         // pay to pubkey
         ECKey toKey = new ECKey();

--- a/tools/src/main/resources/org/bitcoinj/tools/wallet-tool-help.txt
+++ b/tools/src/main/resources/org/bitcoinj/tools/wallet-tool-help.txt
@@ -62,6 +62,30 @@ Usage: wallet-tool --flags action-name
                        If --date is specified, that's the creation date.
                        If --unixtime is specified, that's the creation time and it overrides --date.
                        If you omit both options, the creation time is being cleared (set to 0).
+  send-cltvpaymentchannel
+                       Creates and broadcasts a transaction paying to a CHECKLOCKTIMEVERIFY micropayment channel.
+                       Requires a public key for the money recipient, public key to create the transactions (the
+                       "return" address) and an expiry time.
+                       Options:
+                          --output=pubkey:value sets the amount to lock and the recipient
+                          --refund-to=pubkey sets "our" public key
+                          --fee=value sets the mining fee
+                          --locktime=YYYY/MM/DD sets the expiry time for the channel
+  settle-cltvpaymentchannel
+                       Creates and broadcasts a transaction settling a previous micropayment channel.
+                       This tool, for testing, requires the presence of both private keys.
+                       Options:
+                          --output=pubkey:value sets the destination for the money
+                          --fee=value sets the mining fee
+                          --txhash=hash sets the transaction to spend
+  refund-cltvpaymentchannel
+                       Creates and broadcasts a transaction refunding a previous micropayment channel.
+                       This command can only be called once the expiry for the micropayment channel has passed -
+                       the created transaction won't be accepted into the mempool until that point.
+                       Options:
+                          --output=pubkey:value sets the destination for the money
+                          --fee=value sets the mining fee
+                          --txhash=hash sets the transaction to spend
 
 >>> GENERAL OPTIONS
   --debuglog           Enables logging from the core library.


### PR DESCRIPTION
I added support to the core bitcoinj library for creating, spending and refunding BIP65-style micropayment channel transactions. I also added commands to `WalletTool` for using each of these behaviours and checking that they can be used in testnet.