### PR TITLE
fix incorrect log message in setLockTime

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -1048,7 +1048,7 @@ public class Transaction extends ChildMessage {
                 break;
             }
         }
-        if (!seqNumSet || inputs.isEmpty()) {
+        if ((0L != lockTime) && (!seqNumSet || inputs.isEmpty())) {
             // At least one input must have a non-default sequence number for lock times to have any effect.
             // For instance one of them can be set to zero to make this feature work.
             log.warn("You are setting the lock time on a transaction but none of the inputs have non-default sequence numbers. This will not do what you expect!");


### PR DESCRIPTION
I received this log message when setting a lock time to zero on a transaction. It was mostly just annoying since the setter still worked.
The message is incorrect when attempting to set a lock time of zero because a lock time of zero makes a transaction final in the same way that all sequence numbers being final would also do if the lock time was not zero.

This is the consensus code from Core that shows what I'm talking about:
```
bool IsFinalTx(const CTransaction &tx, int nBlockHeight, int64_t nBlockTime)
{
    if (tx.nLockTime == 0)
        return true;
    if ((int64_t)tx.nLockTime < ((int64_t)tx.nLockTime < LOCKTIME_THRESHOLD ? (int64_t)nBlockHeight : nBlockTime))
        return true;
    BOOST_FOREACH(const CTxIn& txin, tx.vin) {
        if (!(txin.nSequence == CTxIn::SEQUENCE_FINAL))
            return false;
    }
    return true;
}
```