### PR TITLE
Wallet: Make keyChainGroup private again, …

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/core/Wallet.java
@@ -148,7 +148,7 @@ public class Wallet extends BaseTaggableObject
 
     // The key chain group is not thread safe, and generally the whole hierarchy of objects should not be mutated
     // outside the wallet lock. So don't expose this object directly via any accessors!
-    @GuardedBy("keyChainGroupLock") protected KeyChainGroup keyChainGroup;
+    @GuardedBy("keyChainGroupLock") private KeyChainGroup keyChainGroup;
 
     // A list of scripts watched by this wallet.
     @GuardedBy("keyChainGroupLock") private Set<Script> watchedScripts;
@@ -579,6 +579,16 @@ public class Wallet extends BaseTaggableObject
         keyChainGroupLock.lock();
         try {
             return keyChainGroup.numKeys();
+        } finally {
+            keyChainGroupLock.unlock();
+        }
+    }
+
+    @VisibleForTesting
+    public int getKeyChainGroupCombinedKeyLookaheadEpochs() {
+        keyChainGroupLock.lock();
+        try {
+            return keyChainGroup.getCombinedKeyLookaheadEpochs();
         } finally {
             keyChainGroupLock.unlock();
         }

--- a/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -801,13 +801,13 @@ public class PeerGroupTest extends TestWithPeerGroup {
 
         // Send the chain that doesn't have all the transactions in it. The blocks after the exhaustion point should all
         // be ignored.
-        int epoch = wallet.keyChainGroup.getCombinedKeyLookaheadEpochs();
+        int epoch = wallet.getKeyChainGroupCombinedKeyLookaheadEpochs();
         BloomFilter filter = new BloomFilter(params, p1.lastReceivedFilter.bitcoinSerialize());
         filterAndSend(p1, blocks, filter);
         Block exhaustionPoint = blocks.get(3);
         pingAndWait(p1);
 
-        assertNotEquals(epoch, wallet.keyChainGroup.getCombinedKeyLookaheadEpochs());
+        assertNotEquals(epoch, wallet.getKeyChainGroupCombinedKeyLookaheadEpochs());
         // 4th block was end of the lookahead zone and thus was discarded, so we got 3 blocks worth of money (50 each).
         assertEquals(Coin.FIFTY_COINS.multiply(3), wallet.getBalance());
         assertEquals(exhaustionPoint.getPrevBlockHash(), blockChain.getChainHead().getHeader().getHash());


### PR DESCRIPTION
…but add a getKeyChainGroupCombinedKeyLookaheadEpochs() method that is visible for testing.