### PR TITLE
Set connection channel in PaymentChannelServerListener

### DIFF
--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerListener.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerListener.java
@@ -113,6 +113,7 @@ public class PaymentChannelServerListener {
                         handler.closeConnection();
                     else {
                         ServerHandler.this.eventHandler = eventHandler;
+                        ServerHandler.this.eventHandler.setConnectionChannel(socketProtobufHandler);
                         paymentChannelManager.connectionOpen();
                     }
                 }


### PR DESCRIPTION
This method was never actually called with any argument but `null` - this initialises it with the correct value.