### PR TITLE
For watching wallets, store the key creation time…

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/core/Wallet.java
@@ -239,16 +239,20 @@ public class Wallet extends BaseTaggableObject
      * Creates a wallet that tracks payments to and from the HD key hierarchy rooted by the given watching key. A
      * watching key corresponds to account zero in the recommended BIP32 key hierarchy.
      */
-    public static Wallet fromWatchingKey(NetworkParameters params, DeterministicKey watchKey, long creationTimeSeconds) {
-        return new Wallet(params, new KeyChainGroup(params, watchKey, creationTimeSeconds));
+    public static Wallet fromWatchingKey(NetworkParameters params, DeterministicKey watchKey) {
+        return new Wallet(params, new KeyChainGroup(params, watchKey));
     }
 
     /**
      * Creates a wallet that tracks payments to and from the HD key hierarchy rooted by the given watching key. A
-     * watching key corresponds to account zero in the recommended BIP32 key hierarchy.
+     * watching key corresponds to account zero in the recommended BIP32 key hierarchy. The key is specified in base58
+     * notation and the creation time of the key. If you don't know the creation time, you can pass
+     * {@link DeterministicHierarchy#BIP32_STANDARDISATION_TIME_SECS}.
      */
-    public static Wallet fromWatchingKey(NetworkParameters params, DeterministicKey watchKey) {
-        return new Wallet(params, new KeyChainGroup(params, watchKey));
+    public static Wallet fromWatchingKeyB58(NetworkParameters params, String watchKeyB58, long creationTimeSeconds) {
+        final DeterministicKey watchKey = DeterministicKey.deserializeB58(null, watchKeyB58, params);
+        watchKey.setCreationTimeSeconds(creationTimeSeconds);
+        return fromWatchingKey(params, watchKey);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/wallet/BasicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/BasicKeyChain.java
@@ -384,7 +384,7 @@ public class BasicKeyChain implements EncryptableKeyChain {
                     else
                         ecKey = ECKey.fromPublicOnly(pub);
                 }
-                ecKey.setCreationTimeSeconds((key.getCreationTimestamp() + 500) / 1000);
+                ecKey.setCreationTimeSeconds(key.getCreationTimestamp() / 1000);
                 importKeyLocked(ecKey);
             }
         } finally {

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -1315,22 +1315,25 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
     }
 
     public String toString(boolean includePrivateKeys, NetworkParameters params) {
-        final StringBuilder builder2 = new StringBuilder();
+        final DeterministicKey watchingKey = getWatchingKey();
+        final StringBuilder builder = new StringBuilder();
         if (seed != null) {
             if (seed.isEncrypted()) {
-                builder2.append("Seed is encrypted\n");
+                builder.append("Seed is encrypted\n");
             } else if (includePrivateKeys) {
                 final List<String> words = seed.getMnemonicCode();
-                builder2.append("Seed as words: ").append(Utils.join(words)).append('\n');
-                builder2.append("Seed as hex:   ").append(seed.toHexString()).append('\n');
+                builder.append("Seed as words: ").append(Utils.join(words)).append('\n');
+                builder.append("Seed as hex:   ").append(seed.toHexString()).append('\n');
             }
-            builder2.append("Seed birthday: ").append(seed.getCreationTimeSeconds()).append("  [")
+            builder.append("Seed birthday: ").append(seed.getCreationTimeSeconds()).append("  [")
                     .append(Utils.dateTimeFormat(seed.getCreationTimeSeconds() * 1000)).append("]\n");
+        } else {
+            builder.append("Key birthday:  ").append(watchingKey.getCreationTimeSeconds()).append("  [")
+                    .append(Utils.dateTimeFormat(watchingKey.getCreationTimeSeconds() * 1000)).append("]\n");
         }
-        final DeterministicKey watchingKey = getWatchingKey();
-        builder2.append("Key to watch:  ").append(watchingKey.serializePubB58(params)).append('\n');
-        formatAddresses(includePrivateKeys, params, builder2);
-        return builder2.toString();
+        builder.append("Key to watch:  ").append(watchingKey.serializePubB58(params)).append('\n');
+        formatAddresses(includePrivateKeys, params, builder);
+        return builder.toString();
     }
 
     protected void formatAddresses(boolean includePrivateKeys, NetworkParameters params, StringBuilder builder2) {

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
@@ -93,15 +93,6 @@ public class KeyChainGroup implements KeyBag {
         this(params, null, ImmutableList.of(DeterministicKeyChain.watch(watchKey)), null, null);
     }
 
-    /**
-     * Creates a keychain group with no basic chain, and an HD chain that is watching the given watching key which
-     * was assumed to be first used at the given UNIX time.
-     * This HAS to be an account key as returned by {@link DeterministicKeyChain#getWatchingKey()}.
-     */
-    public KeyChainGroup(NetworkParameters params, DeterministicKey watchKey, long creationTimeSecondsSecs) {
-        this(params, null, ImmutableList.of(DeterministicKeyChain.watch(watchKey, creationTimeSecondsSecs)), null, null);
-    }
-
     // Used for deserialization.
     private KeyChainGroup(NetworkParameters params, @Nullable BasicKeyChain basicKeyChain, List<DeterministicKeyChain> chains,
                           @Nullable EnumMap<KeyChain.KeyPurpose, DeterministicKey> currentKeys, @Nullable KeyCrypter crypter) {

--- a/core/src/main/java/org/bitcoinj/wallet/MarriedKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/MarriedKeyChain.java
@@ -103,9 +103,11 @@ public class MarriedKeyChain extends DeterministicKeyChain {
             } else if (entropy != null) {
                 chain = new MarriedKeyChain(entropy, getPassphrase(), seedCreationTimeSecs);
             } else if (seed != null) {
+                seed.setCreationTimeSeconds(seedCreationTimeSecs);
                 chain = new MarriedKeyChain(seed);
             } else {
-                chain = new MarriedKeyChain(watchingKey, seedCreationTimeSecs);
+                watchingKey.setCreationTimeSeconds(seedCreationTimeSecs);
+                chain = new MarriedKeyChain(watchingKey);
             }
             chain.addFollowingAccountKeys(followingKeys, threshold);
             return chain;
@@ -119,10 +121,6 @@ public class MarriedKeyChain extends DeterministicKeyChain {
     // Protobuf deserialization constructors
     MarriedKeyChain(DeterministicKey accountKey) {
         super(accountKey, false);
-    }
-
-    MarriedKeyChain(DeterministicKey accountKey, long seedCreationTimeSecs) {
-        super(accountKey, seedCreationTimeSecs);
     }
 
     MarriedKeyChain(DeterministicSeed seed, KeyCrypter crypter) {

--- a/core/src/test/java/org/bitcoinj/core/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/core/WalletTest.java
@@ -1640,8 +1640,7 @@ public class WalletTest extends TestWithWallet {
     public void watchingWalletWithCreationTime() throws Exception {
         DeterministicKey watchKey = wallet.getWatchingKey();
         String serialized = watchKey.serializePubB58(PARAMS);
-        watchKey = DeterministicKey.deserializeB58(null, serialized, PARAMS);
-        Wallet watchingWallet = Wallet.fromWatchingKey(PARAMS, watchKey, 1415282801);
+        Wallet watchingWallet = Wallet.fromWatchingKeyB58(PARAMS, serialized, 1415282801);
         DeterministicKey key2 = watchingWallet.freshReceiveKey();
         assertEquals(myKey, key2);
 
@@ -3499,8 +3498,7 @@ public class WalletTest extends TestWithWallet {
     public void watchingMarriedWallet() throws Exception {
         DeterministicKey watchKey = wallet.getWatchingKey();
         String serialized = watchKey.serializePubB58(PARAMS);
-        watchKey = DeterministicKey.deserializeB58(null, serialized, PARAMS);
-        Wallet wallet = Wallet.fromWatchingKey(PARAMS, watchKey);
+        Wallet wallet = Wallet.fromWatchingKeyB58(PARAMS, serialized, 0);
         blockStore = new MemoryBlockStore(PARAMS);
         chain = new BlockChain(PARAMS, wallet, blockStore);
 

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -289,7 +289,7 @@ public class WalletProtobufSerializerTest {
 
     @Test
     public void testRoundTripNormalWallet() throws Exception {
-        Wallet wallet1 = roundTrip(myWallet);     
+        Wallet wallet1 = roundTrip(myWallet);
         assertEquals(0, wallet1.getTransactions(true).size());
         assertEquals(Coin.ZERO, wallet1.getBalance());
         assertArrayEquals(myKey.getPubKey(),
@@ -298,6 +298,22 @@ public class WalletProtobufSerializerTest {
                 wallet1.findKeyFromPubHash(myKey.getPubKeyHash()).getPrivKeyBytes());
         assertEquals(myKey.getCreationTimeSeconds(),
                 wallet1.findKeyFromPubHash(myKey.getPubKeyHash()).getCreationTimeSeconds());
+    }
+
+    @Test
+    public void testRoundTripWatchingWallet() throws Exception {
+        final String xpub = "tpubD9LrDvFDrB6wYNhbR2XcRRaT4yCa37TjBR3YthBQvrtEwEq6CKeEXUs3TppQd38rfxmxD1qLkC99iP3vKcKwLESSSYdFAftbrpuhSnsw6XM";
+        final long creationTimeSeconds = 1457019819;
+        Wallet wallet = Wallet.fromWatchingKeyB58(PARAMS, xpub, creationTimeSeconds);
+        Wallet wallet2 = roundTrip(wallet);
+        Wallet wallet3 = roundTrip(wallet2);
+        assertEquals(xpub, wallet.getWatchingKey().serializePubB58(PARAMS));
+        assertEquals(creationTimeSeconds, wallet.getWatchingKey().getCreationTimeSeconds());
+        assertEquals(creationTimeSeconds, wallet2.getWatchingKey().getCreationTimeSeconds());
+        assertEquals(creationTimeSeconds, wallet3.getWatchingKey().getCreationTimeSeconds());
+        assertEquals(creationTimeSeconds, wallet.getEarliestKeyCreationTime());
+        assertEquals(creationTimeSeconds, wallet2.getEarliestKeyCreationTime());
+        assertEquals(creationTimeSeconds, wallet3.getEarliestKeyCreationTime());
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -323,7 +323,7 @@ public class DeterministicKeyChainTest {
         watchingKey = DeterministicKey.deserializeB58(null, pub58, params);
         watchingKey.setCreationTimeSeconds(100000);
         chain = DeterministicKeyChain.watch(watchingKey);
-        assertEquals(DeterministicHierarchy.BIP32_STANDARDISATION_TIME_SECS, chain.getEarliestKeyCreationTime());
+        assertEquals(100000, chain.getEarliestKeyCreationTime());
         chain.setLookaheadSize(10);
         chain.maybeLookAhead();
 

--- a/core/src/wallet.proto
+++ b/core/src/wallet.proto
@@ -120,8 +120,8 @@ message Key {
   // User-provided label associated with the key.
   optional string label = 4;
 
-  // Timestamp stored as millis since epoch. Useful for skipping block bodies before this point. Only reason it's
-  // optional is that some very old wallets don't have this data.
+  // Timestamp stored as millis since epoch. Useful for skipping block bodies before this point. The reason it's
+  // optional is that keys derived from a parent don't have this data.
   optional int64 creation_timestamp = 5;
 
   optional DeterministicKey deterministic_key = 7;


### PR DESCRIPTION
…always in the watching key rather than the DeterministicKeyChain. Creation times in the DeterministicKeyChain can't be persisted to protobuf, as that structure has no full-blown protobuf equivalent.

This means a couple of DeterministicKeyChain, KeyChainGroup and Wallet factory method variants that take creation dates have been removed. On the other hand, a convenient Wallet.fromWatchingKeyB58(params, xpub, creationDate) has been added.

Also adds a test for protobuf-roundtripping watching wallets.

Supposed to fix issue #1209.