### PR TITLE
Move Transaction.isConsistent() to Wallet.isTxConsistent(), …

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -270,29 +270,6 @@ public class Transaction extends ChildMessage {
         return inputTotal;
     }
 
-    /*
-     * If isSpent - check that all my outputs spent, otherwise check that there at least
-     * one unspent.
-     */
-    boolean isConsistent(TransactionBag transactionBag, boolean isSpent) {
-        boolean isActuallySpent = true;
-        for (TransactionOutput o : outputs) {
-            if (o.isAvailableForSpending()) {
-                if (o.isMineOrWatched(transactionBag)) isActuallySpent = false;
-                if (o.getSpentBy() != null) {
-                    log.error("isAvailableForSpending != spentBy");
-                    return false;
-                }
-            } else {
-                if (o.getSpentBy() == null) {
-                    log.error("isAvailableForSpending != spentBy");
-                    return false;
-                }
-            }
-        }
-        return isActuallySpent == isSpent;
-    }
-
     /**
      * Calculates the sum of the outputs that are sending coins to a key in the wallet.
      */

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -112,39 +112,6 @@ public class TransactionTest {
     }
 
     @Test
-    public void isConsistentReturnsFalseAsExpected() {
-        TransactionBag mockTB = createMock(TransactionBag.class);
-
-        TransactionOutput to = createMock(TransactionOutput.class);
-        EasyMock.expect(to.isAvailableForSpending()).andReturn(true);
-        EasyMock.expect(to.isMineOrWatched(mockTB)).andReturn(true);
-        EasyMock.expect(to.getSpentBy()).andReturn(new TransactionInput(PARAMS, null, new byte[0]));
-
-        Transaction tx = FakeTxBuilder.createFakeTxWithoutChange(PARAMS, to);
-
-        replay(to);
-
-        boolean isConsistent = tx.isConsistent(mockTB, false);
-
-        assertEquals(isConsistent, false);
-    }
-
-    @Test
-    public void isConsistentReturnsFalseAsExpected_WhenAvailableForSpendingEqualsFalse() {
-        TransactionOutput to = createMock(TransactionOutput.class);
-        EasyMock.expect(to.isAvailableForSpending()).andReturn(false);
-        EasyMock.expect(to.getSpentBy()).andReturn(null);
-
-        Transaction tx = FakeTxBuilder.createFakeTxWithoutChange(PARAMS, to);
-
-        replay(to);
-
-        boolean isConsistent = tx.isConsistent(createMock(TransactionBag.class), false);
-
-        assertEquals(isConsistent, false);
-    }
-
-    @Test
     public void testEstimatedLockTime_WhenParameterSignifiesBlockHeight() {
         int TEST_LOCK_TIME = 20;
         Date now = Calendar.getInstance().getTime();


### PR DESCRIPTION
…as the wallet was the only consumer of that method.