### PR TITLE
Add method for replacing all transactions in a block

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -778,7 +778,7 @@ public class Block extends Message {
      * Replace the list of transactions in the block. This method is only useful when building thin
      * blocks and using different compression techniques to make blocks smaller. This will not recalculate
      * merkleRoot or block hash.
-     * @param txList
+     * @param txList New list of transactions. Can be null.
      */
     public void replaceTransactionList(List<Transaction> txList) {
         replaceTransactionList(txList, false);
@@ -788,7 +788,8 @@ public class Block extends Message {
      * Replace the list of transactions in the block. This method is only useful when building thin
      * blocks and using different compression techniques to make blocks smaller. If recalc is true
      * then the merkleRoot and block hash will be recalculated. Default is false.
-     * @param txList
+     * @param txList New list of transactions. Can be null.
+     * @param recalc Force a recalculation next time the values are needed
      */
     public void replaceTransactionList(List<Transaction> txList, boolean recalc) {
         transactions = txList;
@@ -797,7 +798,6 @@ public class Block extends Message {
             merkleRoot = null;
             hash = null;
         }
-        // Else, Do not recalculate the merkele root or the block hash
     }
 
     /** Returns the version of the block data structure as defined by the Bitcoin protocol. */

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -774,6 +774,32 @@ public class Block extends Message {
         hash = null;
     }
 
+    /**
+     * Replace the list of transactions in the block. This method is only useful when building thin
+     * blocks and using different compression techniques to make blocks smaller. This will not recalculate
+     * merkleRoot or block hash.
+     * @param txList
+     */
+    public void replaceTransactionList(List<Transaction> txList) {
+        replaceTransactionList(txList, false);
+    }
+
+    /**
+     * Replace the list of transactions in the block. This method is only useful when building thin
+     * blocks and using different compression techniques to make blocks smaller. If recalc is true
+     * then the merkleRoot and block hash will be recalculated. Default is false.
+     * @param txList
+     */
+    public void replaceTransactionList(List<Transaction> txList, boolean recalc) {
+        transactions = txList;
+        if (recalc) {
+            // Force a recalculation next time the values are needed.
+            merkleRoot = null;
+            hash = null;
+        }
+        // Else, Do not recalculate the merkele root or the block hash
+    }
+
     /** Returns the version of the block data structure as defined by the Bitcoin protocol. */
     public long getVersion() {
         return version;

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -789,7 +789,7 @@ public class Block extends Message {
      * blocks and using different compression techniques to make blocks smaller. If recalc is true
      * then the merkleRoot and block hash will be recalculated. Default is false.
      * @param txList New list of transactions. Can be null.
-     * @param recalc Force a recalculation next time the values are needed
+     * @param recalc Force a recalculation next time merkleRoot and block hash are needed
      */
     public void replaceTransactionList(List<Transaction> txList, boolean recalc) {
         transactions = txList;


### PR DESCRIPTION
I created this method since I needed the ability to replace all transactions in the block. This method is required to be able to produce thin blocks using bloom filters. There are many techniques for making smaller blocks, but they all have in common that the transactions needs to be stripped out since these exists in the mempool anyway.