### PR TITLE
Change Wallet's saveNow() to be public instead of protected

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -1458,7 +1458,7 @@ public class Wallet extends BaseTaggableObject
     }
 
     /** If auto saving is enabled, do an immediate sync write to disk ignoring any delays. */
-    protected void saveNow() {
+    public void saveNow() {
         WalletFiles files = vFileManager;
         if (files != null) {
             try {


### PR DESCRIPTION

Comment for the `public WalletFiles autosaveToFile(File f, long delayTime, TimeUnit timeUnit, @Nullable WalletFiles.Listener eventListener)` method reads: 

> You should still save the wallet manually when your program is about to shut down as the JVM will not wait for the background thread.

But being saveNow() `protected`, it's impossible to do it. By being marked as `public`, it's possible to manually save the wallet when the app terminates.