### PR TITLE
DeterministicKeyChain: Allow decrypting DeterministicKeyChain with arbitrary path

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -425,7 +425,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
      * For use in encryption when {@link #toEncrypted(KeyCrypter, KeyParameter)} is called, so that
      * subclasses can override that method and create an instance of the right class.
      *
-     * See also {@link #makeKeyChainFromSeed(DeterministicSeed)}
+     * See also {@link #makeKeyChainFromSeed(DeterministicSeed, ImmutableList<ChildNumber>)}
      */
     protected DeterministicKeyChain(KeyCrypter crypter, KeyParameter aesKey, DeterministicKeyChain chain) {
         // Can't encrypt a watching chain.
@@ -1048,7 +1048,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
         checkState(seed.isEncrypted());
         String passphrase = DEFAULT_PASSPHRASE_FOR_MNEMONIC; // FIXME allow non-empty passphrase
         DeterministicSeed decSeed = seed.decrypt(getKeyCrypter(), passphrase, aesKey);
-        DeterministicKeyChain chain = makeKeyChainFromSeed(decSeed);
+        DeterministicKeyChain chain = makeKeyChainFromSeed(decSeed, getAccountPath());
         // Now double check that the keys match to catch the case where the key is wrong but padding didn't catch it.
         if (!chain.getWatchingKey().getPubKeyPoint().equals(getWatchingKey().getPubKeyPoint()))
             throw new KeyCrypterException("Provided AES key is wrong");
@@ -1075,8 +1075,8 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
      * Subclasses should override this to create an instance of the subclass instead of a plain DKC.
      * This is used in encryption/decryption.
      */
-    protected DeterministicKeyChain makeKeyChainFromSeed(DeterministicSeed seed) {
-        return new DeterministicKeyChain(seed);
+    protected DeterministicKeyChain makeKeyChainFromSeed(DeterministicSeed seed, ImmutableList<ChildNumber> accountPath) {
+        return new DeterministicKeyChain(seed, accountPath);
     }
 
     @Override

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -166,13 +166,14 @@ public class WalletTest extends TestWithWallet {
     }
 
     @Test
-    public void encryptWalletWithArbitraryPath() throws Exception {
+    public void encryptDecryptWalletWithArbitraryPath() throws Exception {
         final byte[] ENTROPY = Sha256Hash.hash("don't use a string seed like this in real life".getBytes());
         KeyChainGroup keyChainGroup = new KeyChainGroup(UNITTEST,
                 new DeterministicSeed(ENTROPY, "", 1389353062L),
                         DeterministicKeyChain.BIP44_ACCOUNT_ZERO_PATH);
         Wallet encryptedWallet = new Wallet(UNITTEST, keyChainGroup);
         encryptedWallet.encrypt(PASSWORD1);
+        encryptedWallet.decrypt(PASSWORD1);
     }
 
     @Test


### PR DESCRIPTION
This is related to https://github.com/bitcoinj/bitcoinj/commit/e0d9683bd54c4e60d71840ad1ab2409016a3e0f9, which was for allowing to encrypt a DeterminisiticKeyChain with an arbitrary path (besides m/0H).

When changing the `encryptWalletWithArbitraryPath` in `WalletTest` to include decryption (`encryptDecryptWalletWithArbitraryPath`), we find this failure:
```
[INFO] Running org.bitcoinj.wallet.WalletTest
[ERROR] Tests run: 123, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 15.943 s <<< FAILURE! - in org.bitcoinj.wallet.WalletTest
[ERROR] encryptDecryptWalletWithArbitraryPath(org.bitcoinj.wallet.WalletTest)  Time elapsed: 0.487 s  <<< ERROR!
org.bitcoinj.crypto.KeyCrypterException: Provided AES key is wrong
        at org.bitcoinj.wallet.WalletTest.encryptWalletWithArbitraryPath(WalletTest.java:176)
```

The failure results from not setting the accountPath  when the decrypted DeterministicKeyChain is created.  

The `makeKeyChainFromSeed` method is modified to include an accountPath parameter.  
