### PR TITLE
Copyright harmonization

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Context.java
+++ b/core/src/main/java/org/bitcoinj/core/Context.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/core/listeners/AbstractBlockChainListener.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/AbstractBlockChainListener.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/core/listeners/BlockChainListener.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/BlockChainListener.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/core/listeners/OnTransactionBroadcastListener.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/OnTransactionBroadcastListener.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/core/package-info.java
+++ b/core/src/main/java/org/bitcoinj/core/package-info.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/crypto/DRMWorkaround.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DRMWorkaround.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/crypto/KeyCrypterException.java
+++ b/core/src/main/java/org/bitcoinj/crypto/KeyCrypterException.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
+++ b/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/crypto/package-info.java
+++ b/core/src/main/java/org/bitcoinj/crypto/package-info.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/jni/NativePaymentChannelHandlerFactory.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativePaymentChannelHandlerFactory.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/jni/NativePaymentChannelServerConnectionEventHandler.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativePaymentChannelServerConnectionEventHandler.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/kits/package-info.java
+++ b/core/src/main/java/org/bitcoinj/kits/package-info.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/net/FilterMerger.java
+++ b/core/src/main/java/org/bitcoinj/net/FilterMerger.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/net/discovery/package-info.java
+++ b/core/src/main/java/org/bitcoinj/net/discovery/package-info.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/net/package-info.java
+++ b/core/src/main/java/org/bitcoinj/net/package-info.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/params/package-info.java
+++ b/core/src/main/java/org/bitcoinj/params/package-info.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentIncrementAck.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentIncrementAck.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/protocols/channels/package-info.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/package-info.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/protocols/package-info.java
+++ b/core/src/main/java/org/bitcoinj/protocols/package-info.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/protocols/payments/PaymentSession.java
+++ b/core/src/main/java/org/bitcoinj/protocols/payments/PaymentSession.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/protocols/payments/package-info.java
+++ b/core/src/main/java/org/bitcoinj/protocols/payments/package-info.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/script/package-info.java
+++ b/core/src/main/java/org/bitcoinj/script/package-info.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/signers/package-info.java
+++ b/core/src/main/java/org/bitcoinj/signers/package-info.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/store/ChainFileLockedException.java
+++ b/core/src/main/java/org/bitcoinj/store/ChainFileLockedException.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/store/LevelDBBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/LevelDBBlockStore.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/store/WindowsMMapHack.java
+++ b/core/src/main/java/org/bitcoinj/store/WindowsMMapHack.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/store/package-info.java
+++ b/core/src/main/java/org/bitcoinj/store/package-info.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/uri/OptionalFieldValidationException.java
+++ b/core/src/main/java/org/bitcoinj/uri/OptionalFieldValidationException.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/uri/RequiredFieldValidationException.java
+++ b/core/src/main/java/org/bitcoinj/uri/RequiredFieldValidationException.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/uri/package-info.java
+++ b/core/src/main/java/org/bitcoinj/uri/package-info.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/utils/BaseTaggableObject.java
+++ b/core/src/main/java/org/bitcoinj/utils/BaseTaggableObject.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/utils/ContextPropagatingThreadFactory.java
+++ b/core/src/main/java/org/bitcoinj/utils/ContextPropagatingThreadFactory.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/utils/DaemonThreadFactory.java
+++ b/core/src/main/java/org/bitcoinj/utils/DaemonThreadFactory.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/utils/TaggableObject.java
+++ b/core/src/main/java/org/bitcoinj/utils/TaggableObject.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/wallet/AllRandomKeysRotating.java
+++ b/core/src/main/java/org/bitcoinj/wallet/AllRandomKeysRotating.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/wallet/AllowUnconfirmedCoinSelector.java
+++ b/core/src/main/java/org/bitcoinj/wallet/AllowUnconfirmedCoinSelector.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/wallet/CoinSelection.java
+++ b/core/src/main/java/org/bitcoinj/wallet/CoinSelection.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/wallet/CoinSelector.java
+++ b/core/src/main/java/org/bitcoinj/wallet/CoinSelector.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/wallet/DefaultCoinSelector.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DefaultCoinSelector.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -1,7 +1,6 @@
 /*
- * Copyright 2014 The bitcoinj developers.
- * Copyright 2015 Andreas Schildbach
- *
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -93,6 +92,8 @@ import static com.google.common.collect.Lists.newLinkedList;
  * keys, you can request 33 keys before more keys will be calculated and the Bloom filter rebuilt and rebroadcast.
  * But even when you are requesting the 33rd key, you will still be looking 100 keys ahead.
  * </p>
+ * 
+ * @author Andreas Schildbach
  */
 @SuppressWarnings("PublicStaticCollectionField")
 public class DeterministicKeyChain implements EncryptableKeyChain {

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicUpgradeRequiredException.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicUpgradeRequiredException.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicUpgradeRequiresPassword.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicUpgradeRequiresPassword.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/wallet/MarriedKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/MarriedKeyChain.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2013 The bitcoinj developers.
- *
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/wallet/UnreadableWalletException.java
+++ b/core/src/main/java/org/bitcoinj/wallet/UnreadableWalletException.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/wallet/listeners/AbstractKeyChainEventListener.java
+++ b/core/src/main/java/org/bitcoinj/wallet/listeners/AbstractKeyChainEventListener.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/main/java/org/bitcoinj/wallet/package-info.java
+++ b/core/src/main/java/org/bitcoinj/wallet/package-info.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/test/java/org/bitcoinj/core/H2FullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/H2FullPrunedBlockChainTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/test/java/org/bitcoinj/core/MemoryFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/MemoryFullPrunedBlockChainTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/test/java/org/bitcoinj/core/PostgresFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PostgresFullPrunedBlockChainTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/test/java/org/bitcoinj/core/TransactionOutputTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionOutputTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/test/java/org/bitcoinj/protocols/channels/ChannelTestUtils.java
+++ b/core/src/test/java/org/bitcoinj/protocols/channels/ChannelTestUtils.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelClientTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelClientTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelServerTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelServerTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/test/java/org/bitcoinj/store/LevelDBBlockStoreTest.java
+++ b/core/src/test/java/org/bitcoinj/store/LevelDBBlockStoreTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/test/java/org/bitcoinj/testing/FooWalletExtension.java
+++ b/core/src/test/java/org/bitcoinj/testing/FooWalletExtension.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/test/java/org/bitcoinj/testing/InboundMessageQueuer.java
+++ b/core/src/test/java/org/bitcoinj/testing/InboundMessageQueuer.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/test/java/org/bitcoinj/utils/BaseTaggableObjectTest.java
+++ b/core/src/test/java/org/bitcoinj/utils/BaseTaggableObjectTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/core/src/test/java/org/bitcoinj/wallet/WalletExtensionsTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletExtensionsTest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/examples/src/main/java/org/bitcoinj/examples/BackupToMnemonicSeed.java
+++ b/examples/src/main/java/org/bitcoinj/examples/BackupToMnemonicSeed.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/examples/src/main/java/org/bitcoinj/examples/DoubleSpend.java
+++ b/examples/src/main/java/org/bitcoinj/examples/DoubleSpend.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/examples/src/main/java/org/bitcoinj/examples/Kit.java
+++ b/examples/src/main/java/org/bitcoinj/examples/Kit.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/examples/src/main/java/org/bitcoinj/examples/RestoreFromSeed.java
+++ b/examples/src/main/java/org/bitcoinj/examples/RestoreFromSeed.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/examples/src/main/java/org/bitcoinj/examples/SendRequest.java
+++ b/examples/src/main/java/org/bitcoinj/examples/SendRequest.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/examples/src/main/javascript/demo.js
+++ b/examples/src/main/javascript/demo.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright by the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // This file shows how to use bitcoinj from Javascript.
 // To run, grab the bitcoinj bundled JAR and then do something like this:
 //

--- a/examples/src/main/javascript/forwarding.js
+++ b/examples/src/main/javascript/forwarding.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright by the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // For more info on how to run/control logging look at demo.js
 //
 // This example shows how to implement the forwarding service demo from the Getting Started tutorial.

--- a/examples/src/main/javascript/payprotocol.js
+++ b/examples/src/main/javascript/payprotocol.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright by the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // Example app that creates a minimal BIP70 payment request with a multisig output, and then prints it to base64.
 
 var bcj = org.bitcoinj;

--- a/examples/src/main/javascript/tor.js
+++ b/examples/src/main/javascript/tor.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright by the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // Example of how to connect to a Tor hidden service and use it as a peer.
 // See demo.js to learn how to invoke this program.
 

--- a/examples/src/main/python/forwarding.py
+++ b/examples/src/main/python/forwarding.py
@@ -1,3 +1,17 @@
+# Copyright by the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # An example of how to use Jython to implement the "Getting Started" tutorial app, which receives coins and simply
 # sends them on (minus a fee).
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright by the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/tools/build-checkpoints
+++ b/tools/build-checkpoints
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright by the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 
 # Check if the jar has been built.

--- a/tools/build-checkpoints.cmd
+++ b/tools/build-checkpoints.cmd
@@ -1,4 +1,19 @@
 @echo off
+
+rem  Copyright by the original author or authors.
+rem
+rem  Licensed under the Apache License, Version 2.0 (the "License");
+rem  you may not use this file except in compliance with the License.
+rem  You may obtain a copy of the License at
+rem
+rem      http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem  Unless required by applicable law or agreed to in writing, software
+rem  distributed under the License is distributed on an "AS IS" BASIS,
+rem  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem  See the License for the specific language governing permissions and
+rem  limitations under the License.
+
 rem Check if the jar has been built.
 set TARGET_JAR=build-checkpoints.jar
 

--- a/tools/src/main/java/org/bitcoinj/tools/BlockImporter.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BlockImporter.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/tools/src/main/java/org/bitcoinj/tools/TestFeeLevel.java
+++ b/tools/src/main/java/org/bitcoinj/tools/TestFeeLevel.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/tools/wallet-tool
+++ b/tools/wallet-tool
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright by the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 
 # Check if the jar has been built.

--- a/tools/wallet-tool.cmd
+++ b/tools/wallet-tool.cmd
@@ -1,4 +1,19 @@
 @echo off
+
+rem  Copyright by the original author or authors.
+rem
+rem  Licensed under the Apache License, Version 2.0 (the "License");
+rem  you may not use this file except in compliance with the License.
+rem  You may obtain a copy of the License at
+rem
+rem      http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem  Unless required by applicable law or agreed to in writing, software
+rem  distributed under the License is distributed on an "AS IS" BASIS,
+rem  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem  See the License for the specific language governing permissions and
+rem  limitations under the License.
+
 rem Check if the jar has been built.
 set TARGET_JAR=wallet-tool.jar
 

--- a/wallettemplate/pom.xml
+++ b/wallettemplate/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright by the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/wallettemplate/src/main/java/wallettemplate/Main.java
+++ b/wallettemplate/src/main/java/wallettemplate/Main.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/wallettemplate/src/main/java/wallettemplate/MainController.java
+++ b/wallettemplate/src/main/java/wallettemplate/MainController.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/wallettemplate/src/main/java/wallettemplate/SendMoneyController.java
+++ b/wallettemplate/src/main/java/wallettemplate/SendMoneyController.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/wallettemplate/src/main/java/wallettemplate/WalletPasswordController.java
+++ b/wallettemplate/src/main/java/wallettemplate/WalletPasswordController.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/wallettemplate/src/main/java/wallettemplate/WalletSetPasswordController.java
+++ b/wallettemplate/src/main/java/wallettemplate/WalletSetPasswordController.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/wallettemplate/src/main/java/wallettemplate/WalletSettingsController.java
+++ b/wallettemplate/src/main/java/wallettemplate/WalletSettingsController.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/wallettemplate/src/main/java/wallettemplate/controls/BitcoinAddressValidator.java
+++ b/wallettemplate/src/main/java/wallettemplate/controls/BitcoinAddressValidator.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/wallettemplate/src/main/java/wallettemplate/controls/ClickableBitcoinAddress.java
+++ b/wallettemplate/src/main/java/wallettemplate/controls/ClickableBitcoinAddress.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/wallettemplate/src/main/java/wallettemplate/controls/NotificationBarPane.java
+++ b/wallettemplate/src/main/java/wallettemplate/controls/NotificationBarPane.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/wallettemplate/src/main/java/wallettemplate/utils/AlertWindowController.java
+++ b/wallettemplate/src/main/java/wallettemplate/utils/AlertWindowController.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/wallettemplate/src/main/java/wallettemplate/utils/BitcoinUIModel.java
+++ b/wallettemplate/src/main/java/wallettemplate/utils/BitcoinUIModel.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/wallettemplate/src/main/java/wallettemplate/utils/GuiUtils.java
+++ b/wallettemplate/src/main/java/wallettemplate/utils/GuiUtils.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/wallettemplate/src/main/java/wallettemplate/utils/KeyDerivationTasks.java
+++ b/wallettemplate/src/main/java/wallettemplate/utils/KeyDerivationTasks.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/wallettemplate/src/main/java/wallettemplate/utils/TextFieldValidator.java
+++ b/wallettemplate/src/main/java/wallettemplate/utils/TextFieldValidator.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/wallettemplate/src/main/java/wallettemplate/utils/ThrottledRunLater.java
+++ b/wallettemplate/src/main/java/wallettemplate/utils/ThrottledRunLater.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/wallettemplate/src/main/java/wallettemplate/utils/WTUtils.java
+++ b/wallettemplate/src/main/java/wallettemplate/utils/WTUtils.java
@@ -1,4 +1,6 @@
 /*
+ * Copyright by the original author or authors.
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at


### PR DESCRIPTION
Add a generic copyright line to all license headers that don't have one. Note it is not legally necessary to state copyright, but we think it makes things easier.

Replace "The bitcoinj developers" copyright statement by the generic statement. There is no such legal entitiy.