### PR TITLE
Bump of orchid version to 1.2.1, …

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -429,7 +429,7 @@
         <dependency>
             <groupId>org.bitcoinj</groupId>
             <artifactId>orchid</artifactId>
-            <version>1.2</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp</groupId>

--- a/orchid/pom.xml
+++ b/orchid/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>orchid</artifactId>
-    <version>1.2</version>
+    <version>1.2.1</version>
 
     <name>Orchid</name>
     <description>Tor library</description>


### PR DESCRIPTION
…which is necessary because we accidently pushed an incomplete version 1.2 to Maven Central last year.