### PR TITLE
Added broadcast multisig contract to wallet bloom filter. Fixes #1181

### DIFF
--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerState.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerState.java
@@ -235,6 +235,7 @@ public class PaymentChannelServerState {
             throw e;
         }
         log.info("Broadcasting multisig contract: {}", multisigContract);
+        wallet.addWatchedScripts(ImmutableList.of(multisigContract.getOutput(0).getScriptPubKey()));
         state = State.WAITING_FOR_MULTISIG_ACCEPTANCE;
         final SettableFuture<PaymentChannelServerState> future = SettableFuture.create();
         Futures.addCallback(broadcaster.broadcastTransaction(multisigContract).future(), new FutureCallback<Transaction>() {


### PR DESCRIPTION
The payment channel contract broadcast future was never completing, since the client was never receiving notification of acceptance into memory pool. This adds the contract to the wallet's watch list so it receives notification.