### PR TITLE
Destruction of temporary byte arrays containing private keys

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/DumpedPrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/core/DumpedPrivateKey.java
@@ -29,7 +29,6 @@ import javax.annotation.Nullable;
  * bytes with a header byte and 4 checksum bytes at the end. If there are 33 private key bytes instead of 32, then
  * the last byte is a discriminator value for the compressed pubkey.
  */
-/* TODO: to be checked: all consumers need to call destroy(), if no longer needed */
 public class DumpedPrivateKey extends VersionedChecksummedBytes {
     private boolean compressed;
 

--- a/core/src/main/java/org/bitcoinj/core/DumpedPrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/core/DumpedPrivateKey.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
  * bytes with a header byte and 4 checksum bytes at the end. If there are 33 private key bytes instead of 32, then
  * the last byte is a discriminator value for the compressed pubkey.
  */
-/* TODO: Class must implement the Destroyable interface + consumer need to call it*/
+/* TODO: to be checked: all consumers need to call destroy(), if no longer needed */
 public class DumpedPrivateKey extends VersionedChecksummedBytes {
     private boolean compressed;
 

--- a/core/src/main/java/org/bitcoinj/core/DumpedPrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/core/DumpedPrivateKey.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
  * bytes with a header byte and 4 checksum bytes at the end. If there are 33 private key bytes instead of 32, then
  * the last byte is a discriminator value for the compressed pubkey.
  */
+/* TODO: Class must implement the Destroyable interface + consumer need to call it*/
 public class DumpedPrivateKey extends VersionedChecksummedBytes {
     private boolean compressed;
 

--- a/core/src/main/java/org/bitcoinj/core/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/core/ECKey.java
@@ -19,6 +19,8 @@
 package org.bitcoinj.core;
 
 import org.bitcoinj.crypto.*;
+import org.bitcoinj.utils.DestructionUtils;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
@@ -423,8 +425,9 @@ public class ECKey implements EncryptableItem {
      * @throws org.bitcoinj.core.ECKey.MissingPrivateKeyException if the private key is missing or encrypted.
      */
     public byte[] toASN1() {
+        byte[] privKeyBytes = null;
         try {
-            byte[] privKeyBytes = getPrivKeyBytes();
+            privKeyBytes = getPrivKeyBytes();
             ByteArrayOutputStream baos = new ByteArrayOutputStream(400);
 
             // ASN1_SEQUENCE(EC_PRIVATEKEY) = {
@@ -442,6 +445,8 @@ public class ECKey implements EncryptableItem {
             return baos.toByteArray();
         } catch (IOException e) {
             throw new RuntimeException(e);  // Cannot happen, writing to memory stream.
+        } finally {
+            DestructionUtils.destroyByteArray(privKeyBytes);
         }
     }
 
@@ -1037,6 +1042,7 @@ public class ECKey implements EncryptableItem {
      */
     public DumpedPrivateKey getPrivateKeyEncoded(NetworkParameters params) {
         return new DumpedPrivateKey(params, getPrivKeyBytes(), isCompressed());
+        // NB: Destruction of the byte array containing the private must be taken care of by DumpedPrivateKey
     }
 
     /**
@@ -1068,8 +1074,14 @@ public class ECKey implements EncryptableItem {
      */
     public ECKey encrypt(KeyCrypter keyCrypter, KeyParameter aesKey) throws KeyCrypterException {
         checkNotNull(keyCrypter);
-        final byte[] privKeyBytes = getPrivKeyBytes();
-        EncryptedData encryptedPrivateKey = keyCrypter.encrypt(privKeyBytes, aesKey);
+        byte[] privKeyBytes = null;
+        EncryptedData encryptedPrivateKey = null;
+        try {
+            privKeyBytes = getPrivKeyBytes();
+            encryptedPrivateKey = keyCrypter.encrypt(privKeyBytes, aesKey);
+        } finally {
+            DestructionUtils.destroyByteArray(privKeyBytes);
+        }
         ECKey result = ECKey.fromEncrypted(encryptedPrivateKey, keyCrypter, getPubKey());
         result.setCreationTimeSeconds(creationTimeSeconds);
         return result;
@@ -1132,10 +1144,12 @@ public class ECKey implements EncryptableItem {
      * @return true if the encrypted key can be decrypted back to the original key successfully.
      */
     public static boolean encryptionIsReversible(ECKey originalKey, ECKey encryptedKey, KeyCrypter keyCrypter, KeyParameter aesKey) {
+        byte[] originalPrivateKeyBytes = null;
+        byte[] rebornKeyBytes = null;
         try {
             ECKey rebornUnencryptedKey = encryptedKey.decrypt(keyCrypter, aesKey);
-            byte[] originalPrivateKeyBytes = originalKey.getPrivKeyBytes();
-            byte[] rebornKeyBytes = rebornUnencryptedKey.getPrivKeyBytes();
+            originalPrivateKeyBytes = originalKey.getPrivKeyBytes();
+            rebornKeyBytes = rebornUnencryptedKey.getPrivKeyBytes();
             if (!Arrays.equals(originalPrivateKeyBytes, rebornKeyBytes)) {
                 log.error("The check that encryption could be reversed failed for {}", originalKey);
                 return false;
@@ -1144,6 +1158,9 @@ public class ECKey implements EncryptableItem {
         } catch (KeyCrypterException kce) {
             log.error(kce.getMessage());
             return false;
+        } finally {
+            DestructionUtils.destroyByteArray(originalPrivateKeyBytes);
+            DestructionUtils.destroyByteArray(rebornKeyBytes);
         }
     }
 
@@ -1236,7 +1253,13 @@ public class ECKey implements EncryptableItem {
     }
 
     public String getPrivateKeyAsHex() {
-        return Utils.HEX.encode(getPrivKeyBytes());
+        byte[] privKeyBytes = null;
+        try {
+            privKeyBytes = getPrivKeyBytes();
+            return Utils.HEX.encode(privKeyBytes);
+        } finally {
+            DestructionUtils.destroyByteArray(privKeyBytes);
+        }
     }
 
     public String getPublicKeyAsHex() {

--- a/core/src/main/java/org/bitcoinj/core/VersionedChecksummedBytes.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionedChecksummedBytes.java
@@ -21,6 +21,11 @@ import static com.google.common.base.Preconditions.checkArgument;
 import java.io.Serializable;
 import java.util.Arrays;
 
+import javax.security.auth.DestroyFailedException;
+import javax.security.auth.Destroyable;
+
+import org.bitcoinj.utils.DestructionUtils;
+
 import com.google.common.base.Objects;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.UnsignedBytes;
@@ -33,9 +38,10 @@ import com.google.common.primitives.UnsignedBytes;
  * <p>and the result is then Base58 encoded. This format is used for addresses, and private keys exported using the
  * dumpprivkey command.</p>
  */
-public class VersionedChecksummedBytes implements Serializable, Cloneable, Comparable<VersionedChecksummedBytes> {
+public class VersionedChecksummedBytes implements Serializable, Cloneable, Comparable<VersionedChecksummedBytes>, Destroyable {
     protected final int version;
     protected byte[] bytes;
+    private boolean destroyed = false;
 
     protected VersionedChecksummedBytes(String encoded) throws AddressFormatException {
         byte[] versionAndDataBytes = Base58.decodeChecked(encoded);
@@ -115,5 +121,16 @@ public class VersionedChecksummedBytes implements Serializable, Cloneable, Compa
      */
     public int getVersion() {
         return version;
+    }
+
+    @Override
+    public void destroy() throws DestroyFailedException {
+        DestructionUtils.destroyByteArray(this.bytes);
+        this.destroyed = true;
+    }
+
+    @Override
+    public boolean isDestroyed() {
+        return this.destroyed;
     }
 }

--- a/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
@@ -18,6 +18,7 @@ package org.bitcoinj.crypto;
 
 import com.google.common.collect.*;
 import org.bitcoinj.core.*;
+import org.bitcoinj.utils.DestructionUtils;
 import org.spongycastle.math.ec.*;
 
 import java.math.*;
@@ -151,14 +152,23 @@ public final class HDKeyDerivation {
         checkArgument(parent.hasPrivKey(), "Parent key must have private key bytes for this method.");
         byte[] parentPublicKey = parent.getPubKeyPoint().getEncoded(true);
         checkState(parentPublicKey.length == 33, "Parent pubkey must be 33 bytes, but is " + parentPublicKey.length);
-        ByteBuffer data = ByteBuffer.allocate(37);
-        if (childNumber.isHardened()) {
-            data.put(parent.getPrivKeyBytes33());
-        } else {
-            data.put(parentPublicKey);
+        
+        byte[] privKey = null;
+        byte[] i = null;
+        try {
+            ByteBuffer data = ByteBuffer.allocate(37);
+            if (childNumber.isHardened()) {
+                privKey = parent.getPrivKeyBytes33();
+                data.put(privKey);
+            } else {
+                data.put(parentPublicKey);
+            }
+            data.putInt(childNumber.i());
+            i = HDUtils.hmacSha512(parent.getChainCode(), data.array());
+        } finally {
+            DestructionUtils.destroyByteArray(privKey);
         }
-        data.putInt(childNumber.i());
-        byte[] i = HDUtils.hmacSha512(parent.getChainCode(), data.array());
+        checkNotNull(i);
         checkState(i.length == 64, i.length);
         byte[] il = Arrays.copyOfRange(i, 0, 32);
         byte[] chainCode = Arrays.copyOfRange(i, 32, 64);

--- a/core/src/main/java/org/bitcoinj/protocols/channels/StoredPaymentChannelServerStates.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/StoredPaymentChannelServerStates.java
@@ -18,6 +18,7 @@ package org.bitcoinj.protocols.channels;
 
 import com.google.common.collect.ImmutableMap;
 import org.bitcoinj.core.*;
+import org.bitcoinj.utils.DestructionUtils;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.Wallet;
 import org.bitcoinj.wallet.WalletExtension;
@@ -29,6 +30,7 @@ import net.jcip.annotations.GuardedBy;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -227,6 +229,8 @@ public class StoredPaymentChannelServerStates implements WalletExtension {
     @Override
     public byte[] serializeWalletExtension() {
         lock.lock();
+        
+        byte[] myKeyPrivKeyBytes = null;
         try {
             final NetworkParameters params = getNetworkParameters();
             // If we haven't attached to a wallet yet we can't check against network parameters
@@ -239,13 +243,18 @@ public class StoredPaymentChannelServerStates implements WalletExtension {
                 checkState(channel.bestValueToMe.signum() >= 0 && 
                         (!hasMaxMoney || channel.bestValueToMe.compareTo(networkMaxMoney) <= 0));
                 checkState(channel.refundTransactionUnlockTimeSecs > 0);
-                checkNotNull(channel.myKey.getPrivKeyBytes());
-                ServerState.StoredServerPaymentChannel.Builder channelBuilder = ServerState.StoredServerPaymentChannel.newBuilder()
+                
+                
+                ServerState.StoredServerPaymentChannel.Builder channelBuilder = null;
+                myKeyPrivKeyBytes = channel.myKey.getPrivKeyBytes();
+                checkNotNull(myKeyPrivKeyBytes);
+                channelBuilder = ServerState.StoredServerPaymentChannel.newBuilder()
                         .setMajorVersion(channel.majorVersion)
                         .setBestValueToMe(channel.bestValueToMe.value)
                         .setRefundTransactionUnlockTimeSecs(channel.refundTransactionUnlockTimeSecs)
                         .setContractTransaction(ByteString.copyFrom(channel.contract.unsafeBitcoinSerialize()))
-                        .setMyKey(ByteString.copyFrom(channel.myKey.getPrivKeyBytes()));
+                        .setMyKey(ByteString.copyFrom(myKeyPrivKeyBytes));
+                
                 if (channel.majorVersion == 1) {
                     channelBuilder.setClientOutput(ByteString.copyFrom(channel.clientOutput.unsafeBitcoinSerialize()));
                 } else {
@@ -257,6 +266,7 @@ public class StoredPaymentChannelServerStates implements WalletExtension {
             }
             return builder.build().toByteArray();
         } finally {
+            DestructionUtils.destroyByteArray(myKeyPrivKeyBytes);
             lock.unlock();
         }
     }

--- a/core/src/main/java/org/bitcoinj/utils/DestructionUtils.java
+++ b/core/src/main/java/org/bitcoinj/utils/DestructionUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright by the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.utils;
+
+/**
+ * Simple utility class, which supports with the destruction of 
+ * security-relevant entities.
+ * @author Nico Schmoigl
+ *
+ */
+public class DestructionUtils {
+
+	/**
+	 * destroys the contents of an arbitrary byte array (which contains security-relevant 
+	 * data, such as a private key) to ensure that it cannot be abused by an attacker.
+	 * @param subject the byte array, which shall be destroyed
+	 */
+	public static void destroyByteArray(byte[] subject) {
+		if (subject == null) {
+			return; // nothing to do
+		}
+		
+		if (subject.length == 0) {
+			return; // nothing to do
+		}
+		
+		for (int i = 0; i<subject.length; i++) {
+			subject[i] = 90; // arbitrary value
+		}
+	}
+}

--- a/core/src/main/java/org/bitcoinj/wallet/BasicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/BasicKeyChain.java
@@ -19,6 +19,7 @@ package org.bitcoinj.wallet;
 import org.bitcoinj.core.BloomFilter;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.crypto.*;
+import org.bitcoinj.utils.DestructionUtils;
 import org.bitcoinj.utils.ListenerRegistration;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.listeners.KeyChainEventListener;
@@ -326,11 +327,16 @@ public class BasicKeyChain implements EncryptableKeyChain {
             checkState(item.getEncryptionType() == Protos.Wallet.EncryptionType.ENCRYPTED_SCRYPT_AES);
             proto.setType(Protos.Key.Type.ENCRYPTED_SCRYPT_AES);
         } else {
-            final byte[] secret = item.getSecretBytes();
-            // The secret might be missing in the case of a watching wallet, or a key for which the private key
-            // is expected to be rederived on the fly from its parent.
-            if (secret != null)
-                proto.setSecretBytes(ByteString.copyFrom(secret));
+            byte[] secret = null;
+            try {
+                secret = item.getSecretBytes();
+                // The secret might be missing in the case of a watching wallet, or a key for which the private key
+                // is expected to be rederived on the fly from its parent.
+                if (secret != null)
+                    proto.setSecretBytes(ByteString.copyFrom(secret));
+            } finally {
+                DestructionUtils.destroyByteArray(secret);
+            }
             proto.setType(Protos.Key.Type.ORIGINAL);
         }
         return proto;

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
@@ -721,16 +721,24 @@ public class KeyChainGroup implements KeyBag {
             log.info("Wallet with existing HD chain is being re-upgraded due to change in key rotation time.");
         }
         log.info("Instantiating new HD chain using oldest non-rotating private key (address: {})", keyToUse.toAddress(params));
-        byte[] entropy = checkNotNull(keyToUse.getSecretBytes());
-        // Private keys should be at least 128 bits long.
-        checkState(entropy.length >= DeterministicSeed.DEFAULT_SEED_ENTROPY_BITS / 8);
-        // We reduce the entropy here to 128 bits because people like to write their seeds down on paper, and 128
-        // bits should be sufficient forever unless the laws of the universe change or ECC is broken; in either case
-        // we all have bigger problems.
-        entropy = Arrays.copyOfRange(entropy, 0, DeterministicSeed.DEFAULT_SEED_ENTROPY_BITS / 8);    // final argument is exclusive range.
-        checkState(entropy.length == DeterministicSeed.DEFAULT_SEED_ENTROPY_BITS / 8);
-        String passphrase = ""; // FIXME allow non-empty passphrase
-        DeterministicKeyChain chain = new DeterministicKeyChain(entropy, passphrase, keyToUse.getCreationTimeSeconds());
+        byte[] entropy = null;
+        DeterministicKeyChain chain = null;
+        
+        try {
+            entropy = checkNotNull(keyToUse.getSecretBytes());
+            // Private keys should be at least 128 bits long.
+            checkState(entropy.length >= DeterministicSeed.DEFAULT_SEED_ENTROPY_BITS / 8);
+            // We reduce the entropy here to 128 bits because people like to write their seeds down on paper, and 128
+            // bits should be sufficient forever unless the laws of the universe change or ECC is broken; in either case
+            // we all have bigger problems.
+            entropy = Arrays.copyOfRange(entropy, 0, DeterministicSeed.DEFAULT_SEED_ENTROPY_BITS / 8);    // final argument is exclusive range.
+            checkState(entropy.length == DeterministicSeed.DEFAULT_SEED_ENTROPY_BITS / 8);
+            String passphrase = ""; // FIXME allow non-empty passphrase
+            chain = new DeterministicKeyChain(entropy, passphrase, keyToUse.getCreationTimeSeconds());
+        } finally {
+            DestructionUtils.destroyByteArray(entropy);
+        }
+        
         if (aesKey != null) {
             chain = chain.toEncrypted(checkNotNull(basic.getKeyCrypter()), aesKey);
         }

--- a/examples/src/main/java/org/bitcoinj/examples/PrivateKeys.java
+++ b/examples/src/main/java/org/bitcoinj/examples/PrivateKeys.java
@@ -44,13 +44,19 @@ public class PrivateKeys {
             // compressed pub key. Otherwise assume it's a raw key.
             ECKey key;
             if (args[0].length() == 51 || args[0].length() == 52) {
-                DumpedPrivateKey dumpedPrivateKey = DumpedPrivateKey.fromBase58(params, args[0]);
-                key = dumpedPrivateKey.getKey();
+                DumpedPrivateKey dumpedPrivateKey = null;
+                try {
+                    dumpedPrivateKey = DumpedPrivateKey.fromBase58(params, args[0]);
+                    key = dumpedPrivateKey.getKey();
+                } finally {
+                    dumpedPrivateKey.destroy();
+                }
             } else {
                 BigInteger privKey = Base58.decodeToBigInteger(args[0]);
                 key = ECKey.fromPrivate(privKey);
             }
             System.out.println("Address from private key is: " + key.toAddress(params).toString());
+
             // And the address ...
             Address destination = Address.fromBase58(params, args[1]);
 
@@ -68,6 +74,10 @@ public class PrivateKeys {
             peerGroup.downloadBlockChain();
             peerGroup.stopAsync();
 
+            // QUALMS security: contents of variable "key" cannot be destroyed properly
+            // Here in this case, however, not to be considered an issue, as
+            // anyhow JVM will be stopped in a second
+            
             // And take them!
             System.out.println("Claiming " + wallet.getBalance().toFriendlyString());
             wallet.sendCoins(peerGroup, destination, wallet.getBalance());

--- a/tools/src/main/java/org/bitcoinj/tools/WalletTool.java
+++ b/tools/src/main/java/org/bitcoinj/tools/WalletTool.java
@@ -65,6 +65,8 @@ import org.spongycastle.crypto.params.KeyParameter;
 import org.spongycastle.util.encoders.Hex;
 
 import javax.annotation.Nullable;
+import javax.security.auth.DestroyFailedException;
+
 import java.io.*;
 import java.math.BigInteger;
 import java.net.InetAddress;
@@ -1356,14 +1358,21 @@ public class WalletTool {
         if (options.has("privkey")) {
             String data = (String) options.valueOf("privkey");
             if (data.startsWith("5J") || data.startsWith("5H") || data.startsWith("5K")) {
-                DumpedPrivateKey dpk;
+                DumpedPrivateKey dpk = null;
                 try {
                     dpk = DumpedPrivateKey.fromBase58(params, data);
+                    key = dpk.getKey();
                 } catch (AddressFormatException e) {
                     System.err.println("Could not parse dumped private key " + data);
                     return;
+                } finally {
+                    try {
+	                    if (dpk != null) 
+	                        dpk.destroy();
+                    } catch (DestroyFailedException e) {
+                        // condition can never be reached - left blank intentionally
+                    }
                 }
-                key = dpk.getKey();
             } else {
                 byte[] decode = Utils.parseAsHexOrBase58(data);
                 if (decode == null) {


### PR DESCRIPTION
There are multiple cases around, where a private key is being copied over (temporarily) in a `byte[]`. Due to the nature of Java, the memory of these arrays is only disposed during garbage collection, if just the reference is being lost. This may pose a security threat, as even though the operation, which required the private key, has already been completed. Yet, the credential-like piece of information still is kept in memory and thus could be spied out by a potential attacker.
A better approach is to delete the content of the array as soon as the private key data is no longer required. By this, even if an attacker could spy on the array later on, no valuable data would be found and thus security isn't compromised.
To facilitate this, a new class `DestructionUtils` is being provided, which provides a utility method for cleaning up byte arrays. Futhermore, several code locations, where a temporary `byte[]` is being used containing private key data, is being cleaned once the array is no longer required.
Furthermore, Java itself also provides an approach for destructing security-sensitive data by its `Destroyable` interface. For ease of consumption, this pattern is applied to `VersionedChecksummedBytes`, which is an ancestor of `DumpedPrivateKey`.

NB: This PR does not solve the much bigger problem of the fact that `ECKey` is not destroyable. For a discussion on this matter, also refer to https://groups.google.com/forum/#!topic/bitcoinj/s-SCDB1QYjY