### PR TITLE
[FIXED] [PaymentProtocol] Fix Improper Check for Certificate Revocation

### DIFF
--- a/core/src/main/java/org/bitcoinj/protocols/payments/PaymentProtocol.java
+++ b/core/src/main/java/org/bitcoinj/protocols/payments/PaymentProtocol.java
@@ -193,8 +193,8 @@ public class PaymentProtocol {
 
             // Retrieves the most-trusted CAs from keystore.
             PKIXParameters params = new PKIXParameters(trustStore);
-            // Revocation not supported in the current version.
-            params.setRevocationEnabled(false);
+            // Revocation is supported in the current version.
+            params.setRevocationEnabled(true);
 
             // Now verify the certificate chain is correct and trusted. This let's us get an identity linked pubkey.
             CertPathValidator validator = CertPathValidator.getInstance("PKIX");


### PR DESCRIPTION
🐛 label: CWE-299

Greetings,

Added to the `PaymentProtocol` class in version 0.12, versions up to and including 0.14.3 can connect to a system with a revoked certificate, which is almost undoubtedly exploitable.

Signed-off-by: Bryon Gloden, CISSP® cissp@bryongloden.com