### PR TITLE
UTXOProvider: getOpenTransactionOutputs() to take a list of ECKeys rather than addresses.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/UTXOProvider.java
+++ b/core/src/main/java/org/bitcoinj/core/UTXOProvider.java
@@ -25,15 +25,13 @@ import java.util.List;
  * <p>A {@link org.bitcoinj.store.FullPrunedBlockStore} is an internal implementation within bitcoinj.</p>
  */
 public interface UTXOProvider {
-
-    // TODO currently the access to outputs is by address. Change to ECKey
     /**
-     * Get the list of {@link UTXO}'s for a given address.
-     * @param addresses List of address.
+     * Get the list of {@link UTXO}'s for given keys.
+     * @param keys List of keys.
      * @return The list of transaction outputs.
      * @throws UTXOProviderException If there is an error.
      */
-    List<UTXO> getOpenTransactionOutputs(List<LegacyAddress> addresses) throws UTXOProviderException;
+    List<UTXO> getOpenTransactionOutputs(List<ECKey> keys) throws UTXOProviderException;
 
     /**
      * Get the height of the chain head.

--- a/core/src/main/java/org/bitcoinj/store/DatabaseFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/DatabaseFullPrunedBlockStore.java
@@ -1150,14 +1150,15 @@ public abstract class DatabaseFullPrunedBlockStore implements FullPrunedBlockSto
     }
 
     @Override
-    public List<UTXO> getOpenTransactionOutputs(List<LegacyAddress> addresses) throws UTXOProviderException {
+    public List<UTXO> getOpenTransactionOutputs(List<ECKey> keys) throws UTXOProviderException {
         PreparedStatement s = null;
         List<UTXO> outputs = new ArrayList<>();
         try {
             maybeConnect();
             s = conn.get().prepareStatement(getTransactionOutputSelectSQL());
-            for (LegacyAddress address : addresses) {
-                s.setString(1, address.toString());
+            for (ECKey key : keys) {
+                // TODO switch to pubKeyHash in order to support native segwit addresses
+                s.setString(1, LegacyAddress.fromKey(params, key).toString());
                 ResultSet rs = s.executeQuery();
                 while (rs.next()) {
                     Sha256Hash hash = Sha256Hash.wrap(rs.getBytes(1));

--- a/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
@@ -412,13 +412,15 @@ public class MemoryFullPrunedBlockStore implements FullPrunedBlockStore {
     }
 
     @Override
-    public List<UTXO> getOpenTransactionOutputs(List<LegacyAddress> addresses) throws UTXOProviderException {
+    public List<UTXO> getOpenTransactionOutputs(List<ECKey> keys) throws UTXOProviderException {
         // This is *NOT* optimal: We go through all the outputs and select the ones we are looking for.
         // If someone uses this store for production then they have a lot more to worry about than an inefficient impl :)
         List<UTXO> foundOutputs = new ArrayList<>();
         List<UTXO> outputsList = transactionOutputMap.values();
         for (UTXO output : outputsList) {
-            for (LegacyAddress address : addresses) {
+            for (ECKey key : keys) {
+                // TODO switch to pubKeyHash in order to support native segwit addresses
+                Address address = LegacyAddress.fromKey(params, key);
                 if (output.getAddress().equals(address.toString())) {
                     foundOutputs.add(output);
                 }

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4300,12 +4300,7 @@ public class Wallet extends BaseTaggableObject
         List<UTXO> candidates = new ArrayList<>();
         List<ECKey> keys = getImportedKeys();
         keys.addAll(getActiveKeyChain().getLeafKeys());
-        List<LegacyAddress> addresses = new ArrayList<>();
-        for (ECKey key : keys) {
-            LegacyAddress address = LegacyAddress.fromKey(params, key);
-            addresses.add(address);
-        }
-        candidates.addAll(utxoProvider.getOpenTransactionOutputs(addresses));
+        candidates.addAll(utxoProvider.getOpenTransactionOutputs(keys));
         return candidates;
     }
 

--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -272,7 +272,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         chain.add(rollingBlock);
         totalAmount = totalAmount.add(amount);
 
-        List<UTXO> outputs = store.getOpenTransactionOutputs(Lists.newArrayList(address));
+        List<UTXO> outputs = store.getOpenTransactionOutputs(Lists.newArrayList(toKey));
         assertNotNull(outputs);
         assertEquals("Wrong Number of Outputs", 1, outputs.size());
         UTXO output = outputs.get(0);

--- a/core/src/test/java/org/bitcoinj/core/TransactionInputTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionInputTest.java
@@ -69,7 +69,7 @@ public class TransactionInputTest {
             }
 
             @Override
-            public List<UTXO> getOpenTransactionOutputs(List<LegacyAddress> addresses) throws UTXOProviderException {
+            public List<UTXO> getOpenTransactionOutputs(List<ECKey> addresses) throws UTXOProviderException {
                 return Lists.newArrayList(utxo);
             }
 


### PR DESCRIPTION
This is needed for supporting native segwit addresses throughout the entire API. Bitcoinj has actually always used UTXOProvider with ECKeys.

Unfortunately some implementations of UTXOProvider use legacy addresses as their database index, where they probably should be using the pubKeyHash: DatabaseFullPrunedBlockStore, MemoryFullPrunedBlockStore. I left the adaption of those stores to native segwit to later PRs. For now, they continue to work with legacy addresses. 

Pinging @kparmar1 because you've written the TODO comment that is resolved with this PR.
