### PR TITLE
Fix two lgtm.com alerts: potential resource leaks

### DIFF
--- a/core/src/main/java/org/bitcoinj/net/discovery/HttpDiscovery.java
+++ b/core/src/main/java/org/bitcoinj/net/discovery/HttpDiscovery.java
@@ -107,10 +107,7 @@ public class HttpDiscovery implements PeerDiscovery {
                 throw ioe;
             }
             
-            if (zip != null){
-                zip.close(); // will close InputStream as well
-            }
-
+            zip.close(); // will close InputStream as well
             return protoToAddrs(proto);
         } catch (PeerDiscoveryException e1) {
             throw e1;

--- a/core/src/main/java/org/bitcoinj/net/discovery/HttpDiscovery.java
+++ b/core/src/main/java/org/bitcoinj/net/discovery/HttpDiscovery.java
@@ -102,12 +102,10 @@ public class HttpDiscovery implements PeerDiscovery {
             PeerSeedProtos.SignedPeerSeeds proto;
             try {
                 proto = PeerSeedProtos.SignedPeerSeeds.parseDelimitedFrom(zip);
-            } catch (IOException ioe){
+            } finally {
                 zip.close(); // will close InputStream as well
-                throw ioe;
             }
             
-            zip.close(); // will close InputStream as well
             return protoToAddrs(proto);
         } catch (PeerDiscoveryException e1) {
             throw e1;

--- a/core/src/main/java/org/bitcoinj/net/discovery/HttpDiscovery.java
+++ b/core/src/main/java/org/bitcoinj/net/discovery/HttpDiscovery.java
@@ -97,9 +97,20 @@ public class HttpDiscovery implements PeerDiscovery {
             if (!response.isSuccessful())
                 throw new PeerDiscoveryException("HTTP request failed: " + response.code() + " " + response.message());
             InputStream stream = response.body().byteStream();
+            
             GZIPInputStream zip = new GZIPInputStream(stream);
-            PeerSeedProtos.SignedPeerSeeds proto = PeerSeedProtos.SignedPeerSeeds.parseDelimitedFrom(zip);
-            stream.close();
+            PeerSeedProtos.SignedPeerSeeds proto;
+            try {
+                proto = PeerSeedProtos.SignedPeerSeeds.parseDelimitedFrom(zip);
+            } catch (IOException ioe){
+                zip.close(); // will close InputStream as well
+                throw ioe;
+            }
+            
+            if (zip != null){
+                zip.close(); // will close InputStream as well
+            }
+
             return protoToAddrs(proto);
         } catch (PeerDiscoveryException e1) {
             throw e1;

--- a/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
@@ -211,7 +211,7 @@ public class BuildCheckpoints {
     }
 
     private static void sanityCheck(File file, int expectedSize) throws IOException {
-    	FileInputStream fis = new FileInputStream(file);
+        FileInputStream fis = new FileInputStream(file);
         CheckpointManager manager;
 
         try {

--- a/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
@@ -211,7 +211,16 @@ public class BuildCheckpoints {
     }
 
     private static void sanityCheck(File file, int expectedSize) throws IOException {
-        CheckpointManager manager = new CheckpointManager(params, new FileInputStream(file));
+    	FileInputStream fis = new FileInputStream(file);
+        CheckpointManager manager;
+
+        try {
+            manager = new CheckpointManager(params, fis);
+        } catch (IOException ioe){
+            fis.close();
+            throw ioe;
+        }
+
         checkState(manager.numCheckpoints() == expectedSize);
 
         if (params.getId().equals(NetworkParameters.ID_MAINNET)) {
@@ -225,6 +234,8 @@ public class BuildCheckpoints {
             checkState(test.getHeader().getHashAsString()
                     .equals("0000000000035ae7d5025c2538067fe7adb1cf5d5d9c31b024137d9090ed13a9"));
         }
+        
+        fis.close();
     }
 
     private static void startPeerGroup(PeerGroup peerGroup, InetAddress ipAddress) {

--- a/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
@@ -216,9 +216,8 @@ public class BuildCheckpoints {
 
         try {
             manager = new CheckpointManager(params, fis);
-        } catch (IOException ioe){
+        } finally {
             fis.close();
-            throw ioe;
         }
 
         checkState(manager.numCheckpoints() == expectedSize);
@@ -234,8 +233,6 @@ public class BuildCheckpoints {
             checkState(test.getHeader().getHashAsString()
                     .equals("0000000000035ae7d5025c2538067fe7adb1cf5d5d9c31b024137d9090ed13a9"));
         }
-        
-        fis.close();
     }
 
     private static void startPeerGroup(PeerGroup peerGroup, InetAddress ipAddress) {


### PR DESCRIPTION
This PR addresses two alerts reported by lgtm.com (@lgtmhq):

```HttpDiscovery.java```: https://lgtm.com/projects/g/bitcoinj/bitcoinj/snapshot/df1f776398d196d24e48653c8c952b97370b1e19/files/core/src/main/java/org/bitcoinj/net/discovery/HttpDiscovery.java#V100

```BuildCheckpoints.java```: https://lgtm.com/projects/g/bitcoinj/bitcoinj/snapshot/df1f776398d196d24e48653c8c952b97370b1e19/files/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java#V214

There are a total of 29 alerts on lgtm.com for bitcoinj - most of them look legit: https://lgtm.com/projects/g/bitcoinj/bitcoinj/alerts/

If you enable automatic code reviews through PR integration, you can actually catch things like this before they get merged into master :smiley:!