### PR TITLE
Payment channels: ClientChannelProperties ServerChannelProperties

### DIFF
--- a/core/src/main/java/org/bitcoinj/protocols/channels/IPaymentChannelClient.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/IPaymentChannelClient.java
@@ -23,6 +23,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 
 import com.google.protobuf.ByteString;
 import org.bitcoin.paymentchannel.Protos;
+import org.bitcoinj.wallet.SendRequest;
 import org.spongycastle.crypto.params.KeyParameter;
 
 import javax.annotation.Nullable;
@@ -145,6 +146,41 @@ public interface IPaymentChannelClient {
          * @param wasInitiated If true, the channel is newly opened. If false, it was resumed.
          */
         void channelOpen(boolean wasInitiated);
+    }
+
+    /**
+     * Set Client payment channel properties.
+     */
+    interface ClientChannelProperties {
+        /**
+         * Modify the sendRequest used for the contract.
+         * @param sendRequest the current sendRequest.
+         * @return the modified sendRequest.
+         */
+        SendRequest modifyContractSendRequest(SendRequest sendRequest);
+
+        /**
+         *  The maximum acceptable min payment. If the server suggests a higher amount
+         *  the channel creation will be aborted.
+         */
+        Coin acceptableMinPayment();
+
+        /**
+         *  The time in seconds, relative to now, on how long this channel should be kept open. Note that is is
+         *  a proposal to the server. The server may in turn propose something different.
+         *  See {@link org.bitcoinj.protocols.channels.IPaymentChannelClient.ClientConnection#acceptExpireTime(long)}
+         *
+         */
+        long timeWindow();
+
+        /**
+         * An enum indicating which versions to support:
+         * VERSION_1: use only version 1 of the protocol
+         * VERSION_2_ALLOW_1: suggest version 2 but allow downgrade to version 1
+         * VERSION_2: suggest version 2 and enforce use of version 2
+         *
+         */
+        PaymentChannelClient.VersionSelector versionSelector();
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClientConnection.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClientConnection.java
@@ -23,6 +23,7 @@ import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.Utils;
 import org.bitcoinj.net.NioClient;
 import org.bitcoinj.net.ProtobufConnection;
+import org.bitcoinj.protocols.channels.IPaymentChannelClient.ClientChannelProperties;
 import org.bitcoinj.wallet.Wallet;
 
 import com.google.common.util.concurrent.ListenableFuture;
@@ -68,44 +69,14 @@ public class PaymentChannelClientConnection {
      */
     public PaymentChannelClientConnection(InetSocketAddress server, int timeoutSeconds, Wallet wallet, ECKey myKey,
                                           Coin maxValue, String serverId) throws IOException, ValueOutOfRangeException {
-        this(server, timeoutSeconds, wallet, myKey, maxValue, serverId,
-                PaymentChannelClient.VersionSelector.VERSION_2_ALLOW_1);
+        this(server, timeoutSeconds, wallet, myKey, maxValue, serverId, null);
     }
 
     /**
      * Attempts to open a new connection to and open a payment channel with the given host and port, blocking until the
-     * connection is open. The server is requested to keep the channel open for
-     * {@link org.bitcoinj.protocols.channels.PaymentChannelClient#DEFAULT_TIME_WINDOW}
-     * seconds. If the server proposes a longer time the channel will be closed.
-     *
-     * @param server          The host/port pair where the server is listening.
-     * @param timeoutSeconds  The connection timeout and read timeout during initialization. This should be large enough
-     *                        to accommodate ECDSA signature operations and network latency.
-     * @param wallet          The wallet which will be paid from, and where completed transactions will be committed.
-     *                        Must be unencrypted. Must already have a {@link StoredPaymentChannelClientStates} object in its extensions set.
-     * @param myKey           A freshly generated keypair used for the multisig contract and refund output.
-     * @param maxValue        The maximum value this channel is allowed to request
-     * @param serverId        A unique ID which is used to attempt reopening of an existing channel.
-     *                        This must be unique to the server, and, if your application is exposing payment channels to some
-     *                        API, this should also probably encompass some caller UID to avoid applications opening channels
-     *                        which were created by others.
-     * @param versionSelector An enum indicating which versions to support:
-     *                        VERSION_1: use only version 1 of the protocol
-     *                        VERSION_2_ALLOW_1: suggest version 2 but allow downgrade to version 1
-     *                        VERSION_2: suggest version 2 and enforce use of version 2
-     * @throws IOException              if there's an issue using the network.
-     * @throws ValueOutOfRangeException if the balance of wallet is lower than maxValue.
-     */
-    public PaymentChannelClientConnection(InetSocketAddress server, int timeoutSeconds, Wallet wallet, ECKey myKey,
-                                          Coin maxValue, String serverId, PaymentChannelClient.VersionSelector versionSelector) throws IOException, ValueOutOfRangeException {
-        this(server, timeoutSeconds, wallet, myKey, maxValue, serverId,
-                PaymentChannelClient.DEFAULT_TIME_WINDOW, null, versionSelector);
-    }
-
-    /**
-     * Attempts to open a new connection to and open a payment channel with the given host and port, blocking until the
-     * connection is open.  The server is requested to keep the channel open for {@param timeWindow}
-     * seconds. If the server proposes a longer time the channel will be closed.
+     * connection is open.  The server is requested to keep the channel open for
+     * {@link org.bitcoinj.protocols.channels.PaymentChannelClient#DEFAULT_TIME_WINDOW} seconds.
+     * If the server proposes a longer time the channel will be closed.
      *
      * @param server          The host/port pair where the server is listening.
      * @param timeoutSeconds  The connection timeout and read timeout during initialization. This should be large enough
@@ -119,16 +90,13 @@ public class PaymentChannelClientConnection {
      *                        This must be unique to the server, and, if your application is exposing payment channels to some
      *                        API, this should also probably encompass some caller UID to avoid applications opening channels
      *                        which were created by others.
-     * @param timeWindow      The time in seconds, relative to now, on how long this channel should be kept open.
      * @param userKeySetup    Key derived from a user password, used to decrypt myKey, if it is encrypted, during setup.
      * @throws IOException              if there's an issue using the network.
      * @throws ValueOutOfRangeException if the balance of wallet is lower than maxValue.
      */
     public PaymentChannelClientConnection(InetSocketAddress server, int timeoutSeconds, Wallet wallet, ECKey myKey,
-                                          Coin maxValue, String serverId, final long timeWindow,
-                                          @Nullable KeyParameter userKeySetup) throws IOException, ValueOutOfRangeException {
-        this(server, timeoutSeconds, wallet, myKey, maxValue, serverId,
-                timeWindow, userKeySetup, PaymentChannelClient.VersionSelector.VERSION_2_ALLOW_1);
+                                          Coin maxValue, String serverId, @Nullable KeyParameter userKeySetup) throws IOException, ValueOutOfRangeException {
+        this(server, timeoutSeconds, wallet, myKey, maxValue, serverId, userKeySetup, PaymentChannelClient.defaultChannelProperties);
     }
 
 
@@ -149,24 +117,20 @@ public class PaymentChannelClientConnection {
      *                 This must be unique to the server, and, if your application is exposing payment channels to some
      *                 API, this should also probably encompass some caller UID to avoid applications opening channels
      *                 which were created by others.
-     * @param timeWindow The time in seconds, relative to now, on how long this channel should be kept open.
      * @param userKeySetup Key derived from a user password, used to decrypt myKey, if it is encrypted, during setup.
-     * @param versionSelector An enum indicating which versions to support:
-     *                        VERSION_1: use only version 1 of the protocol
-     *                        VERSION_2_ALLOW_1: suggest version 2 but allow downgrade to version 1
-     *                        VERSION_2: suggest version 2 and enforce use of version 2
+     * @param clientChannelProperties Modifier to change the channel's configuration.
      *
      * @throws IOException if there's an issue using the network.
      * @throws ValueOutOfRangeException if the balance of wallet is lower than maxValue.
      */
     public PaymentChannelClientConnection(InetSocketAddress server, int timeoutSeconds, Wallet wallet, ECKey myKey,
-                                          Coin maxValue, String serverId, final long timeWindow,
-                                          @Nullable KeyParameter userKeySetup, PaymentChannelClient.VersionSelector versionSelector)
+                                          Coin maxValue, String serverId,
+                                          @Nullable KeyParameter userKeySetup, final ClientChannelProperties clientChannelProperties)
             throws IOException, ValueOutOfRangeException {
         // Glue the object which vends/ingests protobuf messages in order to manage state to the network object which
         // reads/writes them to the wire in length prefixed form.
-        channelClient = new PaymentChannelClient(wallet, myKey, maxValue, Sha256Hash.of(serverId.getBytes()), timeWindow,
-                userKeySetup, new PaymentChannelClient.ClientConnection() {
+        channelClient = new PaymentChannelClient(wallet, myKey, maxValue, Sha256Hash.of(serverId.getBytes()),
+                userKeySetup, clientChannelProperties, new PaymentChannelClient.ClientConnection() {
             @Override
             public void sendToServer(Protos.TwoWayChannelMessage msg) {
                 wireParser.write(msg);
@@ -180,7 +144,7 @@ public class PaymentChannelClientConnection {
 
             @Override
             public boolean acceptExpireTime(long expireTime) {
-                return expireTime <= (timeWindow + Utils.currentTimeSeconds() + 60);  // One extra minute to compensate for time skew and latency
+                return expireTime <= (clientChannelProperties.timeWindow() + Utils.currentTimeSeconds() + 60);  // One extra minute to compensate for time skew and latency
             }
 
             @Override
@@ -189,7 +153,7 @@ public class PaymentChannelClientConnection {
                 // Inform the API user that we're done and ready to roll.
                 channelOpenFuture.set(PaymentChannelClientConnection.this);
             }
-        }, versionSelector);
+        });
 
         // And glue back in the opposite direction - network to the channelClient.
         wireParser = new ProtobufConnection<Protos.TwoWayChannelMessage>(new ProtobufConnection.Listener<Protos.TwoWayChannelMessage>() {

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServer.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServer.java
@@ -129,6 +129,25 @@ public class PaymentChannelServer {
     }
     private final ServerConnection conn;
 
+    public interface ServerChannelProperties {
+        /**
+         * The size of the payment that the client is requested to pay in the initiate phase.
+         */
+        Coin getMinPayment();
+
+        /**
+         * The maximum allowed channel time window in seconds.
+         * Note that the server need to be online for the whole time the channel is open.
+         * Failure to do this could cause loss of all payments received on the channel.
+         */
+        long getMaxTimeWindow();
+
+        /**
+         * The minimum allowed channel time window in seconds, must be larger than 7200.
+         */
+        long getMinTimeWindow();
+    }
+
     // Used to track the negotiated version number
     @GuardedBy("lock") private int majorVersion;
 
@@ -143,6 +162,10 @@ public class PaymentChannelServer {
 
     // The key used for multisig in this channel
     @GuardedBy("lock") private ECKey myKey;
+
+    // The fee server charges for managing (and settling the channel).
+    // This is will be requested in the setup via the min_payment field in the initiate message.
+    private final Coin minPayment;
 
     // The minimum accepted channel value
     private final Coin minAcceptedChannelSize;
@@ -187,7 +210,7 @@ public class PaymentChannelServer {
      */
     public PaymentChannelServer(TransactionBroadcaster broadcaster, Wallet wallet,
                                 Coin minAcceptedChannelSize, ServerConnection conn) {
-        this(broadcaster, wallet, minAcceptedChannelSize, DEFAULT_MIN_TIME_WINDOW, DEFAULT_MAX_TIME_WINDOW, conn);
+        this(broadcaster, wallet, minAcceptedChannelSize, new DefaultServerChannelProperties(), conn);
     }
 
     /**
@@ -201,22 +224,21 @@ public class PaymentChannelServer {
      *                               and may cause fees to be require to settle the channel. A reasonable value depends
      *                               entirely on the expected maximum for the channel, and should likely be somewhere
      *                               between a few bitcents and a bitcoin.
-     * @param minTimeWindow The minimum allowed channel time window in seconds, must be larger than 7200.
-     * @param maxTimeWindow The maximum allowed channel time window in seconds. Note that the server need to be online for the whole time the channel is open.
-     *                              Failure to do this could cause loss of all payments received on the channel.
+     * @param serverChannelProperties Modify the channel's properties. You may extend {@link DefaultServerChannelProperties}
      * @param conn A callback listener which represents the connection to the client (forwards messages we generate to
      *              the client and will close the connection on request)
      */
     public PaymentChannelServer(TransactionBroadcaster broadcaster, Wallet wallet,
-                                Coin minAcceptedChannelSize, long minTimeWindow, long maxTimeWindow, ServerConnection conn) {
+                                Coin minAcceptedChannelSize, ServerChannelProperties serverChannelProperties, ServerConnection conn) {
+        minTimeWindow = serverChannelProperties.getMinTimeWindow();
+        maxTimeWindow = serverChannelProperties.getMaxTimeWindow();
         if (minTimeWindow > maxTimeWindow) throw new IllegalArgumentException("minTimeWindow must be less or equal to maxTimeWindow");
         if (minTimeWindow < HARD_MIN_TIME_WINDOW) throw new IllegalArgumentException("minTimeWindow must be larger than" + HARD_MIN_TIME_WINDOW  + " seconds");
         this.broadcaster = checkNotNull(broadcaster);
         this.wallet = checkNotNull(wallet);
+        this.minPayment = checkNotNull(serverChannelProperties.getMinPayment());
         this.minAcceptedChannelSize = checkNotNull(minAcceptedChannelSize);
         this.conn = checkNotNull(conn);
-        this.minTimeWindow = minTimeWindow;
-        this.maxTimeWindow = maxTimeWindow;
     }
 
     /**
@@ -299,7 +321,7 @@ public class PaymentChannelServer {
                 .setMultisigKey(ByteString.copyFrom(myKey.getPubKey()))
                 .setExpireTimeSecs(expireTime)
                 .setMinAcceptedChannelSize(minAcceptedChannelSize.value)
-                .setMinPayment(Transaction.REFERENCE_DEFAULT_MIN_TX_FEE.value);
+                .setMinPayment(minPayment.value);
 
         conn.sendToClient(Protos.TwoWayChannelMessage.newBuilder()
                 .setInitiate(initiateBuilder)
@@ -634,4 +656,27 @@ public class PaymentChannelServer {
             lock.unlock();
         }
     }
+
+    /**
+     * Extend this class and override the values you want to change.
+     */
+    public static class DefaultServerChannelProperties implements ServerChannelProperties {
+
+        @Override
+        public Coin getMinPayment() {
+            return Transaction.REFERENCE_DEFAULT_MIN_TX_FEE;
+        }
+
+        @Override
+        public long getMaxTimeWindow() {
+            return DEFAULT_MAX_TIME_WINDOW;
+        }
+
+        @Override
+        public long getMinTimeWindow() {
+            return DEFAULT_MIN_TIME_WINDOW;
+        }
+
+    }
+
 }

--- a/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelServerTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelServerTest.java
@@ -92,7 +92,16 @@ public class PaymentChannelServerTest {
         connection.sendToClient(capture(initiateCapture));
 
         replay(connection);
-        dut = new PaymentChannelServer(broadcaster, wallet, Coin.CENT, minTimeWindow, 40000, connection);
+        dut = new PaymentChannelServer(broadcaster, wallet, Coin.CENT, new PaymentChannelServer.DefaultServerChannelProperties() {
+            @Override
+            public long getMinTimeWindow() {
+                return minTimeWindow;
+            }
+            @Override
+            public long getMaxTimeWindow() {
+                return 40000;
+            }
+        }, connection);
 
         dut.connectionOpen();
         dut.receiveMessage(message);
@@ -111,7 +120,14 @@ public class PaymentChannelServerTest {
         connection.sendToClient(capture(initiateCapture));
         replay(connection);
 
-        dut = new PaymentChannelServer(broadcaster, wallet, Coin.CENT, 20000, maxTimeWindow, connection);
+        dut = new PaymentChannelServer(broadcaster, wallet, Coin.CENT, new PaymentChannelServer.DefaultServerChannelProperties(){
+            @Override
+            public long getMaxTimeWindow() {
+                return maxTimeWindow;
+            }
+            @Override
+            public long getMinTimeWindow() { return 20000; }
+        }, connection);
 
         dut.connectionOpen();
         dut.receiveMessage(message);
@@ -123,12 +139,24 @@ public class PaymentChannelServerTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldNotAllowTimeWindowLessThan2h() {
-        dut = new PaymentChannelServer(broadcaster, wallet, Coin.CENT, 7199, 40000, connection);
+        dut = new PaymentChannelServer(broadcaster, wallet, Coin.CENT, new PaymentChannelServer.DefaultServerChannelProperties(){
+            @Override
+            public long getMaxTimeWindow() { return 40000; }
+            @Override
+            public long getMinTimeWindow() {
+                return 7199;
+            }
+        }, connection);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldNotAllowNegativeTimeWindow() {
-        dut = new PaymentChannelServer(broadcaster, wallet, Coin.CENT, 40001, 40000, connection);
+        dut = new PaymentChannelServer(broadcaster, wallet, Coin.CENT, new PaymentChannelServer.DefaultServerChannelProperties(){
+            @Override
+            public long getMaxTimeWindow() { return 40000; }
+            @Override
+            public long getMinTimeWindow() { return 40001; }
+        }, connection);
     }
 
     @Test
@@ -139,7 +167,12 @@ public class PaymentChannelServerTest {
         replay(connection);
         final int expire = 24 * 60 * 60 - 60;  // This the default defined in paymentchannel.proto
 
-        dut = new PaymentChannelServer(broadcaster, wallet, Coin.CENT, expire, expire, connection);
+        dut = new PaymentChannelServer(broadcaster, wallet, Coin.CENT, new PaymentChannelServer.DefaultServerChannelProperties(){
+            @Override
+            public long getMaxTimeWindow() { return expire; }
+            @Override
+            public long getMinTimeWindow() { return expire; }
+        }, connection);
         dut.connectionOpen();
         long expectedExpire = Utils.currentTimeSeconds() + expire;
         dut.receiveMessage(message);

--- a/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelStateTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelStateTest.java
@@ -817,25 +817,21 @@ public class PaymentChannelStateTest extends TestWithWallet {
 
         switch (versionSelector) {
             case VERSION_1:
-                clientState = new PaymentChannelV1ClientState(wallet, myKey, ECKey.fromPublicOnly(serverKey.getPubKey()), CENT, EXPIRE_TIME) {
-                    @Override
-                    protected void editContractSendRequest(SendRequest req) {
-                        req.coinSelector = wallet.getCoinSelector();
-                    }
-                };
+                clientState = new PaymentChannelV1ClientState(wallet, myKey, ECKey.fromPublicOnly(serverKey.getPubKey()), CENT, EXPIRE_TIME) ;
                 break;
             case VERSION_2_ALLOW_1:
             case VERSION_2:
-                clientState = new PaymentChannelV2ClientState(wallet, myKey, ECKey.fromPublicOnly(serverKey.getPubKey()), CENT, EXPIRE_TIME) {
-                    @Override
-                    protected void editContractSendRequest(SendRequest req) {
-                        req.coinSelector = wallet.getCoinSelector();
-                    }
-                };
+                clientState = new PaymentChannelV2ClientState(wallet, myKey, ECKey.fromPublicOnly(serverKey.getPubKey()), CENT, EXPIRE_TIME);
                 break;
         }
         assertEquals(PaymentChannelClientState.State.NEW, clientState.getState());
-        clientState.initiate();
+        clientState.initiate(null, new PaymentChannelClient.DefaultClientChannelProperties() {
+            @Override
+            public SendRequest modifyContractSendRequest(SendRequest sendRequest) {
+                sendRequest.coinSelector = wallet.getCoinSelector();
+                return sendRequest;
+            }
+        });
         assertEquals(getInitialClientState(), clientState.getState());
 
         if (useRefunds()) {


### PR DESCRIPTION
To allow for configurations of the payment channels without adding more parameters to the constructor, one can use the ClientChannelProperties and ServerChannelProperties. 
This change is breaking code using the non default constructors of the PaymentChannelClient, PaymentChannelClientConnection, PaymentChannelServer. 
To ensure that the interfaces can evolve without breaking future code, there are two default implementations DefaultClientChannelProperties, DefaultServerChanelProperties that uses the current default. See ExamplePaymentChannelClient for an example of how to use the DefaultClientChannelProperties.