### PR TITLE
 PeerGroup: Start using VersionMessage.receivingAddr as it was intended

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -1389,6 +1389,7 @@ public class PeerGroup implements TransactionBroadcaster {
         VersionMessage ver = getVersionMessage().duplicate();
         ver.bestHeight = chain == null ? 0 : chain.getBestChainHeight();
         ver.time = Utils.currentTimeSeconds();
+        ver.receivingAddr = address;
 
         Peer peer = createPeer(address, ver);
         peer.addConnectedEventListener(Threading.SAME_THREAD, startupListener);

--- a/core/src/main/java/org/bitcoinj/core/VersionMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionMessage.java
@@ -67,7 +67,7 @@ public class VersionMessage extends Message {
      */
     public long time;
     /**
-     * The network address of the node receiving this message. Not used.
+     * The network address of the node receiving this message.
      */
     public PeerAddress receivingAddr;
     /**


### PR DESCRIPTION
I'm not sure why this field was never set. According to the operator of a full node, bitcoinj clients seem to be the only ones who don't use it.