### PR TITLE
Fix core module build failures caused by Maven surefire plugin

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -197,11 +197,9 @@
                                         <urn>net.jcip:jcip-annotations:1.0:jar:null:compile:afba4942caaeaf46aab0b976afd57cc7c181467e</urn>
                                         <urn>org.apache.maven.plugins:maven-clean-plugin:2.6.1:maven-plugin:null:runtime:bfdf7d6c2f8fc8759457e9d54f458ba56ac7b30f</urn>
                                         <urn>org.apache.maven.plugins:maven-compiler-plugin:3.2:maven-plugin:null:runtime:aec10f274ac07fafab8906cb1aa69669d753b2c2</urn>
-                                        <urn>org.apache.maven.plugins:maven-dependency-plugin:2.10:maven-plugin:null:runtime:af87ceeb71c6499147c5d27f74c9317bf707538e</urn>
                                         <urn>org.apache.maven.plugins:maven-deploy-plugin:2.8.2:maven-plugin:null:runtime:3c2d83ecd387e9843142ae92a0439792c1500319</urn>
                                         <urn>org.apache.maven.plugins:maven-enforcer-plugin:1.0:maven-plugin:null:runtime:ad032b7593576e9fe9305c73865633e163895b29</urn>
                                         <urn>org.apache.maven.plugins:maven-install-plugin:2.5.2:maven-plugin:null:runtime:8a67631619fc3c1d1f036e59362ddce71e1e496f</urn>
-                                        <urn>org.apache.maven.plugins:maven-jar-plugin:2.6:maven-plugin:null:runtime:618f08d0fcdd3929af846ef1b65503b5904f93e3</urn>
                                         <urn>org.apache.maven.plugins:maven-javadoc-plugin:2.10.2:maven-plugin:null:runtime:5f391697fa85cecc7e5bac7ce5a6f9d056a58ba3</urn>
                                         <urn>org.apache.maven.plugins:maven-resources-plugin:2.7:maven-plugin:null:runtime:94af11389943a480ecec7db01b4ded1b9cdf57c5</urn>
                                         <urn>org.apache.maven.plugins:maven-shade-plugin:2.3:maven-plugin:null:runtime:d136adc7abccc9c12adcad6ae7a9bc51b2b7184b</urn>
@@ -337,78 +335,6 @@
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
                 <version>3.1.0</version>
-            </plugin>
-
-            <!-- Create a bundled executable test jar that runs the regtester/pulltester.
-                 The comparison tool is kind of messy and badly needs a seriously refactoring.
-                 It depends on classes which are only in the test tree so we must do some
-                 Maven kung fu here to create a bundle of it, as I couldn't make Maven Shade
-                 do bundling on the test jar for some reason. Maven kind of sucks ...
-              -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>unzip-lib</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>false</overWriteSnapshots>
-                            <overWriteIfNewer>true</overWriteIfNewer>
-                            <artifactItems>
-                                <artifactItem>
-                                    <outputDirectory>target/test-classes/</outputDirectory>
-                                    <groupId>org.bitcoinj</groupId>
-                                    <artifactId>bitcoinj-core</artifactId>
-                                    <version>${project.version}</version>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>unzip-deps</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>target/test-classes/</outputDirectory>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>false</overWriteSnapshots>
-                            <overWriteIfNewer>true</overWriteIfNewer>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                        <configuration>
-                            <archive>
-                                <manifest>
-                                    <mainClass>org.bitcoinj.core.BitcoindComparisonTool</mainClass>
-                                    <addClasspath>false</addClasspath>
-                                </manifest>
-                            </archive>
-                            <finalName>pull</finalName>    <!-- becomes pull-tests.jar on disk (hacky) -->
-                            <excludes>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
-                            </excludes>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Fix core module build failures caused by Maven surefire plugin running JUnit classes.

I ran into this today: https://github.com/travis-ci/travis-ci/issues/2675

Basically, I cloned the repo, `git fetch --all`, `mvn install` (wallet-template module fails), then whenever I run `mvn install` again it failed with:

```
[INFO] --- maven-surefire-plugin:2.19.1:test (default-test) @ bitcoinj-core ---

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running junit.extensions.RepeatedTest
Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 0.046 sec <<< FAILURE! - in junit.extensions.RepeatedTest
initializationError(junit.extensions.RepeatedTest)  Time elapsed: 0.009 sec  <<< ERROR!
java.lang.Exception: Test class should have exactly one public zero-argument constructor

initializationError(junit.extensions.RepeatedTest)  Time elapsed: 0 sec  <<< ERROR!
java.lang.Exception: No runnable methods

Running junit.extensions.TestDecorator
Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 0 sec <<< FAILURE! - in junit.extensions.TestDecorator
initializationError(junit.extensions.TestDecorator)  Time elapsed: 0 sec  <<< ERROR!
java.lang.Exception: Test class should have exactly one public zero-argument constructor

initializationError(junit.extensions.TestDecorator)  Time elapsed: 0 sec  <<< ERROR!
java.lang.Exception: No runnable methods

Running junit.extensions.TestSetup
Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 0 sec <<< FAILURE! - in junit.extensions.TestSetup
initializationError(junit.extensions.TestSetup)  Time elapsed: 0 sec  <<< ERROR!
java.lang.Exception: Test class should have exactly one public zero-argument constructor

initializationError(junit.extensions.TestSetup)  Time elapsed: 0 sec  <<< ERROR!
java.lang.Exception: No runnable methods

Running junit.framework.TestSuite
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0 sec <<< FAILURE! - in junit.framework.TestSuite
initializationError(junit.framework.TestSuite)  Time elapsed: 0 sec  <<< ERROR!
java.lang.IllegalArgumentException: Test class can only have one constructor
```

After some tinkering with `/opt/apache-maven-3.3.9/bin/mvn install -e -X`

I saw that all these junit classes were getting into the config file for surefire to run:

```
> grep junit bitcoinj/core/target/surefire/surefire4281808258863620369tmp
tc.5=org.junit.internal.runners.TestMethod
tc.6=org.junit.internal.runners.TestClass
tc.3=org.junit.rules.TestRule
tc.4=org.junit.Test
tc.1=org.junit.rules.TestWatcher
tc.2=org.junit.rules.TestName
tc.0=org.junit.rules.TestWatchman
tc.9=org.junit.runners.parameterized.TestWithParameters
tc.7=org.junit.runners.model.TestTimedOutException
tc.87=junit.textui.TestRunner
tc.8=org.junit.runners.model.TestClass
tc.88=junit.extensions.RepeatedTest
tc.90=junit.extensions.TestSetup
tc.91=junit.runner.TestRunListener
tc.92=junit.framework.TestResult
tc.93=junit.framework.Test
tc.94=junit.framework.TestFailure
tc.95=junit.framework.TestCase
tc.96=junit.framework.TestListener
tc.97=junit.framework.TestSuite
tc.10=org.junit.validator.TestClassValidator
tc.11=org.junit.experimental.theories.suppliers.TestedOn
tc.89=junit.extensions.TestDecorator
tc.12=org.junit.experimental.theories.suppliers.TestedOnSupplier
```

I made the fix in this PR and those junit classes no longer get into the surefire config and the build works again.
So, this seems like some minor bug/oversight in surefire. But, it's easy to fix by excluding junit classes.
Now I'm back to the wallet-template failing (and I don't care about that right now).

Reference: http://maven.apache.org/surefire/maven-surefire-plugin/examples/inclusion-exclusion.html