### PR TITLE
WIP: Get rid of depth in TransactionConfidence.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -634,14 +634,14 @@ public class Transaction extends ChildMessage {
     /**
      * A transaction is mature if it is either a building coinbase tx that is as deep or deeper than the required coinbase depth, or a non-coinbase tx.
      */
-    public boolean isMature() {
+    public boolean isMature(int bestChainHeight) {
         if (!isCoinBase())
             return true;
 
         if (getConfidence().getConfidenceType() != ConfidenceType.BUILDING)
             return false;
 
-        return getConfidence().getDepthInBlocks() >= params.getSpendableCoinbaseDepth();
+        return getConfidence().getDepthInBlocks(bestChainHeight) >= params.getSpendableCoinbaseDepth();
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -365,17 +365,17 @@ public class TransactionOutput extends ChildMessage {
     }
 
     /**
-     * Returns the depth in blocks of the parent tx.
+     * Returns the block height of the parent tx, if confirmed.
      *
-     * <p>If the transaction appears in the top block, the depth is one. If it's anything else (pending, dead, unknown)
+     * <p>If the transaction appears in a block, the block height is returned. If it's anything else (pending, dead, unknown)
      * then -1.</p>
-     * @return The tx depth or -1.
+     * @return The tx block height or -1.
      */
-    public int getParentTransactionDepthInBlocks() {
+    public int getParentTransactionAppearedAtChainHeight() {
         if (getParentTransaction() != null) {
             TransactionConfidence confidence = getParentTransaction().getConfidence();
             if (confidence.getConfidenceType() == TransactionConfidence.ConfidenceType.BUILDING) {
-                return confidence.getDepthInBlocks();
+                return confidence.getAppearedAtChainHeight();
             }
         }
         return -1;

--- a/core/src/main/java/org/bitcoinj/wallet/DefaultCoinSelector.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DefaultCoinSelector.java
@@ -27,9 +27,7 @@ import java.math.BigInteger;
 import java.util.*;
 
 /**
- * This class implements a {@link CoinSelector} which attempts to get the highest priority
- * possible. This means that the transaction is the most likely to get confirmed. Note that this means we may end up
- * "spending" more priority than would be required to get the transaction we are creating confirmed.
+ * Implementation of a {@link CoinSelector} which priorizes old UTXOs.
  */
 public class DefaultCoinSelector implements CoinSelector {
     @Override
@@ -63,17 +61,14 @@ public class DefaultCoinSelector implements CoinSelector {
         Collections.sort(outputs, new Comparator<TransactionOutput>() {
             @Override
             public int compare(TransactionOutput a, TransactionOutput b) {
-                int depth1 = a.getParentTransactionDepthInBlocks();
-                int depth2 = b.getParentTransactionDepthInBlocks();
+                int aHeight = a.getParentTransactionAppearedAtChainHeight();
+                int bHeight = b.getParentTransactionAppearedAtChainHeight();
+                int c0 = Integer.compare(aHeight, bHeight); // older is 'better'
+                if (c0 != 0) return c0;
                 Coin aValue = a.getValue();
                 Coin bValue = b.getValue();
-                BigInteger aCoinDepth = BigInteger.valueOf(aValue.value).multiply(BigInteger.valueOf(depth1));
-                BigInteger bCoinDepth = BigInteger.valueOf(bValue.value).multiply(BigInteger.valueOf(depth2));
-                int c1 = bCoinDepth.compareTo(aCoinDepth);
+                int c1 = bValue.compareTo(aValue); // higher is 'better'
                 if (c1 != 0) return c1;
-                // The "coin*days" destroyed are equal, sort by value alone to get the lowest transaction size.
-                int c2 = bValue.compareTo(aValue);
-                if (c2 != 0) return c2;
                 // They are entirely equivalent (possibly pending) so sort by hash to ensure a total ordering.
                 BigInteger aHash = a.getParentTransactionHash().toBigInteger();
                 BigInteger bHash = b.getParentTransactionHash().toBigInteger();

--- a/core/src/main/java/org/bitcoinj/wallet/Protos.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Protos.java
@@ -6745,25 +6745,6 @@ public final class Protos {
     com.google.protobuf.ByteString getOverridingTransaction();
 
     /**
-     * <code>optional int32 depth = 4;</code>
-     *
-     * <pre>
-     * If type == BUILDING then this is the depth of the transaction in the blockchain.
-     * Zero confirmations: depth = 0, one confirmation: depth = 1 etc.
-     * </pre>
-     */
-    boolean hasDepth();
-    /**
-     * <code>optional int32 depth = 4;</code>
-     *
-     * <pre>
-     * If type == BUILDING then this is the depth of the transaction in the blockchain.
-     * Zero confirmations: depth = 0, one confirmation: depth = 1 etc.
-     * </pre>
-     */
-    int getDepth();
-
-    /**
      * <code>repeated .wallet.PeerAddress broadcast_by = 6;</code>
      */
     java.util.List<org.bitcoinj.wallet.Protos.PeerAddress> 
@@ -6893,15 +6874,10 @@ public final class Protos {
               overridingTransaction_ = input.readBytes();
               break;
             }
-            case 32: {
-              bitField0_ |= 0x00000008;
-              depth_ = input.readInt32();
-              break;
-            }
             case 50: {
-              if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
+              if (!((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
                 broadcastBy_ = new java.util.ArrayList<org.bitcoinj.wallet.Protos.PeerAddress>();
-                mutable_bitField0_ |= 0x00000010;
+                mutable_bitField0_ |= 0x00000008;
               }
               broadcastBy_.add(input.readMessage(org.bitcoinj.wallet.Protos.PeerAddress.PARSER, extensionRegistry));
               break;
@@ -6912,13 +6888,13 @@ public final class Protos {
               if (value == null) {
                 unknownFields.mergeVarintField(7, rawValue);
               } else {
-                bitField0_ |= 0x00000020;
+                bitField0_ |= 0x00000010;
                 source_ = value;
               }
               break;
             }
             case 64: {
-              bitField0_ |= 0x00000010;
+              bitField0_ |= 0x00000008;
               lastBroadcastedAt_ = input.readInt64();
               break;
             }
@@ -6930,7 +6906,7 @@ public final class Protos {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e.getMessage()).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
+        if (((mutable_bitField0_ & 0x00000008) == 0x00000008)) {
           broadcastBy_ = java.util.Collections.unmodifiableList(broadcastBy_);
         }
         this.unknownFields = unknownFields.build();
@@ -7323,31 +7299,6 @@ public final class Protos {
       return overridingTransaction_;
     }
 
-    public static final int DEPTH_FIELD_NUMBER = 4;
-    private int depth_;
-    /**
-     * <code>optional int32 depth = 4;</code>
-     *
-     * <pre>
-     * If type == BUILDING then this is the depth of the transaction in the blockchain.
-     * Zero confirmations: depth = 0, one confirmation: depth = 1 etc.
-     * </pre>
-     */
-    public boolean hasDepth() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
-    }
-    /**
-     * <code>optional int32 depth = 4;</code>
-     *
-     * <pre>
-     * If type == BUILDING then this is the depth of the transaction in the blockchain.
-     * Zero confirmations: depth = 0, one confirmation: depth = 1 etc.
-     * </pre>
-     */
-    public int getDepth() {
-      return depth_;
-    }
-
     public static final int BROADCAST_BY_FIELD_NUMBER = 6;
     private java.util.List<org.bitcoinj.wallet.Protos.PeerAddress> broadcastBy_;
     /**
@@ -7393,7 +7344,7 @@ public final class Protos {
      * </pre>
      */
     public boolean hasLastBroadcastedAt() {
-      return ((bitField0_ & 0x00000010) == 0x00000010);
+      return ((bitField0_ & 0x00000008) == 0x00000008);
     }
     /**
      * <code>optional int64 last_broadcasted_at = 8;</code>
@@ -7412,7 +7363,7 @@ public final class Protos {
      * <code>optional .wallet.TransactionConfidence.Source source = 7;</code>
      */
     public boolean hasSource() {
-      return ((bitField0_ & 0x00000020) == 0x00000020);
+      return ((bitField0_ & 0x00000010) == 0x00000010);
     }
     /**
      * <code>optional .wallet.TransactionConfidence.Source source = 7;</code>
@@ -7425,7 +7376,6 @@ public final class Protos {
       type_ = org.bitcoinj.wallet.Protos.TransactionConfidence.Type.UNKNOWN;
       appearedAtHeight_ = 0;
       overridingTransaction_ = com.google.protobuf.ByteString.EMPTY;
-      depth_ = 0;
       broadcastBy_ = java.util.Collections.emptyList();
       lastBroadcastedAt_ = 0L;
       source_ = org.bitcoinj.wallet.Protos.TransactionConfidence.Source.SOURCE_UNKNOWN;
@@ -7458,16 +7408,13 @@ public final class Protos {
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeBytes(3, overridingTransaction_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
-        output.writeInt32(4, depth_);
-      }
       for (int i = 0; i < broadcastBy_.size(); i++) {
         output.writeMessage(6, broadcastBy_.get(i));
       }
-      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
         output.writeEnum(7, source_.getNumber());
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeInt64(8, lastBroadcastedAt_);
       }
       getUnknownFields().writeTo(output);
@@ -7491,19 +7438,15 @@ public final class Protos {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, overridingTransaction_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeInt32Size(4, depth_);
-      }
       for (int i = 0; i < broadcastBy_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(6, broadcastBy_.get(i));
       }
-      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
         size += com.google.protobuf.CodedOutputStream
           .computeEnumSize(7, source_.getNumber());
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt64Size(8, lastBroadcastedAt_);
       }
@@ -7638,18 +7581,16 @@ public final class Protos {
         bitField0_ = (bitField0_ & ~0x00000002);
         overridingTransaction_ = com.google.protobuf.ByteString.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000004);
-        depth_ = 0;
-        bitField0_ = (bitField0_ & ~0x00000008);
         if (broadcastByBuilder_ == null) {
           broadcastBy_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000010);
+          bitField0_ = (bitField0_ & ~0x00000008);
         } else {
           broadcastByBuilder_.clear();
         }
         lastBroadcastedAt_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000020);
+        bitField0_ = (bitField0_ & ~0x00000010);
         source_ = org.bitcoinj.wallet.Protos.TransactionConfidence.Source.SOURCE_UNKNOWN;
-        bitField0_ = (bitField0_ & ~0x00000040);
+        bitField0_ = (bitField0_ & ~0x00000020);
         return this;
       }
 
@@ -7690,25 +7631,21 @@ public final class Protos {
           to_bitField0_ |= 0x00000004;
         }
         result.overridingTransaction_ = overridingTransaction_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000008;
-        }
-        result.depth_ = depth_;
         if (broadcastByBuilder_ == null) {
-          if (((bitField0_ & 0x00000010) == 0x00000010)) {
+          if (((bitField0_ & 0x00000008) == 0x00000008)) {
             broadcastBy_ = java.util.Collections.unmodifiableList(broadcastBy_);
-            bitField0_ = (bitField0_ & ~0x00000010);
+            bitField0_ = (bitField0_ & ~0x00000008);
           }
           result.broadcastBy_ = broadcastBy_;
         } else {
           result.broadcastBy_ = broadcastByBuilder_.build();
         }
-        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
-          to_bitField0_ |= 0x00000010;
+        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+          to_bitField0_ |= 0x00000008;
         }
         result.lastBroadcastedAt_ = lastBroadcastedAt_;
-        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
-          to_bitField0_ |= 0x00000020;
+        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+          to_bitField0_ |= 0x00000010;
         }
         result.source_ = source_;
         result.bitField0_ = to_bitField0_;
@@ -7736,14 +7673,11 @@ public final class Protos {
         if (other.hasOverridingTransaction()) {
           setOverridingTransaction(other.getOverridingTransaction());
         }
-        if (other.hasDepth()) {
-          setDepth(other.getDepth());
-        }
         if (broadcastByBuilder_ == null) {
           if (!other.broadcastBy_.isEmpty()) {
             if (broadcastBy_.isEmpty()) {
               broadcastBy_ = other.broadcastBy_;
-              bitField0_ = (bitField0_ & ~0x00000010);
+              bitField0_ = (bitField0_ & ~0x00000008);
             } else {
               ensureBroadcastByIsMutable();
               broadcastBy_.addAll(other.broadcastBy_);
@@ -7756,7 +7690,7 @@ public final class Protos {
               broadcastByBuilder_.dispose();
               broadcastByBuilder_ = null;
               broadcastBy_ = other.broadcastBy_;
-              bitField0_ = (bitField0_ & ~0x00000010);
+              bitField0_ = (bitField0_ & ~0x00000008);
               broadcastByBuilder_ = 
                 com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
                    getBroadcastByFieldBuilder() : null;
@@ -7962,64 +7896,12 @@ public final class Protos {
         return this;
       }
 
-      private int depth_ ;
-      /**
-       * <code>optional int32 depth = 4;</code>
-       *
-       * <pre>
-       * If type == BUILDING then this is the depth of the transaction in the blockchain.
-       * Zero confirmations: depth = 0, one confirmation: depth = 1 etc.
-       * </pre>
-       */
-      public boolean hasDepth() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
-      }
-      /**
-       * <code>optional int32 depth = 4;</code>
-       *
-       * <pre>
-       * If type == BUILDING then this is the depth of the transaction in the blockchain.
-       * Zero confirmations: depth = 0, one confirmation: depth = 1 etc.
-       * </pre>
-       */
-      public int getDepth() {
-        return depth_;
-      }
-      /**
-       * <code>optional int32 depth = 4;</code>
-       *
-       * <pre>
-       * If type == BUILDING then this is the depth of the transaction in the blockchain.
-       * Zero confirmations: depth = 0, one confirmation: depth = 1 etc.
-       * </pre>
-       */
-      public Builder setDepth(int value) {
-        bitField0_ |= 0x00000008;
-        depth_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>optional int32 depth = 4;</code>
-       *
-       * <pre>
-       * If type == BUILDING then this is the depth of the transaction in the blockchain.
-       * Zero confirmations: depth = 0, one confirmation: depth = 1 etc.
-       * </pre>
-       */
-      public Builder clearDepth() {
-        bitField0_ = (bitField0_ & ~0x00000008);
-        depth_ = 0;
-        onChanged();
-        return this;
-      }
-
       private java.util.List<org.bitcoinj.wallet.Protos.PeerAddress> broadcastBy_ =
         java.util.Collections.emptyList();
       private void ensureBroadcastByIsMutable() {
-        if (!((bitField0_ & 0x00000010) == 0x00000010)) {
+        if (!((bitField0_ & 0x00000008) == 0x00000008)) {
           broadcastBy_ = new java.util.ArrayList<org.bitcoinj.wallet.Protos.PeerAddress>(broadcastBy_);
-          bitField0_ |= 0x00000010;
+          bitField0_ |= 0x00000008;
          }
       }
 
@@ -8169,7 +8051,7 @@ public final class Protos {
       public Builder clearBroadcastBy() {
         if (broadcastByBuilder_ == null) {
           broadcastBy_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000010);
+          bitField0_ = (bitField0_ & ~0x00000008);
           onChanged();
         } else {
           broadcastByBuilder_.clear();
@@ -8246,7 +8128,7 @@ public final class Protos {
           broadcastByBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
               org.bitcoinj.wallet.Protos.PeerAddress, org.bitcoinj.wallet.Protos.PeerAddress.Builder, org.bitcoinj.wallet.Protos.PeerAddressOrBuilder>(
                   broadcastBy_,
-                  ((bitField0_ & 0x00000010) == 0x00000010),
+                  ((bitField0_ & 0x00000008) == 0x00000008),
                   getParentForChildren(),
                   isClean());
           broadcastBy_ = null;
@@ -8263,7 +8145,7 @@ public final class Protos {
        * </pre>
        */
       public boolean hasLastBroadcastedAt() {
-        return ((bitField0_ & 0x00000020) == 0x00000020);
+        return ((bitField0_ & 0x00000010) == 0x00000010);
       }
       /**
        * <code>optional int64 last_broadcasted_at = 8;</code>
@@ -8283,7 +8165,7 @@ public final class Protos {
        * </pre>
        */
       public Builder setLastBroadcastedAt(long value) {
-        bitField0_ |= 0x00000020;
+        bitField0_ |= 0x00000010;
         lastBroadcastedAt_ = value;
         onChanged();
         return this;
@@ -8296,7 +8178,7 @@ public final class Protos {
        * </pre>
        */
       public Builder clearLastBroadcastedAt() {
-        bitField0_ = (bitField0_ & ~0x00000020);
+        bitField0_ = (bitField0_ & ~0x00000010);
         lastBroadcastedAt_ = 0L;
         onChanged();
         return this;
@@ -8307,7 +8189,7 @@ public final class Protos {
        * <code>optional .wallet.TransactionConfidence.Source source = 7;</code>
        */
       public boolean hasSource() {
-        return ((bitField0_ & 0x00000040) == 0x00000040);
+        return ((bitField0_ & 0x00000020) == 0x00000020);
       }
       /**
        * <code>optional .wallet.TransactionConfidence.Source source = 7;</code>
@@ -8322,7 +8204,7 @@ public final class Protos {
         if (value == null) {
           throw new NullPointerException();
         }
-        bitField0_ |= 0x00000040;
+        bitField0_ |= 0x00000020;
         source_ = value;
         onChanged();
         return this;
@@ -8331,7 +8213,7 @@ public final class Protos {
        * <code>optional .wallet.TransactionConfidence.Source source = 7;</code>
        */
       public Builder clearSource() {
-        bitField0_ = (bitField0_ & ~0x00000040);
+        bitField0_ = (bitField0_ & ~0x00000020);
         source_ = org.bitcoinj.wallet.Protos.TransactionConfidence.Source.SOURCE_UNKNOWN;
         onChanged();
         return this;
@@ -19239,60 +19121,59 @@ public final class Protos {
       "e\030\005 \001(\003\"\177\n\021TransactionOutput\022\r\n\005value\030\001 " +
       "\002(\003\022\024\n\014script_bytes\030\002 \002(\014\022!\n\031spent_by_tr" +
       "ansaction_hash\030\003 \001(\014\022\"\n\032spent_by_transac" +
-      "tion_index\030\004 \001(\005\"\267\003\n\025TransactionConfiden" +
+      "tion_index\030\004 \001(\005\"\250\003\n\025TransactionConfiden" +
       "ce\0220\n\004type\030\001 \001(\0162\".wallet.TransactionCon" +
       "fidence.Type\022\032\n\022appeared_at_height\030\002 \001(\005",
-      "\022\036\n\026overriding_transaction\030\003 \001(\014\022\r\n\005dept" +
-      "h\030\004 \001(\005\022)\n\014broadcast_by\030\006 \003(\0132\023.wallet.P" +
-      "eerAddress\022\033\n\023last_broadcasted_at\030\010 \001(\003\022" +
-      "4\n\006source\030\007 \001(\0162$.wallet.TransactionConf" +
-      "idence.Source\"`\n\004Type\022\013\n\007UNKNOWN\020\000\022\014\n\010BU" +
-      "ILDING\020\001\022\013\n\007PENDING\020\002\022\025\n\021NOT_IN_BEST_CHA" +
-      "IN\020\003\022\010\n\004DEAD\020\004\022\017\n\013IN_CONFLICT\020\005\"A\n\006Sourc" +
-      "e\022\022\n\016SOURCE_UNKNOWN\020\000\022\022\n\016SOURCE_NETWORK\020" +
-      "\001\022\017\n\013SOURCE_SELF\020\002\"\303\005\n\013Transaction\022\017\n\007ve" +
-      "rsion\030\001 \002(\005\022\014\n\004hash\030\002 \002(\014\022&\n\004pool\030\003 \001(\0162",
-      "\030.wallet.Transaction.Pool\022\021\n\tlock_time\030\004" +
-      " \001(\r\022\022\n\nupdated_at\030\005 \001(\003\0223\n\021transaction_" +
-      "input\030\006 \003(\0132\030.wallet.TransactionInput\0225\n" +
-      "\022transaction_output\030\007 \003(\0132\031.wallet.Trans" +
-      "actionOutput\022\022\n\nblock_hash\030\010 \003(\014\022 \n\030bloc" +
-      "k_relativity_offsets\030\013 \003(\005\0221\n\nconfidence" +
-      "\030\t \001(\0132\035.wallet.TransactionConfidence\0225\n" +
-      "\007purpose\030\n \001(\0162\033.wallet.Transaction.Purp" +
-      "ose:\007UNKNOWN\022+\n\rexchange_rate\030\014 \001(\0132\024.wa" +
-      "llet.ExchangeRate\022\014\n\004memo\030\r \001(\t\"Y\n\004Pool\022",
-      "\013\n\007UNSPENT\020\004\022\t\n\005SPENT\020\005\022\014\n\010INACTIVE\020\002\022\010\n" +
-      "\004DEAD\020\n\022\013\n\007PENDING\020\020\022\024\n\020PENDING_INACTIVE" +
-      "\020\022\"\243\001\n\007Purpose\022\013\n\007UNKNOWN\020\000\022\020\n\014USER_PAYM" +
-      "ENT\020\001\022\020\n\014KEY_ROTATION\020\002\022\034\n\030ASSURANCE_CON" +
-      "TRACT_CLAIM\020\003\022\035\n\031ASSURANCE_CONTRACT_PLED" +
-      "GE\020\004\022\033\n\027ASSURANCE_CONTRACT_STUB\020\005\022\r\n\tRAI" +
-      "SE_FEE\020\006\"N\n\020ScryptParameters\022\014\n\004salt\030\001 \002" +
-      "(\014\022\020\n\001n\030\002 \001(\003:\00516384\022\014\n\001r\030\003 \001(\005:\0018\022\014\n\001p\030" +
-      "\004 \001(\005:\0011\"8\n\tExtension\022\n\n\002id\030\001 \002(\t\022\014\n\004dat" +
-      "a\030\002 \002(\014\022\021\n\tmandatory\030\003 \002(\010\" \n\003Tag\022\013\n\003tag",
-      "\030\001 \002(\t\022\014\n\004data\030\002 \002(\014\"5\n\021TransactionSigne" +
-      "r\022\022\n\nclass_name\030\001 \002(\t\022\014\n\004data\030\002 \001(\014\"\351\004\n\006" +
-      "Wallet\022\032\n\022network_identifier\030\001 \002(\t\022\034\n\024la" +
-      "st_seen_block_hash\030\002 \001(\014\022\036\n\026last_seen_bl" +
-      "ock_height\030\014 \001(\r\022!\n\031last_seen_block_time" +
-      "_secs\030\016 \001(\003\022\030\n\003key\030\003 \003(\0132\013.wallet.Key\022(\n" +
-      "\013transaction\030\004 \003(\0132\023.wallet.Transaction\022" +
-      "&\n\016watched_script\030\017 \003(\0132\016.wallet.Script\022" +
-      "C\n\017encryption_type\030\005 \001(\0162\035.wallet.Wallet" +
-      ".EncryptionType:\013UNENCRYPTED\0227\n\025encrypti",
-      "on_parameters\030\006 \001(\0132\030.wallet.ScryptParam" +
-      "eters\022\022\n\007version\030\007 \001(\005:\0011\022$\n\textension\030\n" +
-      " \003(\0132\021.wallet.Extension\022\023\n\013description\030\013" +
-      " \001(\t\022\031\n\021key_rotation_time\030\r \001(\004\022\031\n\004tags\030" +
-      "\020 \003(\0132\013.wallet.Tag\0226\n\023transaction_signer" +
-      "s\030\021 \003(\0132\031.wallet.TransactionSigner\";\n\016En" +
-      "cryptionType\022\017\n\013UNENCRYPTED\020\001\022\030\n\024ENCRYPT" +
-      "ED_SCRYPT_AES\020\002\"R\n\014ExchangeRate\022\022\n\ncoin_" +
-      "value\030\001 \002(\003\022\022\n\nfiat_value\030\002 \002(\003\022\032\n\022fiat_" +
-      "currency_code\030\003 \002(\tB\035\n\023org.bitcoinj.wall",
-      "etB\006Protos"
+      "\022\036\n\026overriding_transaction\030\003 \001(\014\022)\n\014broa" +
+      "dcast_by\030\006 \003(\0132\023.wallet.PeerAddress\022\033\n\023l" +
+      "ast_broadcasted_at\030\010 \001(\003\0224\n\006source\030\007 \001(\016" +
+      "2$.wallet.TransactionConfidence.Source\"`" +
+      "\n\004Type\022\013\n\007UNKNOWN\020\000\022\014\n\010BUILDING\020\001\022\013\n\007PEN" +
+      "DING\020\002\022\025\n\021NOT_IN_BEST_CHAIN\020\003\022\010\n\004DEAD\020\004\022" +
+      "\017\n\013IN_CONFLICT\020\005\"A\n\006Source\022\022\n\016SOURCE_UNK" +
+      "NOWN\020\000\022\022\n\016SOURCE_NETWORK\020\001\022\017\n\013SOURCE_SEL" +
+      "F\020\002\"\303\005\n\013Transaction\022\017\n\007version\030\001 \002(\005\022\014\n\004" +
+      "hash\030\002 \002(\014\022&\n\004pool\030\003 \001(\0162\030.wallet.Transa",
+      "ction.Pool\022\021\n\tlock_time\030\004 \001(\r\022\022\n\nupdated" +
+      "_at\030\005 \001(\003\0223\n\021transaction_input\030\006 \003(\0132\030.w" +
+      "allet.TransactionInput\0225\n\022transaction_ou" +
+      "tput\030\007 \003(\0132\031.wallet.TransactionOutput\022\022\n" +
+      "\nblock_hash\030\010 \003(\014\022 \n\030block_relativity_of" +
+      "fsets\030\013 \003(\005\0221\n\nconfidence\030\t \001(\0132\035.wallet" +
+      ".TransactionConfidence\0225\n\007purpose\030\n \001(\0162" +
+      "\033.wallet.Transaction.Purpose:\007UNKNOWN\022+\n" +
+      "\rexchange_rate\030\014 \001(\0132\024.wallet.ExchangeRa" +
+      "te\022\014\n\004memo\030\r \001(\t\"Y\n\004Pool\022\013\n\007UNSPENT\020\004\022\t\n",
+      "\005SPENT\020\005\022\014\n\010INACTIVE\020\002\022\010\n\004DEAD\020\n\022\013\n\007PEND" +
+      "ING\020\020\022\024\n\020PENDING_INACTIVE\020\022\"\243\001\n\007Purpose\022" +
+      "\013\n\007UNKNOWN\020\000\022\020\n\014USER_PAYMENT\020\001\022\020\n\014KEY_RO" +
+      "TATION\020\002\022\034\n\030ASSURANCE_CONTRACT_CLAIM\020\003\022\035" +
+      "\n\031ASSURANCE_CONTRACT_PLEDGE\020\004\022\033\n\027ASSURAN" +
+      "CE_CONTRACT_STUB\020\005\022\r\n\tRAISE_FEE\020\006\"N\n\020Scr" +
+      "yptParameters\022\014\n\004salt\030\001 \002(\014\022\020\n\001n\030\002 \001(\003:\005" +
+      "16384\022\014\n\001r\030\003 \001(\005:\0018\022\014\n\001p\030\004 \001(\005:\0011\"8\n\tExt" +
+      "ension\022\n\n\002id\030\001 \002(\t\022\014\n\004data\030\002 \002(\014\022\021\n\tmand" +
+      "atory\030\003 \002(\010\" \n\003Tag\022\013\n\003tag\030\001 \002(\t\022\014\n\004data\030",
+      "\002 \002(\014\"5\n\021TransactionSigner\022\022\n\nclass_name" +
+      "\030\001 \002(\t\022\014\n\004data\030\002 \001(\014\"\351\004\n\006Wallet\022\032\n\022netwo" +
+      "rk_identifier\030\001 \002(\t\022\034\n\024last_seen_block_h" +
+      "ash\030\002 \001(\014\022\036\n\026last_seen_block_height\030\014 \001(" +
+      "\r\022!\n\031last_seen_block_time_secs\030\016 \001(\003\022\030\n\003" +
+      "key\030\003 \003(\0132\013.wallet.Key\022(\n\013transaction\030\004 " +
+      "\003(\0132\023.wallet.Transaction\022&\n\016watched_scri" +
+      "pt\030\017 \003(\0132\016.wallet.Script\022C\n\017encryption_t" +
+      "ype\030\005 \001(\0162\035.wallet.Wallet.EncryptionType" +
+      ":\013UNENCRYPTED\0227\n\025encryption_parameters\030\006",
+      " \001(\0132\030.wallet.ScryptParameters\022\022\n\007versio" +
+      "n\030\007 \001(\005:\0011\022$\n\textension\030\n \003(\0132\021.wallet.E" +
+      "xtension\022\023\n\013description\030\013 \001(\t\022\031\n\021key_rot" +
+      "ation_time\030\r \001(\004\022\031\n\004tags\030\020 \003(\0132\013.wallet." +
+      "Tag\0226\n\023transaction_signers\030\021 \003(\0132\031.walle" +
+      "t.TransactionSigner\";\n\016EncryptionType\022\017\n" +
+      "\013UNENCRYPTED\020\001\022\030\n\024ENCRYPTED_SCRYPT_AES\020\002" +
+      "\"R\n\014ExchangeRate\022\022\n\ncoin_value\030\001 \002(\003\022\022\n\n" +
+      "fiat_value\030\002 \002(\003\022\032\n\022fiat_currency_code\030\003" +
+      " \002(\tB\035\n\023org.bitcoinj.walletB\006Protos"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -19353,7 +19234,7 @@ public final class Protos {
     internal_static_wallet_TransactionConfidence_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_wallet_TransactionConfidence_descriptor,
-        new java.lang.String[] { "Type", "AppearedAtHeight", "OverridingTransaction", "Depth", "BroadcastBy", "LastBroadcastedAt", "Source", });
+        new java.lang.String[] { "Type", "AppearedAtHeight", "OverridingTransaction", "BroadcastBy", "LastBroadcastedAt", "Source", });
     internal_static_wallet_Transaction_descriptor =
       getDescriptor().getMessageTypes().get(8);
     internal_static_wallet_Transaction_fieldAccessorTable = new

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -366,7 +366,6 @@ public class WalletProtobufSerializer {
             confidenceBuilder.setType(Protos.TransactionConfidence.Type.valueOf(confidence.getConfidenceType().getValue()));
             if (confidence.getConfidenceType() == ConfidenceType.BUILDING) {
                 confidenceBuilder.setAppearedAtHeight(confidence.getAppearedAtChainHeight());
-                confidenceBuilder.setDepth(confidence.getDepthInBlocks());
             }
             if (confidence.getConfidenceType() == ConfidenceType.DEAD) {
                 // Copy in the overriding transaction, if available.
@@ -787,13 +786,6 @@ public class WalletProtobufSerializer {
                 return;
             }
             confidence.setAppearedAtChainHeight(confidenceProto.getAppearedAtHeight());
-        }
-        if (confidenceProto.hasDepth()) {
-            if (confidence.getConfidenceType() != ConfidenceType.BUILDING) {
-                log.warn("Have depth but not BUILDING for tx {}", tx.getHashAsString());
-                return;
-            }
-            confidence.setDepthInBlocks(confidenceProto.getDepth());
         }
         if (confidenceProto.hasOverridingTransaction()) {
             if (confidence.getConfidenceType() != ConfidenceType.DEAD) {

--- a/core/src/main/proto/wallet.proto
+++ b/core/src/main/proto/wallet.proto
@@ -197,9 +197,8 @@ message TransactionConfidence {
   // bother to track them all, just the first. This only makes sense if type = DEAD.
   optional bytes overriding_transaction = 3;
 
-  // If type == BUILDING then this is the depth of the transaction in the blockchain.
-  // Zero confirmations: depth = 0, one confirmation: depth = 1 etc.
-  optional int32 depth = 4;
+  // deprecated - do not recycle this numeric identifier
+  // optional int32 depth = 4;
 
   // deprecated - do not recycle this numeric identifier
   // optional int64 work_done = 5;

--- a/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
@@ -331,7 +331,7 @@ public class BlockChainTest {
         // The coinbase tx is not yet available to spend.
         assertEquals(Coin.ZERO, wallet.getBalance());
         assertEquals(wallet.getBalance(BalanceType.ESTIMATED), FIFTY_COINS);
-        assertTrue(!coinbaseTransaction.isMature());
+        assertTrue(!coinbaseTransaction.isMature(wallet.getLastBlockSeenHeight()));
 
         // Attempt to spend the coinbase - this should fail as the coinbase is not mature yet.
         try {
@@ -353,7 +353,7 @@ public class BlockChainTest {
             assertEquals(wallet.getBalance(BalanceType.ESTIMATED), FIFTY_COINS);
 
             // The coinbase transaction is still not mature.
-            assertTrue(!coinbaseTransaction.isMature());
+            assertTrue(!coinbaseTransaction.isMature(wallet.getLastBlockSeenHeight()));
 
             // Attempt to spend the coinbase - this should fail.
             try {
@@ -371,7 +371,7 @@ public class BlockChainTest {
         // Wallet now has the coinbase transaction available for spend.
         assertEquals(wallet.getBalance(), FIFTY_COINS);
         assertEquals(wallet.getBalance(BalanceType.ESTIMATED), FIFTY_COINS);
-        assertTrue(coinbaseTransaction.isMature());
+        assertTrue(coinbaseTransaction.isMature(wallet.getLastBlockSeenHeight()));
 
         // Create a spend with the coinbase BTC to the address in the second wallet - this should now succeed.
         Transaction coinbaseSend2 = wallet.createSend(addressToSendTo, valueOf(49, 0));

--- a/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
@@ -427,9 +427,9 @@ public class ChainSplitTest {
         assertEquals(2, txns.get(1).getConfidence().getAppearedAtChainHeight());
         assertEquals(3, txns.get(2).getConfidence().getAppearedAtChainHeight());
 
-        assertEquals(3, txns.get(0).getConfidence().getDepthInBlocks());
-        assertEquals(2, txns.get(1).getConfidence().getDepthInBlocks());
-        assertEquals(1, txns.get(2).getConfidence().getDepthInBlocks());
+        assertEquals(3, txns.get(0).getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()));
+        assertEquals(2, txns.get(1).getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()));
+        assertEquals(1, txns.get(2).getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()));
 
         // We now have the following chain:
         //     genesis -> b1 -> b2 -> b3
@@ -455,9 +455,9 @@ public class ChainSplitTest {
         assertEquals(2, txns.get(1).getConfidence().getAppearedAtChainHeight());
         assertEquals(3, txns.get(2).getConfidence().getAppearedAtChainHeight());
 
-        assertEquals(3, txns.get(0).getConfidence().getDepthInBlocks());
-        assertEquals(2, txns.get(1).getConfidence().getDepthInBlocks());
-        assertEquals(1, txns.get(2).getConfidence().getDepthInBlocks());
+        assertEquals(3, txns.get(0).getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()));
+        assertEquals(2, txns.get(1).getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()));
+        assertEquals(1, txns.get(2).getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()));
 
         // Now we add another block to make the alternative chain longer.
         Block b6 = b5.createNextBlock(someOtherGuy);
@@ -470,7 +470,7 @@ public class ChainSplitTest {
 
         assertEquals(3, txns.size());
         assertEquals(1, txns.get(0).getConfidence().getAppearedAtChainHeight());
-        assertEquals(4, txns.get(0).getConfidence().getDepthInBlocks());
+        assertEquals(4, txns.get(0).getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()));
 
         // Transaction 1 (in block b2) is now on a side chain, so it goes pending (not see in chain).
         assertEquals(ConfidenceType.PENDING, txns.get(1).getConfidence().getConfidenceType());
@@ -478,7 +478,7 @@ public class ChainSplitTest {
             txns.get(1).getConfidence().getAppearedAtChainHeight();
             fail();
         } catch (IllegalStateException e) {}
-        assertEquals(0, txns.get(1).getConfidence().getDepthInBlocks());
+        assertEquals(0, txns.get(1).getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()));
 
         // ... and back to the first chain.
         Block b7 = b3.createNextBlock(coinsTo);
@@ -501,9 +501,9 @@ public class ChainSplitTest {
         assertEquals(2, txns.get(1).getConfidence().getAppearedAtChainHeight());
         assertEquals(3, txns.get(2).getConfidence().getAppearedAtChainHeight());
 
-        assertEquals(5, txns.get(0).getConfidence().getDepthInBlocks());
-        assertEquals(4, txns.get(1).getConfidence().getDepthInBlocks());
-        assertEquals(3, txns.get(2).getConfidence().getDepthInBlocks());
+        assertEquals(5, txns.get(0).getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()));
+        assertEquals(4, txns.get(1).getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()));
+        assertEquals(3, txns.get(2).getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()));
 
         assertEquals(Coin.valueOf(250, 0), wallet.getBalance());
 
@@ -513,9 +513,9 @@ public class ChainSplitTest {
         chain.add(b9);
         chain.add(b10);
         BigInteger extraWork = b9.getWork().add(b10.getWork());
-        assertEquals(7, txns.get(0).getConfidence().getDepthInBlocks());
-        assertEquals(6, txns.get(1).getConfidence().getDepthInBlocks());
-        assertEquals(5, txns.get(2).getConfidence().getDepthInBlocks());
+        assertEquals(7, txns.get(0).getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()));
+        assertEquals(6, txns.get(1).getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()));
+        assertEquals(5, txns.get(2).getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()));
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTests.java
+++ b/core/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTests.java
@@ -194,7 +194,7 @@ public class FilteredBlockAndPartialMerkleTreeTests extends TestWithPeerGroup {
         assertTrue(transactions.size() == 4);
         for (Transaction tx : transactions) {
             assertTrue(tx.getConfidence().getConfidenceType() == ConfidenceType.BUILDING);
-            assertTrue(tx.getConfidence().getDepthInBlocks() == 1);
+            assertTrue(tx.getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()) == 1);
             assertTrue(tx.getAppearsInHashes().keySet().contains(block.getHash()));
             assertTrue(tx.getAppearsInHashes().size() == 1);
         }

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -155,13 +155,13 @@ public class TransactionTest {
         Transaction tx = FakeTxBuilder.createFakeCoinbaseTx(UNITTEST);
 
         tx.getConfidence().setConfidenceType(ConfidenceType.UNKNOWN);
-        assertEquals(tx.isMature(), false);
+        assertEquals(tx.isMature(Integer.MAX_VALUE), false);
 
         tx.getConfidence().setConfidenceType(ConfidenceType.PENDING);
-        assertEquals(tx.isMature(), false);
+        assertEquals(tx.isMature(Integer.MAX_VALUE), false);
 
         tx.getConfidence().setConfidenceType(ConfidenceType.DEAD);
-        assertEquals(tx.isMature(), false);
+        assertEquals(tx.isMature(Integer.MAX_VALUE), false);
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -246,8 +246,8 @@ public class WalletProtobufSerializerTest {
     }
 
     @Test
-    public void testAppearedAtChainHeightDepthAndWorkDone() throws Exception {
-        // Test the TransactionConfidence appearedAtChainHeight, depth and workDone field are stored.
+    public void testAppearedAtChainHeight() throws Exception {
+        // Test the TransactionConfidence appearedAtChainHeight field is stored.
 
         BlockChain chain = new BlockChain(UNITTEST, myWallet, new MemoryBlockStore(UNITTEST));
 
@@ -284,10 +284,7 @@ public class WalletProtobufSerializerTest {
         assertEquals(1, confidence0.getAppearedAtChainHeight());
         assertEquals(2, confidence1.getAppearedAtChainHeight());
 
-        assertEquals(2, confidence0.getDepthInBlocks());
-        assertEquals(1, confidence1.getDepthInBlocks());
-
-        // Roundtrip the wallet and check it has stored the depth and workDone.
+        // Roundtrip the wallet and check it has stored the appearedAtChainHeight.
         Wallet rebornWallet = roundTrip(myWallet);
 
         Set<Transaction> rebornTxns = rebornWallet.getTransactions(false);
@@ -312,9 +309,6 @@ public class WalletProtobufSerializerTest {
 
         assertEquals(1, rebornConfidence0.getAppearedAtChainHeight());
         assertEquals(2, rebornConfidence1.getAppearedAtChainHeight());
-
-        assertEquals(2, rebornConfidence0.getDepthInBlocks());
-        assertEquals(1, rebornConfidence1.getDepthInBlocks());
     }
 
     private static Wallet roundTrip(Wallet wallet) throws Exception {

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -2324,13 +2324,13 @@ public class WalletTest extends TestWithWallet {
 
         assertTrue(txCent.getOutput(0).isMine(wallet));
         assertTrue(txCent.getOutput(0).isAvailableForSpending());
-        assertEquals(199, txCent.getConfidence().getDepthInBlocks());
+        assertEquals(199, txCent.getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()));
         assertTrue(txCoin.getOutput(0).isMine(wallet));
         assertTrue(txCoin.getOutput(0).isAvailableForSpending());
-        assertEquals(1, txCoin.getConfidence().getDepthInBlocks());
+        assertEquals(1, txCoin.getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()));
         // txCent has higher coin*depth than txCoin...
-        assertTrue(txCent.getOutput(0).getValue().multiply(txCent.getConfidence().getDepthInBlocks())
-                .isGreaterThan(txCoin.getOutput(0).getValue().multiply(txCoin.getConfidence().getDepthInBlocks())));
+        assertTrue(txCent.getOutput(0).getValue().multiply(txCent.getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()))
+                .isGreaterThan(txCoin.getOutput(0).getValue().multiply(txCoin.getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()))));
         // ...so txCent should be selected
         Transaction spend1 = wallet.createSend(OTHER_ADDRESS, CENT);
         assertEquals(1, spend1.getInputs().size());
@@ -2339,13 +2339,13 @@ public class WalletTest extends TestWithWallet {
         sendMoneyToWallet(AbstractBlockChain.NewBlockType.BEST_CHAIN);
         assertTrue(txCent.getOutput(0).isMine(wallet));
         assertTrue(txCent.getOutput(0).isAvailableForSpending());
-        assertEquals(200, txCent.getConfidence().getDepthInBlocks());
+        assertEquals(200, txCent.getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()));
         assertTrue(txCoin.getOutput(0).isMine(wallet));
         assertTrue(txCoin.getOutput(0).isAvailableForSpending());
-        assertEquals(2, txCoin.getConfidence().getDepthInBlocks());
+        assertEquals(2, txCoin.getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()));
         // Now txCent and txCoin have exactly the same coin*depth...
-        assertEquals(txCent.getOutput(0).getValue().multiply(txCent.getConfidence().getDepthInBlocks()),
-                txCoin.getOutput(0).getValue().multiply(txCoin.getConfidence().getDepthInBlocks()));
+        assertEquals(txCent.getOutput(0).getValue().multiply(txCent.getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight())),
+                txCoin.getOutput(0).getValue().multiply(txCoin.getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight())));
         // ...so the larger txCoin should be selected
         Transaction spend2 = wallet.createSend(OTHER_ADDRESS, COIN);
         assertEquals(1, spend2.getInputs().size());
@@ -2354,13 +2354,13 @@ public class WalletTest extends TestWithWallet {
         sendMoneyToWallet(AbstractBlockChain.NewBlockType.BEST_CHAIN);
         assertTrue(txCent.getOutput(0).isMine(wallet));
         assertTrue(txCent.getOutput(0).isAvailableForSpending());
-        assertEquals(201, txCent.getConfidence().getDepthInBlocks());
+        assertEquals(201, txCent.getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()));
         assertTrue(txCoin.getOutput(0).isMine(wallet));
         assertTrue(txCoin.getOutput(0).isAvailableForSpending());
-        assertEquals(3, txCoin.getConfidence().getDepthInBlocks());
+        assertEquals(3, txCoin.getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()));
         // Now txCent has lower coin*depth than txCoin...
-        assertTrue(txCent.getOutput(0).getValue().multiply(txCent.getConfidence().getDepthInBlocks())
-                .isLessThan(txCoin.getOutput(0).getValue().multiply(txCoin.getConfidence().getDepthInBlocks())));
+        assertTrue(txCent.getOutput(0).getValue().multiply(txCent.getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()))
+                .isLessThan(txCoin.getOutput(0).getValue().multiply(txCoin.getConfidence().getDepthInBlocks(wallet.getLastBlockSeenHeight()))));
         // ...so txCoin should be selected
         Transaction spend3 = wallet.createSend(OTHER_ADDRESS, COIN);
         assertEquals(1, spend3.getInputs().size());

--- a/examples/src/main/java/org/bitcoinj/examples/Kit.java
+++ b/examples/src/main/java/org/bitcoinj/examples/Kit.java
@@ -99,7 +99,7 @@ public class Kit {
             public void onTransactionConfidenceChanged(Wallet wallet, Transaction tx) {
                 System.out.println("-----> confidence changed: " + tx.getHashAsString());
                 TransactionConfidence confidence = tx.getConfidence();
-                System.out.println("new block depth: " + confidence.getDepthInBlocks());
+                System.out.println("new block height: " + confidence.getAppearedAtChainHeight());
             }
         });
 


### PR DESCRIPTION
This is work on #877. It's very preview, breaks tests and therefore not intended for merging soon.

Issues:
- Yes, it's an API breaking change. Mostly this means you have to replace `confidence.getDepthInBlocks()` by `confidence.getDepthInBlocks(wallet.getLastBlockSeenHeight());`.
- Height is removed from the wallet protobuf. The field number is blocked for future use. Luckily appearsAtBlockHeight was already present so no migration is needed.
- As intended, ConfidenceListener will not fire on depth change, since the depth is now not part of the confidence any more. This means wallets with responsive UI will miss blockchain confirmations – unless they subscribe to some of the block height listeners too. Perhaps we should add a wallet-based "lastBlockSeenListener", since I suspect the existing listeners will perhaps not fire at the right time.
- The TransactionConfidence.getDepthFuture() needs a replacement, based on the above listener.
- Theoretically, if a block arrives which is irrelevant to the wallet saving could be skipped. Unfortunately, we still need to persist the lastBlockSeenHeight field so for now Wallet.saveLater() still needs to be called on each new block.
- DefaultCoinSelector spends coins based on priority (depth * value). Since priority is no longer a thing with miners (they pick by fee rate) and depth is now not easily available to the DefaultCoinSelector, I tried changing the algorithm to "older first". Unfortunately this breaks many tests. I guess this decision/work should be broken out to a separate PR.