### PR TITLE
Update to okhttp 2.7.2

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -214,8 +214,8 @@
                                         <urn>org.hamcrest:hamcrest-core:1.3:jar:null:test:42a25dc3219429f0e5d060061f71acb49bf010a0</urn>
                                         <urn>org.jacoco:jacoco-maven-plugin:0.7.5.201505241946:maven-plugin:null:runtime:0a5e4dbbcd9b00e5ee42d928e10ab84f6f0b0835</urn>
                                         <urn>org.objenesis:objenesis:1.2:jar:null:test:bfcb0539a071a4c5a30690388903ac48c0667f2a</urn>
-                                        <urn>com.squareup.okhttp:okhttp:2.4.0:jar:null:runtime:40340c0748190fe897baf7bffbc1b282734294e5</urn>
-                                        <urn>com.squareup.okio:okio:1.4.0:jar:null:runtime:5b72bf48563ea8410e650de14aa33ff69a3e8c35</urn>
+                                        <urn>com.squareup.okhttp:okhttp:2.7.2:jar:null:runtime:20f6463eb19ac61960c5d91a094c2f4f0727dc2e</urn>
+                                        <urn>com.squareup.okio:okio:1.6.0:jar:null:runtime:98476622f10715998eacf9240d6b479f12c66143</urn>
                                         <urn>org.slf4j:slf4j-api:1.7.7:jar:null:compile:2b8019b6249bb05d81d3a3094e468753e2b21311</urn>
                                         <urn>org.slf4j:slf4j-jdk14:1.7.7:jar:null:test:25d160723ea37a6cb84e87cd70773ff02997e857</urn>
                                         <urn>org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:maven-plugin:null:runtime:455ca2aa8cd14a06608f1538bd6a1efd09561563</urn>
@@ -501,7 +501,7 @@
         <dependency>
             <groupId>com.squareup.okhttp</groupId>
             <artifactId>okhttp</artifactId>
-            <version>2.4.0</version>
+            <version>2.7.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This is the latest release in the 2.x series. Unlike 3.x, it doesn't break any
API. It has lots of security and Android-related fixes which could affect us.

Also see: https://github.com/square/okhttp/blob/master/CHANGELOG.md