### PR TITLE
Split PeerConnectionEventListener

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/listeners/PeerConnectedEventListener.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/PeerConnectedEventListener.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2011 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.core.listeners;
+
+import org.bitcoinj.core.Peer;
+
+/**
+ * <p>Implementors can listen to events indicating a new peer connecting.</p>
+ */
+public interface PeerConnectedEventListener {
+
+    /**
+     * Called when a peer is connected. If this listener is registered to a {@link Peer} instead of a {@link PeerGroup},
+     * peerCount will always be 1.
+     *
+     * @param peer
+     * @param peerCount the total number of connected peers
+     */
+    void onPeerConnected(Peer peer, int peerCount);
+}

--- a/core/src/main/java/org/bitcoinj/core/listeners/PeerDisconnectedEventListener.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/PeerDisconnectedEventListener.java
@@ -19,13 +19,9 @@ package org.bitcoinj.core.listeners;
 import org.bitcoinj.core.Peer;
 
 /**
- * <p>Implementors can listen to events like peer discovery, connect or disconnects.</p>
- *
- * @deprecated Use the single event interfaces instead
+ * <p>Implementors can listen to events indicating a peer disconnecting.</p>
  */
-@Deprecated
-public interface PeerConnectionEventListener extends PeerConnectedEventListener,
-        PeerDiscoveredEventListener, PeerDisconnectedEventListener {
+public interface PeerDisconnectedEventListener {
 
     /**
      * Called when a peer is disconnected. Note that this won't be called if the listener is registered on a

--- a/core/src/main/java/org/bitcoinj/core/listeners/PeerDiscoveredEventListener.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/PeerDiscoveredEventListener.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2011 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.core.listeners;
+
+import org.bitcoinj.core.Peer;
+import org.bitcoinj.core.PeerAddress;
+import java.util.Set;
+
+/**
+ * <p>Implementors can listen to events for peers being discovered.</p>
+ */
+public interface PeerDiscoveredEventListener {
+    /**
+     * <p>Called when peers are discovered, this happens at startup of {@link PeerGroup} or if we run out of
+     * suitable {@link Peer}s to connect to.</p>
+     *
+     * @param peerAddresses the set of discovered {@link PeerAddress}es
+     */
+    void onPeersDiscovered(Set<PeerAddress> peerAddresses);
+}

--- a/core/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -102,13 +102,26 @@ public class PeerTest extends TestWithNetworkConnections {
     }
 
     @Test
-    public void testAddEventListener() throws Exception {
+    public void testAddConnectedEventListener() throws Exception {
         connect();
-        PeerConnectionEventListener listener = new AbstractPeerConnectionEventListener() {
+        PeerConnectedEventListener listener = new AbstractPeerConnectionEventListener() {
         };
-        peer.addConnectionEventListener(listener);
-        assertTrue(peer.removeConnectionEventListener(listener));
-        assertFalse(peer.removeConnectionEventListener(listener));
+        assertFalse(peer.removeConnectedEventListener(listener));
+        peer.addConnectedEventListener(listener);
+        assertTrue(peer.removeConnectedEventListener(listener));
+        assertFalse(peer.removeConnectedEventListener(listener));
+    }
+
+    @Test
+    public void testAddDisconnectedEventListener() throws Exception {
+        connect();
+        PeerDisconnectedEventListener listener = new AbstractPeerConnectionEventListener() {
+        };
+
+        assertFalse(peer.removeDisconnectedEventListener(listener));
+        peer.addDisconnectedEventListener(listener);
+        assertTrue(peer.removeDisconnectedEventListener(listener));
+        assertFalse(peer.removeDisconnectedEventListener(listener));
     }
 
     // Check that it runs through the event loop and shut down correctly
@@ -749,12 +762,14 @@ public class PeerTest extends TestWithNetworkConnections {
         // Set up the connection with an old version.
         final SettableFuture<Void> connectedFuture = SettableFuture.create();
         final SettableFuture<Void> disconnectedFuture = SettableFuture.create();
-        peer.addConnectionEventListener(new AbstractPeerConnectionEventListener() {
+        peer.addConnectedEventListener(new PeerConnectedEventListener() {
             @Override
             public void onPeerConnected(Peer peer, int peerCount) {
                 connectedFuture.set(null);
             }
+        });
 
+        peer.addDisconnectedEventListener(new PeerDisconnectedEventListener() {
             @Override
             public void onPeerDisconnected(Peer peer, int peerCount) {
                 disconnectedFuture.set(null);
@@ -859,7 +874,7 @@ public class PeerTest extends TestWithNetworkConnections {
         };
         connect(); // Writes out a verack+version.
         final SettableFuture<Void> peerDisconnected = SettableFuture.create();
-        writeTarget.peer.addConnectionEventListener(new AbstractPeerConnectionEventListener() {
+        writeTarget.peer.addDisconnectedEventListener(new PeerDisconnectedEventListener() {
             @Override
             public void onPeerDisconnected(Peer p, int peerCount) {
                 peerDisconnected.set(null);

--- a/core/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
+++ b/core/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
@@ -17,7 +17,8 @@
 
 package org.bitcoinj.testing;
 
-import org.bitcoinj.core.listeners.AbstractPeerConnectionEventListener;
+import org.bitcoinj.core.listeners.PeerDisconnectedEventListener;
+import org.bitcoinj.core.listeners.PreMessageReceivedEventListener;
 import org.bitcoinj.core.*;
 import org.bitcoinj.net.*;
 import org.bitcoinj.params.UnitTestParams;
@@ -39,7 +40,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import org.bitcoinj.core.listeners.PreMessageReceivedEventListener;
 
 /**
  * Utility class that makes it easy to work with mock NetworkConnections.
@@ -149,7 +149,7 @@ public class TestWithNetworkConnections {
         checkArgument(versionMessage.hasBlockChain());
         final AtomicBoolean doneConnecting = new AtomicBoolean(false);
         final Thread thisThread = Thread.currentThread();
-        peer.addConnectionEventListener(new AbstractPeerConnectionEventListener() {
+        peer.addDisconnectedEventListener(new PeerDisconnectedEventListener() {
             @Override
             public void onPeerDisconnected(Peer p, int peerCount) {
                 synchronized (doneConnecting) {

--- a/examples/src/main/java/org/bitcoinj/examples/PeerMonitor.java
+++ b/examples/src/main/java/org/bitcoinj/examples/PeerMonitor.java
@@ -17,7 +17,8 @@
 
 package org.bitcoinj.examples;
 
-import org.bitcoinj.core.listeners.AbstractPeerEventListener;
+import org.bitcoinj.core.listeners.PeerConnectedEventListener;
+import org.bitcoinj.core.listeners.PeerDisconnectedEventListener;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Peer;
 import org.bitcoinj.core.PeerGroup;
@@ -67,13 +68,14 @@ public class PeerMonitor {
         peerGroup.setUserAgent("PeerMonitor", "1.0");
         peerGroup.setMaxConnections(4);
         peerGroup.addPeerDiscovery(new DnsDiscovery(params));
-        peerGroup.addConnectionEventListener(new AbstractPeerEventListener() {
+        peerGroup.addConnectedEventListener(new PeerConnectedEventListener() {
             @Override
             public void onPeerConnected(final Peer peer, int peerCount) {
                 refreshUI();
                 lookupReverseDNS(peer);
             }
-
+        });
+        peerGroup.addDisconnectedEventListener(new PeerDisconnectedEventListener() {
             @Override
             public void onPeerDisconnected(final Peer peer, int peerCount) {
                 refreshUI();

--- a/examples/src/main/java/org/bitcoinj/examples/PrintPeers.java
+++ b/examples/src/main/java/org/bitcoinj/examples/PrintPeers.java
@@ -16,7 +16,8 @@
 
 package org.bitcoinj.examples;
 
-import org.bitcoinj.core.listeners.AbstractPeerEventListener;
+import org.bitcoinj.core.listeners.PeerConnectedEventListener;
+import org.bitcoinj.core.listeners.PeerDisconnectedEventListener;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Peer;
 import org.bitcoinj.core.PeerAddress;
@@ -84,7 +85,7 @@ public class PrintPeers {
             final Peer peer = new Peer(params, new VersionMessage(params, 0), null, new PeerAddress(address));
             final SettableFuture<Void> future = SettableFuture.create();
             // Once the connection has completed version handshaking ...
-            peer.addConnectionEventListener(new AbstractPeerEventListener() {
+            peer.addConnectedEventListener(new PeerConnectedEventListener() {
                 @Override
                 public void onPeerConnected(Peer p, int peerCount) {
                     // Check the chain height it claims to have.
@@ -106,7 +107,8 @@ public class PrintPeers {
                     future.set(null);
                     peer.close();
                 }
-
+            });
+            peer.addDisconnectedEventListener(new PeerDisconnectedEventListener() {
                 @Override
                 public void onPeerDisconnected(Peer p, int peerCount) {
                     if (!future.isDone())

--- a/tools/src/main/java/org/bitcoinj/tools/TestFeeLevel.java
+++ b/tools/src/main/java/org/bitcoinj/tools/TestFeeLevel.java
@@ -15,7 +15,8 @@
 package org.bitcoinj.tools;
 
 import org.bitcoinj.core.*;
-import org.bitcoinj.core.listeners.PeerConnectionEventListener;
+import org.bitcoinj.core.listeners.PeerConnectedEventListener;
+import org.bitcoinj.core.listeners.PeerDisconnectedEventListener;
 import org.bitcoinj.kits.WalletAppKit;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.utils.BriefLogFormatter;
@@ -80,17 +81,13 @@ public class TestFeeLevel {
         System.out.println("Size in bytes is " + request.tx.bitcoinSerialize().length);
         System.out.println("TX is " + request.tx);
         System.out.println("Waiting for " + kit.peerGroup().getMaxConnections() + " connected peers");
-        kit.peerGroup().addConnectionEventListener(new PeerConnectionEventListener() {
-
-            @Override
-            public void onPeersDiscovered(Set<PeerAddress> peerAddresses) {
-            }
-
+        kit.peerGroup().addDisconnectedEventListener(new PeerDisconnectedEventListener() {
             @Override
             public void onPeerDisconnected(Peer peer, int peerCount) {
                 System.out.println(peerCount + " peers connected");
             }
-
+        });
+        kit.peerGroup().addConnectedEventListener(new PeerConnectedEventListener() {
             @Override
             public void onPeerConnected(Peer peer, int peerCount) {
                 System.out.println(peerCount + " peers connected");


### PR DESCRIPTION
Split PeerConnectionEventListener into individual connect, disconnect and discovery listeners.
Remove custom listener registration from Peer, as now it's possible to register a connect listener only, without a disconnect listener.