### PR TITLE
Fix violation of equals/hashCode contract in ECKey

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/core/ECKey.java
@@ -1219,10 +1219,11 @@ public class ECKey implements EncryptableItem {
 
     @Override
     public int hashCode() {
-        // Public keys are random already so we can just use a part of them as the hashcode. Read from the start to
-        // avoid picking up the type code (compressed vs uncompressed) which is tacked on the end.
+        // Public keys are random already so we can just use a part of them as the hashcode.
+        // Read from the X-coord (byte indexes [1-33)) to avoid pick up the
+        // compression indicator, which is the first byte.
         byte[] bits = getPubKey();
-        return Ints.fromBytes(bits[0], bits[1], bits[2], bits[3]);
+        return Ints.fromBytes(bits[1], bits[2], bits[3], bits[4]);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/core/ECKey.java
@@ -1219,11 +1219,7 @@ public class ECKey implements EncryptableItem {
 
     @Override
     public int hashCode() {
-        // Public keys are random already so we can just use a part of them as the hashcode.
-        // Read from the X-coord (byte indexes [1-33)) to avoid pick up the
-        // compression indicator, which is the first byte.
-        byte[] bits = getPubKey();
-        return Ints.fromBytes(bits[1], bits[2], bits[3], bits[4]);
+        return pub.hashCode();
     }
 
     @Override

--- a/core/src/test/java/org/bitcoinj/core/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ECKeyTest.java
@@ -454,4 +454,14 @@ public class ECKeyTest {
         for (byte b : bytes) if (b != 0) return true;
         return false;
     }
+
+    @Test
+    public void testPublicKeysAreEqual() {
+        ECKey key = new ECKey();
+        ECKey pubKey1 = ECKey.fromPublicOnly(key.getPubKeyPoint());
+        assertTrue(pubKey1.isCompressed());
+        ECKey pubKey2 = pubKey1.decompress();
+        assertEquals(pubKey1, pubKey2);
+        assertEquals(pubKey1.hashCode(), pubKey2.hashCode());
+    }
 }


### PR DESCRIPTION
ECKey violates the equals/hashCode contract for
Java objects. Objects that are equivalent via
the equals method, _must_ have the same hash code.

This is not the case for ECKeys when comparing
the compressed and uncompressed forms of a public key.
The implementation of the `equals` method defines
these objects to be equivalent, but the hashCode
method defined them to be distinct!

Original implementation comes from commit
640db52cf48416db8e2b24b502b3775243ad5162
which contains this bug. _1_

Note that the comment identifies the correct intent:

> Public keys are random already so we can just use a part of them as the hashcode. Read from the start to
> avoid picking up the type code (compressed vs uncompressed) which is tacked on the end.

But the second sentence is incorrect. The first byte (index 0) is the type code
(compressed vs. uncompressed), not “the end”.

The code has since been refactored in commit
9219d8a9b5714cf4e65dc046c70930c86416e65d
but the implementation is effectively
identical. _2_

The fix is simple: use the most-significant four
bytes of the X-coordinate of the public key.

1: [640db52](https://github.com/bitcoinj/bitcoinj/commit/640db52cf48416db8e2b24b502b3775243ad5162#diff-b59ef8be77b9148b27a14be59762c0c5R353)
2: [9219d8a](https://github.com/bitcoinj/bitcoinj/commit/9219d8a9b5714cf4e65dc046c70930c86416e65d#diff-1849449aac05f7e59de7ebd56efd7f43R1201)