### PR TITLE
Set DNS seeds according to current values specified in chainparams.cpp

### DIFF
--- a/core/src/main/java/org/bitcoinj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/MainNetParams.java
@@ -74,11 +74,9 @@ public class MainNetParams extends AbstractBitcoinNetParams {
                 "seed.bitcoin.sipa.be",         // Pieter Wuille
                 "dnsseed.bluematt.me",          // Matt Corallo
                 "dnsseed.bitcoin.dashjr.org",   // Luke Dashjr
-                "seed.bitcoinstats.com",        // Chris Decker
-                "seed.bitnodes.io",             // Addy Yeow
-                "bitseed.xf2.org",              // Jeff Garzik
+                "seed.bitcoinstats.com",        // Christian Decker
                 "seed.bitcoin.jonasschnelli.ch",// Jonas Schnelli
-                "bitcoin.bloqseeds.net",        // Bloq
+                "seed.btc.petertodd.org",       // Peter Todd
         };
         httpSeeds = new HttpDiscovery.Details[] {
                 // Andreas Schildbach

--- a/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
@@ -59,10 +59,9 @@ public class TestNet3Params extends AbstractBitcoinNetParams {
 
         dnsSeeds = new String[] {
                 "testnet-seed.bitcoin.jonasschnelli.ch", // Jonas Schnelli
-                "testnet-seed.bluematt.me",              // Matt Corallo
                 "testnet-seed.bitcoin.petertodd.org",    // Peter Todd
+                "testnet-seed.bluematt.me",              // Matt Corallo
                 "testnet-seed.bitcoin.schildbach.de",    // Andreas Schildbach
-                "bitcoin-testnet.bloqseeds.net",         // Bloq
         };
         addrSeeds = null;
         bip32HeaderPub = 0x043587CF;


### PR DESCRIPTION
This fix updates the DNS seed values to match the ones specified in chainparams.cpp of current bitcoind.