### PR TITLE
Remove the concept of "acceptable Base58 address headers" (version headers) for a given network.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Address.java
+++ b/core/src/main/java/org/bitcoinj/core/Address.java
@@ -60,7 +60,7 @@ public class Address extends VersionedChecksummedBytes {
         checkNotNull(params);
         checkArgument(hash160.length == 20, "Addresses are 160-bit hashes, so you must provide 20 bytes");
         if (!isAcceptableVersion(params, version))
-            throw new WrongNetworkException(version, params.getAcceptableAddressCodes());
+            throw new WrongNetworkException(version);
         this.params = params;
     }
 
@@ -119,7 +119,7 @@ public class Address extends VersionedChecksummedBytes {
         super(address);
         if (params != null) {
             if (!isAcceptableVersion(params, version)) {
-                throw new WrongNetworkException(version, params.getAcceptableAddressCodes());
+                throw new WrongNetworkException(version);
             }
             this.params = params;
         } else {
@@ -182,11 +182,10 @@ public class Address extends VersionedChecksummedBytes {
      * Check if a given address version is valid given the NetworkParameters.
      */
     private static boolean isAcceptableVersion(NetworkParameters params, int version) {
-        for (int v : params.getAcceptableAddressCodes()) {
-            if (version == v) {
-                return true;
-            }
-        }
+        if (version == params.getAddressHeader())
+            return true;
+        if (version == params.getP2SHHeader())
+            return true;
         return false;
     }
 

--- a/core/src/main/java/org/bitcoinj/core/DumpedPrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/core/DumpedPrivateKey.java
@@ -69,7 +69,7 @@ public class DumpedPrivateKey extends VersionedChecksummedBytes {
     public DumpedPrivateKey(@Nullable NetworkParameters params, String encoded) throws AddressFormatException {
         super(encoded);
         if (params != null && version != params.getDumpedPrivateKeyHeader())
-            throw new WrongNetworkException(version, new int[]{ params.getDumpedPrivateKeyHeader() });
+            throw new WrongNetworkException(version);
         if (bytes.length != 32 && bytes.length != 33) {
             throw new AddressFormatException("Wrong number of bytes for a private key, not 32 or 33");
         }

--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -100,7 +100,6 @@ public abstract class NetworkParameters {
     protected int spendableCoinbaseDepth;
     protected int subsidyDecreaseBlockCount;
     
-    protected int[] acceptableAddressCodes;
     protected String[] dnsSeeds;
     protected int[] addrSeeds;
     protected HttpDiscovery.Details[] httpSeeds = {};
@@ -344,15 +343,6 @@ public abstract class NetworkParameters {
      */
     public int getTargetTimespan() {
         return targetTimespan;
-    }
-
-    /**
-     * The version codes that prefix addresses which are acceptable on this network. Although Satoshi intended these to
-     * be used for "versioning", in fact they are today used to discriminate what kind of data is contained in the
-     * address and to prevent accidentally sending coins across chains which would destroy them.
-     */
-    public int[] getAcceptableAddressCodes() {
-        return acceptableAddressCodes;
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/WrongNetworkException.java
+++ b/core/src/main/java/org/bitcoinj/core/WrongNetworkException.java
@@ -16,8 +16,6 @@
 
 package org.bitcoinj.core;
 
-import java.util.Arrays;
-
 /**
  * This exception is thrown by the Address class when you try and decode an address with a version code that isn't
  * used by that network. You shouldn't allow the user to proceed in this case as they are trying to send money across
@@ -26,13 +24,9 @@ import java.util.Arrays;
 public class WrongNetworkException extends AddressFormatException {
     /** The version code that was provided in the address. */
     public int verCode;
-    /** The list of acceptable versions that were expected given the addresses network parameters. */
-    public int[] acceptableVersions;
     
-    public WrongNetworkException(int verCode, int[] acceptableVersions) {
-        super("Version code of address did not match acceptable versions for network: " + verCode + " not in " +
-          Arrays.toString(acceptableVersions));
+    public WrongNetworkException(int verCode) {
+        super("Version code of address did not match acceptable versions for network: " + verCode);
         this.verCode = verCode;
-        this.acceptableVersions = acceptableVersions;
     }
 }

--- a/core/src/main/java/org/bitcoinj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/MainNetParams.java
@@ -40,7 +40,6 @@ public class MainNetParams extends AbstractBitcoinNetParams {
         dumpedPrivateKeyHeader = 128;
         addressHeader = 0;
         p2shHeader = 5;
-        acceptableAddressCodes = new int[] { addressHeader, p2shHeader };
         port = 8333;
         packetMagic = 0xf9beb4d9L;
         bip32HeaderPub = 0x0488B21E; //The 4 byte header that serializes in base58 to "xpub".

--- a/core/src/main/java/org/bitcoinj/params/TestNet2Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet2Params.java
@@ -36,7 +36,6 @@ public class TestNet2Params extends AbstractBitcoinNetParams {
         port = 18333;
         addressHeader = 111;
         p2shHeader = 196;
-        acceptableAddressCodes = new int[] { addressHeader, p2shHeader };
         interval = INTERVAL;
         targetTimespan = TARGET_TIMESPAN;
         maxTarget = Utils.decodeCompactBits(0x1d0fffffL);

--- a/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
@@ -46,7 +46,6 @@ public class TestNet3Params extends AbstractBitcoinNetParams {
         port = 18333;
         addressHeader = 111;
         p2shHeader = 196;
-        acceptableAddressCodes = new int[] { addressHeader, p2shHeader };
         dumpedPrivateKeyHeader = 239;
         genesisBlock.setTime(1296688602L);
         genesisBlock.setDifficultyTarget(0x1d00ffffL);

--- a/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
@@ -35,7 +35,6 @@ public class UnitTestParams extends AbstractBitcoinNetParams {
         packetMagic = 0x0b110907;
         addressHeader = 111;
         p2shHeader = 196;
-        acceptableAddressCodes = new int[] { addressHeader, p2shHeader };
         maxTarget = new BigInteger("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16);
         genesisBlock.setTime(System.currentTimeMillis() / 1000);
         genesisBlock.setDifficultyTarget(Block.EASIEST_DIFFICULTY_TARGET);

--- a/core/src/test/java/org/bitcoinj/core/AddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AddressTest.java
@@ -105,7 +105,6 @@ public class AddressTest {
         } catch (WrongNetworkException e) {
             // Success.
             assertEquals(e.verCode, MainNetParams.get().getAddressHeader());
-            assertTrue(Arrays.equals(e.acceptableVersions, TestNet3Params.get().getAcceptableAddressCodes()));
         } catch (AddressFormatException e) {
             fail();
         }
@@ -128,7 +127,6 @@ public class AddressTest {
                 id = "alt.network";
                 addressHeader = 48;
                 p2shHeader = 5;
-                acceptableAddressCodes = new int[] { addressHeader, p2shHeader };
             }
         }
         AltNetwork altNetwork = new AltNetwork();


### PR DESCRIPTION
I just noticed I could extract this from my PR #1516 so it can be discussed and merged individually.

Description:

The concept was always weakly defined, as version headers have been used for different types of
data too (which wasn't included in the list). What's acceptable is always dependent on the
usecase, not only the network.

Also, with the coming Bech32 addresses there are no int version headers any more. Rather, it
uses an HRP (human readable part) which is a string.

This is an API breaking change, but I doubt many users have used this in the form of a list.