### PR TITLE
Finish moving wallet related classes to .wallet package.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
@@ -23,6 +23,7 @@ import com.google.common.util.concurrent.*;
 import org.bitcoinj.core.listeners.*;
 import org.bitcoinj.store.*;
 import org.bitcoinj.utils.*;
+import org.bitcoinj.wallet.Wallet;
 import org.slf4j.*;
 
 import javax.annotation.*;

--- a/core/src/main/java/org/bitcoinj/core/BlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/BlockChain.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.BlockStoreException;
+import org.bitcoinj.wallet.Wallet;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/core/src/main/java/org/bitcoinj/core/Context.java
+++ b/core/src/main/java/org/bitcoinj/core/Context.java
@@ -14,7 +14,6 @@
 
 package org.bitcoinj.core;
 
-import org.bitcoinj.core.Wallet.SendRequest;
 import org.slf4j.*;
 
 import static com.google.common.base.Preconditions.*;

--- a/core/src/main/java/org/bitcoinj/core/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/core/ECKey.java
@@ -29,6 +29,7 @@ import org.bitcoin.NativeSecp256k1;
 import org.bitcoin.NativeSecp256k1Util;
 import org.bitcoin.Secp256k1Context;
 import org.bitcoinj.wallet.Protos;
+import org.bitcoinj.wallet.Wallet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.asn1.*;

--- a/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
@@ -22,6 +22,7 @@ import org.bitcoinj.script.Script.VerifyFlag;
 import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.store.FullPrunedBlockStore;
 import org.bitcoinj.utils.*;
+import org.bitcoinj.wallet.Wallet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -24,6 +24,8 @@ import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.utils.ListenerRegistration;
 import org.bitcoinj.utils.Threading;
+import org.bitcoinj.wallet.Wallet;
+
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -33,6 +33,10 @@ import org.bitcoinj.net.discovery.*;
 import org.bitcoinj.script.*;
 import org.bitcoinj.utils.*;
 import org.bitcoinj.utils.Threading;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.listeners.KeyChainEventListener;
+import org.bitcoinj.wallet.listeners.ScriptsChangeEventListener;
+import org.bitcoinj.wallet.listeners.WalletCoinsReceivedEventListener;
 import org.slf4j.*;
 
 import javax.annotation.*;
@@ -43,7 +47,6 @@ import java.util.concurrent.*;
 import java.util.concurrent.locks.*;
 
 import static com.google.common.base.Preconditions.*;
-import org.bitcoinj.wallet.KeyChainEventListener;
 
 /**
  * <p>Runs a set of connections to the P2P network, brings up connections to replace disconnected nodes and manages

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -23,6 +23,7 @@ import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptOpCodes;
 import org.bitcoinj.utils.ExchangeRate;
+import org.bitcoinj.wallet.Wallet;
 import org.bitcoinj.wallet.WalletTransaction.Pool;
 
 import com.google.common.collect.ImmutableMap;

--- a/core/src/main/java/org/bitcoinj/core/TransactionBag.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionBag.java
@@ -22,7 +22,7 @@ import org.bitcoinj.wallet.WalletTransaction;
 import java.util.Map;
 
 /**
- * This interface is used to abstract the {@link org.bitcoinj.core.Wallet} and the {@link org.bitcoinj.core.Transaction}
+ * This interface is used to abstract the {@link org.bitcoinj.wallet.Wallet} and the {@link org.bitcoinj.core.Transaction}
  */
 public interface TransactionBag {
     /** Returns true if this wallet contains a public key which hashes to the given hash. */

--- a/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.*;
 import com.google.common.base.*;
 import com.google.common.util.concurrent.*;
 import org.bitcoinj.utils.*;
+import org.bitcoinj.wallet.Wallet;
 import org.slf4j.*;
 
 import javax.annotation.*;

--- a/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
@@ -20,6 +20,7 @@ package org.bitcoinj.core;
 import com.google.common.collect.*;
 import com.google.common.util.concurrent.*;
 import org.bitcoinj.utils.*;
+import org.bitcoinj.wallet.Wallet;
 
 import javax.annotation.*;
 import java.util.*;

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -19,6 +19,7 @@ package org.bitcoinj.core;
 
 import com.google.common.base.Objects;
 import org.bitcoinj.script.*;
+import org.bitcoinj.wallet.Wallet;
 import org.slf4j.*;
 
 import javax.annotation.*;

--- a/core/src/main/java/org/bitcoinj/core/listeners/TransactionConfidenceEventListener.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/TransactionConfidenceEventListener.java
@@ -17,7 +17,7 @@
 package org.bitcoinj.core.listeners;
 
 import org.bitcoinj.core.Transaction;
-import org.bitcoinj.core.Wallet;
+import org.bitcoinj.wallet.Wallet;
 
 /**
  * <p>Implementors are called when confidence of a transaction changes.</p>

--- a/core/src/main/java/org/bitcoinj/core/package-info.java
+++ b/core/src/main/java/org/bitcoinj/core/package-info.java
@@ -15,7 +15,7 @@
 /**
  * The core package contains classes for network messages like {@link org.bitcoinj.core.Block} and
  * {@link org.bitcoinj.core.Transaction}, peer connectivity via {@link org.bitcoinj.core.PeerGroup},
- * block chain management and the {@link org.bitcoinj.core.Wallet} class.
+ * and block chain management.
  * If what you're doing can be described as basic bitcoin tasks, the code is probably found here.
  * To learn more please consult the documentation on the website.
  */

--- a/core/src/main/java/org/bitcoinj/jni/NativeKeyChainEventListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeKeyChainEventListener.java
@@ -16,8 +16,8 @@
 
 package org.bitcoinj.jni;
 
-import org.bitcoinj.wallet.KeyChainEventListener;
 import org.bitcoinj.core.ECKey;
+import org.bitcoinj.wallet.listeners.KeyChainEventListener;
 
 import java.util.List;
 

--- a/core/src/main/java/org/bitcoinj/jni/NativeScriptsChangeEventListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeScriptsChangeEventListener.java
@@ -16,9 +16,9 @@
 
 package org.bitcoinj.jni;
 
-import org.bitcoinj.core.listeners.ScriptsChangeEventListener;
-import org.bitcoinj.core.Wallet;
 import org.bitcoinj.script.Script;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.listeners.ScriptsChangeEventListener;
 
 import java.util.List;
 

--- a/core/src/main/java/org/bitcoinj/jni/NativeTransactionConfidenceEventListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeTransactionConfidenceEventListener.java
@@ -17,8 +17,8 @@
 package org.bitcoinj.jni;
 
 import org.bitcoinj.core.listeners.TransactionConfidenceEventListener;
+import org.bitcoinj.wallet.Wallet;
 import org.bitcoinj.core.Transaction;
-import org.bitcoinj.core.Wallet;
 
 /**
  * An event listener that relays events to a native C++ object. A pointer to that object is stored in

--- a/core/src/main/java/org/bitcoinj/jni/NativeWalletChangeEventListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeWalletChangeEventListener.java
@@ -16,8 +16,8 @@
 
 package org.bitcoinj.jni;
 
-import org.bitcoinj.core.listeners.WalletChangeEventListener;
-import org.bitcoinj.core.Wallet;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.listeners.WalletChangeEventListener;
 
 /**
  * An event listener that relays events to a native C++ object. A pointer to that object is stored in

--- a/core/src/main/java/org/bitcoinj/jni/NativeWalletCoinsReceivedEventListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeWalletCoinsReceivedEventListener.java
@@ -16,10 +16,10 @@
 
 package org.bitcoinj.jni;
 
-import org.bitcoinj.core.listeners.WalletCoinsReceivedEventListener;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.listeners.WalletCoinsReceivedEventListener;
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Transaction;
-import org.bitcoinj.core.Wallet;
 
 /**
  * An event listener that relays events to a native C++ object. A pointer to that object is stored in

--- a/core/src/main/java/org/bitcoinj/jni/NativeWalletCoinsSentEventListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeWalletCoinsSentEventListener.java
@@ -16,10 +16,10 @@
 
 package org.bitcoinj.jni;
 
-import org.bitcoinj.core.listeners.WalletCoinsSentEventListener;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.listeners.WalletCoinsSentEventListener;
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Transaction;
-import org.bitcoinj.core.Wallet;
 
 /**
  * An event listener that relays events to a native C++ object. A pointer to that object is stored in

--- a/core/src/main/java/org/bitcoinj/jni/NativeWalletEventListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeWalletEventListener.java
@@ -16,12 +16,12 @@
 
 package org.bitcoinj.jni;
 
-import org.bitcoinj.core.listeners.WalletEventListener;
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.Transaction;
-import org.bitcoinj.core.Wallet;
 import org.bitcoinj.script.Script;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.listeners.WalletEventListener;
 
 import java.util.List;
 

--- a/core/src/main/java/org/bitcoinj/jni/NativeWalletReorganizeEventListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeWalletReorganizeEventListener.java
@@ -16,8 +16,8 @@
 
 package org.bitcoinj.jni;
 
-import org.bitcoinj.core.listeners.WalletReorganizeEventListener;
-import org.bitcoinj.core.Wallet;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.listeners.WalletReorganizeEventListener;
 
 /**
  * An event listener that relays events to a native C++ object. A pointer to that object is stored in

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClient.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClient.java
@@ -20,6 +20,8 @@ package org.bitcoinj.protocols.channels;
 import org.bitcoinj.core.*;
 import org.bitcoinj.protocols.channels.PaymentChannelCloseException.CloseReason;
 import org.bitcoinj.utils.Threading;
+import org.bitcoinj.wallet.Wallet;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClientConnection.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClientConnection.java
@@ -21,9 +21,10 @@ import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.InsufficientMoneyException;
 import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.Utils;
-import org.bitcoinj.core.Wallet;
 import org.bitcoinj.net.NioClient;
 import org.bitcoinj.net.ProtobufConnection;
+import org.bitcoinj.wallet.Wallet;
+
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClientState.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClientState.java
@@ -26,6 +26,8 @@ import org.bitcoinj.core.*;
 import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.utils.Threading;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.listeners.WalletCoinsReceivedEventListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.crypto.params.KeyParameter;
@@ -33,7 +35,6 @@ import org.spongycastle.crypto.params.KeyParameter;
 import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.*;
-import org.bitcoinj.core.listeners.WalletCoinsReceivedEventListener;
 
 /**
  * <p>A payment channel is a method of sending money to someone such that the amount of money you send can be adjusted
@@ -209,7 +210,7 @@ public abstract class PaymentChannelClientState {
      * Creates the initial multisig contract and incomplete refund transaction which can be requested at the appropriate
      * time using {@link PaymentChannelV1ClientState#getIncompleteRefundTransaction} and
      * {@link PaymentChannelV1ClientState#getContract()}. The way the contract is crafted can be adjusted by
-     * overriding {@link PaymentChannelV1ClientState#editContractSendRequest(org.bitcoinj.core.Wallet.SendRequest)}.
+     * overriding {@link PaymentChannelV1ClientState#editContractSendRequest(org.bitcoinj.wallet.Wallet.SendRequest)}.
      * By default unconfirmed coins are allowed to be used, as for micropayments the risk should be relatively low.
      *
      * @throws ValueOutOfRangeException if the value being used is too small to be accepted by the network
@@ -223,7 +224,7 @@ public abstract class PaymentChannelClientState {
      * Creates the initial multisig contract and incomplete refund transaction which can be requested at the appropriate
      * time using {@link PaymentChannelV1ClientState#getIncompleteRefundTransaction} and
      * {@link PaymentChannelV1ClientState#getContract()}. The way the contract is crafted can be adjusted by
-     * overriding {@link PaymentChannelV1ClientState#editContractSendRequest(org.bitcoinj.core.Wallet.SendRequest)}.
+     * overriding {@link PaymentChannelV1ClientState#editContractSendRequest(org.bitcoinj.wallet.Wallet.SendRequest)}.
      * By default unconfirmed coins are allowed to be used, as for micropayments the risk should be relatively low.
      * @param userKey Key derived from a user password, needed for any signing when the wallet is encrypted.
      *                  The wallet KeyCrypter is assumed.

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServer.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServer.java
@@ -20,6 +20,8 @@ import com.google.common.collect.ImmutableMap;
 import org.bitcoinj.core.*;
 import org.bitcoinj.protocols.channels.PaymentChannelCloseException.CloseReason;
 import org.bitcoinj.utils.Threading;
+import org.bitcoinj.wallet.Wallet;
+
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerListener.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerListener.java
@@ -20,10 +20,10 @@ package org.bitcoinj.protocols.channels;
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.TransactionBroadcaster;
-import org.bitcoinj.core.Wallet;
 import org.bitcoinj.net.NioServer;
 import org.bitcoinj.net.ProtobufConnection;
 import org.bitcoinj.net.StreamConnectionFactory;
+import org.bitcoinj.wallet.Wallet;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerState.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerState.java
@@ -16,6 +16,8 @@
 
 package org.bitcoinj.protocols.channels;
 
+import org.bitcoinj.wallet.Wallet;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.FutureCallback;

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelV1ClientState.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelV1ClientState.java
@@ -23,6 +23,7 @@ import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.wallet.AllowUnconfirmedCoinSelector;
+import org.bitcoinj.wallet.Wallet;
 import org.spongycastle.crypto.params.KeyParameter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelV1ServerState.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelV1ServerState.java
@@ -21,6 +21,8 @@ import org.bitcoinj.core.*;
 import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
+import org.bitcoinj.wallet.Wallet;
+
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelV2ClientState.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelV2ClientState.java
@@ -24,6 +24,7 @@ import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.wallet.AllowUnconfirmedCoinSelector;
+import org.bitcoinj.wallet.Wallet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.crypto.params.KeyParameter;

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelV2ServerState.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelV2ServerState.java
@@ -26,6 +26,7 @@ import org.bitcoinj.core.*;
 import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
+import org.bitcoinj.wallet.Wallet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/src/main/java/org/bitcoinj/protocols/channels/StoredPaymentChannelClientStates.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/StoredPaymentChannelClientStates.java
@@ -20,6 +20,9 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import org.bitcoinj.core.*;
 import org.bitcoinj.utils.Threading;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.WalletExtension;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultimap;
 import com.google.common.util.concurrent.SettableFuture;

--- a/core/src/main/java/org/bitcoinj/protocols/channels/StoredPaymentChannelServerStates.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/StoredPaymentChannelServerStates.java
@@ -19,6 +19,9 @@ package org.bitcoinj.protocols.channels;
 import com.google.common.collect.ImmutableMap;
 import org.bitcoinj.core.*;
 import org.bitcoinj.utils.Threading;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.WalletExtension;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.protobuf.ByteString;

--- a/core/src/main/java/org/bitcoinj/protocols/channels/StoredServerChannel.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/StoredServerChannel.java
@@ -17,6 +17,7 @@
 package org.bitcoinj.protocols.channels;
 
 import org.bitcoinj.core.*;
+import org.bitcoinj.wallet.Wallet;
 
 import javax.annotation.Nullable;
 import java.util.Date;

--- a/core/src/main/java/org/bitcoinj/protocols/payments/PaymentSession.java
+++ b/core/src/main/java/org/bitcoinj/protocols/payments/PaymentSession.java
@@ -20,6 +20,8 @@ import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.protocols.payments.PaymentProtocol.PkiVerificationData;
 import org.bitcoinj.uri.BitcoinURI;
 import org.bitcoinj.utils.Threading;
+import org.bitcoinj.wallet.Wallet;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;

--- a/core/src/main/java/org/bitcoinj/signers/MissingSigResolutionSigner.java
+++ b/core/src/main/java/org/bitcoinj/signers/MissingSigResolutionSigner.java
@@ -18,16 +18,16 @@ package org.bitcoinj.signers;
 
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.TransactionInput;
-import org.bitcoinj.core.Wallet;
 import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptChunk;
 import org.bitcoinj.wallet.KeyBag;
+import org.bitcoinj.wallet.Wallet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This transaction signer resolves missing signatures in accordance with the given {@link org.bitcoinj.core.Wallet.MissingSigsMode}.
+ * This transaction signer resolves missing signatures in accordance with the given {@link org.bitcoinj.wallet.Wallet.MissingSigsMode}.
  * If missingSigsMode is USE_OP_ZERO this signer does nothing assuming missing signatures are already presented in
  * scriptSigs as OP_0.
  * In MissingSigsMode.THROW mode this signer will throw an exception. It would be MissingSignatureException

--- a/core/src/main/java/org/bitcoinj/signers/TransactionSigner.java
+++ b/core/src/main/java/org/bitcoinj/signers/TransactionSigner.java
@@ -29,7 +29,7 @@ import java.util.Map;
  * <p>Implementations of this interface are intended to sign inputs of the given transaction. Given transaction may already
  * be partially signed or somehow altered by other signers.</p>
  * <p>To make use of the signer, you need to add it into the  wallet by
- * calling {@link org.bitcoinj.core.Wallet#addTransactionSigner(TransactionSigner)}. Signer will be serialized
+ * calling {@link org.bitcoinj.wallet.Wallet#addTransactionSigner(TransactionSigner)}. Signer will be serialized
  * along with the wallet data. In order for a wallet to recreate signer after deserialization, each signer
  * should have no-args constructor</p>
  */

--- a/core/src/main/java/org/bitcoinj/signers/package-info.java
+++ b/core/src/main/java/org/bitcoinj/signers/package-info.java
@@ -14,7 +14,7 @@
 
 /**
  * Transaction signers know how to calculate signatures over transactions in different contexts, for example, using
- * local private keys or fetching them from remote servers. The {@link org.bitcoinj.core.Wallet} class uses these
+ * local private keys or fetching them from remote servers. The {@link org.bitcoinj.wallet.Wallet} class uses these
  * when sending money.
  */
 package org.bitcoinj.signers;

--- a/core/src/main/java/org/bitcoinj/wallet/BasicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/BasicKeyChain.java
@@ -19,9 +19,10 @@ package org.bitcoinj.wallet;
 import org.bitcoinj.core.BloomFilter;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.crypto.*;
-import org.bitcoinj.store.UnreadableWalletException;
 import org.bitcoinj.utils.ListenerRegistration;
 import org.bitcoinj.utils.Threading;
+import org.bitcoinj.wallet.listeners.KeyChainEventListener;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
@@ -348,8 +349,8 @@ public class BasicKeyChain implements EncryptableKeyChain {
     /**
      * Returns a new BasicKeyChain that contains all basic, ORIGINAL type keys and also any encrypted keys extracted
      * from the list. Unrecognised key types are ignored.
-     * @throws org.bitcoinj.store.UnreadableWalletException.BadPassword if the password doesn't seem to match
-     * @throws org.bitcoinj.store.UnreadableWalletException if the data structures are corrupted/inconsistent
+     * @throws org.bitcoinj.wallet.UnreadableWalletException.BadPassword if the password doesn't seem to match
+     * @throws org.bitcoinj.wallet.UnreadableWalletException if the data structures are corrupted/inconsistent
      */
     public static BasicKeyChain fromProtobufEncrypted(List<Protos.Key> keys, KeyCrypter crypter) throws UnreadableWalletException {
         BasicKeyChain chain = new BasicKeyChain(checkNotNull(crypter));

--- a/core/src/main/java/org/bitcoinj/wallet/DefaultKeyChainFactory.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DefaultKeyChainFactory.java
@@ -17,7 +17,6 @@
 package org.bitcoinj.wallet;
 
 import org.bitcoinj.crypto.*;
-import org.bitcoinj.store.UnreadableWalletException;
 
 /**
  * Default factory for creating keychains while de-serializing.

--- a/core/src/main/java/org/bitcoinj/wallet/DefaultRiskAnalysis.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DefaultRiskAnalysis.java
@@ -25,7 +25,6 @@ import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionConfidence;
 import org.bitcoinj.core.TransactionInput;
 import org.bitcoinj.core.TransactionOutput;
-import org.bitcoinj.core.Wallet;
 import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.script.ScriptChunk;
 import org.slf4j.Logger;

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -23,8 +23,8 @@ import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Utils;
 import org.bitcoinj.crypto.*;
 import org.bitcoinj.script.Script;
-import org.bitcoinj.store.UnreadableWalletException;
 import org.bitcoinj.utils.Threading;
+import org.bitcoinj.wallet.listeners.KeyChainEventListener;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
@@ -19,7 +19,7 @@ package org.bitcoinj.wallet;
 
 import org.bitcoinj.core.Utils;
 import org.bitcoinj.crypto.*;
-import org.bitcoinj.store.UnreadableWalletException;
+
 import com.google.common.base.Charsets;
 import com.google.common.base.Objects;
 import com.google.common.base.Splitter;

--- a/core/src/main/java/org/bitcoinj/wallet/EncryptableKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/EncryptableKeyChain.java
@@ -50,7 +50,7 @@ public interface EncryptableKeyChain extends KeyChain {
     /**
      * Decrypt the key chain with the given AES key and whatever {@link KeyCrypter} is already set. Note that if you
      * just want to spend money from an encrypted wallet, don't decrypt the whole thing first. Instead, set the
-     * {@link org.bitcoinj.core.Wallet.SendRequest#aesKey} field before asking the wallet to build the send.
+     * {@link org.bitcoinj.wallet.Wallet.SendRequest#aesKey} field before asking the wallet to build the send.
      *
      * @param aesKey AES key to use (normally created using KeyCrypter#deriveKey and cached as it is time consuming to
      *               create from a password)

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChain.java
@@ -18,12 +18,13 @@ package org.bitcoinj.wallet;
 
 import org.bitcoinj.core.BloomFilter;
 import org.bitcoinj.core.ECKey;
+import org.bitcoinj.wallet.listeners.KeyChainEventListener;
 
 import java.util.List;
 import java.util.concurrent.Executor;
 
 /**
- * <p>A KeyChain is a class that stores a collection of keys for a {@link org.bitcoinj.core.Wallet}. Key chains
+ * <p>A KeyChain is a class that stores a collection of keys for a {@link org.bitcoinj.wallet.Wallet}. Key chains
  * are expected to be able to look up keys given a hash (i.e. address) or pubkey bytes, and provide keys on request
  * for a given purpose. They can inform event listeners about new keys being added.</p>
  *

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainFactory.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainFactory.java
@@ -18,7 +18,6 @@ package org.bitcoinj.wallet;
 
 import org.bitcoinj.crypto.DeterministicKey;
 import org.bitcoinj.crypto.KeyCrypter;
-import org.bitcoinj.store.UnreadableWalletException;
 
 /**
  * Factory interface for creation keychains while de-serializing a wallet.

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
@@ -22,8 +22,8 @@ import com.google.protobuf.*;
 import org.bitcoinj.core.*;
 import org.bitcoinj.crypto.*;
 import org.bitcoinj.script.*;
-import org.bitcoinj.store.*;
 import org.bitcoinj.utils.*;
+import org.bitcoinj.wallet.listeners.KeyChainEventListener;
 import org.slf4j.*;
 import org.spongycastle.crypto.params.*;
 
@@ -35,7 +35,7 @@ import java.util.concurrent.*;
 import static com.google.common.base.Preconditions.*;
 
 /**
- * <p>A KeyChainGroup is used by the {@link org.bitcoinj.core.Wallet} and
+ * <p>A KeyChainGroup is used by the {@link org.bitcoinj.wallet.Wallet} and
  * manages: a {@link BasicKeyChain} object (which will normally be empty), and zero or more
  * {@link DeterministicKeyChain}s. A deterministic key chain will be created lazily/on demand
  * when a fresh or current key is requested, possibly being initialized from the private key bytes of the earliest non

--- a/core/src/main/java/org/bitcoinj/wallet/RiskAnalysis.java
+++ b/core/src/main/java/org/bitcoinj/wallet/RiskAnalysis.java
@@ -17,7 +17,6 @@
 package org.bitcoinj.wallet;
 
 import org.bitcoinj.core.Transaction;
-import org.bitcoinj.core.Wallet;
 
 import java.util.List;
 

--- a/core/src/main/java/org/bitcoinj/wallet/UnreadableWalletException.java
+++ b/core/src/main/java/org/bitcoinj/wallet/UnreadableWalletException.java
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.store;
+package org.bitcoinj.wallet;
 
 /**
  * Thrown by the {@link WalletProtobufSerializer} when the serialized protocol buffer is either corrupted,

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.core;
+package org.bitcoinj.wallet;
 
 import com.google.common.annotations.*;
 import com.google.common.base.*;
@@ -26,16 +26,52 @@ import com.google.protobuf.*;
 import net.jcip.annotations.*;
 import org.bitcoin.protocols.payments.Protos.*;
 import org.bitcoinj.core.listeners.*;
+import org.bitcoinj.core.AbstractBlockChain;
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.BlockChain;
+import org.bitcoinj.core.BloomFilter;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.Context;
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.FilteredBlock;
+import org.bitcoinj.core.InsufficientMoneyException;
+import org.bitcoinj.core.Message;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.Peer;
+import org.bitcoinj.core.PeerFilterProvider;
+import org.bitcoinj.core.PeerGroup;
+import org.bitcoinj.core.ScriptException;
+import org.bitcoinj.core.Sha256Hash;
+import org.bitcoinj.core.StoredBlock;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionBag;
+import org.bitcoinj.core.TransactionBroadcast;
+import org.bitcoinj.core.TransactionBroadcaster;
+import org.bitcoinj.core.TransactionConfidence;
+import org.bitcoinj.core.TransactionInput;
+import org.bitcoinj.core.TransactionOutPoint;
+import org.bitcoinj.core.TransactionOutput;
+import org.bitcoinj.core.UTXO;
+import org.bitcoinj.core.UTXOProvider;
+import org.bitcoinj.core.UTXOProviderException;
+import org.bitcoinj.core.Utils;
+import org.bitcoinj.core.VarInt;
+import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.core.TransactionConfidence.*;
 import org.bitcoinj.crypto.*;
 import org.bitcoinj.script.*;
 import org.bitcoinj.signers.*;
-import org.bitcoinj.store.*;
 import org.bitcoinj.utils.*;
-import org.bitcoinj.wallet.*;
 import org.bitcoinj.wallet.KeyChain.KeyPurpose;
 import org.bitcoinj.wallet.Protos.Wallet.*;
 import org.bitcoinj.wallet.WalletTransaction.*;
+import org.bitcoinj.wallet.listeners.KeyChainEventListener;
+import org.bitcoinj.wallet.listeners.ScriptsChangeEventListener;
+import org.bitcoinj.wallet.listeners.WalletChangeEventListener;
+import org.bitcoinj.wallet.listeners.WalletCoinsReceivedEventListener;
+import org.bitcoinj.wallet.listeners.WalletCoinsSentEventListener;
+import org.bitcoinj.wallet.listeners.WalletEventListener;
+import org.bitcoinj.wallet.listeners.WalletReorganizeEventListener;
 import org.slf4j.*;
 import org.spongycastle.crypto.params.*;
 
@@ -3697,7 +3733,7 @@ public class Wallet extends BaseTaggableObject
 
         /**
          * When emptyWallet is set, all coins selected by the coin selector are sent to the first output in tx
-         * (its value is ignored and set to {@link org.bitcoinj.core.Wallet#getBalance()} - the fees required
+         * (its value is ignored and set to {@link org.bitcoinj.wallet.Wallet#getBalance()} - the fees required
          * for the transaction). Any additional outputs are removed.
          */
         public boolean emptyWallet = false;

--- a/core/src/main/java/org/bitcoinj/wallet/WalletExtension.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletExtension.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.core;
+package org.bitcoinj.wallet;
 
 /**
  * <p>An object implementing this interface can be added to a {@link Wallet} and provide arbitrary byte arrays that will

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.store;
+package org.bitcoinj.wallet;
 
 import org.bitcoinj.core.*;
 import org.bitcoinj.core.TransactionConfidence.ConfidenceType;
@@ -26,18 +26,14 @@ import org.bitcoinj.signers.LocalTransactionSigner;
 import org.bitcoinj.signers.TransactionSigner;
 import org.bitcoinj.utils.ExchangeRate;
 import org.bitcoinj.utils.Fiat;
-import org.bitcoinj.wallet.DefaultKeyChainFactory;
-import org.bitcoinj.wallet.KeyChainFactory;
-import org.bitcoinj.wallet.KeyChainGroup;
-import org.bitcoinj.wallet.WalletTransaction;
+import org.bitcoinj.wallet.Protos.Wallet.EncryptionType;
+
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.TextFormat;
 import com.google.protobuf.WireFormat;
 
-import org.bitcoinj.wallet.Protos;
-import org.bitcoinj.wallet.Protos.Wallet.EncryptionType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/src/main/java/org/bitcoinj/wallet/WalletTransaction.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletTransaction.java
@@ -21,7 +21,7 @@ import org.bitcoinj.core.Transaction;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Stores data about a transaction that is only relevant to the {@link org.bitcoinj.core.Wallet} class.
+ * Stores data about a transaction that is only relevant to the {@link org.bitcoinj.wallet.Wallet} class.
  */
 public class WalletTransaction {
     public enum Pool {

--- a/core/src/main/java/org/bitcoinj/wallet/listeners/AbstractKeyChainEventListener.java
+++ b/core/src/main/java/org/bitcoinj/wallet/listeners/AbstractKeyChainEventListener.java
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.wallet;
+package org.bitcoinj.wallet.listeners;
 
 import org.bitcoinj.core.ECKey;
 

--- a/core/src/main/java/org/bitcoinj/wallet/listeners/AbstractWalletEventListener.java
+++ b/core/src/main/java/org/bitcoinj/wallet/listeners/AbstractWalletEventListener.java
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.core.listeners;
+package org.bitcoinj.wallet.listeners;
 
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.Transaction;
-import org.bitcoinj.core.Wallet;
 import org.bitcoinj.script.Script;
-import org.bitcoinj.wallet.AbstractKeyChainEventListener;
+import org.bitcoinj.wallet.Wallet;
 
 import java.util.List;
 

--- a/core/src/main/java/org/bitcoinj/wallet/listeners/KeyChainEventListener.java
+++ b/core/src/main/java/org/bitcoinj/wallet/listeners/KeyChainEventListener.java
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.core.listeners;
+package org.bitcoinj.wallet.listeners;
 
-import org.bitcoinj.wallet.KeyChainEventListener;
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.wallet.KeyChain;
 
-/**
- * <p>Common interface for wallet changes and transactions.</p>
- * @deprecated Use the superinterfaces directly instead.
- */
-@Deprecated
-public interface WalletEventListener extends
-        KeyChainEventListener, WalletChangeEventListener,
-        WalletCoinsReceivedEventListener, WalletCoinsSentEventListener,
-        WalletReorganizeEventListener, ScriptsChangeEventListener,
-        TransactionConfidenceEventListener {
+import java.util.List;
+
+public interface KeyChainEventListener {
+    /**
+     * Called whenever a new key is added to the key chain, whether that be via an explicit addition or due to some
+     * other automatic derivation. See the documentation for your {@link KeyChain} implementation for details on what
+     * can trigger this event.
+     */
+    void onKeysAdded(List<ECKey> keys);
 }

--- a/core/src/main/java/org/bitcoinj/wallet/listeners/ScriptsChangeEventListener.java
+++ b/core/src/main/java/org/bitcoinj/wallet/listeners/ScriptsChangeEventListener.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.core.listeners;
+package org.bitcoinj.wallet.listeners;
 
-import org.bitcoinj.core.Wallet;
 import org.bitcoinj.script.Script;
+import org.bitcoinj.wallet.Wallet;
 
 import java.util.List;
 

--- a/core/src/main/java/org/bitcoinj/wallet/listeners/WalletChangeEventListener.java
+++ b/core/src/main/java/org/bitcoinj/wallet/listeners/WalletChangeEventListener.java
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.core.listeners;
+package org.bitcoinj.wallet.listeners;
 
-import org.bitcoinj.core.Wallet;
+import org.bitcoinj.wallet.Wallet;
 
 /**
  * <p>Implementors are called when the contents of the wallet changes, for instance due to receiving/sending money

--- a/core/src/main/java/org/bitcoinj/wallet/listeners/WalletCoinsReceivedEventListener.java
+++ b/core/src/main/java/org/bitcoinj/wallet/listeners/WalletCoinsReceivedEventListener.java
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.core.listeners;
+package org.bitcoinj.wallet.listeners;
 
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Transaction;
-import org.bitcoinj.core.Wallet;
+import org.bitcoinj.wallet.Wallet;
 
 /**
  * <p>Implementors are called when the contents of the wallet changes, for instance due to receiving/sending money

--- a/core/src/main/java/org/bitcoinj/wallet/listeners/WalletCoinsSentEventListener.java
+++ b/core/src/main/java/org/bitcoinj/wallet/listeners/WalletCoinsSentEventListener.java
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.core.listeners;
+package org.bitcoinj.wallet.listeners;
 
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Transaction;
-import org.bitcoinj.core.Wallet;
+import org.bitcoinj.wallet.Wallet;
 
 /**
  * <p>Implementors are called when the contents of the wallet changes, for instance due to receiving/sending money

--- a/core/src/main/java/org/bitcoinj/wallet/listeners/WalletEventListener.java
+++ b/core/src/main/java/org/bitcoinj/wallet/listeners/WalletEventListener.java
@@ -14,17 +14,18 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.wallet;
+package org.bitcoinj.wallet.listeners;
 
-import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.listeners.TransactionConfidenceEventListener;
 
-import java.util.List;
-
-public interface KeyChainEventListener {
-    /**
-     * Called whenever a new key is added to the key chain, whether that be via an explicit addition or due to some
-     * other automatic derivation. See the documentation for your {@link KeyChain} implementation for details on what
-     * can trigger this event.
-     */
-    void onKeysAdded(List<ECKey> keys);
+/**
+ * <p>Common interface for wallet changes and transactions.</p>
+ * @deprecated Use the superinterfaces directly instead.
+ */
+@Deprecated
+public interface WalletEventListener extends
+        KeyChainEventListener, WalletChangeEventListener,
+        WalletCoinsReceivedEventListener, WalletCoinsSentEventListener,
+        WalletReorganizeEventListener, ScriptsChangeEventListener,
+        TransactionConfidenceEventListener {
 }

--- a/core/src/main/java/org/bitcoinj/wallet/listeners/WalletReorganizeEventListener.java
+++ b/core/src/main/java/org/bitcoinj/wallet/listeners/WalletReorganizeEventListener.java
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.core.listeners;
+package org.bitcoinj.wallet.listeners;
 
-import org.bitcoinj.core.Wallet;
+import org.bitcoinj.wallet.Wallet;
 
 /**
  * <p>Implementors are called when the wallet is reorganized.</p>

--- a/core/src/main/java/org/bitcoinj/wallet/package-info.java
+++ b/core/src/main/java/org/bitcoinj/wallet/package-info.java
@@ -13,7 +13,7 @@
  */
 
 /**
- * Classes that support the {@link org.bitcoinj.core.Wallet}, which knows how to find and save transactions relevant to
+ * Classes that support the {@link org.bitcoinj.wallet.Wallet}, which knows how to find and save transactions relevant to
  * a set of keys or scripts, calculate balances, and spend money: the wallet has many features and can be extended
  * in various ways, please refer to the website for documentation on how to use it.
  */

--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -25,6 +25,7 @@ import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.store.FullPrunedBlockStore;
 import org.bitcoinj.utils.BlockFileLoader;
 import org.bitcoinj.utils.BriefLogFormatter;
+import org.bitcoinj.wallet.Wallet;
 import org.bitcoinj.wallet.WalletTransaction;
 import org.junit.Before;
 import org.junit.Test;

--- a/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
@@ -17,7 +17,6 @@
 
 package org.bitcoinj.core;
 
-import org.bitcoinj.core.Wallet.BalanceType;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.TestNet2Params;
 import org.bitcoinj.params.UnitTestParams;
@@ -25,6 +24,9 @@ import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.testing.FakeTxBuilder;
 import org.bitcoinj.utils.BriefLogFormatter;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.Wallet.BalanceType;
+
 import com.google.common.util.concurrent.ListenableFuture;
 import org.junit.rules.ExpectedException;
 import org.junit.Before;

--- a/core/src/test/java/org/bitcoinj/core/BlockTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockTest.java
@@ -20,12 +20,13 @@ package org.bitcoinj.core;
 import com.google.common.io.ByteStreams;
 
 import org.bitcoinj.core.AbstractBlockChain.NewBlockType;
-import org.bitcoinj.core.Wallet.BalanceType;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.TestNet2Params;
 import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.params.UnitTestParams;
 import org.bitcoinj.script.ScriptOpCodes;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.Wallet.BalanceType;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/core/src/test/java/org/bitcoinj/core/BloomFilterTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BloomFilterTest.java
@@ -19,6 +19,7 @@ package org.bitcoinj.core;
 
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.wallet.KeyChainGroup;
+import org.bitcoinj.wallet.Wallet;
 import org.junit.Test;
 
 import java.util.Arrays;

--- a/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
@@ -17,9 +17,6 @@
 
 package org.bitcoinj.core;
 
-import org.bitcoinj.core.listeners.WalletChangeEventListener;
-import org.bitcoinj.core.listeners.WalletCoinsReceivedEventListener;
-import org.bitcoinj.core.listeners.WalletReorganizeEventListener;
 import org.bitcoinj.core.listeners.TransactionConfidenceEventListener;
 import org.bitcoinj.core.TransactionConfidence.ConfidenceType;
 import org.bitcoinj.params.UnitTestParams;
@@ -27,8 +24,11 @@ import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.testing.FakeTxBuilder;
 import org.bitcoinj.utils.BriefLogFormatter;
 import org.bitcoinj.utils.Threading;
-
+import org.bitcoinj.wallet.Wallet;
 import org.bitcoinj.wallet.WalletTransaction;
+import org.bitcoinj.wallet.listeners.WalletChangeEventListener;
+import org.bitcoinj.wallet.listeners.WalletCoinsReceivedEventListener;
+import org.bitcoinj.wallet.listeners.WalletReorganizeEventListener;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;

--- a/core/src/test/java/org/bitcoinj/core/ParseByteCacheTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ParseByteCacheTest.java
@@ -21,6 +21,7 @@ import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.UnitTestParams;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.MemoryBlockStore;
+import org.bitcoinj.wallet.Wallet;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -25,6 +25,7 @@ import org.bitcoinj.core.listeners.*;
 import org.bitcoinj.net.discovery.*;
 import org.bitcoinj.testing.*;
 import org.bitcoinj.utils.*;
+import org.bitcoinj.wallet.Wallet;
 import org.junit.*;
 import org.junit.runner.*;
 import org.junit.runners.*;

--- a/core/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -23,6 +23,9 @@ import org.bitcoinj.testing.FakeTxBuilder;
 import org.bitcoinj.testing.InboundMessageQueuer;
 import org.bitcoinj.testing.TestWithNetworkConnections;
 import org.bitcoinj.utils.Threading;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.listeners.WalletCoinsReceivedEventListener;
+
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.common.util.concurrent.Uninterruptibles;

--- a/core/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.*;
 import org.bitcoinj.core.listeners.TransactionConfidenceEventListener;
 import org.bitcoinj.testing.*;
 import org.bitcoinj.utils.*;
+import org.bitcoinj.wallet.Wallet;
 import org.junit.*;
 import org.junit.runner.*;
 import org.junit.runners.*;

--- a/core/src/test/java/org/bitcoinj/core/TransactionOutputTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionOutputTest.java
@@ -19,6 +19,7 @@ import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.testing.TestWithWallet;
+import org.bitcoinj.wallet.Wallet;
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;

--- a/core/src/test/java/org/bitcoinj/protocols/channels/ChannelConnectionTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/channels/ChannelConnectionTest.java
@@ -17,10 +17,13 @@
 package org.bitcoinj.protocols.channels;
 
 import org.bitcoinj.core.*;
-import org.bitcoinj.store.WalletProtobufSerializer;
 import org.bitcoinj.testing.TestWithWallet;
 import org.bitcoinj.utils.Threading;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.WalletExtension;
 import org.bitcoinj.wallet.WalletFiles;
+import org.bitcoinj.wallet.WalletProtobufSerializer;
+
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;

--- a/core/src/test/java/org/bitcoinj/protocols/channels/ChannelTestUtils.java
+++ b/core/src/test/java/org/bitcoinj/protocols/channels/ChannelTestUtils.java
@@ -17,7 +17,7 @@ package org.bitcoinj.protocols.channels;
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.TransactionBroadcaster;
-import org.bitcoinj.core.Wallet;
+import org.bitcoinj.wallet.Wallet;
 
 import com.google.common.base.Objects;
 import com.google.common.util.concurrent.Futures;

--- a/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelClientTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelClientTest.java
@@ -15,6 +15,8 @@
 package org.bitcoinj.protocols.channels;
 
 import org.bitcoinj.core.*;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.WalletExtension;
 import org.bitcoin.paymentchannel.Protos;
 import org.easymock.Capture;
 import org.easymock.EasyMock;

--- a/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelServerTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelServerTest.java
@@ -17,7 +17,7 @@ package org.bitcoinj.protocols.channels;
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.TransactionBroadcaster;
 import org.bitcoinj.core.Utils;
-import org.bitcoinj.core.Wallet;
+import org.bitcoinj.wallet.Wallet;
 import org.bitcoin.paymentchannel.Protos;
 import org.easymock.Capture;
 import org.junit.Before;

--- a/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelStateTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelStateTest.java
@@ -21,6 +21,8 @@ import org.bitcoinj.core.Wallet.SendRequest;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.testing.TestWithWallet;
+import org.bitcoinj.wallet.Wallet;
+
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -17,7 +17,6 @@
 
 package org.bitcoinj.store;
 
-import org.bitcoinj.core.listeners.WalletCoinsReceivedEventListener;
 import org.bitcoinj.core.*;
 import org.bitcoinj.core.Transaction.Purpose;
 import org.bitcoinj.core.TransactionConfidence.ConfidenceType;
@@ -35,6 +34,11 @@ import com.google.protobuf.ByteString;
 
 import org.bitcoinj.wallet.MarriedKeyChain;
 import org.bitcoinj.wallet.Protos;
+import org.bitcoinj.wallet.UnreadableWalletException;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.WalletExtension;
+import org.bitcoinj.wallet.WalletProtobufSerializer;
+import org.bitcoinj.wallet.listeners.WalletCoinsReceivedEventListener;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/core/src/test/java/org/bitcoinj/testing/FooWalletExtension.java
+++ b/core/src/test/java/org/bitcoinj/testing/FooWalletExtension.java
@@ -14,8 +14,8 @@
 
 package org.bitcoinj.testing;
 
-import org.bitcoinj.core.Wallet;
-import org.bitcoinj.core.WalletExtension;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.WalletExtension;
 
 import java.util.Arrays;
 

--- a/core/src/test/java/org/bitcoinj/testing/MockTransactionBroadcaster.java
+++ b/core/src/test/java/org/bitcoinj/testing/MockTransactionBroadcaster.java
@@ -18,6 +18,8 @@ package org.bitcoinj.testing;
 
 import org.bitcoinj.core.*;
 import org.bitcoinj.utils.Threading;
+import org.bitcoinj.wallet.Wallet;
+
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.SettableFuture;

--- a/core/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
+++ b/core/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
@@ -26,6 +26,8 @@ import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.utils.BriefLogFormatter;
 import org.bitcoinj.utils.Threading;
+import org.bitcoinj.wallet.Wallet;
+
 import com.google.common.util.concurrent.SettableFuture;
 
 import javax.annotation.Nullable;

--- a/core/src/test/java/org/bitcoinj/testing/TestWithWallet.java
+++ b/core/src/test/java/org/bitcoinj/testing/TestWithWallet.java
@@ -21,6 +21,7 @@ import org.bitcoinj.params.UnitTestParams;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.utils.BriefLogFormatter;
+import org.bitcoinj.wallet.Wallet;
 
 import javax.annotation.Nullable;
 

--- a/core/src/test/java/org/bitcoinj/wallet/BasicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/BasicKeyChainTest.java
@@ -22,14 +22,14 @@ import org.bitcoinj.core.Utils;
 import org.bitcoinj.crypto.KeyCrypter;
 import org.bitcoinj.crypto.KeyCrypterException;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
-import org.bitcoinj.store.UnreadableWalletException;
 import org.bitcoinj.utils.Threading;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import org.bitcoinj.wallet.AbstractKeyChainEventListener;
+
 import org.bitcoinj.wallet.BasicKeyChain;
 import org.bitcoinj.wallet.KeyChain;
 import org.bitcoinj.wallet.Protos;
+import org.bitcoinj.wallet.listeners.AbstractKeyChainEventListener;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -20,9 +20,9 @@ import org.bitcoinj.core.*;
 import org.bitcoinj.crypto.*;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.UnitTestParams;
-import org.bitcoinj.store.UnreadableWalletException;
 import org.bitcoinj.utils.BriefLogFormatter;
 import org.bitcoinj.utils.Threading;
+import org.bitcoinj.wallet.listeners.AbstractKeyChainEventListener;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;

--- a/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
@@ -21,6 +21,8 @@ import org.bitcoinj.crypto.*;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.utils.BriefLogFormatter;
 import org.bitcoinj.utils.Threading;
+import org.bitcoinj.wallet.listeners.KeyChainEventListener;
+
 import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Test;

--- a/core/src/test/java/org/bitcoinj/wallet/WalletExtensionsTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletExtensionsTest.java
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.core;
+package org.bitcoinj.wallet;
 
 import org.bitcoinj.testing.FooWalletExtension;
 import org.bitcoinj.testing.TestWithWallet;

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -15,15 +15,27 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.core;
+package org.bitcoinj.wallet;
 
-import org.bitcoinj.core.listeners.WalletChangeEventListener;
-import org.bitcoinj.core.listeners.WalletCoinsReceivedEventListener;
-import org.bitcoinj.core.listeners.WalletCoinsSentEventListener;
 import org.bitcoinj.core.listeners.TransactionConfidenceEventListener;
+import org.bitcoinj.core.AbstractBlockChain;
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.Block;
+import org.bitcoinj.core.BlockChain;
+import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.InsufficientMoneyException;
+import org.bitcoinj.core.PeerAddress;
+import org.bitcoinj.core.Sha256Hash;
+import org.bitcoinj.core.StoredBlock;
+import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.TransactionConfidence;
+import org.bitcoinj.core.TransactionInput;
+import org.bitcoinj.core.TransactionOutPoint;
+import org.bitcoinj.core.TransactionOutput;
+import org.bitcoinj.core.Utils;
+import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.core.TransactionConfidence.ConfidenceType;
-import org.bitcoinj.core.Wallet.BalanceType;
-import org.bitcoinj.core.Wallet.SendRequest;
 import org.bitcoinj.crypto.*;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
@@ -31,14 +43,16 @@ import org.bitcoinj.signers.StatelessTransactionSigner;
 import org.bitcoinj.signers.TransactionSigner;
 import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.store.MemoryBlockStore;
-import org.bitcoinj.store.UnreadableWalletException;
-import org.bitcoinj.store.WalletProtobufSerializer;
 import org.bitcoinj.testing.*;
 import org.bitcoinj.utils.ExchangeRate;
 import org.bitcoinj.utils.Fiat;
 import org.bitcoinj.utils.Threading;
-import org.bitcoinj.wallet.*;
+import org.bitcoinj.wallet.Wallet.BalanceType;
 import org.bitcoinj.wallet.WalletTransaction.Pool;
+import org.bitcoinj.wallet.listeners.KeyChainEventListener;
+import org.bitcoinj.wallet.listeners.WalletChangeEventListener;
+import org.bitcoinj.wallet.listeners.WalletCoinsReceivedEventListener;
+import org.bitcoinj.wallet.listeners.WalletCoinsSentEventListener;
 import org.easymock.EasyMock;
 
 import com.google.common.collect.ImmutableList;
@@ -46,6 +60,7 @@ import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
 import org.bitcoinj.wallet.Protos.Wallet.EncryptionType;
+import org.bitcoinj.wallet.Wallet.SendRequest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;

--- a/examples/src/main/java/org/bitcoinj/examples/BackupToMnemonicSeed.java
+++ b/examples/src/main/java/org/bitcoinj/examples/BackupToMnemonicSeed.java
@@ -16,9 +16,9 @@ package org.bitcoinj.examples;
 
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Utils;
-import org.bitcoinj.core.Wallet;
 import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.wallet.DeterministicSeed;
+import org.bitcoinj.wallet.Wallet;
 
 /**
  * The following example shows you how to create a deterministic seed from a hierarchical deterministic wallet represented as a mnemonic code.

--- a/examples/src/main/java/org/bitcoinj/examples/DoubleSpend.java
+++ b/examples/src/main/java/org/bitcoinj/examples/DoubleSpend.java
@@ -20,6 +20,7 @@ import org.bitcoinj.kits.WalletAppKit;
 import org.bitcoinj.params.RegTestParams;
 import org.bitcoinj.utils.BriefLogFormatter;
 import org.bitcoinj.utils.Threading;
+import org.bitcoinj.wallet.Wallet;
 
 import java.io.File;
 

--- a/examples/src/main/java/org/bitcoinj/examples/DumpWallet.java
+++ b/examples/src/main/java/org/bitcoinj/examples/DumpWallet.java
@@ -16,9 +16,9 @@
 
 package org.bitcoinj.examples;
 
-import org.bitcoinj.core.Wallet;
-
 import java.io.File;
+
+import org.bitcoinj.wallet.Wallet;
 
 /**
  * DumpWallet loads a serialized wallet and prints information about what it contains.

--- a/examples/src/main/java/org/bitcoinj/examples/ExamplePaymentChannelClient.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ExamplePaymentChannelClient.java
@@ -29,6 +29,9 @@ import org.bitcoinj.protocols.channels.StoredPaymentChannelClientStates;
 import org.bitcoinj.protocols.channels.ValueOutOfRangeException;
 import org.bitcoinj.utils.BriefLogFormatter;
 import org.bitcoinj.utils.Threading;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.WalletExtension;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;

--- a/examples/src/main/java/org/bitcoinj/examples/ExamplePaymentChannelServer.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ExamplePaymentChannelServer.java
@@ -24,11 +24,12 @@ import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.VerificationException;
-import org.bitcoinj.core.WalletExtension;
 import org.bitcoinj.kits.WalletAppKit;
 import org.bitcoinj.params.RegTestParams;
 import org.bitcoinj.protocols.channels.*;
 import org.bitcoinj.utils.BriefLogFormatter;
+import org.bitcoinj.wallet.WalletExtension;
+
 import com.google.common.collect.ImmutableList;
 
 import com.google.common.util.concurrent.ListenableFuture;

--- a/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
@@ -24,6 +24,9 @@ import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.RegTestParams;
 import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.utils.BriefLogFormatter;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.listeners.WalletCoinsReceivedEventListener;
+
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -31,7 +34,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 import java.io.File;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import org.bitcoinj.core.listeners.WalletCoinsReceivedEventListener;
 
 /**
  * ForwardingService demonstrates basic usage of the library. It sits on the network and when it receives coins, simply

--- a/examples/src/main/java/org/bitcoinj/examples/Kit.java
+++ b/examples/src/main/java/org/bitcoinj/examples/Kit.java
@@ -18,14 +18,16 @@ import org.bitcoinj.core.*;
 import org.bitcoinj.kits.WalletAppKit;
 import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.script.Script;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.listeners.KeyChainEventListener;
+import org.bitcoinj.wallet.listeners.ScriptsChangeEventListener;
+import org.bitcoinj.wallet.listeners.WalletCoinsReceivedEventListener;
+import org.bitcoinj.wallet.listeners.WalletCoinsSentEventListener;
 
 import java.io.File;
 import java.util.List;
-import org.bitcoinj.core.listeners.WalletCoinsReceivedEventListener;
-import org.bitcoinj.core.listeners.WalletCoinsSentEventListener;
-import org.bitcoinj.core.listeners.ScriptsChangeEventListener;
+
 import org.bitcoinj.core.listeners.TransactionConfidenceEventListener;
-import org.bitcoinj.wallet.KeyChainEventListener;
 
 /**
  * The following example shows how to use the by bitcoinj provided WalletAppKit.

--- a/examples/src/main/java/org/bitcoinj/examples/PrivateKeys.java
+++ b/examples/src/main/java/org/bitcoinj/examples/PrivateKeys.java
@@ -20,6 +20,7 @@ package org.bitcoinj.examples;
 import org.bitcoinj.core.*;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.store.MemoryBlockStore;
+import org.bitcoinj.wallet.Wallet;
 
 import java.math.BigInteger;
 import java.net.InetAddress;

--- a/examples/src/main/java/org/bitcoinj/examples/RefreshWallet.java
+++ b/examples/src/main/java/org/bitcoinj/examples/RefreshWallet.java
@@ -21,9 +21,10 @@ import org.bitcoinj.core.*;
 import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.MemoryBlockStore;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.listeners.WalletCoinsReceivedEventListener;
 
 import java.io.File;
-import org.bitcoinj.core.listeners.WalletCoinsReceivedEventListener;
 
 /**
  * RefreshWallet loads a wallet, then processes the block chain to update the transaction pools within it.

--- a/examples/src/main/java/org/bitcoinj/examples/RestoreFromSeed.java
+++ b/examples/src/main/java/org/bitcoinj/examples/RestoreFromSeed.java
@@ -20,6 +20,7 @@ import org.bitcoinj.net.discovery.DnsDiscovery;
 import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.store.SPVBlockStore;
 import org.bitcoinj.wallet.DeterministicSeed;
+import org.bitcoinj.wallet.Wallet;
 
 import java.io.File;
 

--- a/examples/src/main/java/org/bitcoinj/examples/SendRequest.java
+++ b/examples/src/main/java/org/bitcoinj/examples/SendRequest.java
@@ -18,9 +18,10 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.bitcoinj.core.*;
-import org.bitcoinj.core.Wallet.BalanceType;
 import org.bitcoinj.kits.WalletAppKit;
 import org.bitcoinj.params.TestNet3Params;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.Wallet.BalanceType;
 
 import java.io.File;
 

--- a/tools/src/main/java/org/bitcoinj/tools/TestFeeLevel.java
+++ b/tools/src/main/java/org/bitcoinj/tools/TestFeeLevel.java
@@ -20,6 +20,7 @@ import org.bitcoinj.core.listeners.PeerDisconnectedEventListener;
 import org.bitcoinj.kits.WalletAppKit;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.utils.BriefLogFormatter;
+import org.bitcoinj.wallet.Wallet;
 
 import java.io.File;
 

--- a/tools/src/main/java/org/bitcoinj/tools/WalletTool.java
+++ b/tools/src/main/java/org/bitcoinj/tools/WalletTool.java
@@ -18,7 +18,6 @@
 package org.bitcoinj.tools;
 
 import org.bitcoinj.core.*;
-import org.bitcoinj.core.Wallet.BalanceType;
 import org.bitcoinj.crypto.*;
 import org.bitcoinj.net.discovery.DnsDiscovery;
 import org.bitcoinj.params.MainNetParams;
@@ -50,12 +49,16 @@ import joptsimple.util.DateConverter;
 
 import org.bitcoinj.core.listeners.BlocksDownloadedEventListener;
 import org.bitcoinj.core.listeners.DownloadProgressTracker;
-import org.bitcoinj.core.listeners.WalletChangeEventListener;
-import org.bitcoinj.core.listeners.WalletCoinsReceivedEventListener;
-import org.bitcoinj.core.listeners.WalletCoinsSentEventListener;
-import org.bitcoinj.core.listeners.WalletReorganizeEventListener;
 import org.bitcoinj.wallet.MarriedKeyChain;
 import org.bitcoinj.wallet.Protos;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.WalletExtension;
+import org.bitcoinj.wallet.WalletProtobufSerializer;
+import org.bitcoinj.wallet.Wallet.BalanceType;
+import org.bitcoinj.wallet.listeners.WalletChangeEventListener;
+import org.bitcoinj.wallet.listeners.WalletCoinsReceivedEventListener;
+import org.bitcoinj.wallet.listeners.WalletCoinsSentEventListener;
+import org.bitcoinj.wallet.listeners.WalletReorganizeEventListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.crypto.params.KeyParameter;

--- a/wallettemplate/src/main/java/wallettemplate/SendMoneyController.java
+++ b/wallettemplate/src/main/java/wallettemplate/SendMoneyController.java
@@ -16,6 +16,8 @@ package wallettemplate;
 
 import javafx.scene.layout.HBox;
 import org.bitcoinj.core.*;
+import org.bitcoinj.wallet.Wallet;
+
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import javafx.event.ActionEvent;

--- a/wallettemplate/src/main/java/wallettemplate/utils/BitcoinUIModel.java
+++ b/wallettemplate/src/main/java/wallettemplate/utils/BitcoinUIModel.java
@@ -15,6 +15,9 @@
 package wallettemplate.utils;
 
 import org.bitcoinj.core.listeners.DownloadProgressTracker;
+import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.wallet.listeners.AbstractWalletEventListener;
+import org.bitcoinj.wallet.listeners.WalletChangeEventListener;
 import org.bitcoinj.core.*;
 import javafx.application.Platform;
 import javafx.beans.property.ReadOnlyDoubleProperty;
@@ -23,7 +26,6 @@ import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
 
 import java.util.Date;
-import org.bitcoinj.core.listeners.WalletChangeEventListener;
 
 /**
  * A class that exposes relevant bitcoin stuff as JavaFX bindable properties.


### PR DESCRIPTION
These classes are moved to .wallet:
- Wallet + WalletTest
- WalletExtension + WalletExtensionsTest
- WalletProtobufSerializer
- UnreadableWalletException

These listeners are moved to .wallet.listeners:
- WalletEventListener
- WalletChangeEventListener
- WalletCoinsReceivedEventListener
- WalletCoinsSentEventListener
- WalletReorganizeEventListener
- ScriptsChangeEventListener
- AbstractWalletEventListener
- KeyChainEventListener
- AbstractKeyChainEventListener

The plan is to merge this just before the next release 0.14, so that the diff between the future master and 0.14.x maintenance releases stays small.