### PR TITLE
Transaction: modify hashForSignature() to be thread-safe.

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -413,4 +413,28 @@ public class TransactionTest {
         tx.getInputs().get(0).setSequenceNumber(TransactionInput.NO_SEQUENCE - 2);
         assertTrue(tx.isOptInFullRBF());
     }
+
+    /**
+     * Ensure that hashForSignature() doesn't modify a transaction's data, which could wreak multithreading havoc
+     */
+    @Test
+    public void testHashForSignatureThreadSafety() {
+        Block genesis = UnitTestParams.get().getGenesisBlock();
+        Block block1 = genesis.createNextBlock(new ECKey().toAddress(UnitTestParams.get()),
+                    genesis.getTransactions().get(0).getOutput(0).getOutPointFor());
+
+        final Transaction tx = block1.getTransactions().get(1);
+        final String txHash = tx.getHashAsString();
+        final String txNormalizedHash = tx.hashForSignature(0, new byte[0], (byte) (Transaction.SigHash.ALL.ordinal() + 1)).toString();
+
+        for (int i = 0; i < 100; i++) {
+            // ensure the transaction object itself was not modified; if it was, the hash will change
+            assertEquals(txHash, tx.getHashAsString());
+            new Thread(){
+                public void run() {
+                    assertEquals(txNormalizedHash, tx.hashForSignature(0, new byte[0], (byte) (Transaction.SigHash.ALL.ordinal() + 1)).toString());
+                }
+            };
+        }
+    }
 }


### PR DESCRIPTION
I've been using hashForSignature more often recently to generate normalized hashes and I ran into a multithreading issue. I noticed that different threads that were operating on the same transaction would suddenly think that the regular hash for it had changed.

I think this is a fairly straightforward fix to create a new transaction object and then perform all of the operations upon it instead of upon the original transaction object that may be referenced by other threads.