### PR TITLE
Disable retargeting for regtest - option 2

### DIFF
--- a/core/src/main/java/org/bitcoinj/params/RegTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/RegTestParams.java
@@ -30,7 +30,9 @@ public class RegTestParams extends TestNet2Params {
 
     public RegTestParams() {
         super();
-        interval = 10000;
+        // Difficulty adjustments are disabled for regtest. 
+        // By setting the block interval for difficulty adjustments to Integer.MAX_VALUE we make sure difficulty never changes.    
+        interval = Integer.MAX_VALUE;
         maxTarget = MAX_TARGET;
         subsidyDecreaseBlockCount = 150;
         port = 18444;


### PR DESCRIPTION
Retargeting is disabled on bitcoin core for regtest, but enabled on bitcoinj for regtest.

See https://github.com/bitcoin/bitcoin/blob/master/src/chainparams.cpp#L257
See https://github.com/bitcoin/bitcoin/blob/master/src/pow.cpp#L54

If you have a bitcoind running on regtest with more than 10k blocks, and use bitcoinj to sync with it, it will reject blocks starting on block 10,000.

I wrote 2 different solutions:

Solution 1: The way it is implemented on bitcoin core (The other PR I created https://github.com/bitcoinj/bitcoinj/pull/1273)
Solution 2: Simple solution (this PR)
