### PR TITLE
Unit tests: Disable a nasty HotSpot optimization that causes exception messages…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -321,7 +321,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Xmx1024m ${surefireArgLine}</argLine><!-- Last argument is required for code coverage to work. -->
+                    <!-- First argument increases the maximum heap size, second argument disables a nasty HotSpot optimization
+                         (see http://jawspeak.com/2010/05/26/hotspot-caused-exceptions-to-lose-their-stack-traces-in-production-and-the-fix/)
+                         and last argument is required for code coverage to work. -->
+                    <argLine>-Xmx1024m -XX:-OmitStackTraceInFastThrow ${surefireArgLine}</argLine>
                     <runOrder>alphabetical</runOrder>
                     <systemProperties>
                         <property>


### PR DESCRIPTION
…and traces to go missing.

For more information, see http://jawspeak.com/2010/05/26/hotspot-caused-exceptions-to-lose-their-stack-traces-in-production-and-the-fix/

This is related to #1409, some discussion has also happened there.