### PR TITLE
Strings literals should be placed on the left side when checking for equality

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/RejectMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/RejectMessage.java
@@ -101,7 +101,7 @@ public class RejectMessage extends Message {
         byte[] reasonBytes = reason.getBytes("UTF-8");
         stream.write(new VarInt(reasonBytes.length).encode());
         stream.write(reasonBytes);
-        if (message.equals("block") || message.equals("tx"))
+        if ("block".equals(message) || "tx".equals(message))
             stream.write(messageHash.getReversedBytes());
     }
 

--- a/core/src/main/java/org/bitcoinj/protocols/payments/PaymentProtocol.java
+++ b/core/src/main/java/org/bitcoinj/protocols/payments/PaymentProtocol.java
@@ -136,7 +136,7 @@ public class PaymentProtocol {
             final Protos.PaymentRequest paymentRequestToSign = paymentRequest.build();
 
             final String algorithm;
-            if (privateKey.getAlgorithm().equalsIgnoreCase("RSA"))
+            if ("RSA".equalsIgnoreCase(privateKey.getAlgorithm()))
                 algorithm = "SHA256withRSA";
             else
                 throw new IllegalStateException(privateKey.getAlgorithm());
@@ -166,14 +166,14 @@ public class PaymentProtocol {
         List<X509Certificate> certs = null;
         try {
             final String pkiType = paymentRequest.getPkiType();
-            if (pkiType.equals("none"))
+            if ("none".equals(pkiType))
                 // Nothing to verify. Everything is fine. Move along.
                 return null;
 
             String algorithm;
-            if (pkiType.equals("x509+sha256"))
+            if ("x509+sha256".equals(pkiType))
                 algorithm = "SHA256withRSA";
-            else if (pkiType.equals("x509+sha1"))
+            else if ("x509+sha1".equals(pkiType))
                 algorithm = "SHA1withRSA";
             else
                 throw new PaymentProtocolException.InvalidPkiType("Unsupported PKI type: " + pkiType);

--- a/tools/src/main/java/org/bitcoinj/tools/PaymentProtocolTool.java
+++ b/tools/src/main/java/org/bitcoinj/tools/PaymentProtocolTool.java
@@ -55,9 +55,9 @@ public class PaymentProtocolTool {
                 Protos.PaymentRequest request = Protos.PaymentRequest.parseFrom(stream);
                 stream.close();
                 session = new PaymentSession(request);
-            } else if (uri.getScheme().equals("http")) {
+            } else if ("http".equals(uri.getScheme())) {
                 session = PaymentSession.createFromUrl(arg).get();
-            } else if (uri.getScheme().equals("bitcoin")) {
+            } else if ("bitcoin".equals(uri.getScheme())) {
                 BitcoinURI bcuri = new BitcoinURI(arg);
                 final String paymentRequestUrl = bcuri.getPaymentRequestUrl();
                 if (paymentRequestUrl == null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1132 - Strings literals should be placed on the left side when checking for equality. 

You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1132

Please let me know if you have any questions.
Kirill.