### PR TITLE
Change method BlockChain.rollbackBlockStore from protected to public.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/BlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/BlockChain.java
@@ -99,7 +99,7 @@ public class BlockChain extends AbstractBlockChain {
     }
 
     @Override
-    protected void rollbackBlockStore(int height) throws BlockStoreException {
+    public void rollbackBlockStore(int height) throws BlockStoreException {
         lock.lock();
         try {
             int currentHeight = getBestChainHeight();


### PR DESCRIPTION
This method can be used by a wallet to replay from a given height. For example a wallet receives a transaction with OP_RETURN that incurs in new keys imported to the wallet. The wallet needs to process again the block if relevant transactions are found in it. 

I believe this approach can be used to solve bad wallet syncs as a product of race conditions between filtered blocks and transactions as mentioned in #1029 .
