### PR TITLE
Fix spelling of Tor

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The bitcoinj library is a Java implementation of the Bitcoin protocol, which all
 
 * Java 6 for the core modules, Java 8 for everything else
 * [Maven 3+](http://maven.apache.org) - for building the project
-* [Orchid](https://github.com/subgraph/Orchid) - for secure communications over [TOR](https://www.torproject.org)
+* [Orchid](https://github.com/subgraph/Orchid) - for secure communications over [Tor](https://www.torproject.org)
 * [Google Protocol Buffers](https://github.com/google/protobuf) - for use with serialization and hardware communications
 
 ### Getting started


### PR DESCRIPTION
[*'Tor is not spelled "TOR". Only the first letter is capitalized.'*](https://www.torproject.org/docs/faq.html.en#WhyCalledTor)