### PR TITLE
Added a SIGINT hook, so a partial checkpoint file gets written

### DIFF
--- a/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
@@ -152,8 +152,18 @@ public class BuildCheckpoints {
             }
         });
 
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                System.out.println("Shutdown requested!");
+                end(checkpoints, suffix, peerGroup, store);
+            }
+        });
         peerGroup.downloadBlockChain();
+        end(checkpoints, suffix, peerGroup, store);
+    }
 
+    private static void end(TreeMap<Integer, StoredBlock> checkpoints, String suffix, PeerGroup peerGroup, BlockStore store) {
         checkState(checkpoints.size() > 0);
 
         final File plainFile = new File("checkpoints" + suffix);


### PR DESCRIPTION
When the checkpoints tool gets stuck, you loose the syncing you did, as SIGINT makes it skip writing the checkpoints file. This change allows you to rescue the scanned checkpoints.