### PR TITLE
revisit payment channel time locked transaction sequence numbers

### DIFF
--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelV1ClientState.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelV1ClientState.java
@@ -151,7 +151,9 @@ public class PaymentChannelV1ClientState extends PaymentChannelClientState {
         // in future as it breaks the intended design of timelocking/tx replacement, but for now it simplifies this
         // specific protocol somewhat.
         refundTx = new Transaction(params);
-        refundTx.addInput(multisigOutput).setSequenceNumber(0);   // Allow replacement when it's eventually reactivated.
+        // don't disable lock time. the sequence will be included in the server's signature and thus won't be changeable.
+        // by using this sequence value, we avoid extra full replace-by-fee and relative lock time processing.
+        refundTx.addInput(multisigOutput).setSequenceNumber(TransactionInput.NO_SEQUENCE - 1L);
         refundTx.setLockTime(expiryTime);
         if (totalValue.compareTo(Coin.CENT) < 0 && Context.get().isEnsureMinRequiredFee()) {
             // Must pay min fee.

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelV1ServerState.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelV1ServerState.java
@@ -125,9 +125,9 @@ public class PaymentChannelV1ServerState extends PaymentChannelServerState {
         // Verify that the refund transaction has a single input (that we can fill to sign the multisig output).
         if (refundTx.getInputs().size() != 1)
             throw new VerificationException("Refund transaction does not have exactly one input");
-        // Verify that the refund transaction has a time lock on it and a sequence number of zero.
-        if (refundTx.getInput(0).getSequenceNumber() != 0)
-            throw new VerificationException("Refund transaction's input's sequence number is non-0");
+        // Verify that the refund transaction has a time lock on it and a sequence number that does not disable lock time.
+        if (refundTx.getInput(0).getSequenceNumber() == TransactionInput.NO_SEQUENCE)
+            throw new VerificationException("Refund transaction's input's sequence number disables lock time");
         if (refundTx.getLockTime() < minExpireTime)
             throw new VerificationException("Refund transaction has a lock time too soon");
         // Verify the transaction has one output (we don't care about its contents, its up to the client)


### PR DESCRIPTION
This is not urgent. But, after considering BIP 125 and BIP 68, I thought that the sequence numbers of the time locked payment channel transactions could use some revisiting.

For v1 channels, the refund sequence number was being set to zero. As more nodes upgrade to Core 0.12 and later, that changes the semantics of the replace-ability being signaled. Also, since the sequence is covered by the server's signature, I don't see needing to increment the sequence number being desirable or even practical. Really, all that the sequence number needs to be is non-final, so that the lock time is not disabled. Also, by not using zero, when BIP 68 goes into effect, these transactions will not require as much processing (bit 31 is set to 1). If full RBF signaling is desired, then an alternative to `TransactionInput.NO_SEQUENCE - 1L` would be `0x80000000` or, maybe better `TransactionInput.NO_SEQUENCE - 2L`. Both ways will avoid the unnecessary BIP 68 input age processing.

For v2 channels, most of what I said for v1 channels applies, except that the server does not have to sign the refund transaction and thus the client could change the sequence number if there was a need to (but I don't see a need to). Full RBF does not consider a higher sequence number, just whether it pays a sufficiently higher fee.

Let me know what you think. It'll still work if these are not changed. But changing them I think is a little more efficient and aligns better with BIP 125's statements about client support.

https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki - Relative lock-time using consensus-enforced sequence numbers

https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki - Opt-in Full Replace-by-Fee Signaling