### PR TITLE
Remove concept of 'from address'

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -18,7 +18,6 @@
 package org.bitcoinj.core;
 
 import org.bitcoinj.script.Script;
-import org.bitcoinj.script.ScriptError;
 import org.bitcoinj.script.ScriptException;
 import org.bitcoinj.wallet.DefaultRiskAnalysis;
 import org.bitcoinj.wallet.KeyBag;
@@ -192,21 +191,6 @@ public class TransactionInput extends ChildMessage {
         this.scriptSig = new WeakReference<>(checkNotNull(scriptSig));
         // TODO: This should all be cleaned up so we have a consistent internal representation.
         setScriptBytes(scriptSig.getProgram());
-    }
-
-    /**
-     * Convenience method that returns the from address of this input by parsing the scriptSig. The concept of a
-     * "from address" is not well defined in Bitcoin and you should not assume that senders of a transaction can
-     * actually receive coins on the same address they used to sign (e.g. this is not true for shared wallets).
-     */
-    @Deprecated
-    public Address getFromAddress() throws ScriptException {
-        if (isCoinBase()) {
-            throw new ScriptException(
-                    ScriptError.SCRIPT_ERR_UNKNOWN_ERROR,
-                    "This is a coinbase transaction which generates new coins. It does not have a from address.");
-        }
-        return getScriptSig().getFromAddress(params);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -316,16 +316,6 @@ public class Script {
     }
 
     /**
-     * For 2-element [input] scripts assumes that the paid-to-address can be derived from the public key.
-     * The concept of a "from address" isn't well defined in Bitcoin and you should not assume the sender of a
-     * transaction can actually receive coins on it. This method may be removed in future.
-     */
-    @Deprecated
-    public Address getFromAddress(NetworkParameters params) throws ScriptException {
-        return new Address(params, Utils.sha256hash160(getPubKey()));
-    }
-
-    /**
      * Gets the destination address from this script, if it's in the required form (see getPubKey).
      */
     public Address getToAddress(NetworkParameters params) throws ScriptException {

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -460,8 +460,6 @@ public class WalletTest extends TestWithWallet {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
-    // Having a test for deprecated method getFromAddress() is no evil so we suppress the warning here.
     public void customTransactionSpending() throws Exception {
         // We'll set up a wallet that receives a coin, then sends a coin of lesser value and keeps the change.
         Coin v1 = valueOf(3, 0);
@@ -483,7 +481,8 @@ public class WalletTest extends TestWithWallet {
 
         // Do some basic sanity checks.
         assertEquals(1, t2.getInputs().size());
-        assertEquals(myAddress, t2.getInput(0).getScriptSig().getFromAddress(PARAMS));
+        // check 'from address' -- in a unit test this is fine
+        assertEquals(myAddress, new Address(PARAMS, Utils.sha256hash160(t2.getInput(0).getScriptSig().getPubKey())));
         assertEquals(TransactionConfidence.ConfidenceType.UNKNOWN, t2.getConfidence().getConfidenceType());
 
         // We have NOT proven that the signature is correct!


### PR DESCRIPTION
Segwit is another nail on the coffin, because for each pubkey there is now also a segwit address.
A number of wallets will not recognize returned payments if sent to the wrong address type.