### PR TITLE
TransactionConfidence: Add lastBroadcastedAt, the time a transaction…

### DIFF
--- a/core/src/main/java/org/bitcoinj/store/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/store/WalletProtobufSerializer.java
@@ -366,6 +366,9 @@ public class WalletProtobufSerializer {
                     .build();
             confidenceBuilder.addBroadcastBy(proto);
         }
+        Date lastBroadcastedAt = confidence.getLastBroadcastedAt();
+        if (lastBroadcastedAt != null)
+            confidenceBuilder.setLastBroadcastedAt(lastBroadcastedAt.getTime());
         txBuilder.setConfidence(confidenceBuilder);
     }
 
@@ -779,6 +782,8 @@ public class WalletProtobufSerializer {
             address.setServices(BigInteger.valueOf(proto.getServices()));
             confidence.markBroadcastBy(address);
         }
+        if (confidenceProto.hasLastBroadcastedAt())
+            confidence.setLastBroadcastedAt(new Date(confidenceProto.getLastBroadcastedAt()));
         switch (confidenceProto.getSource()) {
             case SOURCE_SELF: confidence.setSource(TransactionConfidence.Source.SELF); break;
             case SOURCE_NETWORK: confidence.setSource(TransactionConfidence.Source.NETWORK); break;

--- a/core/src/main/java/org/bitcoinj/wallet/Protos.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Protos.java
@@ -6571,6 +6571,23 @@ public final class Protos {
         int index);
 
     /**
+     * <code>optional int64 last_broadcasted_at = 8;</code>
+     *
+     * <pre>
+     * Millis since epoch the transaction was last announced to us.
+     * </pre>
+     */
+    boolean hasLastBroadcastedAt();
+    /**
+     * <code>optional int64 last_broadcasted_at = 8;</code>
+     *
+     * <pre>
+     * Millis since epoch the transaction was last announced to us.
+     * </pre>
+     */
+    long getLastBroadcastedAt();
+
+    /**
      * <code>optional .wallet.TransactionConfidence.Source source = 7;</code>
      */
     boolean hasSource();
@@ -6678,9 +6695,14 @@ public final class Protos {
               if (value == null) {
                 unknownFields.mergeVarintField(7, rawValue);
               } else {
-                bitField0_ |= 0x00000010;
+                bitField0_ |= 0x00000020;
                 source_ = value;
               }
+              break;
+            }
+            case 64: {
+              bitField0_ |= 0x00000010;
+              lastBroadcastedAt_ = input.readInt64();
               break;
             }
           }
@@ -7144,13 +7166,36 @@ public final class Protos {
       return broadcastBy_.get(index);
     }
 
+    public static final int LAST_BROADCASTED_AT_FIELD_NUMBER = 8;
+    private long lastBroadcastedAt_;
+    /**
+     * <code>optional int64 last_broadcasted_at = 8;</code>
+     *
+     * <pre>
+     * Millis since epoch the transaction was last announced to us.
+     * </pre>
+     */
+    public boolean hasLastBroadcastedAt() {
+      return ((bitField0_ & 0x00000010) == 0x00000010);
+    }
+    /**
+     * <code>optional int64 last_broadcasted_at = 8;</code>
+     *
+     * <pre>
+     * Millis since epoch the transaction was last announced to us.
+     * </pre>
+     */
+    public long getLastBroadcastedAt() {
+      return lastBroadcastedAt_;
+    }
+
     public static final int SOURCE_FIELD_NUMBER = 7;
     private org.bitcoinj.wallet.Protos.TransactionConfidence.Source source_;
     /**
      * <code>optional .wallet.TransactionConfidence.Source source = 7;</code>
      */
     public boolean hasSource() {
-      return ((bitField0_ & 0x00000010) == 0x00000010);
+      return ((bitField0_ & 0x00000020) == 0x00000020);
     }
     /**
      * <code>optional .wallet.TransactionConfidence.Source source = 7;</code>
@@ -7165,6 +7210,7 @@ public final class Protos {
       overridingTransaction_ = com.google.protobuf.ByteString.EMPTY;
       depth_ = 0;
       broadcastBy_ = java.util.Collections.emptyList();
+      lastBroadcastedAt_ = 0L;
       source_ = org.bitcoinj.wallet.Protos.TransactionConfidence.Source.SOURCE_UNKNOWN;
     }
     private byte memoizedIsInitialized = -1;
@@ -7201,8 +7247,11 @@ public final class Protos {
       for (int i = 0; i < broadcastBy_.size(); i++) {
         output.writeMessage(6, broadcastBy_.get(i));
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
         output.writeEnum(7, source_.getNumber());
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        output.writeInt64(8, lastBroadcastedAt_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -7233,9 +7282,13 @@ public final class Protos {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(6, broadcastBy_.get(i));
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
         size += com.google.protobuf.CodedOutputStream
           .computeEnumSize(7, source_.getNumber());
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(8, lastBroadcastedAt_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSerializedSize = size;
@@ -7376,8 +7429,10 @@ public final class Protos {
         } else {
           broadcastByBuilder_.clear();
         }
-        source_ = org.bitcoinj.wallet.Protos.TransactionConfidence.Source.SOURCE_UNKNOWN;
+        lastBroadcastedAt_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000020);
+        source_ = org.bitcoinj.wallet.Protos.TransactionConfidence.Source.SOURCE_UNKNOWN;
+        bitField0_ = (bitField0_ & ~0x00000040);
         return this;
       }
 
@@ -7434,6 +7489,10 @@ public final class Protos {
         if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
           to_bitField0_ |= 0x00000010;
         }
+        result.lastBroadcastedAt_ = lastBroadcastedAt_;
+        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
+          to_bitField0_ |= 0x00000020;
+        }
         result.source_ = source_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
@@ -7488,6 +7547,9 @@ public final class Protos {
               broadcastByBuilder_.addAllMessages(other.broadcastBy_);
             }
           }
+        }
+        if (other.hasLastBroadcastedAt()) {
+          setLastBroadcastedAt(other.getLastBroadcastedAt());
         }
         if (other.hasSource()) {
           setSource(other.getSource());
@@ -7975,12 +8037,60 @@ public final class Protos {
         return broadcastByBuilder_;
       }
 
+      private long lastBroadcastedAt_ ;
+      /**
+       * <code>optional int64 last_broadcasted_at = 8;</code>
+       *
+       * <pre>
+       * Millis since epoch the transaction was last announced to us.
+       * </pre>
+       */
+      public boolean hasLastBroadcastedAt() {
+        return ((bitField0_ & 0x00000020) == 0x00000020);
+      }
+      /**
+       * <code>optional int64 last_broadcasted_at = 8;</code>
+       *
+       * <pre>
+       * Millis since epoch the transaction was last announced to us.
+       * </pre>
+       */
+      public long getLastBroadcastedAt() {
+        return lastBroadcastedAt_;
+      }
+      /**
+       * <code>optional int64 last_broadcasted_at = 8;</code>
+       *
+       * <pre>
+       * Millis since epoch the transaction was last announced to us.
+       * </pre>
+       */
+      public Builder setLastBroadcastedAt(long value) {
+        bitField0_ |= 0x00000020;
+        lastBroadcastedAt_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional int64 last_broadcasted_at = 8;</code>
+       *
+       * <pre>
+       * Millis since epoch the transaction was last announced to us.
+       * </pre>
+       */
+      public Builder clearLastBroadcastedAt() {
+        bitField0_ = (bitField0_ & ~0x00000020);
+        lastBroadcastedAt_ = 0L;
+        onChanged();
+        return this;
+      }
+
       private org.bitcoinj.wallet.Protos.TransactionConfidence.Source source_ = org.bitcoinj.wallet.Protos.TransactionConfidence.Source.SOURCE_UNKNOWN;
       /**
        * <code>optional .wallet.TransactionConfidence.Source source = 7;</code>
        */
       public boolean hasSource() {
-        return ((bitField0_ & 0x00000020) == 0x00000020);
+        return ((bitField0_ & 0x00000040) == 0x00000040);
       }
       /**
        * <code>optional .wallet.TransactionConfidence.Source source = 7;</code>
@@ -7995,7 +8105,7 @@ public final class Protos {
         if (value == null) {
           throw new NullPointerException();
         }
-        bitField0_ |= 0x00000020;
+        bitField0_ |= 0x00000040;
         source_ = value;
         onChanged();
         return this;
@@ -8004,7 +8114,7 @@ public final class Protos {
        * <code>optional .wallet.TransactionConfidence.Source source = 7;</code>
        */
       public Builder clearSource() {
-        bitField0_ = (bitField0_ & ~0x00000020);
+        bitField0_ = (bitField0_ & ~0x00000040);
         source_ = org.bitcoinj.wallet.Protos.TransactionConfidence.Source.SOURCE_UNKNOWN;
         onChanged();
         return this;
@@ -18911,59 +19021,60 @@ public final class Protos {
       "\030\004 \001(\r\022\r\n\005value\030\005 \001(\003\"\177\n\021TransactionOutp" +
       "ut\022\r\n\005value\030\001 \002(\003\022\024\n\014script_bytes\030\002 \002(\014\022" +
       "!\n\031spent_by_transaction_hash\030\003 \001(\014\022\"\n\032sp" +
-      "ent_by_transaction_index\030\004 \001(\005\"\232\003\n\025Trans" +
+      "ent_by_transaction_index\030\004 \001(\005\"\267\003\n\025Trans" +
       "actionConfidence\0220\n\004type\030\001 \001(\0162\".wallet." +
       "TransactionConfidence.Type\022\032\n\022appeared_a" +
       "t_height\030\002 \001(\005\022\036\n\026overriding_transaction",
       "\030\003 \001(\014\022\r\n\005depth\030\004 \001(\005\022)\n\014broadcast_by\030\006 " +
-      "\003(\0132\023.wallet.PeerAddress\0224\n\006source\030\007 \001(\016" +
-      "2$.wallet.TransactionConfidence.Source\"`" +
-      "\n\004Type\022\013\n\007UNKNOWN\020\000\022\014\n\010BUILDING\020\001\022\013\n\007PEN" +
-      "DING\020\002\022\025\n\021NOT_IN_BEST_CHAIN\020\003\022\010\n\004DEAD\020\004\022" +
-      "\017\n\013IN_CONFLICT\020\005\"A\n\006Source\022\022\n\016SOURCE_UNK" +
-      "NOWN\020\000\022\022\n\016SOURCE_NETWORK\020\001\022\017\n\013SOURCE_SEL" +
-      "F\020\002\"\303\005\n\013Transaction\022\017\n\007version\030\001 \002(\005\022\014\n\004" +
-      "hash\030\002 \002(\014\022&\n\004pool\030\003 \001(\0162\030.wallet.Transa" +
-      "ction.Pool\022\021\n\tlock_time\030\004 \001(\r\022\022\n\nupdated",
-      "_at\030\005 \001(\003\0223\n\021transaction_input\030\006 \003(\0132\030.w" +
-      "allet.TransactionInput\0225\n\022transaction_ou" +
-      "tput\030\007 \003(\0132\031.wallet.TransactionOutput\022\022\n" +
-      "\nblock_hash\030\010 \003(\014\022 \n\030block_relativity_of" +
-      "fsets\030\013 \003(\005\0221\n\nconfidence\030\t \001(\0132\035.wallet" +
-      ".TransactionConfidence\0225\n\007purpose\030\n \001(\0162" +
-      "\033.wallet.Transaction.Purpose:\007UNKNOWN\022+\n" +
-      "\rexchange_rate\030\014 \001(\0132\024.wallet.ExchangeRa" +
-      "te\022\014\n\004memo\030\r \001(\t\"Y\n\004Pool\022\013\n\007UNSPENT\020\004\022\t\n" +
-      "\005SPENT\020\005\022\014\n\010INACTIVE\020\002\022\010\n\004DEAD\020\n\022\013\n\007PEND",
-      "ING\020\020\022\024\n\020PENDING_INACTIVE\020\022\"\243\001\n\007Purpose\022" +
-      "\013\n\007UNKNOWN\020\000\022\020\n\014USER_PAYMENT\020\001\022\020\n\014KEY_RO" +
-      "TATION\020\002\022\034\n\030ASSURANCE_CONTRACT_CLAIM\020\003\022\035" +
-      "\n\031ASSURANCE_CONTRACT_PLEDGE\020\004\022\033\n\027ASSURAN" +
-      "CE_CONTRACT_STUB\020\005\022\r\n\tRAISE_FEE\020\006\"N\n\020Scr" +
-      "yptParameters\022\014\n\004salt\030\001 \002(\014\022\020\n\001n\030\002 \001(\003:\005" +
-      "16384\022\014\n\001r\030\003 \001(\005:\0018\022\014\n\001p\030\004 \001(\005:\0011\"8\n\tExt" +
-      "ension\022\n\n\002id\030\001 \002(\t\022\014\n\004data\030\002 \002(\014\022\021\n\tmand" +
-      "atory\030\003 \002(\010\" \n\003Tag\022\013\n\003tag\030\001 \002(\t\022\014\n\004data\030" +
-      "\002 \002(\014\"5\n\021TransactionSigner\022\022\n\nclass_name",
-      "\030\001 \002(\t\022\014\n\004data\030\002 \001(\014\"\351\004\n\006Wallet\022\032\n\022netwo" +
-      "rk_identifier\030\001 \002(\t\022\034\n\024last_seen_block_h" +
-      "ash\030\002 \001(\014\022\036\n\026last_seen_block_height\030\014 \001(" +
-      "\r\022!\n\031last_seen_block_time_secs\030\016 \001(\003\022\030\n\003" +
-      "key\030\003 \003(\0132\013.wallet.Key\022(\n\013transaction\030\004 " +
-      "\003(\0132\023.wallet.Transaction\022&\n\016watched_scri" +
-      "pt\030\017 \003(\0132\016.wallet.Script\022C\n\017encryption_t" +
-      "ype\030\005 \001(\0162\035.wallet.Wallet.EncryptionType" +
-      ":\013UNENCRYPTED\0227\n\025encryption_parameters\030\006" +
-      " \001(\0132\030.wallet.ScryptParameters\022\022\n\007versio",
-      "n\030\007 \001(\005:\0011\022$\n\textension\030\n \003(\0132\021.wallet.E" +
-      "xtension\022\023\n\013description\030\013 \001(\t\022\031\n\021key_rot" +
-      "ation_time\030\r \001(\004\022\031\n\004tags\030\020 \003(\0132\013.wallet." +
-      "Tag\0226\n\023transaction_signers\030\021 \003(\0132\031.walle" +
-      "t.TransactionSigner\";\n\016EncryptionType\022\017\n" +
-      "\013UNENCRYPTED\020\001\022\030\n\024ENCRYPTED_SCRYPT_AES\020\002" +
-      "\"R\n\014ExchangeRate\022\022\n\ncoin_value\030\001 \002(\003\022\022\n\n" +
-      "fiat_value\030\002 \002(\003\022\032\n\022fiat_currency_code\030\003" +
-      " \002(\tB\035\n\023org.bitcoinj.walletB\006Protos"
+      "\003(\0132\023.wallet.PeerAddress\022\033\n\023last_broadca" +
+      "sted_at\030\010 \001(\003\0224\n\006source\030\007 \001(\0162$.wallet.T" +
+      "ransactionConfidence.Source\"`\n\004Type\022\013\n\007U" +
+      "NKNOWN\020\000\022\014\n\010BUILDING\020\001\022\013\n\007PENDING\020\002\022\025\n\021N" +
+      "OT_IN_BEST_CHAIN\020\003\022\010\n\004DEAD\020\004\022\017\n\013IN_CONFL" +
+      "ICT\020\005\"A\n\006Source\022\022\n\016SOURCE_UNKNOWN\020\000\022\022\n\016S" +
+      "OURCE_NETWORK\020\001\022\017\n\013SOURCE_SELF\020\002\"\303\005\n\013Tra" +
+      "nsaction\022\017\n\007version\030\001 \002(\005\022\014\n\004hash\030\002 \002(\014\022" +
+      "&\n\004pool\030\003 \001(\0162\030.wallet.Transaction.Pool\022",
+      "\021\n\tlock_time\030\004 \001(\r\022\022\n\nupdated_at\030\005 \001(\003\0223" +
+      "\n\021transaction_input\030\006 \003(\0132\030.wallet.Trans" +
+      "actionInput\0225\n\022transaction_output\030\007 \003(\0132" +
+      "\031.wallet.TransactionOutput\022\022\n\nblock_hash" +
+      "\030\010 \003(\014\022 \n\030block_relativity_offsets\030\013 \003(\005" +
+      "\0221\n\nconfidence\030\t \001(\0132\035.wallet.Transactio" +
+      "nConfidence\0225\n\007purpose\030\n \001(\0162\033.wallet.Tr" +
+      "ansaction.Purpose:\007UNKNOWN\022+\n\rexchange_r" +
+      "ate\030\014 \001(\0132\024.wallet.ExchangeRate\022\014\n\004memo\030" +
+      "\r \001(\t\"Y\n\004Pool\022\013\n\007UNSPENT\020\004\022\t\n\005SPENT\020\005\022\014\n",
+      "\010INACTIVE\020\002\022\010\n\004DEAD\020\n\022\013\n\007PENDING\020\020\022\024\n\020PE" +
+      "NDING_INACTIVE\020\022\"\243\001\n\007Purpose\022\013\n\007UNKNOWN\020" +
+      "\000\022\020\n\014USER_PAYMENT\020\001\022\020\n\014KEY_ROTATION\020\002\022\034\n" +
+      "\030ASSURANCE_CONTRACT_CLAIM\020\003\022\035\n\031ASSURANCE" +
+      "_CONTRACT_PLEDGE\020\004\022\033\n\027ASSURANCE_CONTRACT" +
+      "_STUB\020\005\022\r\n\tRAISE_FEE\020\006\"N\n\020ScryptParamete" +
+      "rs\022\014\n\004salt\030\001 \002(\014\022\020\n\001n\030\002 \001(\003:\00516384\022\014\n\001r\030" +
+      "\003 \001(\005:\0018\022\014\n\001p\030\004 \001(\005:\0011\"8\n\tExtension\022\n\n\002i" +
+      "d\030\001 \002(\t\022\014\n\004data\030\002 \002(\014\022\021\n\tmandatory\030\003 \002(\010" +
+      "\" \n\003Tag\022\013\n\003tag\030\001 \002(\t\022\014\n\004data\030\002 \002(\014\"5\n\021Tr",
+      "ansactionSigner\022\022\n\nclass_name\030\001 \002(\t\022\014\n\004d" +
+      "ata\030\002 \001(\014\"\351\004\n\006Wallet\022\032\n\022network_identifi" +
+      "er\030\001 \002(\t\022\034\n\024last_seen_block_hash\030\002 \001(\014\022\036" +
+      "\n\026last_seen_block_height\030\014 \001(\r\022!\n\031last_s" +
+      "een_block_time_secs\030\016 \001(\003\022\030\n\003key\030\003 \003(\0132\013" +
+      ".wallet.Key\022(\n\013transaction\030\004 \003(\0132\023.walle" +
+      "t.Transaction\022&\n\016watched_script\030\017 \003(\0132\016." +
+      "wallet.Script\022C\n\017encryption_type\030\005 \001(\0162\035" +
+      ".wallet.Wallet.EncryptionType:\013UNENCRYPT" +
+      "ED\0227\n\025encryption_parameters\030\006 \001(\0132\030.wall",
+      "et.ScryptParameters\022\022\n\007version\030\007 \001(\005:\0011\022" +
+      "$\n\textension\030\n \003(\0132\021.wallet.Extension\022\023\n" +
+      "\013description\030\013 \001(\t\022\031\n\021key_rotation_time\030" +
+      "\r \001(\004\022\031\n\004tags\030\020 \003(\0132\013.wallet.Tag\0226\n\023tran" +
+      "saction_signers\030\021 \003(\0132\031.wallet.Transacti" +
+      "onSigner\";\n\016EncryptionType\022\017\n\013UNENCRYPTE" +
+      "D\020\001\022\030\n\024ENCRYPTED_SCRYPT_AES\020\002\"R\n\014Exchang" +
+      "eRate\022\022\n\ncoin_value\030\001 \002(\003\022\022\n\nfiat_value\030" +
+      "\002 \002(\003\022\032\n\022fiat_currency_code\030\003 \002(\tB\035\n\023org" +
+      ".bitcoinj.walletB\006Protos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -19024,7 +19135,7 @@ public final class Protos {
     internal_static_wallet_TransactionConfidence_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_wallet_TransactionConfidence_descriptor,
-        new java.lang.String[] { "Type", "AppearedAtHeight", "OverridingTransaction", "Depth", "BroadcastBy", "Source", });
+        new java.lang.String[] { "Type", "AppearedAtHeight", "OverridingTransaction", "Depth", "BroadcastBy", "LastBroadcastedAt", "Source", });
     internal_static_wallet_Transaction_descriptor =
       getDescriptor().getMessageTypes().get(8);
     internal_static_wallet_Transaction_fieldAccessorTable = new

--- a/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -367,7 +367,10 @@ public class PeerGroupTest extends TestWithPeerGroup {
         Transaction tx = FakeTxBuilder.createFakeTx(params, valueOf(20, 0), address);
         InventoryMessage inv = new InventoryMessage(params);
         inv.addTransaction(tx);
-        
+
+        assertEquals(0, tx.getConfidence().numBroadcastPeers());
+        assertNull(tx.getConfidence().getLastBroadcastedAt());
+
         // Peer 2 advertises the tx but does not receive it yet.
         inbound(p2, inv);
         assertTrue(outbound(p2) instanceof GetDataMessage);
@@ -390,6 +393,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         assertEquals(2, tx.getConfidence().numBroadcastPeers());
         assertTrue(tx.getConfidence().wasBroadcastBy(peerOf(p1).getAddress()));
         assertTrue(tx.getConfidence().wasBroadcastBy(peerOf(p2).getAddress()));
+        assertNotNull(tx.getConfidence().getLastBroadcastedAt());
 
         tx.getConfidence().addEventListener(new TransactionConfidence.Listener() {
             @Override

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -114,6 +114,7 @@ public class WalletProtobufSerializerTest {
         Transaction t1copy = wallet1.getTransaction(t1.getHash());
         assertArrayEquals(t1.bitcoinSerialize(), t1copy.bitcoinSerialize());
         assertEquals(2, t1copy.getConfidence().numBroadcastPeers());
+        assertNotNull(t1copy.getConfidence().getLastBroadcastedAt());
         assertEquals(TransactionConfidence.Source.NETWORK, t1copy.getConfidence().getSource());
         
         Protos.Wallet walletProto = new WalletProtobufSerializer().walletToProto(myWallet);

--- a/core/src/wallet.proto
+++ b/core/src/wallet.proto
@@ -201,6 +201,9 @@ message TransactionConfidence {
 
   repeated PeerAddress broadcast_by = 6;
 
+  // Millis since epoch the transaction was last announced to us.
+  optional int64 last_broadcasted_at = 8;
+
   // Where did we get this transaction from? Knowing the source may help us to risk analyze pending transactions.
   enum Source {
     SOURCE_UNKNOWN = 0;  // We don't know where it came from, or this is a wallet from the future.
@@ -212,6 +215,8 @@ message TransactionConfidence {
     // - from a wallet that uses trusted computing/secure hardware that won't create double spends
   }
   optional Source source = 7;
+
+  // Next tag: 9
 }
 
 /** A bitcoin transaction */


### PR DESCRIPTION
…was last announced to us.

The idea of this new field is that if a pending transaction was not announced for a longer time,
it is unlikely to confirm. Thus, the user should be warned and maybe the transaction removed from
the wallet at some point.