### PR TITLE
Peer: Fix version handshake.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -459,6 +459,12 @@ public class Peer extends PeerSocketHandler {
             currentFilteredBlock = null;
         }
 
+        // No further communication is possible until version handshake is complete.
+        if (!(m instanceof VersionMessage || m instanceof VersionAck
+                || (versionHandshakeFuture.isDone() && !versionHandshakeFuture.isCancelled())))
+            throw new ProtocolException(
+                    "Received " + m.getClass().getSimpleName() + " before version handshake is complete.");
+
         if (m instanceof Ping) {
             processPing((Ping) m);
         } else if (m instanceof Pong) {


### PR DESCRIPTION
This PR fixes two issues with the version handshake:

- Handshake is only complete when both halves (incoming and outgoing version+verack) are complete. Both of these halves run in parallel. Previously, in some cases we started sending messages even if the handshake wasn't complete.
- I the remote Peer sends main protocol messages while handshake is still in progress, that's a protocol violation. TODO investigate if we should pardon such violations and just log them.