### PR TITLE
Wallet: Get rid of the concept of a "base fee".

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -333,7 +333,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         Wallet.SendRequest req = Wallet.SendRequest.to(address2, amount2);
         wallet.completeTx(req);
         wallet.commitTx(req.tx);
-        Coin fee = req.fee;
+        Coin fee = Coin.ZERO;
 
         // There should be one pending tx (our spend).
         assertEquals("Wrong number of PENDING.4", 1, wallet.getPoolSize(WalletTransaction.Pool.PENDING));

--- a/tools/src/main/java/org/bitcoinj/tools/WalletTool.java
+++ b/tools/src/main/java/org/bitcoinj/tools/WalletTool.java
@@ -219,7 +219,7 @@ public class WalletTool {
         xpubkeysFlag = parser.accepts("xpubkeys").withRequiredArg();
         OptionSpec<String> outputFlag = parser.accepts("output").withRequiredArg();
         parser.accepts("value").withRequiredArg();
-        parser.accepts("fee").withRequiredArg();
+        OptionSpec<String> feePerKbOption = parser.accepts("fee-per-kb").withRequiredArg();
         unixtimeFlag = parser.accepts("unixtime").withRequiredArg().ofType(Long.class);
         OptionSpec<String> conditionFlag = parser.accepts("condition").withRequiredArg();
         parser.accepts("locktime").withRequiredArg();
@@ -355,16 +355,15 @@ public class WalletTool {
                     System.err.println("--payment-request and --output cannot be used together.");
                     return;
                 } else if (options.has(outputFlag)) {
-                    Coin fee = Coin.ZERO;
-                    if (options.has("fee")) {
-                        fee = parseCoin((String)options.valueOf("fee"));
-                    }
+                    Coin feePerKb = Coin.ZERO;
+                    if (options.has(feePerKbOption))
+                        feePerKb = parseCoin((String) options.valueOf(feePerKbOption));
                     String lockTime = null;
                     if (options.has("locktime")) {
                         lockTime = (String) options.valueOf("locktime");
                     }
                     boolean allowUnconfirmed = options.has("allow-unconfirmed");
-                    send(outputFlag.values(options), fee, lockTime, allowUnconfirmed);
+                    send(outputFlag.values(options), feePerKb, lockTime, allowUnconfirmed);
                 } else if (options.has(paymentRequestLocation)) {
                     sendPaymentRequest(paymentRequestLocation.value(options), !options.has("no-pki"));
                 } else {
@@ -377,10 +376,9 @@ public class WalletTool {
                     System.err.println("You must specify a --output=addr:value");
                     return;
                 }
-                Coin fee = Coin.ZERO;
-                if (options.has("fee")) {
-                    fee = parseCoin((String) options.valueOf("fee"));
-                }
+                Coin feePerKb = Coin.ZERO;
+                if (options.has(feePerKbOption))
+                    feePerKb = parseCoin((String) options.valueOf(feePerKbOption));
                 if (!options.has("locktime")) {
                     System.err.println("You must specify a --locktime");
                     return;
@@ -391,39 +389,37 @@ public class WalletTool {
                     System.err.println("You must specify an address to refund money to after expiry: --refund-to=addr");
                     return;
                 }
-                sendCLTVPaymentChannel(refundFlag.value(options), outputFlag.value(options), fee, lockTime, allowUnconfirmed);
+                sendCLTVPaymentChannel(refundFlag.value(options), outputFlag.value(options), feePerKb, lockTime, allowUnconfirmed);
                 } break;
             case SETTLE_CLTVPAYMENTCHANNEL: {
                 if (!options.has(outputFlag)) {
                     System.err.println("You must specify a --output=addr:value");
                     return;
                 }
-                Coin fee = Coin.ZERO;
-                if (options.has("fee")) {
-                    fee = parseCoin((String) options.valueOf("fee"));
-                }
+                Coin feePerKb = Coin.ZERO;
+                if (options.has(feePerKbOption))
+                    feePerKb = parseCoin((String) options.valueOf(feePerKbOption));
                 boolean allowUnconfirmed = options.has("allow-unconfirmed");
                 if (!options.has(txHashFlag)) {
                     System.err.println("You must specify the transaction to spend: --txhash=tx-hash");
                     return;
                 }
-                settleCLTVPaymentChannel(txHashFlag.value(options), outputFlag.value(options), fee, allowUnconfirmed);
+                settleCLTVPaymentChannel(txHashFlag.value(options), outputFlag.value(options), feePerKb, allowUnconfirmed);
                 } break;
             case REFUND_CLTVPAYMENTCHANNEL: {
                 if (!options.has(outputFlag)) {
                     System.err.println("You must specify a --output=addr:value");
                     return;
                 }
-                Coin fee = Coin.ZERO;
-                if (options.has("fee")) {
-                    fee = parseCoin((String) options.valueOf("fee"));
-                }
+                Coin feePerKb = Coin.ZERO;
+                if (options.has(feePerKbOption))
+                    feePerKb = parseCoin((String) options.valueOf(feePerKbOption));
                 boolean allowUnconfirmed = options.has("allow-unconfirmed");
                 if (!options.has(txHashFlag)) {
                     System.err.println("You must specify the transaction to spend: --txhash=tx-hash");
                     return;
                 }
-                refundCLTVPaymentChannel(txHashFlag.value(options), outputFlag.value(options), fee, allowUnconfirmed);
+                refundCLTVPaymentChannel(txHashFlag.value(options), outputFlag.value(options), feePerKb, allowUnconfirmed);
             } break;
             case ENCRYPT: encrypt(); break;
             case DECRYPT: decrypt(); break;
@@ -567,7 +563,7 @@ public class WalletTool {
         }
     }
 
-    private static void send(List<String> outputs, Coin fee, String lockTimeStr, boolean allowUnconfirmed) throws VerificationException {
+    private static void send(List<String> outputs, Coin feePerKb, String lockTimeStr, boolean allowUnconfirmed) throws VerificationException {
         try {
             // Convert the input strings to outputs.
             Transaction t = new Transaction(params);
@@ -598,7 +594,7 @@ public class WalletTool {
                 log.info("Emptying out wallet, recipient may get less than what you expect");
                 req.emptyWallet = true;
             }
-            req.fee = fee;
+            req.feePerKb = feePerKb;
             if (allowUnconfirmed) {
                 wallet.allowSpendingUnconfirmedTransactions();
             }
@@ -685,7 +681,7 @@ public class WalletTool {
         }
     }
 
-    private static void sendCLTVPaymentChannel(String refund, String output, Coin fee, String lockTimeStr, boolean allowUnconfirmed) throws VerificationException {
+    private static void sendCLTVPaymentChannel(String refund, String output, Coin feePerKb, String lockTimeStr, boolean allowUnconfirmed) throws VerificationException {
         try {
             // Convert the input strings to outputs.
             ECKey outputKey, refundKey;
@@ -729,7 +725,7 @@ public class WalletTool {
                 log.info("Emptying out wallet, recipient may get less than what you expect");
                 req.emptyWallet = true;
             }
-            req.fee = fee;
+            req.feePerKb = feePerKb;
             if (allowUnconfirmed) {
                 wallet.allowSpendingUnconfirmedTransactions();
             }
@@ -771,12 +767,8 @@ public class WalletTool {
 
     /**
      * Settles a CLTV payment channel transaction given that we own both private keys (ie. for testing).
-     * @param txHash
-     * @param output
-     * @param fee
-     * @param allowUnconfirmed
      */
-    private static void settleCLTVPaymentChannel(String txHash, String output, Coin fee, boolean allowUnconfirmed) {
+    private static void settleCLTVPaymentChannel(String txHash, String output, Coin feePerKb, boolean allowUnconfirmed) {
         try {
             OutputSpec outputSpec;
             Coin value;
@@ -800,7 +792,7 @@ public class WalletTool {
             Wallet.SendRequest req = outputSpec.isAddress() ?
                     Wallet.SendRequest.to(outputSpec.addr, value) :
                     Wallet.SendRequest.to(params, outputSpec.key, value);
-            req.fee = fee;
+            req.feePerKb = feePerKb;
 
             Transaction lockTimeVerify = wallet.getTransaction(Sha256Hash.wrap(txHash));
             if (lockTimeVerify == null) {
@@ -818,7 +810,7 @@ public class WalletTool {
                 return;
             }
 
-            if (!req.fee.add(value).equals(lockTimeVerifyOutput.getValue())) {
+            if (!value.equals(lockTimeVerifyOutput.getValue())) {
                 System.err.println("You must spend all the money in the input transaction");
             }
 
@@ -878,12 +870,8 @@ public class WalletTool {
 
     /**
      * Refunds a CLTV payment channel transaction after the lock time has expired.
-     * @param txHash
-     * @param output
-     * @param fee
-     * @param allowUnconfirmed
      */
-    private static void refundCLTVPaymentChannel(String txHash, String output, Coin fee, boolean allowUnconfirmed) {
+    private static void refundCLTVPaymentChannel(String txHash, String output, Coin feePerKb, boolean allowUnconfirmed) {
         try {
             OutputSpec outputSpec;
             Coin value;
@@ -907,7 +895,7 @@ public class WalletTool {
             Wallet.SendRequest req = outputSpec.isAddress() ?
                     Wallet.SendRequest.to(outputSpec.addr, value) :
                     Wallet.SendRequest.to(params, outputSpec.key, value);
-            req.fee = fee;
+            req.feePerKb = feePerKb;
 
             Transaction lockTimeVerify = wallet.getTransaction(Sha256Hash.wrap(txHash));
             if (lockTimeVerify == null) {
@@ -927,7 +915,7 @@ public class WalletTool {
 
             req.tx.setLockTime(lockTimeVerifyOutput.getScriptPubKey().getCLTVPaymentChannelExpiry().longValue());
 
-            if (!req.fee.add(value).equals(lockTimeVerifyOutput.getValue())) {
+            if (!value.equals(lockTimeVerifyOutput.getValue())) {
                 System.err.println("You must spend all the money in the input transaction");
             }
 

--- a/tools/src/main/resources/org/bitcoinj/tools/wallet-tool-help.txt
+++ b/tools/src/main/resources/org/bitcoinj/tools/wallet-tool-help.txt
@@ -45,7 +45,7 @@ Usage: wallet-tool --flags action-name
                          --payment-request=http://merchant.com/pay.php?123
 
                        Other options include:
-                          --fee=0.01  sets the tx fee
+                          --fee-per-kb=0.0005 sets the tx fee
                           --locktime=1234  sets the lock time to block 1234
                           --locktime=2013/01/01  sets the lock time to 1st Jan 2013
                           --allow-unconfirmed will let you create spends of pending non-change outputs.
@@ -69,14 +69,14 @@ Usage: wallet-tool --flags action-name
                        Options:
                           --output=pubkey:value sets the amount to lock and the recipient
                           --refund-to=pubkey sets "our" public key
-                          --fee=value sets the mining fee
+                          --fee-per-kb=value sets the network fee
                           --locktime=YYYY/MM/DD sets the expiry time for the channel
   settle-cltvpaymentchannel
                        Creates and broadcasts a transaction settling a previous micropayment channel.
                        This tool, for testing, requires the presence of both private keys.
                        Options:
                           --output=pubkey:value sets the destination for the money
-                          --fee=value sets the mining fee
+                          --fee-per-kb=value sets the network fee
                           --txhash=hash sets the transaction to spend
   refund-cltvpaymentchannel
                        Creates and broadcasts a transaction refunding a previous micropayment channel.
@@ -84,7 +84,7 @@ Usage: wallet-tool --flags action-name
                        the created transaction won't be accepted into the mempool until that point.
                        Options:
                           --output=pubkey:value sets the destination for the money
-                          --fee=value sets the mining fee
+                          --fee-per-kb=value sets the network fee
                           --txhash=hash sets the transaction to spend
 
 >>> GENERAL OPTIONS


### PR DESCRIPTION
Fee is always expressed as a rate in Coin per 1000 bytes.

SendRequest.fee was removed; use SendRequest.feePerKb for requesting a certain fee rate. If the field was
read for knowing the calculated fee, use SendRequest.tx.getFee() instead.

Also makes a couple of unit tests independent of fee.