### PR TITLE
Get rid of SendRequest.DEFAULT_FEE_PER_KB "constant".

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Context.java
+++ b/core/src/main/java/org/bitcoinj/core/Context.java
@@ -1,5 +1,6 @@
 package org.bitcoinj.core;
 
+import org.bitcoinj.core.Wallet.SendRequest;
 import org.slf4j.*;
 
 import static com.google.common.base.Preconditions.*;
@@ -30,6 +31,8 @@ public class Context {
     private TxConfidenceTable confidenceTable;
     private NetworkParameters params;
     private int eventHorizon = 100;
+    private boolean ensureMinRequiredFee = true;
+    private Coin feePerKb = Transaction.REFERENCE_DEFAULT_MIN_TX_FEE;
 
     /**
      * Creates a new context object. For now, this will be done for you by the framework. Eventually you will be
@@ -46,15 +49,18 @@ public class Context {
     }
 
     /**
-     * Creates a new context object. For now, this will be done for you by the framework. Eventually you will be
-     * expected to do this yourself in the same manner as fetching a NetworkParameters object (at the start of your app).
+     * Creates a new custom context object. This is mainly meant for unit tests for now.
      *
      * @param params The network parameters that will be associated with this context.
      * @param eventHorizon Number of blocks after which the library will delete data and be unable to always process reorgs (see {@link #getEventHorizon()}.
+     * @param feePerKb The default fee per 1000 bytes of transaction data to pay when completing transactions. For details, see {@link SendRequest#feePerKb}.
+     * @param ensureMinRequiredFee Whether to ensure the minimum required fee by default when completing transactions. For details, see {@link SendRequest#ensureMinRequiredFee}.
      */
-    public Context(NetworkParameters params, int eventHorizon) {
+    public Context(NetworkParameters params, int eventHorizon, Coin feePerKb, boolean ensureMinRequiredFee) {
         this(params);
         this.eventHorizon = eventHorizon;
+        this.feePerKb = feePerKb;
+        this.ensureMinRequiredFee = ensureMinRequiredFee;
     }
 
     private static volatile Context lastConstructed;
@@ -154,5 +160,19 @@ public class Context {
      */
     public int getEventHorizon() {
         return eventHorizon;
+    }
+
+    /**
+     * The default fee per 1000 bytes of transaction data to pay when completing transactions. For details, see {@link SendRequest#feePerKb}.
+     */
+    public Coin getFeePerKb() {
+        return feePerKb;
+    }
+
+    /**
+     * Whether to ensure the minimum required fee by default when completing transactions. For details, see {@link SendRequest#ensureMinRequiredFee}.
+     */
+    public boolean isEnsureMinRequiredFee() {
+        return ensureMinRequiredFee;
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/core/Wallet.java
@@ -3721,13 +3721,7 @@ public class Wallet extends BaseTaggableObject
          * when choosing which transactions to add to a block. Note that, to keep this equivalent to Bitcoin Core
          * definition, a kilobyte is defined as 1000 bytes, not 1024.</p>
          */
-        public Coin feePerKb = DEFAULT_FEE_PER_KB;
-
-        /**
-         * If you want to modify the default fee for your entire app without having to change each SendRequest you make,
-         * you can do it here. This is primarily useful for unit tests.
-         */
-        public static Coin DEFAULT_FEE_PER_KB = Transaction.REFERENCE_DEFAULT_MIN_TX_FEE;
+        public Coin feePerKb = Context.get().getFeePerKb();
 
         /**
          * <p>Requires that there be enough fee for a default Bitcoin Core to at least relay the transaction.
@@ -3738,7 +3732,7 @@ public class Wallet extends BaseTaggableObject
          * 26,000 bytes. If you get a transaction which is that large, you should set a feePerKb of at least
          * {@link Transaction#REFERENCE_DEFAULT_MIN_TX_FEE}.</p>
          */
-        public boolean ensureMinRequiredFee = true;
+        public boolean ensureMinRequiredFee = Context.get().isEnsureMinRequiredFee();
 
         /**
          * If true (the default), the inputs will be signed.

--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -37,9 +37,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.bitcoinj.core.Coin.FIFTY_COINS;
-import org.bitcoinj.store.BlockStore;
-import org.bitcoinj.store.MemoryBlockStore;
-import org.bitcoinj.testing.FakeTxBuilder;
 import static org.junit.Assert.*;
 import org.junit.rules.ExpectedException;
 
@@ -60,12 +57,11 @@ public abstract class AbstractFullPrunedBlockChainTest {
     };
     protected FullPrunedBlockChain chain;
     protected FullPrunedBlockStore store;
-    protected Context context;
 
     @Before
     public void setUp() throws Exception {
         BriefLogFormatter.init();
-        context = new Context(PARAMS);
+        Context.propagate(new Context(PARAMS, 100, Coin.ZERO, false));
     }
 
     public abstract FullPrunedBlockStore createStore(NetworkParameters params, int blockCount)

--- a/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
@@ -73,11 +73,10 @@ public class BlockChainTest {
     @Before
     public void setUp() throws Exception {
         BriefLogFormatter.initVerbose();
-        Context testNetContext = new Context(testNet);
-        testNetChain = new BlockChain(testNet, new Wallet(testNetContext), new MemoryBlockStore(testNet));
-        Wallet.SendRequest.DEFAULT_FEE_PER_KB = Coin.ZERO;
-        Context context = new Context(PARAMS);
-        wallet = new Wallet(context) {
+        Context.propagate(new Context(testNet, 100, Coin.ZERO, false));
+        testNetChain = new BlockChain(testNet, new Wallet(testNet), new MemoryBlockStore(testNet));
+        Context.propagate(new Context(PARAMS, 100, Coin.ZERO, false));
+        wallet = new Wallet(PARAMS) {
             @Override
             public void receiveFromBlock(Transaction tx, StoredBlock block, BlockChain.NewBlockType blockType,
                                          int relativityOffset) throws VerificationException {
@@ -94,11 +93,6 @@ public class BlockChainTest {
         chain = new BlockChain(PARAMS, wallet, blockStore);
 
         coinbaseTo = wallet.currentReceiveKey().toAddress(PARAMS);
-    }
-
-    @After
-    public void tearDown() {
-        Wallet.SendRequest.DEFAULT_FEE_PER_KB = Transaction.REFERENCE_DEFAULT_MIN_TX_FEE;
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
@@ -59,10 +59,9 @@ public class ChainSplitTest {
     public void setUp() throws Exception {
         BriefLogFormatter.init();
         Utils.setMockClock(); // Use mock clock
-        Wallet.SendRequest.DEFAULT_FEE_PER_KB = Coin.ZERO;
-        Context context = new Context(PARAMS);
+        Context.propagate(new Context(PARAMS, 100, Coin.ZERO, false));
         MemoryBlockStore blockStore = new MemoryBlockStore(PARAMS);
-        wallet = new Wallet(context);
+        wallet = new Wallet(PARAMS);
         ECKey key1 = wallet.freshReceiveKey();
         ECKey key2 = wallet.freshReceiveKey();
         chain = new BlockChain(PARAMS, wallet, blockStore);

--- a/core/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
@@ -244,7 +244,6 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
         // Do the same thing with an offline transaction.
         peerGroup.removeWallet(wallet);
         Wallet.SendRequest req = Wallet.SendRequest.to(dest, valueOf(2, 0));
-        req.ensureMinRequiredFee = false;
         Transaction t3 = checkNotNull(wallet.sendCoinsOffline(req));
         assertNull(outbound(p1));  // Nothing sent.
         // Add the wallet to the peer group (simulate initialization). Transactions should be announced.

--- a/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelStateTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelStateTest.java
@@ -88,6 +88,7 @@ public class PaymentChannelStateTest extends TestWithWallet {
     public void setUp() throws Exception {
         Utils.setMockClock(); // Use mock clock
         super.setUp();
+        Context.propagate(new Context(PARAMS, 100, Coin.ZERO, true));
         wallet.addExtension(new StoredPaymentChannelClientStates(wallet, new TransactionBroadcaster() {
             @Override
             public TransactionBroadcast broadcastTransaction(Transaction tx) {
@@ -710,7 +711,7 @@ public class PaymentChannelStateTest extends TestWithWallet {
         } catch (ValueOutOfRangeException e) {}
 
         clientState = makeClientState(wallet, myKey, ECKey.fromPublicOnly(serverKey.getPubKey()),
-                                                    Transaction.MIN_NONDUST_OUTPUT.subtract(Coin.SATOSHI).add(Transaction.REFERENCE_DEFAULT_MIN_TX_FEE),
+                Transaction.MIN_NONDUST_OUTPUT.subtract(Coin.SATOSHI).add(Transaction.REFERENCE_DEFAULT_MIN_TX_FEE),
                 EXPIRE_TIME);
         assertEquals(PaymentChannelClientState.State.NEW, clientState.getState());
         try {

--- a/core/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
+++ b/core/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
@@ -82,9 +82,7 @@ public class TestWithNetworkConnections {
     
     public void setUp(BlockStore blockStore) throws Exception {
         BriefLogFormatter.init();
-
-        context = new Context(PARAMS);
-        Wallet.SendRequest.DEFAULT_FEE_PER_KB = Coin.ZERO;
+        Context.propagate(new Context(PARAMS, 100, Coin.ZERO, false));
         this.blockStore = blockStore;
         // Allow subclasses to override the wallet object with their own.
         if (wallet == null) {
@@ -131,7 +129,6 @@ public class TestWithNetworkConnections {
     }
 
     public void tearDown() throws Exception {
-        Wallet.SendRequest.DEFAULT_FEE_PER_KB = Transaction.REFERENCE_DEFAULT_MIN_TX_FEE;
         stopPeerServers();
     }
 

--- a/core/src/test/java/org/bitcoinj/testing/TestWithWallet.java
+++ b/core/src/test/java/org/bitcoinj/testing/TestWithWallet.java
@@ -47,8 +47,7 @@ public class TestWithWallet {
 
     public void setUp() throws Exception {
         BriefLogFormatter.init();
-        Wallet.SendRequest.DEFAULT_FEE_PER_KB = Coin.ZERO;
-        Context ctx = new Context(PARAMS);
+        Context.propagate(new Context(PARAMS, 100, Coin.ZERO, false));
         wallet = new Wallet(PARAMS);
         myKey = wallet.currentReceiveKey();
         myAddress = myKey.toAddress(PARAMS);
@@ -57,7 +56,6 @@ public class TestWithWallet {
     }
 
     public void tearDown() throws Exception {
-        Wallet.SendRequest.DEFAULT_FEE_PER_KB = Transaction.REFERENCE_DEFAULT_MIN_TX_FEE;
     }
 
     @Nullable

--- a/examples/src/main/java/org/bitcoinj/examples/ExamplePaymentChannelClient.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ExamplePaymentChannelClient.java
@@ -198,7 +198,7 @@ public class ExamplePaymentChannelClient {
 
     private void waitForSufficientBalance(Coin amount) {
         // Not enough money in the wallet.
-        Coin amountPlusFee = amount.add(Wallet.SendRequest.DEFAULT_FEE_PER_KB);
+        Coin amountPlusFee = amount.add(Transaction.REFERENCE_DEFAULT_MIN_TX_FEE);
         // ESTIMATED because we don't really need to wait for confirmation.
         ListenableFuture<Coin> balanceFuture = appKit.wallet().getBalanceFuture(amountPlusFee, Wallet.BalanceType.ESTIMATED);
         if (!balanceFuture.isDone()) {


### PR DESCRIPTION
If you have been reading that field, you probably want to use Transaction.REFERENCE_DEFAULT_MIN_TX_FEE.
If you have been writing to that field to change the SendRequest.feePerKb default, use a Context.feePerKb
instead. There is also a new Context.ensureMinRequiredFee.