### PR TITLE
Check if open transaction exists before inserting (Postgresql-specific)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,4 @@ more info on this technique.
 ### Where next?
 
 Now you are ready to [follow the tutorial](https://bitcoinj.github.io/getting-started).
+

--- a/core/src/main/java/org/bitcoinj/store/DatabaseFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/DatabaseFullPrunedBlockStore.java
@@ -648,7 +648,6 @@ public abstract class DatabaseFullPrunedBlockStore implements FullPrunedBlockSto
                 throw e;
 
             s.close();
-            s = null;
             s = conn.get().prepareStatement(getUpdateHeadersSQL());
             s.setBoolean(1, true);
             s.setBytes(2, hashBytes);
@@ -714,7 +713,6 @@ public abstract class DatabaseFullPrunedBlockStore implements FullPrunedBlockSto
                 }
                 s.executeUpdate();
                 s.close();
-                s = null;
                 try {
                     putUpdateStoredBlock(storedBlock, true);
                 } catch (SQLException e) {
@@ -727,7 +725,6 @@ public abstract class DatabaseFullPrunedBlockStore implements FullPrunedBlockSto
                 // There is probably an update-or-insert statement, but it wasn't obvious from the docs
                 if (s != null) {
                     s.close();
-                    s = null;
                 }
                 s = conn.get().prepareStatement(getUpdateUndoableBlocksSQL());
                 s.setBytes(3, hashBytes);
@@ -740,7 +737,6 @@ public abstract class DatabaseFullPrunedBlockStore implements FullPrunedBlockSto
                 }
                 s.executeUpdate();
                 s.close();
-                s = null;
             } finally {
                 if (s != null) {
                     s.close();

--- a/core/src/main/java/org/bitcoinj/store/PostgresFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/PostgresFullPrunedBlockStore.java
@@ -178,6 +178,13 @@ public class PostgresFullPrunedBlockStore extends DatabaseFullPrunedBlockStore {
     }
     
     protected boolean isSupportsOnConflict() {
+        if (supportsOnConflict == null) {
+            // The DatabaseFullPrunedBlockStore constructor may call createNewStore() which calls overridden method put(),
+            // before this class's constructor has been executed (and initialized final fields). This is a workaround for
+            // that problem.
+            return false;
+        }
+        
         Connection conn = this.conn.get();
         Long n = supportsOnConflict.get();
         if (n != null) {


### PR DESCRIPTION
Postgresql invalidates the entire transaction if a duplicate key exception is thrown, so an extra check to see if the open output exists is done prior to inserting. The put(...) method already does this, but addUnspentTransactionOutput(...) did not.
