### PR TITLE
Disable retargeting for regtest - option 1

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -79,6 +79,7 @@ public abstract class NetworkParameters {
     protected int dumpedPrivateKeyHeader;
     protected int interval;
     protected int targetTimespan;
+    protected boolean noRetargeting;
     protected byte[] alertSigningKey;
     protected int bip32HeaderPub;
     protected int bip32HeaderPriv;
@@ -345,6 +346,15 @@ public abstract class NetworkParameters {
     public int getTargetTimespan() {
         return targetTimespan;
     }
+
+    /**
+     * Whether to skip retargeting. 
+     * If set to false, the node works as usual: recalculates the difficulty using targetTimespan and interval.
+     * If set to true, the difficulty is never recalculated
+     */
+    public boolean getNoRetargeting() {
+        return noRetargeting;
+    }    
 
     /**
      * The version codes that prefix addresses which are acceptable on this network. Although Satoshi intended these to

--- a/core/src/main/java/org/bitcoinj/params/AbstractBitcoinNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/AbstractBitcoinNetParams.java
@@ -67,7 +67,7 @@ public abstract class AbstractBitcoinNetParams extends NetworkParameters {
         Block prev = storedPrev.getHeader();
 
         // Is this supposed to be a difficulty transition point?
-        if (!isDifficultyTransitionPoint(storedPrev)) {
+        if (!isDifficultyTransitionPoint(storedPrev) || getNoRetargeting()) {
 
             // No ... so check the difficulty didn't actually change.
             if (nextBlock.getDifficultyTarget() != prev.getDifficultyTarget())

--- a/core/src/main/java/org/bitcoinj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/MainNetParams.java
@@ -36,6 +36,7 @@ public class MainNetParams extends AbstractBitcoinNetParams {
         super();
         interval = INTERVAL;
         targetTimespan = TARGET_TIMESPAN;
+        noRetargeting = false;
         maxTarget = Utils.decodeCompactBits(0x1d00ffffL);
         dumpedPrivateKeyHeader = 128;
         addressHeader = 0;

--- a/core/src/main/java/org/bitcoinj/params/RegTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/RegTestParams.java
@@ -31,6 +31,7 @@ public class RegTestParams extends TestNet2Params {
     public RegTestParams() {
         super();
         interval = 10000;
+        noRetargeting = true;        
         maxTarget = MAX_TARGET;
         subsidyDecreaseBlockCount = 150;
         port = 18444;

--- a/core/src/main/java/org/bitcoinj/params/TestNet2Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet2Params.java
@@ -39,6 +39,7 @@ public class TestNet2Params extends AbstractBitcoinNetParams {
         acceptableAddressCodes = new int[] { addressHeader, p2shHeader };
         interval = INTERVAL;
         targetTimespan = TARGET_TIMESPAN;
+        noRetargeting = false;
         maxTarget = Utils.decodeCompactBits(0x1d0fffffL);
         dumpedPrivateKeyHeader = 239;
         genesisBlock.setTime(1296688602L);

--- a/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
@@ -42,6 +42,7 @@ public class TestNet3Params extends AbstractBitcoinNetParams {
         packetMagic = 0x0b110907;
         interval = INTERVAL;
         targetTimespan = TARGET_TIMESPAN;
+        noRetargeting = false;
         maxTarget = Utils.decodeCompactBits(0x1d00ffffL);
         port = 18333;
         addressHeader = 111;

--- a/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
@@ -44,6 +44,7 @@ public class UnitTestParams extends AbstractBitcoinNetParams {
         interval = 10;
         dumpedPrivateKeyHeader = 239;
         targetTimespan = 200000000;  // 6 years. Just a very big number.
+        noRetargeting = false;        
         spendableCoinbaseDepth = 5;
         subsidyDecreaseBlockCount = 100;
         dnsSeeds = null;


### PR DESCRIPTION
Retargeting is disabled on bitcoin core for regtest, but enabled on bitcoinj for regtest.

See https://github.com/bitcoin/bitcoin/blob/master/src/chainparams.cpp#L257
See https://github.com/bitcoin/bitcoin/blob/master/src/pow.cpp#L54

If you have a bitcoind running on regtest with more than 10k blocks, and use bitcoinj to sync with it, it will reject blocks starting on block 10,000.

I wrote 2 different solutions:

Solution 1: The way it is implemented on bitcoin core (this PR)
Solution 2: Simple solution (The other PR I created: https://github.com/bitcoinj/bitcoinj/pull/1274)
