### PR TITLE
Constructors should only call non-overridable methods

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
@@ -169,7 +169,7 @@ public abstract class AbstractBlockChain {
      * have never been in use, or if the wallet has been loaded along with the BlockChain. Note that adding multiple
      * wallets is not well tested!
      */
-    public void addWallet(Wallet wallet) {
+    public final void addWallet(Wallet wallet) {
         addNewBestBlockListener(Threading.SAME_THREAD, wallet);
         addReorganizeListener(Threading.SAME_THREAD, wallet);
         addTransactionReceivedListener(Threading.SAME_THREAD, wallet);
@@ -231,7 +231,7 @@ public abstract class AbstractBlockChain {
     /**
      * Adds a {@link NewBestBlockListener} listener to the chain.
      */
-    public void addNewBestBlockListener(Executor executor, NewBestBlockListener listener) {
+    public final void addNewBestBlockListener(Executor executor, NewBestBlockListener listener) {
         newBestBlockListeners.add(new ListenerRegistration<NewBestBlockListener>(listener, executor));
     }
 
@@ -245,7 +245,7 @@ public abstract class AbstractBlockChain {
     /**
      * Adds a generic {@link ReorganizeListener} listener to the chain.
      */
-    public void addReorganizeListener(Executor executor, ReorganizeListener listener) {
+    public final void addReorganizeListener(Executor executor, ReorganizeListener listener) {
         reorganizeListeners.add(new ListenerRegistration<ReorganizeListener>(listener, executor));
     }
 
@@ -259,7 +259,7 @@ public abstract class AbstractBlockChain {
     /**
      * Adds a generic {@link TransactionReceivedInBlockListener} listener to the chain.
      */
-    public void addTransactionReceivedListener(Executor executor, TransactionReceivedInBlockListener listener) {
+    public final void addTransactionReceivedListener(Executor executor, TransactionReceivedInBlockListener listener) {
         transactionReceivedListeners.add(new ListenerRegistration<TransactionReceivedInBlockListener>(listener, executor));
     }
 
@@ -860,7 +860,7 @@ public abstract class AbstractBlockChain {
     /**
      * @return the height of the best known chain, convenience for <tt>getChainHead().getHeight()</tt>.
      */
-    public int getBestChainHeight() {
+    public final int getBestChainHeight() {
         return getChainHead().getHeight();
     }
 

--- a/core/src/main/java/org/bitcoinj/core/ChildMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/ChildMessage.java
@@ -55,7 +55,7 @@ public abstract class ChildMessage extends Message {
         this.parent = parent;
     }
 
-    public void setParent(@Nullable Message parent) {
+    public final void setParent(@Nullable Message parent) {
         if (this.parent != null && this.parent != parent && parent != null) {
             // After old parent is unlinked it won't be able to receive notice if this ChildMessage
             // changes internally.  To be safe we invalidate the parent cache to ensure it rebuilds

--- a/core/src/main/java/org/bitcoinj/core/VarInt.java
+++ b/core/src/main/java/org/bitcoinj/core/VarInt.java
@@ -67,7 +67,7 @@ public class VarInt {
     /**
      * Returns the minimum encoded size of the value.
      */
-    public int getSizeInBytes() {
+    public final int getSizeInBytes() {
         return sizeOf(value);
     }
 

--- a/core/src/main/java/org/bitcoinj/core/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/core/Wallet.java
@@ -336,7 +336,7 @@ public class Wallet extends BaseTaggableObject
      * <p>Transaction signer should be fully initialized before adding to the wallet, otherwise {@link IllegalStateException}
      * will be thrown</p>
      */
-    public void addTransactionSigner(TransactionSigner signer) {
+    public final void addTransactionSigner(TransactionSigner signer) {
         lock.lock();
         try {
             if (signer.isReady())

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicHierarchy.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicHierarchy.java
@@ -60,7 +60,7 @@ public class DeterministicHierarchy {
      * Inserts a key into the heirarchy. Used during deserialization: you normally don't need this. Keys must be
      * inserted in order.
      */
-    public void putKey(DeterministicKey key) {
+    public final void putKey(DeterministicKey key) {
         ImmutableList<ChildNumber> path = key.getPath();
         // Update our tracking of what the next child in each branch of the tree should be. Just assume that keys are
         // inserted in order here.

--- a/core/src/main/java/org/bitcoinj/net/AbstractTimeoutHandler.java
+++ b/core/src/main/java/org/bitcoinj/net/AbstractTimeoutHandler.java
@@ -41,7 +41,7 @@ public abstract class AbstractTimeoutHandler {
      *
      * <p>This call will reset the current progress towards the timeout.</p>
      */
-    public synchronized void setTimeoutEnabled(boolean timeoutEnabled) {
+    public synchronized final void setTimeoutEnabled(boolean timeoutEnabled) {
         this.timeoutEnabled = timeoutEnabled;
         resetTimeout();
     }
@@ -56,7 +56,7 @@ public abstract class AbstractTimeoutHandler {
      *
      * <p>This call will reset the current progress towards the timeout.</p>
      */
-    public synchronized void setSocketTimeout(int timeoutMillis) {
+    public synchronized final void setSocketTimeout(int timeoutMillis) {
         this.timeoutMillis = timeoutMillis;
         resetTimeout();
     }

--- a/core/src/main/java/org/bitcoinj/protocols/channels/StoredPaymentChannelClientStates.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/StoredPaymentChannelClientStates.java
@@ -81,7 +81,7 @@ public class StoredPaymentChannelClientStates implements WalletExtension {
      *
      * @param transactionBroadcaster which is used to complete and announce contract and refund transactions.
      */
-    public void setTransactionBroadcaster(TransactionBroadcaster transactionBroadcaster) {
+    public final void setTransactionBroadcaster(TransactionBroadcaster transactionBroadcaster) {
         this.announcePeerGroupFuture.set(checkNotNull(transactionBroadcaster));
     }
 

--- a/core/src/main/java/org/bitcoinj/protocols/channels/StoredPaymentChannelServerStates.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/StoredPaymentChannelServerStates.java
@@ -85,7 +85,7 @@ public class StoredPaymentChannelServerStates implements WalletExtension {
      *
      * @param broadcaster Used when the payment channels are closed
      */
-    public void setTransactionBroadcaster(TransactionBroadcaster broadcaster) {
+    public final void setTransactionBroadcaster(TransactionBroadcaster broadcaster) {
         this.broadcasterFuture.set(checkNotNull(broadcaster));
     }
 

--- a/core/src/main/java/org/bitcoinj/store/DatabaseFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/DatabaseFullPrunedBlockStore.java
@@ -420,7 +420,7 @@ public abstract class DatabaseFullPrunedBlockStore implements FullPrunedBlockSto
      * <p>This will also automatically set up the schema if it does not exist within the DB.</p>
      * @throws BlockStoreException if successful connection to the DB couldn't be made.
      */
-    protected synchronized void maybeConnect() throws BlockStoreException {
+    protected synchronized final void maybeConnect() throws BlockStoreException {
         try {
             if (conn.get() != null && !conn.get().isClosed())
                 return;

--- a/core/src/main/java/org/bitcoinj/store/MemoryBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryBlockStore.java
@@ -50,7 +50,7 @@ public class MemoryBlockStore implements BlockStore {
     }
 
     @Override
-    public synchronized void put(StoredBlock block) throws BlockStoreException {
+    public synchronized final void put(StoredBlock block) throws BlockStoreException {
         if (blockMap == null) throw new BlockStoreException("MemoryBlockStore is closed");
         Sha256Hash hash = block.getHeader().getHash();
         blockMap.put(hash, block);
@@ -69,7 +69,7 @@ public class MemoryBlockStore implements BlockStore {
     }
 
     @Override
-    public void setChainHead(StoredBlock chainHead) throws BlockStoreException {
+    public final void setChainHead(StoredBlock chainHead) throws BlockStoreException {
         if (blockMap == null) throw new BlockStoreException("MemoryBlockStore is closed");
         this.chainHead = chainHead;
     }

--- a/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
@@ -282,7 +282,7 @@ public class MemoryFullPrunedBlockStore implements FullPrunedBlockStore {
     }
     
     @Override
-    public synchronized void put(StoredBlock storedBlock, StoredUndoableBlock undoableBlock) throws BlockStoreException {
+    public synchronized final void put(StoredBlock storedBlock, StoredUndoableBlock undoableBlock) throws BlockStoreException {
         Preconditions.checkNotNull(blockMap, "MemoryFullPrunedBlockStore is closed");
         Sha256Hash hash = storedBlock.getHeader().getHash();
         fullBlockMap.put(hash, storedBlock.getHeight(), undoableBlock);
@@ -319,7 +319,7 @@ public class MemoryFullPrunedBlockStore implements FullPrunedBlockStore {
     }
 
     @Override
-    public synchronized void setChainHead(StoredBlock chainHead) throws BlockStoreException {
+    public synchronized final void setChainHead(StoredBlock chainHead) throws BlockStoreException {
         Preconditions.checkNotNull(blockMap, "MemoryFullPrunedBlockStore is closed");
         this.chainHead = chainHead;
     }
@@ -331,7 +331,7 @@ public class MemoryFullPrunedBlockStore implements FullPrunedBlockStore {
     }
 
     @Override
-    public synchronized void setVerifiedChainHead(StoredBlock chainHead) throws BlockStoreException {
+    public synchronized final void setVerifiedChainHead(StoredBlock chainHead) throws BlockStoreException {
         Preconditions.checkNotNull(blockMap, "MemoryFullPrunedBlockStore is closed");
         this.verifiedChainHead = chainHead;
         if (this.chainHead.getHeight() < chainHead.getHeight())

--- a/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
@@ -150,7 +150,7 @@ public class SPVBlockStore implements BlockStore {
     }
 
     /** Returns the size in bytes of the file that is used to store the chain with the current parameters. */
-    public int getFileSize() {
+    public final int getFileSize() {
         return RECORD_SIZE * numHeaders + FILE_PROLOGUE_BYTES /* extra kilobyte for stuff */;
     }
 

--- a/core/src/main/java/org/bitcoinj/uri/BitcoinURI.java
+++ b/core/src/main/java/org/bitcoinj/uri/BitcoinURI.java
@@ -297,7 +297,7 @@ public class BitcoinURI {
      * @return The URL where a payment request (as specified in BIP 70) may
      *         be fetched.
      */
-    public String getPaymentRequestUrl() {
+    public final String getPaymentRequestUrl() {
         return (String) parameterMap.get(FIELD_PAYMENT_REQUEST_URL);
     }
 

--- a/core/src/main/java/org/bitcoinj/utils/ExponentialBackoff.java
+++ b/core/src/main/java/org/bitcoinj/utils/ExponentialBackoff.java
@@ -73,7 +73,7 @@ public class ExponentialBackoff implements Comparable<ExponentialBackoff> {
     }
 
     /** Track a success - reset back off interval to the initial value */
-    public void trackSuccess() {
+    public final void trackSuccess() {
         backoff = params.initial;
         retryTime = Utils.currentTimeMillis();
     }

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
@@ -249,7 +249,7 @@ public class KeyChainGroup implements KeyBag {
     }
 
     /** Returns the key chain that's used for generation of fresh/current keys. This is always the newest HD chain. */
-    public DeterministicKeyChain getActiveKeyChain() {
+    public final DeterministicKeyChain getActiveKeyChain() {
         if (chains.isEmpty()) {
             if (basic.numKeys() > 0) {
                 log.warn("No HD chain present but random keys are: you probably deserialized an old wallet.");
@@ -483,7 +483,7 @@ public class KeyChainGroup implements KeyBag {
      * from multiple keychains in a multisig relationship.
      * @see org.bitcoinj.wallet.MarriedKeyChain
      */
-    public boolean isMarried() {
+    public final boolean isMarried() {
         return !chains.isEmpty() && getActiveKeyChain().isMarried();
     }
 

--- a/wallettemplate/src/main/java/wallettemplate/WalletPasswordController.java
+++ b/wallettemplate/src/main/java/wallettemplate/WalletPasswordController.java
@@ -58,7 +58,7 @@ public class WalletPasswordController {
         checkNotNull(keyCrypter);   // We should never arrive at this GUI if the wallet isn't actually encrypted.
         KeyDerivationTasks tasks = new KeyDerivationTasks(keyCrypter, password, getTargetTime()) {
             @Override
-            protected void onFinish(KeyParameter aesKey, int timeTakenMsec) {
+            protected final void onFinish(KeyParameter aesKey, int timeTakenMsec) {
                 checkGuiThread();
                 if (Main.bitcoin.wallet().checkAESKey(aesKey)) {
                     WalletPasswordController.this.aesKey.set(aesKey);

--- a/wallettemplate/src/main/java/wallettemplate/WalletSetPasswordController.java
+++ b/wallettemplate/src/main/java/wallettemplate/WalletSetPasswordController.java
@@ -86,7 +86,7 @@ public class WalletSetPasswordController {
         // Deriving the actual key runs on a background thread. 500msec is empirical on my laptop (actual val is more like 333 but we give padding time).
         KeyDerivationTasks tasks = new KeyDerivationTasks(scrypt, password, estimatedKeyDerivationTime) {
             @Override
-            protected void onFinish(KeyParameter aesKey, int timeTakenMsec) {
+            protected final void onFinish(KeyParameter aesKey, int timeTakenMsec) {
                 // Write the target time to the wallet so we can make the progress bar work when entering the password.
                 WalletPasswordController.setTargetTime(Duration.ofMillis(timeTakenMsec));
                 // The actual encryption part doesn't take very long as most private keys are derived on demand.

--- a/wallettemplate/src/main/java/wallettemplate/utils/BitcoinUIModel.java
+++ b/wallettemplate/src/main/java/wallettemplate/utils/BitcoinUIModel.java
@@ -27,7 +27,7 @@ public class BitcoinUIModel {
         setWallet(wallet);
     }
 
-    public void setWallet(Wallet wallet) {
+    public final void setWallet(Wallet wallet) {
         wallet.addEventListener(new AbstractWalletEventListener() {
             @Override
             public void onWalletChanged(Wallet wallet) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1699 - (Constructors should only call non-overridable methods) Calling an overridable method from a constructor could result in failures or strange behaviors when instantiating a subclass which overrides the method.

You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1699

Please let me know if you have any questions.

Kirill.