### PR TITLE
Remove Context requirement from Transaction.toString()

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -636,8 +636,6 @@ public class Transaction extends ChildMessage {
     public String toString(@Nullable AbstractBlockChain chain) {
         StringBuilder s = new StringBuilder();
         s.append("  ").append(getHashAsString()).append('\n');
-        if (hasConfidence())
-            s.append("  confidence: ").append(getConfidence()).append('\n');
         if (updatedAt != null)
             s.append("  updated: ").append(Utils.dateTimeFormat(updatedAt)).append('\n');
         if (isTimeLocked()) {


### PR DESCRIPTION
For me, by far the most common cause of `Content.get()`'s "Performing thread fixup" warnings is from when I call `Transaction.toString()` from a thread outside of BitcoinJ's control.

It doesn't seem like it's really necessary for the `toString()` to look something up in global state, so this change just avoids printing out the transaction confidence if it can't be looked up without a warning.

If you prefer, I'm happy to also do the simpler change of just removing confidence entirely from this `toString()`.