### PR TITLE
Fix download progress tracking

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/listeners/DownloadProgressTracker.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/DownloadProgressTracker.java
@@ -66,8 +66,13 @@ public class DownloadProgressTracker extends AbstractPeerDataEventListener {
 
         if (blocksLeft == 0) {
             caughtUp = true;
+            if (lastPercent != 100) {
+                lastPercent = 100;
+                progress(lastPercent, blocksLeft, new Date(block.getTimeSeconds() * 1000));
+            }
             doneDownload();
             future.set(peer.getBestHeight());
+            return;
         }
 
         if (blocksLeft < 0 || originalBlocksLeft <= 0)


### PR DESCRIPTION
Currently progress() can be called after doneDownload() which should not
happen. Also make sure that we call progress() with 100% progress before we
call doneDownload() - this is in case any existing users have given up on
downDownload() being called at the right time and instead use 100% progress
as their signal that downloading is complete.
