### PR TITLE
Bugfix on javascript forward example (wrong package).

### DIFF
--- a/examples/src/main/javascript/forwarding.js
+++ b/examples/src/main/javascript/forwarding.js
@@ -44,7 +44,7 @@ print("QRcode: http://qrickit.com/api/qr?d=" + uri);
 
 wallet.allowSpendingUnconfirmedTransactions()
 
-var listener = Java.extend(bcj.core.AbstractWalletEventListener);
+var listener = Java.extend(bcj.wallet.listeners.AbstractWalletEventListener);
 wallet.addEventListener(new listener() {
     onCoinsReceived: function(wallet, tx, prevBalance, newBalance) {
         print("Received money! " + newBalance.toFriendlyString());


### PR DESCRIPTION
Fixed the "TypeError: Java.extend needs at least one type argument" bug (wrong package)