### PR TITLE
DRMWorkaround.java exception in java 1.8.0_161

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DRMWorkaround.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DRMWorkaround.java
@@ -42,8 +42,15 @@ public class DRMWorkaround {
             return;
         try {
             Field gate = Class.forName("javax.crypto.JceSecurity").getDeclaredField("isRestricted");
+            //gate.setAccessible(true);
+            //gate.setBoolean(null, false);
+            if ( Modifier.isFinal(gate.getModifiers()) ) {
+            	Field modifiers = Field.class.getDeclaredField("modifiers");
+            	modifiers.setAccessible(true);
+            	modifiers.setInt(gate, gate.getModifiers() & ~Modifier.FINAL);
+            }
             gate.setAccessible(true);
-            gate.setBoolean(null, false);
+            gate.setBoolean(null, false); // isRestricted = false;
             final Field allPerm = Class.forName("javax.crypto.CryptoAllPermission").getDeclaredField("INSTANCE");
             allPerm.setAccessible(true);
             Object accessAllAreasCard = allPerm.get(null);

--- a/core/src/main/java/org/bitcoinj/crypto/DRMWorkaround.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DRMWorkaround.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 
 public class DRMWorkaround {
     private static Logger log = LoggerFactory.getLogger(DRMWorkaround.class);


### PR DESCRIPTION
Fix for Exception:
DRMWorkaround.maybeDisableExportControls: Failed to deactivate AES-256 barrier logic, Tor mode/BIP38 decryption may crash if this JVM requires it: Can not set static final boolean field javax.crypto.JceSecurity.isRestricted to (boolean)false