### PR TITLE
Added capability to run example payment channels on regtest, test or main nets

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -37,6 +37,11 @@
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
+            <groupId>net.sf.jopt-simple</groupId>
+            <artifactId>jopt-simple</artifactId>
+            <version>4.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
             <version>1.7.7</version>

--- a/examples/src/main/java/org/bitcoinj/examples/NetworkEnum.java
+++ b/examples/src/main/java/org/bitcoinj/examples/NetworkEnum.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013 Google Inc.
+ * Copyright 2014 Andreas Schildbach
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.examples;
+
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.params.MainNetParams;
+import org.bitcoinj.params.RegTestParams;
+import org.bitcoinj.params.TestNet3Params;
+
+public enum NetworkEnum {
+    MAIN,
+    PROD, // alias for MAIN
+    TEST,
+    REGTEST;
+
+    public NetworkParameters get() {
+        switch(this) {
+            case MAIN:
+            case PROD:
+                return MainNetParams.get();
+            case TEST:
+                return TestNet3Params.get();
+            case REGTEST:
+            default:
+                return RegTestParams.get();
+        }
+    }
+}


### PR DESCRIPTION
I added an extra command line option to the `ExamplePaymentChannelClient` and `ExamplePaymentChannelServer` programs to allow them to run on testnet or mainnet as well as regtest net.