### PR TITLE
Support generating URIs for non-Bitcoin networks

### DIFF
--- a/core/src/main/java/org/bitcoinj/uri/BitcoinURI.java
+++ b/core/src/main/java/org/bitcoinj/uri/BitcoinURI.java
@@ -129,7 +129,6 @@ public class BitcoinURI {
      */
     public BitcoinURI(@Nullable NetworkParameters params, String input) throws BitcoinURIParseException {
         checkNotNull(input);
-        log.debug("Attempting to parse '{}' for {}", input, params == null ? "any" : params.getId());
 
         String scheme = null == params
             ? AbstractBitcoinNetParams.BITCOIN_SCHEME
@@ -345,28 +344,43 @@ public class BitcoinURI {
         return builder.toString();
     }
 
-    public static String convertToBitcoinURI(Address address, Coin amount, String label, String message) {
-        return convertToBitcoinURI(address.toString(), amount, label, message);
-    }
-
     /**
      * Simple Bitcoin URI builder using known good fields.
-     * 
+     *
      * @param address The Bitcoin address
      * @param amount The amount
      * @param label A label
      * @param message A message
      * @return A String containing the Bitcoin URI
      */
-    public static String convertToBitcoinURI(String address, @Nullable Coin amount, @Nullable String label,
-                                             @Nullable String message) {
+    public static String convertToBitcoinURI(Address address, Coin amount,
+                                             String label, String message) {
+        return convertToBitcoinURI(address.getParameters(), address.toString(), amount, label, message);
+    }
+
+    /**
+     * Simple Bitcoin URI builder using known good fields.
+     *
+     * @param params The network parameters that determine which network the URI
+     * is for.
+     * @param address The Bitcoin address
+     * @param amount The amount
+     * @param label A label
+     * @param message A message
+     * @return A String containing the Bitcoin URI
+     */
+    public static String convertToBitcoinURI(NetworkParameters params,
+                                             String address, @Nullable Coin amount,
+                                             @Nullable String label, @Nullable String message) {
+        checkNotNull(params);
         checkNotNull(address);
         if (amount != null && amount.signum() < 0) {
             throw new IllegalArgumentException("Coin must be positive");
         }
         
         StringBuilder builder = new StringBuilder();
-        builder.append(BITCOIN_SCHEME).append(":").append(address);
+        String scheme = params.getUriScheme();
+        builder.append(scheme).append(":").append(address);
         
         boolean questionMarkHasBeenOutput = false;
         

--- a/core/src/test/java/org/bitcoinj/uri/BitcoinURITest.java
+++ b/core/src/test/java/org/bitcoinj/uri/BitcoinURITest.java
@@ -24,11 +24,13 @@ import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 
 import static org.bitcoinj.core.Coin.*;
+import org.bitcoinj.core.NetworkParameters;
 import static org.junit.Assert.*;
 
 public class BitcoinURITest {
     private BitcoinURI testObject = null;
 
+    private NetworkParameters params = MainNetParams.get();
     private static final String MAINNET_GOOD_ADDRESS = "1KzTSfqjF2iKCduwz59nv2uqh1W2JsTxZH";
 
     @Test
@@ -66,6 +68,17 @@ public class BitcoinURITest {
         // no amount, no label, no message
         assertEquals("bitcoin:" + MAINNET_GOOD_ADDRESS, BitcoinURI.convertToBitcoinURI(goodAddress, null, null, null));
         assertEquals("bitcoin:" + MAINNET_GOOD_ADDRESS, BitcoinURI.convertToBitcoinURI(goodAddress, null, "", ""));
+
+        // different scheme
+        final NetworkParameters alternativeParameters = new MainNetParams() {
+                @Override
+                public String getUriScheme() {
+                    return "test";
+                }
+        };
+
+        assertEquals("test:" + MAINNET_GOOD_ADDRESS + "?amount=12.34&label=Hello&message=AMessage",
+             BitcoinURI.convertToBitcoinURI(Address.fromBase58(alternativeParameters, MAINNET_GOOD_ADDRESS), parseCoin("12.34"), "Hello", "AMessage"));
     }
 
     @Test


### PR DESCRIPTION
Adds in a new convertToBitcoinURI() method which takes in network parameters to determine the scheme from, for altcoin URI support.
