### PR TITLE
Fixed stored channel timers failing, fixed v2 server deserialisation

### DIFF
--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerState.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerState.java
@@ -122,6 +122,7 @@ public abstract class PaymentChannelServerState {
             this.serverKey = checkNotNull(storedServerChannel.myKey);
             this.storedServerChannel = storedServerChannel;
             this.bestValueToMe = checkNotNull(storedServerChannel.bestValueToMe);
+            this.minExpireTime = storedServerChannel.refundTransactionUnlockTimeSecs;
             this.bestValueSignature = storedServerChannel.bestValueSignature;
             checkArgument(bestValueToMe.equals(Coin.ZERO) || bestValueSignature != null);
             storedServerChannel.state = this;

--- a/core/src/main/java/org/bitcoinj/protocols/channels/StoredPaymentChannelClientStates.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/StoredPaymentChannelClientStates.java
@@ -207,10 +207,16 @@ public class StoredPaymentChannelClientStates implements WalletExtension {
             channelTimeoutHandler.schedule(new TimerTask() {
                 @Override
                 public void run() {
-                    TransactionBroadcaster announcePeerGroup = getAnnouncePeerGroup();
-                    removeChannel(channel);
-                    announcePeerGroup.broadcastTransaction(channel.contract);
-                    announcePeerGroup.broadcastTransaction(channel.refund);
+                    try {
+                        TransactionBroadcaster announcePeerGroup = getAnnouncePeerGroup();
+                        removeChannel(channel);
+                        announcePeerGroup.broadcastTransaction(channel.contract);
+                        announcePeerGroup.broadcastTransaction(channel.refund);
+                    } catch (Exception e) {
+                        // Something went wrong closing the channel - we catch
+                        // here or else we take down the whole Timer.
+                        log.error("Auto-closing channel failed", e);
+                    }
                 }
                 // Add the difference between real time and Utils.now() so that test-cases can use a mock clock.
             }, new Date(channel.expiryTimeSeconds() * 1000 + (System.currentTimeMillis() - Utils.currentTimeMillis())));

--- a/core/src/main/java/org/bitcoinj/protocols/channels/StoredPaymentChannelServerStates.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/StoredPaymentChannelServerStates.java
@@ -190,7 +190,13 @@ public class StoredPaymentChannelServerStates implements WalletExtension {
                 @Override
                 public void run() {
                     log.info("Auto-closing channel: {}", channel);
-                    closeChannel(channel);
+                    try {
+                        closeChannel(channel);
+                    } catch (Exception e) {
+                        // Something went wrong closing the channel - we catch
+                        // here or else we take down the whole Timer.
+                        log.error("Auto-closing channel failed", e);
+                    }
                 }
             }, autocloseTime);
         } finally {


### PR DESCRIPTION
* I added catch-all exception handlers to the `TimerTask` scheduled methods in the stored client and server channels - if something does fail during broadcast of transactions in either end of the payment channel then it won't take down the entire `TimerTask` with it now.
* I noticed that deserialised V2 servers weren't setting the expiry time correctly.