### PR TITLE
Don't throw away orphan block transactions before they are sent to listeners.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
@@ -113,10 +113,7 @@ public abstract class AbstractBlockChain {
             final boolean filtered = filteredTxHashes != null && filteredTxn != null;
             Preconditions.checkArgument((block.transactions == null && filtered)
                                         || (block.transactions != null && !filtered));
-            if (!shouldVerifyTransactions())
-                this.block = block.cloneAsHeader();
-            else
-                this.block = block;
+            this.block = block;
             this.filteredTxHashes = filteredTxHashes;
             this.filteredTxn = filteredTxn;
         }


### PR DESCRIPTION
This is my proposed fix for https://github.com/bitcoinj/bitcoinj/issues/1121

I've checked that all unit tests pass and that my regression tests pass, both when my regression test suite continuously disconnects and reconnects nodes and when it keeps them all connected.

I'm sure there are other ways to fix the problem, though it's not clear to me why you'd ever want to throw away the transactions from the orphan block, so this seems like a simple solution.