### PR TITLE
Fix Integer overflow in BitcoinSerializer.BitcoinPacketHeader

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
@@ -367,7 +367,7 @@ public class BitcoinSerializer extends MessageSerializer {
             size = (int) readUint32(header, cursor);
             cursor += 4;
 
-            if (size > Message.MAX_SIZE)
+            if (size > Message.MAX_SIZE || size < 0)
                 throw new ProtocolException("Message size too large: " + size);
 
             // Old clients don't send the checksum.


### PR DESCRIPTION
Casting readUint32(...) to int could result in negative size. Causes crash at BitcoinSerializer.java:164