### PR TITLE
TransactionInput: Fix cached scriptSig gets thrown away when using se…

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -169,10 +169,10 @@ public class TransactionInput extends ChildMessage {
     }
 
     /** Set the given program as the scriptSig that is supposed to satisfy the connected output script. */
-    public void setScriptSig(Script scriptSig) {
-        this.scriptSig = new WeakReference<Script>(checkNotNull(scriptSig));
+    public void setScriptSig(final Script scriptSig) {
         // TODO: This should all be cleaned up so we have a consistent internal representation.
         setScriptBytes(scriptSig.getProgram());
+        this.scriptSig = new WeakReference<Script>(scriptSig);
     }
 
     /**

--- a/core/src/test/java/org/bitcoinj/core/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/core/WalletTest.java
@@ -3249,6 +3249,8 @@ public class WalletTest extends TestWithWallet {
         assertEquals(200, tx.getInputs().size());
     }
 
+    private static final byte[] EMPTY_SIG = {};
+
     @Test
     public void completeTxPartiallySignedWithDummySigs() throws Exception {
         byte[] dummySig = TransactionSignature.dummy().encodeToBitcoin();
@@ -3257,8 +3259,7 @@ public class WalletTest extends TestWithWallet {
 
     @Test
     public void completeTxPartiallySignedWithEmptySig() throws Exception {
-        byte[] emptySig = {};
-        completeTxPartiallySigned(Wallet.MissingSigsMode.USE_OP_ZERO, emptySig);
+        completeTxPartiallySigned(Wallet.MissingSigsMode.USE_OP_ZERO, EMPTY_SIG);
     }
 
     @Test (expected = ECKey.MissingPrivateKeyException.class)
@@ -3281,14 +3282,12 @@ public class WalletTest extends TestWithWallet {
 
     @Test
     public void completeTxPartiallySignedMarriedWithEmptySig() throws Exception {
-        byte[] emptySig = {};
-        completeTxPartiallySignedMarried(Wallet.MissingSigsMode.USE_OP_ZERO, emptySig);
+        completeTxPartiallySignedMarried(Wallet.MissingSigsMode.USE_OP_ZERO, EMPTY_SIG);
     }
 
     @Test (expected = TransactionSigner.MissingSignatureException.class)
     public void completeTxPartiallySignedMarriedThrows() throws Exception {
-        byte[] emptySig = {};
-        completeTxPartiallySignedMarried(Wallet.MissingSigsMode.THROW, emptySig);
+        completeTxPartiallySignedMarried(Wallet.MissingSigsMode.THROW, EMPTY_SIG);
     }
 
     @Test (expected = TransactionSigner.MissingSignatureException.class)


### PR DESCRIPTION
…tScriptSig().

It will get recreated in getScriptSig() but this can be more expensive than expected.
