### PR TITLE
Making OP_RETURN to have 80 bytes.

### DIFF
--- a/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
@@ -433,7 +433,7 @@ public class ScriptBuilder {
      * the ledger.
      */
     public static Script createOpReturnScript(byte[] data) {
-        checkArgument(data.length <= 40);
+        checkArgument(data.length <= 80);
         return new ScriptBuilder().op(OP_RETURN).data(data).build();
     }
 


### PR DESCRIPTION
Making OP_RETURN to have 80 bytes instead of the previous 40 bytes.

This is to be consistent with the bitcoin-core, which have made it back to 80 bytes.