### PR TITLE
Avoid NPE on preallocated exception without message

### DIFF
--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClient.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClient.java
@@ -475,8 +475,10 @@ public class PaymentChannelClient implements IPaymentChannelClient {
             } catch (VerificationException e) {
                 log.error("Caught verification exception handling message from server", e);
                 errorBuilder = Protos.Error.newBuilder()
-                        .setCode(Protos.Error.ErrorCode.BAD_TRANSACTION)
-                        .setExplanation(e.getMessage());
+                        .setCode(Protos.Error.ErrorCode.BAD_TRANSACTION);
+                if (e.getMessage() != null) {
+                    errorBuilder.setExplanation(e.getMessage());
+                }
                 closeReason = CloseReason.REMOTE_SENT_INVALID_MESSAGE;
             } catch (IllegalStateException e) {
                 log.error("Caught illegal state exception handling message from server", e);

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServer.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServer.java
@@ -526,8 +526,10 @@ public class PaymentChannelServer {
         log.error(message);
         Protos.Error.Builder errorBuilder;
         errorBuilder = Protos.Error.newBuilder()
-                .setCode(errorCode)
-                .setExplanation(message);
+                .setCode(errorCode);
+        if (message != null) {
+            errorBuilder.setExplanation(message);
+        }
         conn.sendToClient(Protos.TwoWayChannelMessage.newBuilder()
                 .setError(errorBuilder)
                 .setType(Protos.TwoWayChannelMessage.MessageType.ERROR)

--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -1541,7 +1541,7 @@ public class Script {
 
             // This RuntimeException occurs when signing as we run partial/invalid scripts to see if they need more
             // signing work to be done inside LocalTransactionSigner.signInputs.
-            if (!e1.getMessage().contains("Reached past end of ASN.1 stream"))
+            if (e1.getMessage() != null && !e1.getMessage().contains("Reached past end of ASN.1 stream"))
                 log.warn("Signature checking failed!", e1);
         }
 


### PR DESCRIPTION
Hello.

I'm trying to make my own research on bitconj codebase. During test execution I ran into NPE in code added by commit 83995e9284c1f76b07fb2cc587555296b7f61dec. There is check, which doesn't expect exception message to be null. So I just made additional null-check, so it will not throw NPE and will not log noisy messages.

The cause is an optimisation in HotSpot. Here is an article about it: http://jawspeak.com/2010/05/26/hotspot-caused-exceptions-to-lose-their-stack-traces-in-production-and-the-fix/

My solution is not so good. The best solution would be to completely avoid 'legal' exceptions in this case. However, my knowledge is not enough for it. 

Hope this helps.