### PR TITLE
Transaction: Limit initial size of inputs and outputs ArrayList.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -122,6 +122,12 @@ public class Transaction extends ChildMessage {
      */
     public static final Coin MIN_NONDUST_OUTPUT = Coin.valueOf(546); // satoshis
 
+    /**
+     * Max initial size of inputs and outputs ArrayList.
+     */
+    public static final int MAX_INITIAL_INPUTS_OUTPUTS_SIZE = 20;
+
+
     // These are bitcoin serialized.
     private long version;
     private ArrayList<TransactionInput> inputs;
@@ -568,7 +574,7 @@ public class Transaction extends ChildMessage {
         // First come the inputs.
         long numInputs = readVarInt();
         optimalEncodingMessageSize += VarInt.sizeOf(numInputs);
-        inputs = new ArrayList<>((int) numInputs);
+        inputs = new ArrayList<>(Math.min((int) numInputs, MAX_INITIAL_INPUTS_OUTPUTS_SIZE));
         for (long i = 0; i < numInputs; i++) {
             TransactionInput input = new TransactionInput(params, this, payload, cursor, serializer);
             inputs.add(input);
@@ -579,7 +585,7 @@ public class Transaction extends ChildMessage {
         // Now the outputs
         long numOutputs = readVarInt();
         optimalEncodingMessageSize += VarInt.sizeOf(numOutputs);
-        outputs = new ArrayList<>((int) numOutputs);
+        outputs = new ArrayList<>(Math.min((int) numOutputs, MAX_INITIAL_INPUTS_OUTPUTS_SIZE));
         for (long i = 0; i < numOutputs; i++) {
             TransactionOutput output = new TransactionOutput(params, this, payload, cursor, serializer);
             outputs.add(output);


### PR DESCRIPTION
Limits initial size of inputs and outputs ArrayLists when parsing a tx.

This prevents this DoS attack:

- Somehow the attacker needs to get a p2p connection to the bitcoinj node.
- The attacker sends a tx msg that says the tx contains a trillion inputs.
- bitcoinj tries to instantiate an ArrayList with a size of a trillion.
- OutOfMemoryError and the bitcoinj node is down.