### PR TITLE
Add listeners before starting peer group

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -108,9 +108,9 @@ public class PeerGroupTest extends TestWithPeerGroup {
 
     @Test
     public void listener() throws Exception {
-        peerGroup.start();
         peerGroup.addConnectionEventListener(listener);
         peerGroup.addPreMessageReceivedEventListener(preMessageReceivedListener);
+        peerGroup.start();
 
         // Create a couple of peers.
         InboundMessageQueuer p1 = connectPeer(1);


### PR DESCRIPTION
Okay, so it can't do anything until later, but still good practice to add the listeners first.
