### PR TITLE
Extract fee calculation from Wallet

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/core/Wallet.java
@@ -3535,6 +3535,11 @@ public class Wallet extends BaseTaggableObject
         public Coin feePerKb = DEFAULT_FEE_PER_KB;
 
         /**
+         * <p>Code for estimating fees on a transaction.</p>
+         */
+        public FeeCalculator feeEstimator = new DefaultFeeCalculator();
+
+        /**
          * If you want to modify the default fee for your entire app without having to change each SendRequest you make,
          * you can do it here. This is primarily useful for unit tests.
          */
@@ -4790,13 +4795,7 @@ public class Wallet extends BaseTaggableObject
         while (true) {
             resetTxInputs(req, originalInputs);
 
-            Coin fees = req.fee == null ? Coin.ZERO : req.fee;
-            if (lastCalculatedSize > 0) {
-                // If the size is exactly 1000 bytes then we'll over-pay, but this should be rare.
-                fees = fees.add(req.feePerKb.multiply((lastCalculatedSize / 1000) + 1));
-            } else {
-                fees = fees.add(req.feePerKb);  // First time around the loop.
-            }
+            Coin fees = req.feeEstimator.calculateFees(req, lastCalculatedSize);
             if (needAtLeastReferenceFee && fees.compareTo(Transaction.REFERENCE_DEFAULT_MIN_TX_FEE) < 0)
                 fees = Transaction.REFERENCE_DEFAULT_MIN_TX_FEE;
 

--- a/core/src/main/java/org/bitcoinj/wallet/DefaultFeeCalculator.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DefaultFeeCalculator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015 Ross Nicoll
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.wallet;
+
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.Wallet;
+
+/**
+ * Default fee calculator intended for the Bitcoin network.
+ */
+public class DefaultFeeCalculator implements FeeCalculator {
+    @Override
+    public Coin calculateFees(Wallet.SendRequest req, int calculatedSize) {
+        return calculateFees(req.fee, req.feePerKb, calculatedSize);
+    }
+
+    @Override
+    public Coin calculateFees(Coin fee, Coin feePerKb, Transaction tx) {
+        return calculateFees(fee, feePerKb, tx.getOptimalEncodingMessageSize());
+    }
+
+    private Coin calculateFees(Coin fee, Coin feePerKb, int calculatedSize) {
+        Coin fees = fee == null ? Coin.ZERO : fee;
+        if (calculatedSize > 0) {
+            // If the size is exactly 1000 bytes then we'll over-pay, but this should be rare.
+            fees = fees.add(feePerKb.multiply((calculatedSize / 1000) + 1));
+        } else {
+            fees = fees.add(feePerKb);  // First time around the loop.
+        }
+        return fees;
+    }
+}

--- a/core/src/main/java/org/bitcoinj/wallet/FeeCalculator.java
+++ b/core/src/main/java/org/bitcoinj/wallet/FeeCalculator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 Ross Nicoll
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.wallet;
+
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.Wallet;
+
+/**
+ * Modular calculator for transaction fees.
+ */
+public interface FeeCalculator {
+    /**
+     * Calculate the fees required for a send request.
+     *
+     * @param req the request to take fee calculation variables (fee and fee per
+     * kilobyte) from. Implementations may use the contained transaction for
+     * information such as structure of the outputs, but must use calculatedSize
+     * for the total transactions size.
+     * @param calculatedSize the calculateSize of the transaction including change
+     * outputs.
+     * @return fees required for the request.
+     */
+    public Coin calculateFees(Wallet.SendRequest req, int calculatedSize);
+
+    /**
+     * Calculate the fees required for a transaction.
+     *
+     * @param fee the base fee to pay for the transaction.
+     * @param feePerKb the additional fee per kilobyte of data.
+     * @param tx the transaction to calculate fee for.
+     * @return fees required for the transaction.
+     */
+    public Coin calculateFees(Coin fee, Coin feePerKb, Transaction tx);
+}

--- a/core/src/test/java/org/bitcoinj/wallet/FeeCalculatorTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/FeeCalculatorTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2015 jrn.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.wallet;
+
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.Context;
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionOutput;
+import org.bitcoinj.core.Wallet;
+import org.bitcoinj.params.MainNetParams;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FeeCalculatorTest {
+    private NetworkParameters params;
+
+    @Before
+    public void setUp() throws Exception {
+        params = MainNetParams.get();
+        Context context = new Context(params);
+    }
+
+    @Test
+    public void shouldCalculateSendRequestFee() {
+        ECKey key = new ECKey();
+        Address address = key.toAddress(params);
+        Transaction previousTx = new Transaction(params);
+        TransactionOutput previousOut = previousTx.addOutput(Coin.COIN, address);
+
+        Wallet.SendRequest req = Wallet.SendRequest.to(address, Coin.COIN);
+        req.fee = Coin.ZERO;
+        req.feePerKb = Coin.CENT;
+        FeeCalculator feeCalculator = new DefaultFeeCalculator();
+        Coin expected = Coin.CENT;
+        Coin actual = feeCalculator.calculateFees(req, req.tx.getOptimalEncodingMessageSize());
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldCalculateTransactionFee() {
+        ECKey key = new ECKey();
+        Address address = key.toAddress(params);
+        Transaction previousTx = new Transaction(params);
+        TransactionOutput previousOut = previousTx.addOutput(Coin.COIN, address);
+        Transaction tx = new Transaction(params);
+
+        tx.addInput(previousOut);
+        tx.addOutput(Coin.COIN, address);
+
+        FeeCalculator feeCalculator = new DefaultFeeCalculator();
+        Coin expected = Coin.CENT;
+        Coin actual = feeCalculator.calculateFees(Coin.ZERO, Coin.CENT, tx);
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
Extract the core fee calculation code from the wallet, so that it can be shared by other code (i.e. where transactions are built outside the wallet) and can be replaced (i.e. for altcoins).