### PR TITLE
Check that getCountAtOrAbove is not null, to avoid null pointer exception

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -514,7 +514,8 @@ public abstract class NetworkParameters {
         // Start enforcing CHECKLOCKTIMEVERIFY, (BIP65) for block.nVersion=4
         // blocks, when 75% of the network has upgraded:
         if (block.getVersion() >= Block.BLOCK_VERSION_BIP65 &&
-            tally.getCountAtOrAbove(Block.BLOCK_VERSION_BIP65) > this.getMajorityEnforceBlockUpgrade()) {
+                tally.getCountAtOrAbove(Block.BLOCK_VERSION_BIP65) != null &&
+                tally.getCountAtOrAbove(Block.BLOCK_VERSION_BIP65) > this.getMajorityEnforceBlockUpgrade()) {
             verifyFlags.add(Script.VerifyFlag.CHECKLOCKTIMEVERIFY);
         }
 


### PR DESCRIPTION
tally.getCountAtOrAbove(Block.BLOCK_VERSION_BIP65) is compared against getMajorityEnforceBlockUpgrade() without checking for nullity. This is an issue since it is initialized to null in utils/VersionTally.java if the version window is not full. This resulted in a null pointer exception in regtest mode that prevented downloading of the blockchain.