### PR TITLE
Added PaymentChannelServer encrypted wallet support

### DIFF
--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerListener.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerListener.java
@@ -28,6 +28,7 @@ import org.bitcoinj.wallet.Wallet;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
 import org.bitcoin.paymentchannel.Protos;
+import org.spongycastle.crypto.params.KeyParameter;
 
 import javax.annotation.Nullable;
 
@@ -87,6 +88,12 @@ public class PaymentChannelServerListener {
 
                 @Override public ListenableFuture<ByteString> paymentIncrease(Coin by, Coin to, @Nullable ByteString info) {
                     return eventHandler.paymentIncrease(by, to, info);
+                }
+
+                @Nullable
+                @Override
+                public ListenableFuture<KeyParameter> getUserKey() {
+                    return null;
                 }
             });
 

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerState.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerState.java
@@ -30,6 +30,7 @@ import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.script.Script;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.spongycastle.crypto.params.KeyParameter;
 
 import javax.annotation.Nullable;
 
@@ -300,7 +301,20 @@ public abstract class PaymentChannelServerState {
      *         will never complete, a timeout should be used.
      * @throws InsufficientMoneyException If the payment tx would have cost more in fees to spend than it is worth.
      */
-    public abstract ListenableFuture<Transaction> close() throws InsufficientMoneyException;
+    public ListenableFuture<Transaction> close() throws InsufficientMoneyException {
+        return close(null);
+    }
+
+    /**
+     * <p>Closes this channel and broadcasts the highest value payment transaction on the network.</p>
+     *
+     * @param userKey The AES key to use for decryption of the private key. If null then no decryption is required.
+     * @return a future which completes when the provided multisig contract successfully broadcasts, or throws if the
+     *         broadcast fails for some reason. Note that if the network simply rejects the transaction, this future
+     *         will never complete, a timeout should be used.
+     * @throws InsufficientMoneyException If the payment tx would have cost more in fees to spend than it is worth.
+     */
+    public abstract ListenableFuture<Transaction> close(@Nullable KeyParameter userKey) throws InsufficientMoneyException;
 
     /**
      * Gets the highest payment to ourselves (which we will receive on settle(), not including fees)

--- a/core/src/test/java/org/bitcoinj/protocols/channels/ChannelTestUtils.java
+++ b/core/src/test/java/org/bitcoinj/protocols/channels/ChannelTestUtils.java
@@ -24,6 +24,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
 import org.bitcoin.paymentchannel.Protos;
+import org.spongycastle.crypto.params.KeyParameter;
 
 import javax.annotation.Nullable;
 import java.util.concurrent.BlockingQueue;
@@ -57,6 +58,12 @@ public class ChannelTestUtils {
         public ListenableFuture<ByteString> paymentIncrease(Coin by, Coin to, @Nullable ByteString info) {
             q.add(new UpdatePair(to, info));
             return Futures.immediateFuture(ByteString.copyFromUtf8(by.toPlainString()));
+        }
+
+        @Nullable
+        @Override
+        public ListenableFuture<KeyParameter> getUserKey() {
+            return null;
         }
 
         public Protos.TwoWayChannelMessage getNextMsg() throws InterruptedException {


### PR DESCRIPTION
I added support for encrypted wallets to `PaymentChannelServer`. In its current form this results in a breaking API change, namely the addition of `PaymentChannelServer.ServerConnection.getUserKey()`.