### PR TITLE
Delegate the process of creating the block locator related to 1259

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/strategies/BlockLocatorStrategy.java
+++ b/core/src/main/java/org/bitcoinj/core/strategies/BlockLocatorStrategy.java
@@ -1,0 +1,19 @@
+package org.bitcoinj.core.strategies;
+
+import org.bitcoinj.core.AbstractBlockChain;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.Sha256Hash;
+
+import java.util.List;
+
+public interface BlockLocatorStrategy {
+    /**
+     * Creates a list of hashes to be used in a block locator
+     * @param blockChain the block chain to be updated
+     * @return list of hashes
+     */
+    public List<Sha256Hash> createBlockLocator(AbstractBlockChain blockChain);
+
+    public void setNetworkParameters(NetworkParameters params);
+
+}

--- a/core/src/main/java/org/bitcoinj/core/strategies/LinearBlockLocatorStrategy.java
+++ b/core/src/main/java/org/bitcoinj/core/strategies/LinearBlockLocatorStrategy.java
@@ -1,0 +1,50 @@
+package org.bitcoinj.core.strategies;
+
+import org.bitcoinj.core.*;
+import org.bitcoinj.store.BlockStore;
+import org.bitcoinj.store.BlockStoreException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * This class does not do the exponential thinning as suggested here:
+ *
+ *   https://en.bitcoin.it/wiki/Protocol_specification#getblocks
+ *
+ * This is because it requires scanning all the block chain headers, which is very slow. Instead we add the top
+ * 100 block headers. If there is a re-org deeper than that, we'll end up downloading the entire chain. We
+ * must always put the genesis block as the first entry.
+ */
+public class LinearBlockLocatorStrategy implements BlockLocatorStrategy {
+    private static final Logger log = LoggerFactory.getLogger(LinearBlockLocatorStrategy.class);
+    private NetworkParameters params;
+
+    public List<Sha256Hash> createBlockLocator(AbstractBlockChain chain) {
+        List<Sha256Hash> blockLocator = null;
+        try {
+            BlockStore store = checkNotNull(chain).getBlockStore();
+            blockLocator = new ArrayList<Sha256Hash>(51);
+            StoredBlock cursor = store.getChainHead();
+            for (int i = 100; cursor != null && i > 0; i--) {
+                blockLocator.add(cursor.getHeader().getHash());
+                cursor = cursor.getPrev(store);
+            }
+            // Only add the locator if we didn't already do so. If the chain is < 50 blocks we already reached it.
+            if (cursor != null)
+                blockLocator.add(checkNotNull(params).getGenesisBlock().getHash());
+        } catch (BlockStoreException e) {
+            log.error("Failed to walk the block chain whilst constructing a locator");
+        }
+        return blockLocator;
+    }
+
+    @Override
+    public void setNetworkParameters(NetworkParameters params) {
+        this.params = checkNotNull(params, "NetworkParameters cannot be null");
+    }
+}

--- a/core/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -970,4 +970,9 @@ public class PeerTest extends TestWithNetworkConnections {
                     || (e instanceof SocketException && e.getMessage().equals("Socket is closed")));
         }
     }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullBlockLocatorStrategy() {
+        peer.setBlockLocatorStrategy(null);
+    }
 }

--- a/core/src/test/java/org/bitcoinj/core/strategies/LinearBlockLocatorStrategyTest.java
+++ b/core/src/test/java/org/bitcoinj/core/strategies/LinearBlockLocatorStrategyTest.java
@@ -1,0 +1,20 @@
+package org.bitcoinj.core.strategies;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class LinearBlockLocatorStrategyTest {
+
+    LinearBlockLocatorStrategy linearBlockLocatorStrategy;
+
+    @Before
+    public void setUp() throws Exception {
+        linearBlockLocatorStrategy = new LinearBlockLocatorStrategy();
+
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullParams() {
+        linearBlockLocatorStrategy.setNetworkParameters(null);
+    }
+}


### PR DESCRIPTION
This is a refactor to abstract the logic of creating the block locator from the peer. This will allow for development of a "dense at first, then sparse" implementation. This does not directly address issue #1259 but removes a "todo" from the code.