### PR TITLE
Wallet:  Allow encrypting DeterministicKeyChain with arbitrary path

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -433,6 +433,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
         checkNotNull(chain.seed);
 
         checkArgument(!chain.rootKey.isEncrypted(), "Chain already encrypted");
+        setAccountPath(chain.getAccountPath());
 
         this.issuedExternalKeys = chain.issuedExternalKeys;
         this.issuedInternalKeys = chain.issuedInternalKeys;

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -166,6 +166,16 @@ public class WalletTest extends TestWithWallet {
     }
 
     @Test
+    public void encryptWalletWithArbitraryPath() throws Exception {
+        final byte[] ENTROPY = Sha256Hash.hash("don't use a string seed like this in real life".getBytes());
+        KeyChainGroup keyChainGroup = new KeyChainGroup(UNITTEST,
+                new DeterministicSeed(ENTROPY, "", 1389353062L),
+                        DeterministicKeyChain.BIP44_ACCOUNT_ZERO_PATH);
+        Wallet encryptedWallet = new Wallet(UNITTEST, keyChainGroup);
+        encryptedWallet.encrypt(PASSWORD1);
+    }
+
+    @Test
     public void basicSpendingFromP2SH() throws Exception {
         createMarriedWallet(2, 2);
         myAddress = wallet.currentAddress(KeyChain.KeyPurpose.RECEIVE_FUNDS);


### PR DESCRIPTION
This is in reference to issue #1532.

This pull request contains a test that will fail, if `setAccountPath(chain.getAccountPath());` is missing from the DeterministicKeyChain constructor used during the encryption process.  The account path needs to be set in the new DeterministicKeyChain so it will find the correct path instead of assuming the default `0H`.

The failure report would have been as follows if the account path is not set:
```
[INFO] Running org.bitcoinj.wallet.WalletTest
[ERROR] Tests run: 123, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 16.327 s <<< FAILURE! - in org.bitcoinj.wallet.WalletTest
[ERROR] encryptWalletWithArbitraryPath(org.bitcoinj.wallet.WalletTest)  Time elapsed: 0.328 s  <<< ERROR!
java.lang.IllegalArgumentException: No key found for absolute path M/0H.
        at org.bitcoinj.wallet.WalletTest.encryptWalletWithArbitraryPath(WalletTest.java:175)
```
