### PR TITLE
RegTestParams: MAX_TARGET to be created out of 64 hex digits

### DIFF
--- a/core/src/main/java/org/bitcoinj/params/RegTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/RegTestParams.java
@@ -26,7 +26,7 @@ import static com.google.common.base.Preconditions.checkState;
  * Network parameters for the regression test mode of bitcoind in which all blocks are trivially solvable.
  */
 public class RegTestParams extends TestNet2Params {
-    private static final BigInteger MAX_TARGET = new BigInteger("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16);
+    private static final BigInteger MAX_TARGET = new BigInteger("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16);
 
     public RegTestParams() {
         super();


### PR DESCRIPTION
MAX_TARGET is actually created out of 66 hex digits
>>> len("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
66

It should be
>>> len("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
64