### PR TITLE
fix NPE in Wallet.calculateAllSpendCandidatesFromUTXOProvider

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/core/Wallet.java
@@ -4153,8 +4153,9 @@ public class Wallet extends BaseTaggableObject
         for (Transaction tx : pending.values()) {
             // Remove the spent outputs.
             for (TransactionInput input : tx.getInputs()) {
-                if (input.getConnectedOutput().isMine(this)) {
-                    candidates.remove(input.getConnectedOutput());
+                TransactionOutput output = input.getConnectedOutput();
+                if (output != null && output.isMine(this)) {
+                    candidates.remove(output);
                 }
             }
             // Add change outputs. Do not try and spend coinbases that were mined too recently, the protocol forbids it.


### PR DESCRIPTION
to prevent the following which happens sometimes when receiving funds to a wallet associated with a UTXO provider such as the MySQLFullPrunedBlockStore
(pardon the out-of-date line numbers in this stacktrace)

java.lang.NullPointerException: null
    at org.bitcoinj.core.Wallet.calculateAllSpendCandidatesFromUTXOProvider(Wallet.java:3950) ~[classes/:na]
    at org.bitcoinj.core.Wallet.calculateAllSpendCandidates(Wallet.java:3892) ~[classes/:na]
    at org.bitcoinj.core.Wallet.calculateAllSpendCandidates(Wallet.java:3867) ~[classes/:na]
