### PR TITLE
Allow to specify buffer size for saving wallet file via OutputStream

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -131,10 +131,7 @@ public class WalletProtobufSerializer {
      */
     public void writeWallet(Wallet wallet, OutputStream output) throws IOException {
         Protos.Wallet walletProto = walletToProto(wallet);
-
-        int serializedSize = walletProto.getSerializedSize();
-        int bufferSize = serializedSize > this.walletWriteBufferSize ? this.walletWriteBufferSize : serializedSize;
-        final CodedOutputStream codedOutput = CodedOutputStream.newInstance(output, bufferSize);
+        final CodedOutputStream codedOutput = CodedOutputStream.newInstance(output, this.walletWriteBufferSize);
         walletProto.writeTo(codedOutput);
         codedOutput.flush();
     }

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -31,6 +31,7 @@ import org.bitcoinj.wallet.Protos.Wallet.EncryptionType;
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.CodedOutputStream;
 import com.google.protobuf.TextFormat;
 import com.google.protobuf.WireFormat;
 
@@ -120,8 +121,17 @@ public class WalletProtobufSerializer {
      * Equivalent to <tt>walletToProto(wallet).writeTo(output);</tt>
      */
     public void writeWallet(Wallet wallet, OutputStream output) throws IOException {
+        this.writeWallet(wallet, output, CodedOutputStream.DEFAULT_BUFFER_SIZE);
+    }
+
+    public void writeWallet(Wallet wallet, OutputStream output, int bufferSize) throws IOException {
         Protos.Wallet walletProto = walletToProto(wallet);
-        walletProto.writeTo(output);
+
+        int serializedSize = walletProto.getSerializedSize();
+        bufferSize = serializedSize > bufferSize ? bufferSize : serializedSize;
+        final CodedOutputStream codedOutput = CodedOutputStream.newInstance(output, bufferSize);
+        walletProto.writeTo(codedOutput);
+        codedOutput.flush();
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -79,6 +79,7 @@ public class WalletProtobufSerializer {
     protected Map<ByteString, Transaction> txMap;
 
     private boolean requireMandatoryExtensions = true;
+    private int walletWriteBufferSize = CodedOutputStream.DEFAULT_BUFFER_SIZE;
 
     public interface WalletFactory {
         Wallet create(NetworkParameters params, KeyChainGroup keyChainGroup);
@@ -115,20 +116,24 @@ public class WalletProtobufSerializer {
         requireMandatoryExtensions = value;
     }
 
+	/**
+     * Change buffer size for writing wallet to output stream. Default is {@link com.google.protobuf.CodedOutputStream.DEFAULT_BUFFER_SIZE}
+     * @param walletWriteBufferSize - buffer size in bytes
+     */
+    public void setWalletWriteBufferSize(int walletWriteBufferSize) {
+        this.walletWriteBufferSize = walletWriteBufferSize;
+    }
+
     /**
      * Formats the given wallet (transactions and keys) to the given output stream in protocol buffer format.<p>
      *
      * Equivalent to <tt>walletToProto(wallet).writeTo(output);</tt>
      */
     public void writeWallet(Wallet wallet, OutputStream output) throws IOException {
-        this.writeWallet(wallet, output, CodedOutputStream.DEFAULT_BUFFER_SIZE);
-    }
-
-    public void writeWallet(Wallet wallet, OutputStream output, int bufferSize) throws IOException {
         Protos.Wallet walletProto = walletToProto(wallet);
 
         int serializedSize = walletProto.getSerializedSize();
-        bufferSize = serializedSize > bufferSize ? bufferSize : serializedSize;
+        int bufferSize = serializedSize > this.walletWriteBufferSize ? this.walletWriteBufferSize : serializedSize;
         final CodedOutputStream codedOutput = CodedOutputStream.newInstance(output, bufferSize);
         walletProto.writeTo(codedOutput);
         codedOutput.flush();


### PR DESCRIPTION
Now it's possible to specify system dependent output buffer size for better IO performance writing wallet to disk.

```java
public class MyWallet extends Wallet {

	public static final int WALLET_IO_BUFFER_SIZE = 512 * 1024; // 512KB

	// ...

	@Override
	public void saveToFileStream(OutputStream f) throws IOException {
		lock.lock();
		try {
			new WalletProtobufSerializer().writeWallet(this, f, WALLET_IO_BUFFER_SIZE);
		} finally {
			lock.unlock();
		}
	}
}
```