### PR TITLE
Add AddressScript interface to ease handling of BECH32 addresses

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Address.java
+++ b/core/src/main/java/org/bitcoinj/core/Address.java
@@ -22,7 +22,12 @@ package org.bitcoinj.core;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Arrays;
 
+import com.google.common.base.Objects;
+import com.google.common.primitives.Ints;
+import com.google.common.primitives.UnsignedBytes;
 import org.bitcoinj.params.Networks;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.Script.ScriptType;
@@ -31,6 +36,7 @@ import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 import static org.bitcoinj.core.AddressScript.AddressFormat.BASE58;
 import static org.bitcoinj.script.Script.ScriptType.P2PKH;
 import static org.bitcoinj.script.Script.ScriptType.P2SH;
@@ -46,26 +52,14 @@ import static org.bitcoinj.script.Script.ScriptType.P2SH;
  * should be interpreted. Whilst almost all addresses today are hashes of public keys, another (currently unsupported
  * type) can contain a hash of a script instead.</p>
  */
-public class Address extends VersionedChecksummedBytes implements AddressScript {
-    /**
-     * An address is a RIPEMD160 hash of a public key, therefore is always 160 bits or 20 bytes.
-     */
-    public static final int LENGTH = 20;
+public class Address implements AddressScript, Serializable, Cloneable, Comparable<Address>{
 
-    private transient NetworkParameters params;
+    protected final AddressScript addressScript;
 
-    /**
-     * Construct an address from parameters, the address version, and the hash160 form. Example:<p>
-     *
-     * <pre>new Address(MainNetParams.get(), NetworkParameters.getAddressHeader(), Hex.decode("4a22c3c4cbb31e4d03b15550636762bda0baf85a"));</pre>
-     */
-    public Address(NetworkParameters params, int version, byte[] hash160) throws WrongNetworkException {
-        super(version, hash160);
-        checkNotNull(params);
-        checkArgument(hash160.length == 20, "Addresses are 160-bit hashes, so you must provide 20 bytes");
-        if (!isAcceptableVersion(params, version))
-            throw new WrongNetworkException(version, params.getAcceptableAddressCodes());
-        this.params = params;
+    Address(AddressScript address) {
+        checkNotNull(address);
+        checkState(!(address instanceof Address), "Cannot pass Address here");
+        addressScript = address;
     }
 
     /**
@@ -73,24 +67,137 @@ public class Address extends VersionedChecksummedBytes implements AddressScript 
      *
      * <pre>new Address(MainNetParams.get(), ScriptType.P2PKH, Hex.decode("4a22c3c4cbb31e4d03b15550636762bda0baf85a"));</pre>
      */
-    public Address(NetworkParameters params, ScriptType scriptType, byte[] hash160) {
-        super(scriptTypeToVersion(params, scriptType), hash160);
-        checkArgument(hash160.length == LENGTH, "Addresses are 160-bit hashes, so you must provide 20 bytes");
-        this.params = params;
-    }
-
-    private static int scriptTypeToVersion(NetworkParameters params, ScriptType scriptType) {
+    Address(NetworkParameters params, ScriptType scriptType, byte[] hash160) {
         switch (scriptType) {
             case P2PKH:
-                return params.getAddressHeader();
             case P2SH:
-                return params.getP2SHHeader();
+                addressScript = new Base58Address(params, scriptType, hash160);
+                break;
+            // TODO Implement SegWit script types
+//            case P2WPKH:
+//            case P2WSH:
+//                addressScript = new SegWitAddress(params, scriptType, hash160);
+//                break;
             default:
                 throw new IllegalArgumentException("Unsupported script type: " + scriptType);
         }
     }
 
+    public static Address fromString(@Nullable NetworkParameters params, String str) throws AddressFormatException {
+        AddressScript address;
+        try {
+            address = Base58Address.fromBase58(params, str);
+        } catch (WrongNetworkException x) {
+            throw x;
+        } catch (AddressFormatException x) {
+            try {
+                // TODO Implement SegWit addresses
+                throw x;
+//                address = SegwitAddress.fromBech32(params, str);
+            } catch (WrongNetworkException x2) {
+                throw x;
+            } catch (AddressFormatException x2) {
+                throw new AddressFormatException(str);
+            }
+        }
+        return fromAddressScript(address);
+    }
+
+    public static Address fromAddressScript(AddressScript address) {
+        if (address instanceof Address) {
+            return (Address) address;
+        } else {
+            return new Address(address);
+        }
+    }
+
+    /**
+     * Examines the version byte of the address and attempts to find a matching NetworkParameters. If you aren't sure
+     * which network the address is intended for (eg, it was provided by a user), you can use this to decide if it is
+     * compatible with the current wallet. You should be able to handle a null response from this method. Note that the
+     * parameters returned is not necessarily the same as the one the Address was created with.
+     *
+     * @return a NetworkParameters representing the network the address is intended for.
+     */
+    public NetworkParameters getParameters() {
+        return addressScript.getParameters();
+    }
+
+
+    @Override
+    public AddressFormat getAddressFormat() {
+        return addressScript.getAddressFormat();
+    }
+
+    @Override
+    public ScriptType getScriptType() {
+        return addressScript.getScriptType();
+    }
+
+    @Override
+    public byte[] getValue() {
+        return addressScript.getValue();
+    }
+
+    @Override
+    public String toString() {
+        return addressScript.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return addressScript.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Address other = (Address) o;
+        return addressScript.equals(other.addressScript);
+    }
+
+    /**
+     * This implementation narrows the return type to <code>Address</code>.
+     */
+    @Override
+    public Address clone() throws CloneNotSupportedException {
+        return (Address) super.clone();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * This implementation uses an optimized Google Guava method to compare <code>bytes</code>.
+     */
+    @Override
+    public int compareTo(Address o) {
+        int result = Ints.compare(addressScript.getScriptType().ordinal(), o.getScriptType().ordinal());
+        return result != 0 ? result :
+                UnsignedBytes.lexicographicalComparator().compare(addressScript.getValue(), o.getValue());
+    }
+
+
+    /* ************************************************************************
+     * ************************************************************************
+     * Deprecated stuff bellow
+     * ************************************************************************
+     * ************************************************************************
+     */
+
+
+    /**
+     * Construct an address from parameters, the address version, and the hash160 form. Example:<p>
+     *
+     * <pre>new Address(MainNetParams.get(), NetworkParameters.getAddressHeader(), Hex.decode("4a22c3c4cbb31e4d03b15550636762bda0baf85a"));</pre>
+     */
+    @Deprecated
+    public Address(NetworkParameters params, int version, byte[] hash160) throws WrongNetworkException {
+        addressScript = new Base58Address(params, version, hash160);
+    }
+
     /** Returns an Address that represents the given P2SH script hash. */
+    @Deprecated
     public static Address fromP2SHHash(NetworkParameters params, byte[] hash160) {
         try {
             return new Address(params, params.getP2SHHeader(), hash160);
@@ -100,6 +207,7 @@ public class Address extends VersionedChecksummedBytes implements AddressScript 
     }
 
     /** Returns an Address that represents the script hash extracted from the given scriptPubKey */
+    @Deprecated
     public static Address fromP2SHScript(NetworkParameters params, Script scriptPubKey) {
         checkArgument(scriptPubKey.isPayToScriptHash(), "Not a P2SH script");
         return fromP2SHHash(params, scriptPubKey.getPubKeyHash());
@@ -116,6 +224,7 @@ public class Address extends VersionedChecksummedBytes implements AddressScript 
      * @throws WrongNetworkException
      *             if the given address is valid but for a different chain (eg testnet vs mainnet)
      */
+    @Deprecated
     public static Address fromBase58(@Nullable NetworkParameters params, String base58) throws AddressFormatException {
         return new Address(params, base58);
     }
@@ -125,60 +234,32 @@ public class Address extends VersionedChecksummedBytes implements AddressScript 
      *
      * <pre>new Address(MainNetParams.get(), Hex.decode("4a22c3c4cbb31e4d03b15550636762bda0baf85a"));</pre>
      */
+    @Deprecated
     public Address(NetworkParameters params, byte[] hash160) {
-        super(params.getAddressHeader(), hash160);
         checkArgument(hash160.length == 20, "Addresses are 160-bit hashes, so you must provide 20 bytes");
-        this.params = params;
+        addressScript = new Base58Address(params, hash160);
     }
 
     /** @deprecated Use {@link #fromBase58(NetworkParameters, String)} */
     @Deprecated
     public Address(@Nullable NetworkParameters params, String address) throws AddressFormatException {
-        super(address);
-        if (params != null) {
-            if (!isAcceptableVersion(params, version)) {
-                throw new WrongNetworkException(version, params.getAcceptableAddressCodes());
-            }
-            this.params = params;
-        } else {
-            NetworkParameters paramsFound = null;
-            for (NetworkParameters p : Networks.get()) {
-                if (isAcceptableVersion(p, version)) {
-                    paramsFound = p;
-                    break;
-                }
-            }
-            if (paramsFound == null)
-                throw new AddressFormatException("No network found for " + address);
-
-            this.params = paramsFound;
-        }
+        addressScript = new Base58Address(params, address);
+        //
     }
 
     /** The (big endian) 20 byte hash that is the core of a Bitcoin address. */
+    @Deprecated
     public byte[] getHash160() {
-        return bytes;
+        return addressScript.getValue();
     }
 
     /**
      * Returns true if this address is a Pay-To-Script-Hash (P2SH) address.
      * See also https://github.com/bitcoin/bips/blob/master/bip-0013.mediawiki: Address Format for pay-to-script-hash
      */
+    @Deprecated
     public boolean isP2SHAddress() {
-        final NetworkParameters parameters = getParameters();
-        return parameters != null && this.version == parameters.p2shHeader;
-    }
-
-    /**
-     * Examines the version byte of the address and attempts to find a matching NetworkParameters. If you aren't sure
-     * which network the address is intended for (eg, it was provided by a user), you can use this to decide if it is
-     * compatible with the current wallet. You should be able to handle a null response from this method. Note that the
-     * parameters returned is not necessarily the same as the one the Address was created with.
-     *
-     * @return a NetworkParameters representing the network the address is intended for.
-     */
-    public NetworkParameters getParameters() {
-        return params;
+        return addressScript.getScriptType() == P2SH;
     }
 
     /**
@@ -190,7 +271,7 @@ public class Address extends VersionedChecksummedBytes implements AddressScript 
      */
     public static NetworkParameters getParametersFromAddress(String address) throws AddressFormatException {
         try {
-            return Address.fromBase58(null, address).getParameters();
+            return Address.fromString(null, address).getParameters();
         } catch (WrongNetworkException e) {
             throw new RuntimeException(e);  // Cannot happen.
         }
@@ -199,6 +280,7 @@ public class Address extends VersionedChecksummedBytes implements AddressScript 
     /**
      * Check if a given address version is valid given the NetworkParameters.
      */
+    @Deprecated
     private static boolean isAcceptableVersion(NetworkParameters params, int version) {
         for (int v : params.getAcceptableAddressCodes()) {
             if (version == v) {
@@ -208,38 +290,4 @@ public class Address extends VersionedChecksummedBytes implements AddressScript 
         return false;
     }
 
-    /**
-     * This implementation narrows the return type to <code>Address</code>.
-     */
-    @Override
-    public Address clone() throws CloneNotSupportedException {
-        return (Address) super.clone();
-    }
-
-    // Java serialization
-
-    private void writeObject(ObjectOutputStream out) throws IOException {
-        out.defaultWriteObject();
-        out.writeUTF(params.id);
-    }
-
-    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
-        in.defaultReadObject();
-        params = NetworkParameters.fromID(in.readUTF());
-    }
-
-    @Override
-    public AddressFormat getAddressFormat() {
-        return BASE58;
-    }
-
-    @Override
-    public ScriptType getScriptType() {
-        return isP2SHAddress() ? P2SH : P2PKH;
-    }
-
-    @Override
-    public byte[] getValue() {
-        return bytes;
-    }
 }

--- a/core/src/main/java/org/bitcoinj/core/AddressScript.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressScript.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 John Jegutanis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.core;
+
+import org.bitcoinj.script.Script.ScriptType;
+
+public interface AddressScript {
+    enum AddressFormat {
+        BASE58,
+        BECH32
+    }
+
+    /** Get the script type of this address */
+    ScriptType getScriptType();
+
+    /** Get the hash value of this address */
+    byte[] getValue();
+
+    /** Get the network parameters of this address */
+    NetworkParameters getParameters();
+
+    /** Get the destination type */
+    AddressFormat getAddressFormat();
+}

--- a/core/src/main/java/org/bitcoinj/core/Base58Address.java
+++ b/core/src/main/java/org/bitcoinj/core/Base58Address.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2011 Google Inc.
+ * Copyright 2014 Giannis Dzegoutanis
+ * Copyright 2015 Andreas Schildbach
+ * Copyright 2018 John Jegutanis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.core;
+
+import org.bitcoinj.params.Networks;
+import org.bitcoinj.script.Script;
+import org.bitcoinj.script.Script.ScriptType;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.bitcoinj.core.AddressScript.AddressFormat.BASE58;
+import static org.bitcoinj.script.Script.ScriptType.P2PKH;
+import static org.bitcoinj.script.Script.ScriptType.P2SH;
+
+/**
+ * <p>A Bitcoin address looks like 1MsScoe2fTJoq4ZPdQgqyhgWeoNamYPevy and is derived from an elliptic curve public key
+ * plus a set of network parameters. Not to be confused with a {@link PeerAddress} or {@link AddressMessage}
+ * which are about network (TCP) addresses.</p>
+ *
+ * <p>A standard address is built by taking the RIPE-MD160 hash of the public key bytes, with a version prefix and a
+ * checksum suffix, then encoding it textually as base58. The version prefix is used to both denote the network for
+ * which the address is valid (see {@link NetworkParameters}, and also to indicate how the bytes inside the address
+ * should be interpreted. Whilst almost all addresses today are hashes of public keys, another (currently unsupported
+ * type) can contain a hash of a script instead.</p>
+ */
+public class Base58Address extends VersionedChecksummedBytes implements AddressScript {
+    /**
+     * An address is a RIPEMD160 hash of a public key, therefore is always 160 bits or 20 bytes.
+     */
+    public static final int LENGTH = 20;
+
+    private transient NetworkParameters params;
+
+    /**
+     * Construct an address from parameters, the address version, and the hash160 form. Example:<p>
+     *
+     * <pre>new Address(MainNetParams.get(), NetworkParameters.getAddressHeader(), Hex.decode("4a22c3c4cbb31e4d03b15550636762bda0baf85a"));</pre>
+     */
+    public Base58Address(NetworkParameters params, int version, byte[] hash160) throws WrongNetworkException {
+        super(version, hash160);
+        checkNotNull(params);
+        checkArgument(hash160.length == 20, "Addresses are 160-bit hashes, so you must provide 20 bytes");
+        if (!isAcceptableVersion(params, version))
+            throw new WrongNetworkException(version, params.getAcceptableAddressCodes());
+        this.params = params;
+    }
+
+    /**
+     * Construct an address from parameters, the address script type, and the hash160 form. Example:<p>
+     *
+     * <pre>new Address(MainNetParams.get(), ScriptType.P2PKH, Hex.decode("4a22c3c4cbb31e4d03b15550636762bda0baf85a"));</pre>
+     */
+    public Base58Address(NetworkParameters params, ScriptType scriptType, byte[] hash160) {
+        super(scriptTypeToVersion(params, scriptType), hash160);
+        checkArgument(hash160.length == LENGTH, "Addresses are 160-bit hashes, so you must provide 20 bytes");
+        this.params = params;
+    }
+
+    private static int scriptTypeToVersion(NetworkParameters params, ScriptType scriptType) {
+        switch (scriptType) {
+            case P2PKH:
+                return params.getAddressHeader();
+            case P2SH:
+                return params.getP2SHHeader();
+            default:
+                throw new IllegalArgumentException("Unsupported script type: " + scriptType);
+        }
+    }
+
+    /** Returns an Address that represents the given P2SH script hash. */
+    public static Base58Address fromP2SHHash(NetworkParameters params, byte[] hash160) {
+        try {
+            return new Base58Address(params, params.getP2SHHeader(), hash160);
+        } catch (WrongNetworkException e) {
+            throw new RuntimeException(e);  // Cannot happen.
+        }
+    }
+
+    /** Returns an Address that represents the script hash extracted from the given scriptPubKey */
+    public static Base58Address fromP2SHScript(NetworkParameters params, Script scriptPubKey) {
+        checkArgument(scriptPubKey.isPayToScriptHash(), "Not a P2SH script");
+        return fromP2SHHash(params, scriptPubKey.getPubKeyHash());
+    }
+
+    /**
+     * Construct an address from its Base58 representation.
+     * @param params
+     *            The expected NetworkParameters or null if you don't want validation.
+     * @param base58
+     *            The textual form of the address, such as "17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL".
+     * @throws AddressFormatException
+     *             if the given base58 doesn't parse or the checksum is invalid
+     * @throws WrongNetworkException
+     *             if the given address is valid but for a different chain (eg testnet vs mainnet)
+     */
+    public static Base58Address fromBase58(@Nullable NetworkParameters params, String base58) throws AddressFormatException {
+        return new Base58Address(params, base58);
+    }
+
+    /**
+     * Construct an address from parameters and the hash160 form. Example:<p>
+     *
+     * <pre>new Address(MainNetParams.get(), Hex.decode("4a22c3c4cbb31e4d03b15550636762bda0baf85a"));</pre>
+     */
+    public Base58Address(NetworkParameters params, byte[] hash160) {
+        super(params.getAddressHeader(), hash160);
+        checkArgument(hash160.length == 20, "Addresses are 160-bit hashes, so you must provide 20 bytes");
+        this.params = params;
+    }
+
+    /** @deprecated Use {@link #fromBase58(NetworkParameters, String)} */
+    @Deprecated
+    public Base58Address(@Nullable NetworkParameters params, String address) throws AddressFormatException {
+        super(address);
+        if (params != null) {
+            if (!isAcceptableVersion(params, version)) {
+                throw new WrongNetworkException(version, params.getAcceptableAddressCodes());
+            }
+            this.params = params;
+        } else {
+            NetworkParameters paramsFound = null;
+            for (NetworkParameters p : Networks.get()) {
+                if (isAcceptableVersion(p, version)) {
+                    paramsFound = p;
+                    break;
+                }
+            }
+            if (paramsFound == null)
+                throw new AddressFormatException("No network found for " + address);
+
+            this.params = paramsFound;
+        }
+    }
+
+    /** The (big endian) 20 byte hash that is the core of a Bitcoin address. */
+    public byte[] getHash160() {
+        return bytes;
+    }
+
+    /**
+     * Returns true if this address is a Pay-To-Script-Hash (P2SH) address.
+     * See also https://github.com/bitcoin/bips/blob/master/bip-0013.mediawiki: Address Format for pay-to-script-hash
+     */
+    public boolean isP2SHAddress() {
+        final NetworkParameters parameters = getParameters();
+        return parameters != null && this.version == parameters.p2shHeader;
+    }
+
+    /**
+     * Examines the version byte of the address and attempts to find a matching NetworkParameters. If you aren't sure
+     * which network the address is intended for (eg, it was provided by a user), you can use this to decide if it is
+     * compatible with the current wallet. You should be able to handle a null response from this method. Note that the
+     * parameters returned is not necessarily the same as the one the Address was created with.
+     *
+     * @return a NetworkParameters representing the network the address is intended for.
+     */
+    public NetworkParameters getParameters() {
+        return params;
+    }
+
+    /**
+     * Given an address, examines the version byte and attempts to find a matching NetworkParameters. If you aren't sure
+     * which network the address is intended for (eg, it was provided by a user), you can use this to decide if it is
+     * compatible with the current wallet.
+     * @return a NetworkParameters of the address
+     * @throws AddressFormatException if the string wasn't of a known version
+     */
+    public static NetworkParameters getParametersFromAddress(String address) throws AddressFormatException {
+        try {
+            return Base58Address.fromBase58(null, address).getParameters();
+        } catch (WrongNetworkException e) {
+            throw new RuntimeException(e);  // Cannot happen.
+        }
+    }
+
+    /**
+     * Check if a given address version is valid given the NetworkParameters.
+     */
+    private static boolean isAcceptableVersion(NetworkParameters params, int version) {
+        for (int v : params.getAcceptableAddressCodes()) {
+            if (version == v) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * This implementation narrows the return type to <code>Address</code>.
+     */
+    @Override
+    public Base58Address clone() throws CloneNotSupportedException {
+        return (Base58Address) super.clone();
+    }
+
+    // Java serialization
+
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        out.defaultWriteObject();
+        out.writeUTF(params.id);
+    }
+
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        params = NetworkParameters.fromID(in.readUTF());
+    }
+
+    @Override
+    public AddressFormat getAddressFormat() {
+        return BASE58;
+    }
+
+    @Override
+    public ScriptType getScriptType() {
+        return isP2SHAddress() ? P2SH : P2PKH;
+    }
+
+    @Override
+    public byte[] getValue() {
+        return bytes;
+    }
+}

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -880,7 +880,7 @@ public class Transaction extends ChildMessage {
     /**
      * Creates an output based on the given address and value, adds it to this transaction, and returns the new output.
      */
-    public TransactionOutput addOutput(Coin value, Address address) {
+    public TransactionOutput addOutput(Coin value, AddressScript address) {
         return addOutput(new TransactionOutput(params, this, value, address));
     }
 

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -83,9 +83,9 @@ public class TransactionOutput extends ChildMessage {
     /**
      * Creates an output that sends 'value' to the given address (public key hash). The amount should be created with
      * something like {@link Coin#valueOf(int, int)}. Typically you would use
-     * {@link Transaction#addOutput(Coin, Address)} instead of creating a TransactionOutput directly.
+     * {@link Transaction#addOutput(Coin, AddressScript)} instead of creating a TransactionOutput directly.
      */
-    public TransactionOutput(NetworkParameters params, @Nullable Transaction parent, Coin value, Address to) {
+    public TransactionOutput(NetworkParameters params, @Nullable Transaction parent, Coin value, AddressScript to) {
         this(params, parent, value, ScriptBuilder.createOutputScript(to).getProgram());
     }
 

--- a/core/src/main/java/org/bitcoinj/script/ScriptPattern.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptPattern.java
@@ -17,6 +17,7 @@
 package org.bitcoinj.script;
 
 import org.bitcoinj.core.Address;
+import org.bitcoinj.core.Base58Address;
 
 import java.util.List;
 
@@ -27,12 +28,14 @@ import static org.bitcoinj.script.ScriptOpCodes.*;
  * This is a Script pattern matcher with some typical script patterns
  */
 public class ScriptPattern {
+    private static final int HASH160_LENGTH = 20;
+
     public static boolean isSentToAddress(List<ScriptChunk> chunks) {
         return chunks.size() == 5 &&
                chunks.get(0).equalsOpCode(OP_DUP) &&
                chunks.get(1).equalsOpCode(OP_HASH160) &&
                chunks.get(2).data != null &&
-               chunks.get(2).data.length == Address.LENGTH &&
+               chunks.get(2).data.length == HASH160_LENGTH &&
                chunks.get(3).equalsOpCode(OP_EQUALVERIFY) &&
                chunks.get(4).equalsOpCode(OP_CHECKSIG);
     }
@@ -47,7 +50,7 @@ public class ScriptPattern {
                chunks.get(0).equalsOpCode(OP_HASH160) &&
                chunks.get(1).opcode == 0x14 &&
                chunks.get(1).data != null &&
-               chunks.get(1).data.length == Address.LENGTH &&
+               chunks.get(1).data.length == HASH160_LENGTH &&
                chunks.get(2).equalsOpCode(OP_EQUAL);
     }
 

--- a/core/src/test/java/org/bitcoinj/core/AddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AddressTest.java
@@ -31,7 +31,10 @@ import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.bitcoinj.core.AddressScript.AddressFormat.BASE58;
 import static org.bitcoinj.core.Utils.HEX;
+import static org.bitcoinj.script.Script.ScriptType.P2PKH;
+import static org.bitcoinj.script.Script.ScriptType.P2SH;
 import static org.junit.Assert.*;
 
 public class AddressTest {
@@ -251,5 +254,67 @@ public class AddressTest {
         int resultsString = a.toString().compareTo(b.toString());
         assertTrue( resultBytes < 0 );
         assertTrue( resultsString < 0 );
+    }
+
+
+    @Test
+    public void addressScript() {
+        // P2PKH
+        AddressScript mainAddress = Address.fromBase58(mainParams, "17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL");
+        assertEquals(BASE58, mainAddress.getAddressFormat());
+        assertEquals(P2PKH, mainAddress.getScriptType());
+        assertArrayEquals(HEX.decode("4a22c3c4cbb31e4d03b15550636762bda0baf85a"), mainAddress.getValue());
+        assertEquals("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL", mainAddress.toString());
+        assertEquals(mainParams, mainAddress.getParameters());
+
+        mainAddress = new Address(mainParams, P2PKH, HEX.decode("4a22c3c4cbb31e4d03b15550636762bda0baf85a"));
+        assertEquals(BASE58, mainAddress.getAddressFormat());
+        assertEquals(P2PKH, mainAddress.getScriptType());
+        assertArrayEquals(HEX.decode("4a22c3c4cbb31e4d03b15550636762bda0baf85a"), mainAddress.getValue());
+        assertEquals("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL", mainAddress.toString());
+        assertEquals(mainParams, mainAddress.getParameters());
+
+        AddressScript testAddress = Address.fromBase58(testParams, "n4eA2nbYqErp7H6jebchxAN59DmNpksexv");
+        assertEquals(BASE58, testAddress.getAddressFormat());
+        assertEquals(P2PKH, testAddress.getScriptType());
+        assertArrayEquals(HEX.decode("fda79a24e50ff70ff42f7d89585da5bd19d9e5cc"), testAddress.getValue());
+        assertEquals("n4eA2nbYqErp7H6jebchxAN59DmNpksexv", testAddress.toString());
+        assertEquals(testParams, testAddress.getParameters());
+
+        testAddress = new Address(testParams, P2PKH, HEX.decode("fda79a24e50ff70ff42f7d89585da5bd19d9e5cc"));
+        assertEquals(BASE58, testAddress.getAddressFormat());
+        assertEquals(P2PKH, testAddress.getScriptType());
+        assertArrayEquals(HEX.decode("fda79a24e50ff70ff42f7d89585da5bd19d9e5cc"), testAddress.getValue());
+        assertEquals("n4eA2nbYqErp7H6jebchxAN59DmNpksexv", testAddress.toString());
+        assertEquals(testParams, testAddress.getParameters());
+
+        // P2SH
+        AddressScript mainNetP2SHAddress = Address.fromBase58(mainParams, "35b9vsyH1KoFT5a5KtrKusaCcPLkiSo1tU");
+        assertEquals(BASE58, mainNetP2SHAddress.getAddressFormat());
+        assertEquals(P2SH, mainNetP2SHAddress.getScriptType());
+        assertArrayEquals(HEX.decode("2ac4b0b501117cc8119c5797b519538d4942e90e"), mainNetP2SHAddress.getValue());
+        assertEquals("35b9vsyH1KoFT5a5KtrKusaCcPLkiSo1tU", mainNetP2SHAddress.toString());
+        assertEquals(mainParams, mainNetP2SHAddress.getParameters());
+
+        mainNetP2SHAddress = new Address(mainParams, P2SH, HEX.decode("2ac4b0b501117cc8119c5797b519538d4942e90e"));
+        assertEquals(BASE58, mainNetP2SHAddress.getAddressFormat());
+        assertEquals(P2SH, mainNetP2SHAddress.getScriptType());
+        assertArrayEquals(HEX.decode("2ac4b0b501117cc8119c5797b519538d4942e90e"), mainNetP2SHAddress.getValue());
+        assertEquals("35b9vsyH1KoFT5a5KtrKusaCcPLkiSo1tU", mainNetP2SHAddress.toString());
+        assertEquals(mainParams, mainNetP2SHAddress.getParameters());
+
+        AddressScript testNetP2SHAddress = Address.fromBase58(testParams, "2MuVSxtfivPKJe93EC1Tb9UhJtGhsoWEHCe");
+        assertEquals(BASE58, testNetP2SHAddress.getAddressFormat());
+        assertEquals(P2SH, testNetP2SHAddress.getScriptType());
+        assertArrayEquals(HEX.decode("18a0e827269b5211eb51a4af1b2fa69333efa722"), testNetP2SHAddress.getValue());
+        assertEquals("2MuVSxtfivPKJe93EC1Tb9UhJtGhsoWEHCe", testNetP2SHAddress.toString());
+        assertEquals(testParams, testNetP2SHAddress.getParameters());
+
+        testNetP2SHAddress = new Address(testParams, P2SH, HEX.decode("18a0e827269b5211eb51a4af1b2fa69333efa722"));
+        assertEquals(BASE58, testNetP2SHAddress.getAddressFormat());
+        assertEquals(P2SH, testNetP2SHAddress.getScriptType());
+        assertArrayEquals(HEX.decode("18a0e827269b5211eb51a4af1b2fa69333efa722"), testNetP2SHAddress.getValue());
+        assertEquals("2MuVSxtfivPKJe93EC1Tb9UhJtGhsoWEHCe", testNetP2SHAddress.toString());
+        assertEquals(testParams, testNetP2SHAddress.getParameters());
     }
 }

--- a/core/src/test/java/org/bitcoinj/core/AddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AddressTest.java
@@ -155,10 +155,10 @@ public class AddressTest {
     public void p2shAddress() throws Exception {
         // Test that we can construct P2SH addresses
         Address mainNetP2SHAddress = Address.fromBase58(MainNetParams.get(), "35b9vsyH1KoFT5a5KtrKusaCcPLkiSo1tU");
-        assertEquals(mainNetP2SHAddress.version, MainNetParams.get().p2shHeader);
+        assertEquals(((Base58Address)mainNetP2SHAddress.addressScript).getVersion(), MainNetParams.get().p2shHeader);
         assertTrue(mainNetP2SHAddress.isP2SHAddress());
         Address testNetP2SHAddress = Address.fromBase58(TestNet3Params.get(), "2MuVSxtfivPKJe93EC1Tb9UhJtGhsoWEHCe");
-        assertEquals(testNetP2SHAddress.version, TestNet3Params.get().p2shHeader);
+        assertEquals(((Base58Address)testNetP2SHAddress.addressScript).getVersion(), TestNet3Params.get().p2shHeader);
         assertTrue(testNetP2SHAddress.isP2SHAddress());
 
         // Test that we can determine what network a P2SH address belongs to
@@ -205,7 +205,7 @@ public class AddressTest {
     @Test
     public void roundtripBase58() throws Exception {
         String base58 = "17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL";
-        assertEquals(base58, Address.fromBase58(null, base58).toBase58());
+        assertEquals(base58, Address.fromBase58(null, base58).toString());
     }
 
     @Test


### PR DESCRIPTION
DO NOT MERGE, feedback is needed.

This is a proof of concept of how to handle Bech32 addresses using a new `AddressScript` interface.

The `Address#getHash160()` method that is replaced by the `getValue()` as SegWit uses 160 or 256 bit hashes.

The new `getScriptType()` method is a replacement for the `Address#isP2SHAddress()` where we get the exact `Script.ScriptType` that the address represent. For example the existing addresses will return either `P2PKH` or `P2SH` and the future Bech32 addresses will return either `P2WPKH` or `P2WSH`. Notice that it is easier to add SegWit support to `ScriptBuilder#createOutputScript` when we switch the `Script.ScriptType` enum.

Finally the `getAddressFormat()` returns `AddressFormat.BASE58` for the existing `Address` and `AddressFormat.BECH32` for the new SegWit addresses.

Ideally all APIs should be changed to use the new interface and it is easy when we pass parameters to methods but return values are trickier. Unless we are OK with breaking the API.

It is missing the `Comparable` that is defined in `VersionedChecksummedBytes`, any ideas of how it could be handled?