### PR TITLE
Another max coins check, involving a series of transactions

### DIFF
--- a/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
@@ -19,6 +19,7 @@ package org.bitcoinj.wallet;
 
 import com.google.common.collect.*;
 import org.bitcoinj.core.*;
+import org.bitcoinj.core.Wallet.BalanceType;
 import org.bitcoinj.crypto.*;
 import org.bitcoinj.params.*;
 import org.bitcoinj.script.*;
@@ -30,6 +31,7 @@ import java.util.*;
 
 import static org.bitcoinj.core.Coin.*;
 import static org.bitcoinj.script.ScriptOpCodes.*;
+import static org.bitcoinj.testing.FakeTxBuilder.createFakeTxWithoutChangeAddress;
 import static org.junit.Assert.*;
 
 public class DefaultRiskAnalysisTest {
@@ -227,6 +229,20 @@ public class DefaultRiskAnalysisTest {
     public void optInFullRBF() throws Exception {
         Transaction tx = FakeTxBuilder.createFakeTx(params);
         tx.getInput(0).setSequenceNumber(TransactionInput.NO_SEQUENCE - 2);
+        DefaultRiskAnalysis analysis = DefaultRiskAnalysis.FACTORY.create(wallet, tx, NO_DEPS);
+        assertEquals(RiskAnalysis.Result.NON_FINAL, analysis.analyze());
+        assertEquals(tx, analysis.getNonFinal());
+    }
+
+    @Test
+    public void multipleTransactionsExceedMaximumCoins() {
+        // First check if receiving a max coins transaction is fine.
+        Address address = wallet.currentReceiveAddress();
+        Transaction tx = createFakeTxWithoutChangeAddress(params, params.getMaxMoney(), address);
+        assertEquals(RiskAnalysis.Result.OK, DefaultRiskAnalysis.FACTORY.create(wallet, tx, NO_DEPS).analyze());
+
+        // The prepare the wallet with one satoshi and check max coins again. It should be risky now.
+        wallet.commitTx(createFakeTxWithoutChangeAddress(params, Coin.SATOSHI, address));
         DefaultRiskAnalysis analysis = DefaultRiskAnalysis.FACTORY.create(wallet, tx, NO_DEPS);
         assertEquals(RiskAnalysis.Result.NON_FINAL, analysis.analyze());
         assertEquals(tx, analysis.getNonFinal());


### PR DESCRIPTION
Transactions that would cause estimated balance to exceed the maximum allowed are considered risky. There is a risk that the culprit is actually a previous transaction and we're punishing the wrong one, but this situation will clear up as transactions are confirmed. Most important is that the balance will not rise too high.