### PR TITLE
Add setter for wallet factory to WalletAppKit.

### DIFF
--- a/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
+++ b/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
@@ -179,6 +179,14 @@ public class WalletAppKit extends AbstractIdleService {
     }
 
     /**
+     * Sets a wallet factory which will be used when the kit creates a new wallet.
+     */
+    public WalletAppKit setWalletFactory(WalletProtobufSerializer.WalletFactory walletFactory) {
+        this.walletFactory = walletFactory;
+        return this;
+    }
+
+    /**
      * If called, then an embedded Tor client library will be used to connect to the P2P network. The user does not need
      * any additional software for this: it's all pure Java. As of April 2014 <b>this mode is experimental</b>.
      */


### PR DESCRIPTION
While playing with the WalletAppKit I noticed that it optionally makes uses of a WalletFactory, but provides no way of setting one. This commit adds a setter for it. This makes it possible to use the WalletAppKit for things like a watching wallet, without having to extend WalletAppKit.

I hope this can be included - cheers!
