### PR TITLE
Split wallet events into single method interfaces

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/listeners/AbstractWalletEventListener.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/AbstractWalletEventListener.java
@@ -65,6 +65,9 @@ public abstract class AbstractWalletEventListener extends AbstractKeyChainEventL
         onChange();
     }
 
+    /**
+     * Default method called on change events.
+     */
     public void onChange() {
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/listeners/ScriptsChangeEventListener.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/ScriptsChangeEventListener.java
@@ -16,16 +16,20 @@
 
 package org.bitcoinj.core.listeners;
 
-import org.bitcoinj.wallet.KeyChainEventListener;
+import org.bitcoinj.core.Wallet;
+import org.bitcoinj.script.Script;
+
+import java.util.List;
 
 /**
- * <p>Common interface for wallet changes and transactions.</p>
- * @deprecated Use the superinterfaces directly instead.
+ * <p>Implementors are called when the contents of the wallet changes, for instance due to receiving/sending money
+ * or a block chain re-organize. It may be convenient to derive from {@link AbstractWalletEventListener} instead.</p>
  */
-@Deprecated
-public interface WalletEventListener extends 
-        KeyChainEventListener, WalletChangeEventListener,
-        WalletCoinsReceivedEventListener, WalletCoinsSentEventListener,
-        WalletReorganizeEventListener, ScriptsChangeEventListener,
-        TransactionConfidenceEventListener {
+public interface ScriptsChangeEventListener {
+    /**
+     * Called whenever a new watched script is added to the wallet.
+     *
+     * @param isAddingScripts will be true if added scripts, false if removed scripts.
+     */
+    void onScriptsChanged(Wallet wallet, List<Script> scripts, boolean isAddingScripts);
 }

--- a/core/src/main/java/org/bitcoinj/core/listeners/TransactionConfidenceEventListener.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/TransactionConfidenceEventListener.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.core.listeners;
+
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.Wallet;
+
+/**
+ * <p>Implementors are called when confidence of a transaction changes.</p>
+ */
+public interface TransactionConfidenceEventListener {
+    /**
+     * <p>Called when a transaction changes its confidence level. You can also attach event listeners to
+     * the individual transactions, if you don't care about all of them. Usually you would save the wallet to disk after
+     * receiving this callback unless you already set up autosaving.</p>
+     *
+     * <p>You should pay attention to this callback in case a transaction becomes <i>dead</i>, that is, a transaction
+     * you believed to be active (send or receive) becomes overridden by the network. This can happen if</p>
+     *
+     * <ol>
+     *     <li>You are sharing keys between wallets and accidentally create/broadcast a double spend.</li>
+     *     <li>Somebody is attacking the network and reversing transactions, ie, the user is a victim of fraud.</li>
+     *     <li>A bug: for example you create a transaction, broadcast it but fail to commit it. The {@link Wallet}
+     *     will then re-use the same outputs when creating the next spend.</li>
+     * </ol><p>
+     *
+     * <p>To find if the transaction is dead, you can use <tt>tx.getConfidence().getConfidenceType() ==
+     * TransactionConfidence.ConfidenceType.DEAD</tt>. If it is, you should notify the user
+     * in some way so they know the thing they bought may not arrive/the thing they sold should not be dispatched.</p>
+     *
+     * <p>Note that this callback will be invoked for every transaction in the wallet, for every new block that is
+     * received (because the depth has changed). <b>If you want to update a UI view from the contents of the wallet
+     * it is more efficient to use onWalletChanged instead.</b></p>
+     */
+    void onTransactionConfidenceChanged(Wallet wallet, Transaction tx);
+}

--- a/core/src/main/java/org/bitcoinj/core/listeners/WalletChangeEventListener.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/WalletChangeEventListener.java
@@ -16,56 +16,13 @@
 
 package org.bitcoinj.core.listeners;
 
-import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.Wallet;
-import org.bitcoinj.script.Script;
-import org.bitcoinj.wallet.KeyChainEventListener;
-
-import java.util.List;
 
 /**
  * <p>Implementors are called when the contents of the wallet changes, for instance due to receiving/sending money
  * or a block chain re-organize. It may be convenient to derive from {@link AbstractWalletEventListener} instead.</p>
  */
-public interface WalletChangeEventListener extends KeyChainEventListener {
-    // TODO: Finish onReorganize to be more useful.
-    /**
-     * <p>This is called when a block is received that triggers a block chain re-organization.</p>
-     *
-     * <p>A re-organize means that the consensus (chain) of the network has diverged and now changed from what we
-     * believed it was previously. Usually this won't matter because the new consensus will include all our old
-     * transactions assuming we are playing by the rules. However it's theoretically possible for our balance to
-     * change in arbitrary ways, most likely, we could lose some money we thought we had.</p>
-     *
-     * <p>It is safe to use methods of wallet whilst inside this callback.</p>
-     */
-    void onReorganize(Wallet wallet);
-
-    /**
-     * <p>Called when a transaction changes its confidence level. You can also attach event listeners to
-     * the individual transactions, if you don't care about all of them. Usually you would save the wallet to disk after
-     * receiving this callback unless you already set up autosaving.</p>
-     *
-     * <p>You should pay attention to this callback in case a transaction becomes <i>dead</i>, that is, a transaction
-     * you believed to be active (send or receive) becomes overridden by the network. This can happen if</p>
-     *
-     * <ol>
-     *     <li>You are sharing keys between wallets and accidentally create/broadcast a double spend.</li>
-     *     <li>Somebody is attacking the network and reversing transactions, ie, the user is a victim of fraud.</li>
-     *     <li>A bug: for example you create a transaction, broadcast it but fail to commit it. The {@link Wallet}
-     *     will then re-use the same outputs when creating the next spend.</li>
-     * </ol><p>
-     *
-     * <p>To find if the transaction is dead, you can use <tt>tx.getConfidence().getConfidenceType() ==
-     * TransactionConfidence.ConfidenceType.DEAD</tt>. If it is, you should notify the user
-     * in some way so they know the thing they bought may not arrive/the thing they sold should not be dispatched.</p>
-     *
-     * <p>Note that this callback will be invoked for every transaction in the wallet, for every new block that is
-     * received (because the depth has changed). <b>If you want to update a UI view from the contents of the wallet
-     * it is more efficient to use onWalletChanged instead.</b></p>
-     */
-    void onTransactionConfidenceChanged(Wallet wallet, Transaction tx);
-
+public interface WalletChangeEventListener {
     /**
      * <p>Designed for GUI applications to refresh their transaction lists. This callback is invoked in the following
      * situations:</p>
@@ -85,11 +42,4 @@ public interface WalletChangeEventListener extends KeyChainEventListener {
      * rather than one per transaction per block. Note that this is <b>not</b> called when a key is added. </p>
      */
     void onWalletChanged(Wallet wallet);
-
-    /**
-     * Called whenever a new watched script is added to the wallet.
-     *
-     * @param isAddingScripts will be true if added scripts, false if removed scripts.
-     */
-    void onScriptsChanged(Wallet wallet, List<Script> scripts, boolean isAddingScripts);
 }

--- a/core/src/main/java/org/bitcoinj/core/listeners/WalletCoinsReceivedEventListener.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/WalletCoinsReceivedEventListener.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.core.listeners;
+
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.Wallet;
+
+/**
+ * <p>Implementors are called when the contents of the wallet changes, for instance due to receiving/sending money
+ * or a block chain re-organize. It may be convenient to derive from {@link AbstractWalletEventListener} instead.</p>
+ */
+public interface WalletCoinsReceivedEventListener {
+    /**
+     * This is called when a transaction is seen that sends coins <b>to</b> this wallet, either because it
+     * was broadcast across the network or because a block was received. If a transaction is seen when it was broadcast,
+     * onCoinsReceived won't be called again when a block containing it is received. If you want to know when such a
+     * transaction receives its first confirmation, register a {@link TransactionConfidence} event listener using
+     * the object retrieved via {@link org.bitcoinj.core.Transaction#getConfidence()}. It's safe to modify the
+     * wallet in this callback, for example, by spending the transaction just received.
+     *
+     * @param wallet      The wallet object that received the coins
+     * @param tx          The transaction which sent us the coins.
+     * @param prevBalance Balance before the coins were received.
+     * @param newBalance  Current balance of the wallet. This is the 'estimated' balance.
+     */
+    void onCoinsReceived(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance);
+}

--- a/core/src/main/java/org/bitcoinj/core/listeners/WalletCoinsSentEventListener.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/WalletCoinsSentEventListener.java
@@ -19,30 +19,12 @@ package org.bitcoinj.core.listeners;
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.Wallet;
-import org.bitcoinj.script.Script;
-import org.bitcoinj.wallet.KeyChainEventListener;
-
-import java.util.List;
 
 /**
  * <p>Implementors are called when the contents of the wallet changes, for instance due to receiving/sending money
  * or a block chain re-organize. It may be convenient to derive from {@link AbstractWalletEventListener} instead.</p>
  */
-public interface WalletCoinEventListener {
-    /**
-     * This is called when a transaction is seen that sends coins <b>to</b> this wallet, either because it
-     * was broadcast across the network or because a block was received. If a transaction is seen when it was broadcast,
-     * onCoinsReceived won't be called again when a block containing it is received. If you want to know when such a
-     * transaction receives its first confirmation, register a {@link TransactionConfidence} event listener using
-     * the object retrieved via {@link org.bitcoinj.core.Transaction#getConfidence()}. It's safe to modify the
-     * wallet in this callback, for example, by spending the transaction just received.
-     *
-     * @param wallet      The wallet object that received the coins
-     * @param tx          The transaction which sent us the coins.
-     * @param prevBalance Balance before the coins were received.
-     * @param newBalance  Current balance of the wallet. This is the 'estimated' balance.
-     */
-    void onCoinsReceived(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance);
+public interface WalletCoinsSentEventListener {
 
     /**
      * This is called when a transaction is seen that sends coins <b>from</b> this wallet, either

--- a/core/src/main/java/org/bitcoinj/core/listeners/WalletReorganizeEventListener.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/WalletReorganizeEventListener.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.core.listeners;
+
+import org.bitcoinj.core.Wallet;
+
+
+/**
+ * <p>Implementors are called when the wallet is reorganized.</p>
+ */
+public interface WalletReorganizeEventListener {
+    // TODO: Finish onReorganize to be more useful.
+    /**
+     * <p>This is called when a block is received that triggers a block chain re-organization.</p>
+     *
+     * <p>A re-organize means that the consensus (chain) of the network has diverged and now changed from what we
+     * believed it was previously. Usually this won't matter because the new consensus will include all our old
+     * transactions assuming we are playing by the rules. However it's theoretically possible for our balance to
+     * change in arbitrary ways, most likely, we could lose some money we thought we had.</p>
+     *
+     * <p>It is safe to use methods of wallet whilst inside this callback.</p>
+     */
+    void onReorganize(Wallet wallet);
+}

--- a/core/src/main/java/org/bitcoinj/jni/NativeKeyChainEventListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeKeyChainEventListener.java
@@ -14,18 +14,21 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.core.listeners;
+package org.bitcoinj.jni;
 
 import org.bitcoinj.wallet.KeyChainEventListener;
+import org.bitcoinj.core.ECKey;
+
+import java.util.List;
 
 /**
- * <p>Common interface for wallet changes and transactions.</p>
- * @deprecated Use the superinterfaces directly instead.
+ * An event listener that relays events to a native C++ object. A pointer to that object is stored in
+ * this class using JNI on the native side, thus several instances of this can point to different actual
+ * native implementations.
  */
-@Deprecated
-public interface WalletEventListener extends 
-        KeyChainEventListener, WalletChangeEventListener,
-        WalletCoinsReceivedEventListener, WalletCoinsSentEventListener,
-        WalletReorganizeEventListener, ScriptsChangeEventListener,
-        TransactionConfidenceEventListener {
+public class NativeKeyChainEventListener implements KeyChainEventListener {
+    public long ptr;
+
+    @Override
+    public native void onKeysAdded(List<ECKey> keys);
 }

--- a/core/src/main/java/org/bitcoinj/jni/NativeScriptsChangeEventListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeScriptsChangeEventListener.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.jni;
+
+import org.bitcoinj.core.listeners.ScriptsChangeEventListener;
+import org.bitcoinj.core.Wallet;
+import org.bitcoinj.script.Script;
+
+import java.util.List;
+
+/**
+ * An event listener that relays events to a native C++ object. A pointer to that object is stored in
+ * this class using JNI on the native side, thus several instances of this can point to different actual
+ * native implementations.
+ */
+public class NativeScriptsChangeEventListener implements ScriptsChangeEventListener {
+    public long ptr;
+
+    @Override
+    public native void onScriptsChanged(Wallet wallet, List<Script> scripts, boolean isAddingScripts);
+}

--- a/core/src/main/java/org/bitcoinj/jni/NativeTransactionConfidenceEventListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeTransactionConfidenceEventListener.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.jni;
+
+import org.bitcoinj.core.listeners.TransactionConfidenceEventListener;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.Wallet;
+
+/**
+ * An event listener that relays events to a native C++ object. A pointer to that object is stored in
+ * this class using JNI on the native side, thus several instances of this can point to different actual
+ * native implementations.
+ */
+public class NativeTransactionConfidenceEventListener implements TransactionConfidenceEventListener {
+    public long ptr;
+
+    @Override
+    public native void onTransactionConfidenceChanged(Wallet wallet, Transaction tx);
+}

--- a/core/src/main/java/org/bitcoinj/jni/NativeWalletChangeEventListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeWalletChangeEventListener.java
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.core.listeners;
+package org.bitcoinj.jni;
 
-import org.bitcoinj.wallet.KeyChainEventListener;
+import org.bitcoinj.core.listeners.WalletChangeEventListener;
+import org.bitcoinj.core.Wallet;
 
 /**
- * <p>Common interface for wallet changes and transactions.</p>
- * @deprecated Use the superinterfaces directly instead.
+ * An event listener that relays events to a native C++ object. A pointer to that object is stored in
+ * this class using JNI on the native side, thus several instances of this can point to different actual
+ * native implementations.
  */
-@Deprecated
-public interface WalletEventListener extends 
-        KeyChainEventListener, WalletChangeEventListener,
-        WalletCoinsReceivedEventListener, WalletCoinsSentEventListener,
-        WalletReorganizeEventListener, ScriptsChangeEventListener,
-        TransactionConfidenceEventListener {
+public class NativeWalletChangeEventListener implements WalletChangeEventListener {
+    public long ptr;
+
+    @Override
+    public native void onWalletChanged(Wallet wallet);
 }

--- a/core/src/main/java/org/bitcoinj/jni/NativeWalletCoinsReceivedEventListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeWalletCoinsReceivedEventListener.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.jni;
+
+import org.bitcoinj.core.listeners.WalletCoinsReceivedEventListener;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.Wallet;
+
+/**
+ * An event listener that relays events to a native C++ object. A pointer to that object is stored in
+ * this class using JNI on the native side, thus several instances of this can point to different actual
+ * native implementations.
+ */
+public class NativeWalletCoinsReceivedEventListener implements WalletCoinsReceivedEventListener {
+    public long ptr;
+
+    @Override
+    public native void onCoinsReceived(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance);
+}

--- a/core/src/main/java/org/bitcoinj/jni/NativeWalletCoinsSentEventListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeWalletCoinsSentEventListener.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.jni;
+
+import org.bitcoinj.core.listeners.WalletCoinsSentEventListener;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.Wallet;
+
+/**
+ * An event listener that relays events to a native C++ object. A pointer to that object is stored in
+ * this class using JNI on the native side, thus several instances of this can point to different actual
+ * native implementations.
+ */
+public class NativeWalletCoinsSentEventListener implements WalletCoinsSentEventListener {
+    public long ptr;
+
+    @Override
+    public native void onCoinsSent(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance);
+}

--- a/core/src/main/java/org/bitcoinj/jni/NativeWalletReorganizeEventListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeWalletReorganizeEventListener.java
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.core.listeners;
+package org.bitcoinj.jni;
 
-import org.bitcoinj.wallet.KeyChainEventListener;
+import org.bitcoinj.core.listeners.WalletReorganizeEventListener;
+import org.bitcoinj.core.Wallet;
 
 /**
- * <p>Common interface for wallet changes and transactions.</p>
- * @deprecated Use the superinterfaces directly instead.
+ * An event listener that relays events to a native C++ object. A pointer to that object is stored in
+ * this class using JNI on the native side, thus several instances of this can point to different actual
+ * native implementations.
  */
-@Deprecated
-public interface WalletEventListener extends 
-        KeyChainEventListener, WalletChangeEventListener,
-        WalletCoinsReceivedEventListener, WalletCoinsSentEventListener,
-        WalletReorganizeEventListener, ScriptsChangeEventListener,
-        TransactionConfidenceEventListener {
+public class NativeWalletReorganizeEventListener implements WalletReorganizeEventListener {
+    public long ptr;
+
+    @Override
+    public native void onReorganize(Wallet wallet);
 }

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClientState.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClientState.java
@@ -16,7 +16,6 @@
 
 package org.bitcoinj.protocols.channels;
 
-import org.bitcoinj.core.listeners.AbstractWalletEventListener;
 import org.bitcoinj.core.*;
 import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.script.Script;
@@ -37,6 +36,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.*;
+import org.bitcoinj.core.listeners.WalletCoinsReceivedEventListener;
 
 /**
  * <p>A payment channel is a method of sending money to someone such that the amount of money you send can be adjusted
@@ -173,7 +173,7 @@ public class PaymentChannelClientState {
         if (storedChannel != null && storedChannel.close != null) {
             watchCloseConfirmations();
         }
-        wallet.addEventListener(new AbstractWalletEventListener() {
+        wallet.addCoinsReceivedEventListener(Threading.SAME_THREAD, new WalletCoinsReceivedEventListener() {
             @Override
             public void onCoinsReceived(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {
                 synchronized (PaymentChannelClientState.this) {
@@ -189,7 +189,7 @@ public class PaymentChannelClientState {
                     }
                 }
             }
-        }, Threading.SAME_THREAD);
+        });
     }
 
     private void watchCloseConfirmations() {

--- a/core/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -527,7 +527,7 @@ public class PeerTest extends TestWithNetworkConnections {
         // Check that if we request dependency download to be disabled and receive a relevant tx, things work correctly.
         Transaction tx = FakeTxBuilder.createFakeTx(params, COIN, address);
         final Transaction[] result = new Transaction[1];
-        wallet.addEventListener(new AbstractWalletEventListener() {
+        wallet.addCoinsReceivedEventListener(new WalletCoinsReceivedEventListener() {
             @Override
             public void onCoinsReceived(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {
                 result[0] = tx;
@@ -644,7 +644,7 @@ public class PeerTest extends TestWithNetworkConnections {
         ECKey key = wallet.freshReceiveKey();
         peer.addWallet(wallet);
         final Transaction[] vtx = new Transaction[1];
-        wallet.addEventListener(new AbstractWalletEventListener() {
+        wallet.addCoinsReceivedEventListener(new WalletCoinsReceivedEventListener() {
             @Override
             public void onCoinsReceived(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {
                 vtx[0] = tx;
@@ -696,7 +696,7 @@ public class PeerTest extends TestWithNetworkConnections {
         wallet.setAcceptRiskyTransactions(shouldAccept);
         peer.addWallet(wallet);
         final Transaction[] vtx = new Transaction[1];
-        wallet.addEventListener(new AbstractWalletEventListener() {
+        wallet.addCoinsReceivedEventListener(new WalletCoinsReceivedEventListener() {
             @Override
             public void onCoinsReceived(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {
                 vtx[0] = tx;
@@ -775,7 +775,7 @@ public class PeerTest extends TestWithNetworkConnections {
 
     @Test
     public void exceptionListener() throws Exception {
-        wallet.addEventListener(new AbstractWalletEventListener() {
+        wallet.addCoinsReceivedEventListener(new WalletCoinsReceivedEventListener() {
             @Override
             public void onCoinsReceived(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {
                 throw new NullPointerException("boo!");

--- a/core/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
@@ -18,7 +18,7 @@
 package org.bitcoinj.core;
 
 import com.google.common.util.concurrent.*;
-import org.bitcoinj.core.listeners.AbstractWalletEventListener;
+import org.bitcoinj.core.listeners.TransactionConfidenceEventListener;
 import org.bitcoinj.testing.*;
 import org.bitcoinj.utils.*;
 import org.junit.*;
@@ -198,7 +198,7 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
 
         // Check that the wallet informs us of changes in confidence as the transaction ripples across the network.
         final Transaction[] transactions = new Transaction[1];
-        wallet.addEventListener(new AbstractWalletEventListener() {
+        wallet.addTransactionConfidenceEventListener(new TransactionConfidenceEventListener() {
             @Override
             public void onTransactionConfidenceChanged(Wallet wallet, Transaction tx) {
                 transactions[0] = tx;

--- a/core/src/test/java/org/bitcoinj/core/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/core/WalletTest.java
@@ -17,8 +17,10 @@
 
 package org.bitcoinj.core;
 
-import org.bitcoinj.core.listeners.AbstractWalletEventListener;
-import org.bitcoinj.core.listeners.WalletCoinEventListener;
+import org.bitcoinj.core.listeners.WalletChangeEventListener;
+import org.bitcoinj.core.listeners.WalletCoinsReceivedEventListener;
+import org.bitcoinj.core.listeners.WalletCoinsSentEventListener;
+import org.bitcoinj.core.listeners.TransactionConfidenceEventListener;
 import org.bitcoinj.core.TransactionConfidence.ConfidenceType;
 import org.bitcoinj.core.Wallet.SendRequest;
 import org.bitcoinj.crypto.*;
@@ -412,15 +414,10 @@ public class WalletTest extends TestWithWallet {
 
     private static void broadcastAndCommit(Wallet wallet, Transaction t) throws Exception {
         final LinkedList<Transaction> txns = Lists.newLinkedList();
-        wallet.addCoinEventListener(new WalletCoinEventListener() {
+        wallet.addCoinsSentEventListener(new WalletCoinsSentEventListener() {
             @Override
             public void onCoinsSent(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {
                 txns.add(tx);
-            }
-
-            @Override
-            public void onCoinsReceived(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {
-                // Ignore
             }
         });
 
@@ -559,26 +556,27 @@ public class WalletTest extends TestWithWallet {
         final Coin[] bigints = new Coin[4];
         final Transaction[] txn = new Transaction[2];
         final LinkedList<Transaction> confTxns = new LinkedList<Transaction>();
-        wallet.addEventListener(new AbstractWalletEventListener() {
+        wallet.addCoinsReceivedEventListener(new WalletCoinsReceivedEventListener() {
             @Override
             public void onCoinsReceived(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {
-                super.onCoinsReceived(wallet, tx, prevBalance, newBalance);
                 bigints[0] = prevBalance;
                 bigints[1] = newBalance;
                 txn[0] = tx;
             }
-
+        });
+        
+        wallet.addCoinsSentEventListener(new WalletCoinsSentEventListener() {
             @Override
             public void onCoinsSent(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {
-                super.onCoinsSent(wallet, tx, prevBalance, newBalance);
                 bigints[2] = prevBalance;
                 bigints[3] = newBalance;
                 txn[1] = tx;
             }
+        });
 
+        wallet.addTransactionConfidenceEventListener(new TransactionConfidenceEventListener() {
             @Override
             public void onTransactionConfidenceChanged(Wallet wallet, Transaction tx) {
-                super.onTransactionConfidenceChanged(wallet, tx);
                 confTxns.add(tx);
             }
         });
@@ -813,17 +811,18 @@ public class WalletTest extends TestWithWallet {
         final Transaction[] eventDead = new Transaction[1];
         final Transaction[] eventReplacement = new Transaction[1];
         final int[] eventWalletChanged = new int[1];
-        wallet.addEventListener(new AbstractWalletEventListener() {
+        wallet.addTransactionConfidenceEventListener(new TransactionConfidenceEventListener() {
             @Override
             public void onTransactionConfidenceChanged(Wallet wallet, Transaction tx) {
-                super.onTransactionConfidenceChanged(wallet, tx);
                 if (tx.getConfidence().getConfidenceType() ==
                         TransactionConfidence.ConfidenceType.DEAD) {
                     eventDead[0] = tx;
                     eventReplacement[0] = tx.getConfidence().getOverridingTransaction();
                 }
             }
+        });
 
+        wallet.addChangeEventListener(new WalletChangeEventListener() {
             @Override
             public void onWalletChanged(Wallet wallet) {
                 eventWalletChanged[0]++;
@@ -1277,7 +1276,7 @@ public class WalletTest extends TestWithWallet {
         final boolean[] flags = new boolean[2];
         final Transaction[] notifiedTx = new Transaction[1];
         final int[] walletChanged = new int[1];
-        wallet.addEventListener(new AbstractWalletEventListener() {
+        wallet.addCoinsReceivedEventListener(new WalletCoinsReceivedEventListener() {
             @Override
             public void onCoinsReceived(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {
                 // Check we got the expected transaction.
@@ -1289,7 +1288,9 @@ public class WalletTest extends TestWithWallet {
                 flags[1] = tx.isPending();
                 notifiedTx[0] = tx;
             }
+        });
 
+        wallet.addChangeEventListener(new WalletChangeEventListener() {
             @Override
             public void onWalletChanged(Wallet wallet) {
                 walletChanged[0]++;
@@ -1345,17 +1346,12 @@ public class WalletTest extends TestWithWallet {
         // Check that if we receive a pending tx we did not send, it updates our spent flags correctly.
         final Transaction[] txn = new Transaction[1];
         final Coin[] bigints = new Coin[2];
-        wallet.addCoinEventListener(new WalletCoinEventListener() {
+        wallet.addCoinsSentEventListener(new WalletCoinsSentEventListener() {
             @Override
             public void onCoinsSent(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {
                 txn[0] = tx;
                 bigints[0] = prevBalance;
                 bigints[1] = newBalance;
-            }
-
-            @Override
-            public void onCoinsReceived(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {
-                // Do nothing
             }
         });
         // Receive some coins.
@@ -1399,15 +1395,16 @@ public class WalletTest extends TestWithWallet {
         t2.addInput(doubleSpentOut);
 
         final Transaction[] called = new Transaction[2];
-        wallet.addEventListener(new AbstractWalletEventListener() {
+        wallet.addCoinsReceivedEventListener(new WalletCoinsReceivedEventListener() {
             @Override
             public void onCoinsReceived(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {
                 called[0] = tx;
             }
+        });
 
+        wallet.addTransactionConfidenceEventListener(new TransactionConfidenceEventListener() {
             @Override
             public void onTransactionConfidenceChanged(Wallet wallet, Transaction tx) {
-                super.onTransactionConfidenceChanged(wallet, tx);
                 if (tx.getConfidence().getConfidenceType() ==
                         TransactionConfidence.ConfidenceType.DEAD) {
                     called[0] = tx;
@@ -2951,29 +2948,19 @@ public class WalletTest extends TestWithWallet {
     @Test
     public void exceptionsDoNotBlockAllListeners() throws Exception {
         // Check that if a wallet listener throws an exception, the others still run.
-        wallet.addCoinEventListener(new WalletCoinEventListener() {
+        wallet.addCoinsReceivedEventListener(new WalletCoinsReceivedEventListener() {
             @Override
             public void onCoinsReceived(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {
                 log.info("onCoinsReceived 1");
                 throw new RuntimeException("barf");
             }
-
-            @Override
-            public void onCoinsSent(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {
-                // Do nothing
-            }
         });
         final AtomicInteger flag = new AtomicInteger();
-        wallet.addCoinEventListener(new WalletCoinEventListener() {
+        wallet.addCoinsReceivedEventListener(new WalletCoinsReceivedEventListener() {
             @Override
             public void onCoinsReceived(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {
                 log.info("onCoinsReceived 2");
                 flag.incrementAndGet();
-            }
-
-            @Override
-            public void onCoinsSent(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {
-                // Do nothing
             }
         });
 
@@ -3419,12 +3406,12 @@ public class WalletTest extends TestWithWallet {
         // Check that we can register an event listener, generate some keys and the callbacks are invoked properly.
         wallet = new Wallet(params);
         final List<ECKey> keys = Lists.newLinkedList();
-        wallet.addEventListener(new AbstractWalletEventListener() {
+        wallet.addKeyChainEventListener(Threading.SAME_THREAD, new KeyChainEventListener() {
             @Override
             public void onKeysAdded(List<ECKey> k) {
                 keys.addAll(k);
             }
-        }, Threading.SAME_THREAD);
+        });
         wallet.freshReceiveKey();
         assertEquals(1, keys.size());
     }

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -17,7 +17,7 @@
 
 package org.bitcoinj.store;
 
-import org.bitcoinj.core.listeners.AbstractWalletEventListener;
+import org.bitcoinj.core.listeners.WalletCoinsReceivedEventListener;
 import org.bitcoinj.core.*;
 import org.bitcoinj.core.Transaction.Purpose;
 import org.bitcoinj.core.TransactionConfidence.ConfidenceType;
@@ -212,7 +212,7 @@ public class WalletProtobufSerializerTest {
         BlockChain chain = new BlockChain(params, myWallet, new MemoryBlockStore(params));
 
         final ArrayList<Transaction> txns = new ArrayList<Transaction>(2);
-        myWallet.addEventListener(new AbstractWalletEventListener() {
+        myWallet.addCoinsReceivedEventListener(new WalletCoinsReceivedEventListener() {
             @Override
             public void onCoinsReceived(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {
                 txns.add(tx);

--- a/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
@@ -17,7 +17,6 @@
 
 package org.bitcoinj.examples;
 
-import org.bitcoinj.core.listeners.AbstractWalletEventListener;
 import org.bitcoinj.core.*;
 import org.bitcoinj.crypto.KeyCrypterException;
 import org.bitcoinj.kits.WalletAppKit;
@@ -32,6 +31,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import java.io.File;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import org.bitcoinj.core.listeners.WalletCoinsReceivedEventListener;
 
 /**
  * ForwardingService demonstrates basic usage of the library. It sits on the network and when it receives coins, simply
@@ -79,7 +79,7 @@ public class ForwardingService {
         kit.awaitRunning();
 
         // We want to know when we receive money.
-        kit.wallet().addEventListener(new AbstractWalletEventListener() {
+        kit.wallet().addCoinsReceivedEventListener(new WalletCoinsReceivedEventListener() {
             @Override
             public void onCoinsReceived(Wallet w, Transaction tx, Coin prevBalance, Coin newBalance) {
                 // Runs in the dedicated "user thread" (see bitcoinj docs for more info on this).

--- a/examples/src/main/java/org/bitcoinj/examples/Kit.java
+++ b/examples/src/main/java/org/bitcoinj/examples/Kit.java
@@ -14,7 +14,6 @@
 
 package org.bitcoinj.examples;
 
-import org.bitcoinj.core.listeners.AbstractWalletEventListener;
 import org.bitcoinj.core.*;
 import org.bitcoinj.kits.WalletAppKit;
 import org.bitcoinj.params.TestNet3Params;
@@ -22,6 +21,11 @@ import org.bitcoinj.script.Script;
 
 import java.io.File;
 import java.util.List;
+import org.bitcoinj.core.listeners.WalletCoinsReceivedEventListener;
+import org.bitcoinj.core.listeners.WalletCoinsSentEventListener;
+import org.bitcoinj.core.listeners.ScriptsChangeEventListener;
+import org.bitcoinj.core.listeners.TransactionConfidenceEventListener;
+import org.bitcoinj.wallet.KeyChainEventListener;
 
 /**
  * The following example shows how to use the by bitcoinj provided WalletAppKit.
@@ -56,10 +60,44 @@ public class Kit {
         // bitcoinj is working a lot with the Google Guava libraries. The WalletAppKit extends the AbstractIdleService. Have a look at the introduction to Guava services: https://code.google.com/p/guava-libraries/wiki/ServiceExplained
         kit.startAsync();
         kit.awaitRunning();
-
-        // To observe wallet events (like coins received) we implement a EventListener class that extends the AbstractWalletEventListener bitcoinj then calls the different functions from the EventListener class
-        WalletListener wListener = new WalletListener();
-        kit.wallet().addEventListener(wListener);
+        
+        kit.wallet().addCoinsReceivedEventListener(new WalletCoinsReceivedEventListener() {
+            @Override
+            public void onCoinsReceived(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {
+                System.out.println("-----> coins resceived: " + tx.getHashAsString());
+                System.out.println("received: " + tx.getValue(wallet));
+            }
+        });
+        
+        kit.wallet().addCoinsSentEventListener(new WalletCoinsSentEventListener() {
+            @Override
+            public void onCoinsSent(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {
+                System.out.println("coins sent");
+            }
+        });
+        
+        kit.wallet().addKeyChainEventListener(new KeyChainEventListener() {
+            @Override
+            public void onKeysAdded(List<ECKey> keys) {
+                System.out.println("new key added");
+            }
+        });
+        
+        kit.wallet().addScriptsChangeEventListener(new ScriptsChangeEventListener() {
+            @Override
+            public void onScriptsChanged(Wallet wallet, List<Script> scripts, boolean isAddingScripts) {
+                System.out.println("new script added");
+            }
+        });
+        
+        kit.wallet().addTransactionConfidenceEventListener(new TransactionConfidenceEventListener() {
+            @Override
+            public void onTransactionConfidenceChanged(Wallet wallet, Transaction tx) {
+                System.out.println("-----> confidence changed: " + tx.getHashAsString());
+                TransactionConfidence confidence = tx.getConfidence();
+                System.out.println("new block depth: " + confidence.getDepthInBlocks());
+            }
+        });
 
         // Ready to run. The kit syncs the blockchain and our wallet event listener gets notified when something happens.
         // To test everything we create and print a fresh receiving address. Send some coins to that address and see if everything works.
@@ -69,46 +107,6 @@ public class Kit {
         //System.out.println("shutting down again");
         //kit.stopAsync();
         //kit.awaitTerminated();
-    }
-
-    // The Wallet event listener its implementations get called on wallet changes.
-    static class WalletListener extends AbstractWalletEventListener {
-
-        @Override
-        public void onCoinsReceived(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {
-            System.out.println("-----> coins resceived: " + tx.getHashAsString());
-            System.out.println("received: " + tx.getValue(wallet));
-        }
-
-        @Override
-        public void onTransactionConfidenceChanged(Wallet wallet, Transaction tx) {
-            System.out.println("-----> confidence changed: " + tx.getHashAsString());
-            TransactionConfidence confidence = tx.getConfidence();
-            System.out.println("new block depth: " + confidence.getDepthInBlocks());
-        }
-
-        @Override
-        public void onCoinsSent(Wallet wallet, Transaction tx, Coin prevBalance, Coin newBalance) {
-            System.out.println("coins sent");
-        }
-
-        @Override
-        public void onReorganize(Wallet wallet) {
-        }
-
-        @Override
-        public void onWalletChanged(Wallet wallet) {
-        }
-
-        @Override
-        public void onKeysAdded(List<ECKey> keys) {
-            System.out.println("new key added");
-        }
-
-        @Override
-        public void onScriptsChanged(Wallet wallet, List<Script> scripts, boolean isAddingScripts) {
-            System.out.println("new script added");
-        }
     }
 
 }

--- a/examples/src/main/java/org/bitcoinj/examples/RefreshWallet.java
+++ b/examples/src/main/java/org/bitcoinj/examples/RefreshWallet.java
@@ -17,13 +17,13 @@
 
 package org.bitcoinj.examples;
 
-import org.bitcoinj.core.listeners.AbstractWalletEventListener;
 import org.bitcoinj.core.*;
 import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.MemoryBlockStore;
 
 import java.io.File;
+import org.bitcoinj.core.listeners.WalletCoinsReceivedEventListener;
 
 /**
  * RefreshWallet loads a wallet, then processes the block chain to update the transaction pools within it.
@@ -42,7 +42,7 @@ public class RefreshWallet {
         final PeerGroup peerGroup = new PeerGroup(params, chain);
         peerGroup.startAsync();
 
-        wallet.addEventListener(new AbstractWalletEventListener() {
+        wallet.addCoinsReceivedEventListener(new WalletCoinsReceivedEventListener() {
             @Override
             public synchronized void onCoinsReceived(Wallet w, Transaction tx, Coin prevBalance, Coin newBalance) {
                 System.out.println("\nReceived tx " + tx.getHashAsString());

--- a/wallettemplate/src/main/java/wallettemplate/utils/BitcoinUIModel.java
+++ b/wallettemplate/src/main/java/wallettemplate/utils/BitcoinUIModel.java
@@ -10,6 +10,7 @@ import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
 
 import java.util.Date;
+import org.bitcoinj.core.listeners.WalletChangeEventListener;
 
 /**
  * A class that exposes relevant bitcoin stuff as JavaFX bindable properties.
@@ -28,13 +29,12 @@ public class BitcoinUIModel {
     }
 
     public final void setWallet(Wallet wallet) {
-        wallet.addEventListener(new AbstractWalletEventListener() {
+        wallet.addChangeEventListener(Platform::runLater, new WalletChangeEventListener() {
             @Override
             public void onWalletChanged(Wallet wallet) {
-                super.onWalletChanged(wallet);
                 update(wallet);
             }
-        }, Platform::runLater);
+        });
         update(wallet);
     }
 


### PR DESCRIPTION
Provides per-event methods for wallet listeners, so they're then compatible with lambda functions, and updates all call to use these methods.

Still need to look at whether network events can be split up, but wanted to raise this as its own PR.
