### PR TITLE
Send to native segwit addresses

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -131,7 +131,7 @@ public class TransactionOutput extends ChildMessage {
     @Nullable
     public LegacyAddress getAddressFromP2PKHScript(NetworkParameters networkParameters) throws ScriptException{
         if (ScriptPattern.isPayToPubKeyHash(getScriptPubKey()))
-            return getScriptPubKey().getToAddress(networkParameters);
+            return (LegacyAddress) getScriptPubKey().getToAddress(networkParameters);
 
         return null;
     }
@@ -151,7 +151,7 @@ public class TransactionOutput extends ChildMessage {
     @Nullable
     public LegacyAddress getAddressFromP2SH(NetworkParameters networkParameters) throws ScriptException{
         if (ScriptPattern.isPayToScriptHash(getScriptPubKey()))
-            return getScriptPubKey().getToAddress(networkParameters);
+            return (LegacyAddress) getScriptPubKey().getToAddress(networkParameters);
 
         return null;
     }

--- a/core/src/main/java/org/bitcoinj/script/ScriptPattern.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptPattern.java
@@ -18,6 +18,7 @@
 package org.bitcoinj.script;
 
 import org.bitcoinj.core.LegacyAddress;
+import org.bitcoinj.core.SegwitAddress;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -103,6 +104,34 @@ public class ScriptPattern {
      */
     public static byte[] extractKeyFromPayToPubKey(Script script) {
         return script.chunks.get(0).data;
+    }
+
+    /**
+     * Returns true if this script is of the form OP_0 <hash>. This can either be a P2WPKH or P2WSH scriptPubKey. These
+     * two script types were introduced with segwit.
+     */
+    public static boolean isPayToWitnessHash(Script script) {
+        List<ScriptChunk> chunks = script.chunks;
+        if (chunks.size() != 2)
+            return false;
+        if (!chunks.get(0).equalsOpCode(OP_0))
+            return false;
+        byte[] chunk1data = chunks.get(1).data;
+        if (chunk1data == null)
+            return false;
+        if (chunk1data.length != SegwitAddress.WITNESS_PROGRAM_LENGTH_PKH
+                && chunk1data.length != SegwitAddress.WITNESS_PROGRAM_LENGTH_SH)
+            return false;
+        return true;
+    }
+
+    /**
+     * Extract the pubkey hash from a P2WPKH or the script hash from a P2WSH scriptPubKey. It's important that the
+     * script is in the correct form, so you will want to guard calls to this method with
+     * {@link #isPayToWitnessHash(Script)}.
+     */
+    public static byte[] extractHashFromPayToWitnessHash(Script script) {
+        return script.chunks.get(1).data;
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/store/LevelDBFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/LevelDBFullPrunedBlockStore.java
@@ -29,6 +29,7 @@ import java.io.*;
 import java.nio.ByteBuffer;
 
 import org.bitcoinj.core.LegacyAddress;
+import org.bitcoinj.core.Address;
 import org.bitcoinj.core.AddressFormatException;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.NetworkParameters;
@@ -461,7 +462,7 @@ public class LevelDBFullPrunedBlockStore implements FullPrunedBlockStore {
                 }
                 if (txout != null) {
                     Script sc = txout.getScript();
-                    LegacyAddress address = sc.getToAddress(params, true);
+                    Address address = sc.getToAddress(params, true);
                     UTXO output = new UTXO(txout.getHash(), txout.getIndex(), txout.getValue(), txout.getHeight(),
                             txout.isCoinbase(), txout.getScript(), address.toString());
                     results.add(output);
@@ -887,7 +888,7 @@ public class LevelDBFullPrunedBlockStore implements FullPrunedBlockStore {
             String address = out.getAddress();
             if (address == null || address.equals("")) {
                 Script sc = out.getScript();
-                a = sc.getToAddress(params);
+                a = (LegacyAddress) sc.getToAddress(params);
                 hashBytes = a.getHash();
             } else {
                 a = LegacyAddress.fromBase58(params, out.getAddress());

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
@@ -124,8 +124,8 @@ public class KeyChainGroup implements KeyBag {
 
         if (isMarried()) {
             for (Map.Entry<KeyChain.KeyPurpose, DeterministicKey> entry : this.currentKeys.entrySet()) {
-                LegacyAddress address = makeP2SHOutputScript(entry.getValue(), getActiveKeyChain()).getToAddress(params);
-                currentAddresses.put(entry.getKey(), address);
+                Address address = makeP2SHOutputScript(entry.getValue(), getActiveKeyChain()).getToAddress(params);
+                currentAddresses.put(entry.getKey(), (LegacyAddress) address);
             }
         }
     }

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -1005,7 +1005,7 @@ public class Wallet extends BaseTaggableObject
             List<LegacyAddress> addresses = new LinkedList<>();
             for (Script script : watchedScripts)
                 if (ScriptPattern.isPayToPubKeyHash(script))
-                    addresses.add(script.getToAddress(params));
+                    addresses.add(((LegacyAddress) script.getToAddress(params)));
             return addresses;
         } finally {
             keyChainGroupLock.unlock();

--- a/core/src/test/java/org/bitcoinj/core/SegwitAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/SegwitAddressTest.java
@@ -28,8 +28,10 @@ import java.util.Locale;
 
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.TestNet3Params;
+import org.bitcoinj.script.Script;
 import org.bitcoinj.script.Script.ScriptType;
 import org.bitcoinj.script.ScriptBuilder;
+import org.bitcoinj.script.ScriptPattern;
 import org.junit.Test;
 
 import com.google.common.base.MoreObjects;
@@ -103,6 +105,11 @@ public class SegwitAddressTest {
             assertEquals(valid.expectedScriptPubKey,
                     Utils.HEX.encode(ScriptBuilder.createOutputScript(address).getProgram()));
             assertEquals(valid.address.toLowerCase(Locale.ROOT), address.toBech32());
+            if (valid.expectedWitnessVersion == 0) {
+                Script expectedScriptPubKey = new Script(Utils.HEX.decode(valid.expectedScriptPubKey));
+                assertEquals(address, SegwitAddress.fromHash(valid.expectedParams,
+                        ScriptPattern.extractHashFromPayToWitnessHash(expectedScriptPubKey)));
+            }
             assertEquals(valid.expectedWitnessVersion, address.getWitnessVersion());
         }
     }

--- a/core/src/test/java/org/bitcoinj/script/ScriptPatternTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptPatternTest.java
@@ -20,8 +20,10 @@ package org.bitcoinj.script;
 import com.google.common.collect.Lists;
 
 import org.bitcoinj.core.LegacyAddress;
-import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.SegwitAddress;
+import org.bitcoinj.core.Sha256Hash;
+import org.bitcoinj.core.ECKey;
 import org.bitcoinj.params.MainNetParams;
 import org.junit.Test;
 
@@ -42,11 +44,17 @@ public class ScriptPatternTest {
         assertTrue(ScriptPattern.isPayToScriptHash(
                 ScriptBuilder.createP2SHOutputScript(2, keys)
         ));
-        assertTrue(ScriptPattern.isSentToMultisig(
-                ScriptBuilder.createMultiSigOutputScript(2, keys)
-        ));
         assertTrue(ScriptPattern.isPayToPubKey(
                 ScriptBuilder.createOutputScript(keys.get(0))
+        ));
+        assertTrue(ScriptPattern.isPayToWitnessHash(
+                ScriptBuilder.createOutputScript(SegwitAddress.fromHash(MAINNET, keys.get(0).getPubKeyHash()))
+        ));
+        assertTrue(ScriptPattern.isPayToWitnessHash(
+                ScriptBuilder.createOutputScript(SegwitAddress.fromHash(MAINNET, Sha256Hash.hash(new byte[0])))
+        ));
+        assertTrue(ScriptPattern.isSentToMultisig(
+                ScriptBuilder.createMultiSigOutputScript(2, keys)
         ));
         assertTrue(ScriptPattern.isSentToCltvPaymentChannel(
                 ScriptBuilder.createCLTVPaymentChannelOutput(BigInteger.ONE, keys.get(0), keys.get(1))

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -2928,7 +2928,7 @@ public class WalletTest extends TestWithWallet {
         assertEquals(THREE_CENTS, tx.getValueSentFromMe(wallet));
         assertEquals(THREE_CENTS.subtract(tx.getFee()), tx.getValueSentToMe(wallet));
         // TX sends to one of our addresses (for now we ignore married wallets).
-        final LegacyAddress toAddress = tx.getOutput(0).getScriptPubKey().getToAddress(UNITTEST);
+        final LegacyAddress toAddress = (LegacyAddress) tx.getOutput(0).getScriptPubKey().getToAddress(UNITTEST);
         final ECKey rotatingToKey = wallet.findKeyFromPubHash(toAddress.getHash());
         assertNotNull(rotatingToKey);
         assertFalse(wallet.isKeyRotating(rotatingToKey));


### PR DESCRIPTION
Teach SendRequest and Wallet to send to native segwit addresses.

Determine native segwit destination addresses of a transaction by parsing the segwit scriptPubKey.
