### PR TITLE
complete SigHash enum and make updates to stop using ordinal

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ECKeyTest.java
@@ -447,7 +447,7 @@ public class ECKeyTest {
         new Random().nextBytes(hash);
         byte[] sigBytes = key.sign(Sha256Hash.wrap(hash)).encodeToDER();
         byte[] encodedSig = Arrays.copyOf(sigBytes, sigBytes.length + 1);
-        encodedSig[sigBytes.length] = (byte) (Transaction.SigHash.ALL.ordinal() + 1);
+        encodedSig[sigBytes.length] = Transaction.SigHash.ALL.byteValue();
         if (!TransactionSignature.isEncodingCanonical(encodedSig)) {
             log.error(Utils.HEX.encode(sigBytes));
             fail();

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -759,7 +759,7 @@ public class FullBlockTestGenerator {
                     try {
                         ByteArrayOutputStream bos = new UnsafeByteArrayOutputStream(73);
                         bos.write(coinbaseOutKey.sign(hash).encodeToDER());
-                        bos.write(SigHash.SINGLE.ordinal() + 1);
+                        bos.write(SigHash.SINGLE.value);
                         byte[] signature = bos.toByteArray();
 
                         ByteArrayOutputStream scriptSigBos = new UnsafeByteArrayOutputStream(signature.length + b39p2shScriptPubKey.length + 3);
@@ -830,7 +830,7 @@ public class FullBlockTestGenerator {
                             ByteArrayOutputStream bos = new UnsafeByteArrayOutputStream(
                                     73);
                             bos.write(coinbaseOutKey.sign(hash).encodeToDER());
-                            bos.write(SigHash.SINGLE.ordinal() + 1);
+                            bos.write(SigHash.SINGLE.value);
                             byte[] signature = bos.toByteArray();
 
                             ByteArrayOutputStream scriptSigBos = new UnsafeByteArrayOutputStream(

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -392,14 +392,14 @@ public class TransactionTest {
 
         final Transaction tx = block1.getTransactions().get(1);
         final String txHash = tx.getHashAsString();
-        final String txNormalizedHash = tx.hashForSignature(0, new byte[0], (byte) (Transaction.SigHash.ALL.ordinal() + 1)).toString();
+        final String txNormalizedHash = tx.hashForSignature(0, new byte[0], Transaction.SigHash.ALL.byteValue()).toString();
 
         for (int i = 0; i < 100; i++) {
             // ensure the transaction object itself was not modified; if it was, the hash will change
             assertEquals(txHash, tx.getHashAsString());
             new Thread(){
                 public void run() {
-                    assertEquals(txNormalizedHash, tx.hashForSignature(0, new byte[0], (byte) (Transaction.SigHash.ALL.ordinal() + 1)).toString());
+                    assertEquals(txNormalizedHash, tx.hashForSignature(0, new byte[0], Transaction.SigHash.ALL.byteValue()).toString());
                 }
             };
         }

--- a/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelStateTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelStateTest.java
@@ -513,7 +513,7 @@ public class PaymentChannelStateTest extends TestWithWallet {
             assertEquals(PaymentChannelServerState.State.WAITING_FOR_MULTISIG_CONTRACT, serverState.getState());
 
             byte[] refundSigCopy = Arrays.copyOf(refundSig, refundSig.length);
-            refundSigCopy[refundSigCopy.length - 1] = (byte) (Transaction.SigHash.NONE.ordinal() + 1);
+            refundSigCopy[refundSigCopy.length - 1] = Transaction.SigHash.NONE.byteValue();
             try {
                 clientV1State().provideRefundSignature(refundSigCopy, null);
                 fail();
@@ -627,7 +627,7 @@ public class PaymentChannelStateTest extends TestWithWallet {
         totalPayment = totalPayment.add(size);
 
         byte[] signatureCopy = Arrays.copyOf(signature, signature.length);
-        signatureCopy[signatureCopy.length - 1] = (byte) ((Transaction.SigHash.NONE.ordinal() + 1) | 0x80);
+        signatureCopy[signatureCopy.length - 1] = Transaction.SigHash.ANYONECANPAY_NONE.byteValue();
         try {
             serverState.incrementPayment(halfCoin.subtract(totalPayment), signatureCopy);
             fail();
@@ -659,7 +659,7 @@ public class PaymentChannelStateTest extends TestWithWallet {
         assertEquals(totalPayment, halfCoin);
 
         signatureCopy = Arrays.copyOf(signature, signature.length);
-        signatureCopy[signatureCopy.length - 1] = (byte) ((Transaction.SigHash.SINGLE.ordinal() + 1) | 0x80);
+        signatureCopy[signatureCopy.length - 1] = Transaction.SigHash.ANYONECANPAY_SINGLE.byteValue();
         try {
             serverState.incrementPayment(halfCoin.subtract(totalPayment), signatureCopy);
             fail();


### PR DESCRIPTION
Complete the SigHash enum and make updates to stop using the enum's ordinal while preserving the original ordinal value for any existing code that might use it.

In my own code, I found that I was using an enum defined like below. The changes in this PR, deviate slightly from my original code in order to preserve the ordinal values of the original bitcoinj enum should any external code depend on it still. All in all, I think these changes make the SigHash enum more complete and make the code a little easier to read (less brittle with the removal of the ordinal dependency in the core code) with fewer casts. Let me know if I missed something, but I think my references checks were pretty complete and all the bitcoinj projects still compile and pass tests.

```
public enum Sighash {
  UNSET(0), ALL(1), NONE(2), SINGLE(3), ANYONECANPAY(0x80), ANYONECANPAY_ALL(0x81), ANYONECANPAY_NONE(0x82), ANYONECANPAY_SINGLE(0x83);
  private final int type;

  /**
   * @param type
   */
  private Sighash(final int type) {
    this.type = type;
  }

  /**
   * @return the type as a byte
   */
  public byte byteValue() {
    return (byte) this.type;
  }

  /**
   * @return the type
   */
  public int intValue() {
    return this.type;
  }
}
```