### PR TITLE
Refactor mnemonic code tests for maintainability and empty passphrases

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Utils.java
+++ b/core/src/main/java/org/bitcoinj/core/Utils.java
@@ -17,23 +17,31 @@
 
 package org.bitcoinj.core;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Ordering;
-import com.google.common.io.BaseEncoding;
-import com.google.common.primitives.Ints;
-import org.spongycastle.crypto.digests.RIPEMD160Digest;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.math.BigInteger;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
+
+import org.spongycastle.crypto.digests.RIPEMD160Digest;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Ordering;
+import com.google.common.io.BaseEncoding;
+import com.google.common.primitives.Ints;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;

--- a/core/src/main/java/org/bitcoinj/core/Utils.java
+++ b/core/src/main/java/org/bitcoinj/core/Utils.java
@@ -17,30 +17,23 @@
 
 package org.bitcoinj.core;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Ordering;
+import com.google.common.io.BaseEncoding;
+import com.google.common.primitives.Ints;
+import org.spongycastle.crypto.digests.RIPEMD160Digest;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.math.BigInteger;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.TimeZone;
+import java.util.*;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
-
-import org.spongycastle.crypto.digests.RIPEMD160Digest;
-
-import com.google.common.base.Joiner;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Ordering;
-import com.google.common.io.BaseEncoding;
-import com.google.common.primitives.Ints;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
@@ -554,5 +547,14 @@ public class Utils {
 
     public static boolean isMac() {
         return System.getProperty("os.name").toLowerCase().contains("mac");
+    }
+
+    /**
+     * Split the words of a string into a list of strings.
+     * @param words A string of words separated by one or more whitespace characters.
+     * @return each word as an element of a list
+     */
+    public static List<String> split(String words) {
+        return new ArrayList<>(Arrays.asList(words.split("\\s+")));
     }
 }

--- a/core/src/test/java/org/bitcoinj/core/UtilsTest.java
+++ b/core/src/test/java/org/bitcoinj/core/UtilsTest.java
@@ -18,7 +18,6 @@
 
 package org.bitcoinj.core;
 
-
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Date;

--- a/core/src/test/java/org/bitcoinj/core/UtilsTest.java
+++ b/core/src/test/java/org/bitcoinj/core/UtilsTest.java
@@ -18,12 +18,13 @@
 
 package org.bitcoinj.core;
 
-import org.junit.Test;
 
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+
+import org.junit.Test;
 
 import static org.junit.Assert.*;
 

--- a/core/src/test/java/org/bitcoinj/core/UtilsTest.java
+++ b/core/src/test/java/org/bitcoinj/core/UtilsTest.java
@@ -18,11 +18,12 @@
 
 package org.bitcoinj.core;
 
+import org.junit.Test;
+
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Date;
-
-import org.junit.Test;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -110,5 +111,24 @@ public class UtilsTest {
         byte[] expected = new byte[]{-128};                 // -128 == 1000_0000 (compl-2)
         byte[] actual = Utils.bigIntegerToBytes(b, 1);
         assertTrue(Arrays.equals(expected, actual));
+    }
+
+    @Test
+    public void split_WordsWithWhitespace() {
+        String sentence = "These words  are    separated\rby\n\ndifferent amounts and types of white space";
+        final List<String> words = Utils.split(sentence);
+        assertEquals(12, words.size());
+        assertEquals("These", words.get(0));
+        assertEquals("words", words.get(1));
+        assertEquals("are", words.get(2));
+        assertEquals("separated", words.get(3));
+        assertEquals("by", words.get(4));
+        assertEquals("different", words.get(5));
+        assertEquals("amounts", words.get(6));
+        assertEquals("and", words.get(7));
+        assertEquals("types", words.get(8));
+        assertEquals("of", words.get(9));
+        assertEquals("white", words.get(10));
+        assertEquals("space", words.get(11));
     }
 }

--- a/core/src/test/java/org/bitcoinj/crypto/MnemonicCodeTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/MnemonicCodeTest.java
@@ -17,7 +17,6 @@
 
 package org.bitcoinj.crypto;
 
-import org.bitcoinj.core.Utils;
 import com.google.common.collect.Lists;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,152 +27,19 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.bitcoinj.core.Utils.HEX;
-import static org.junit.Assert.assertEquals;
 
+/**
+ * Test the various guard clauses of {@link MnemonicCode}.
+ *
+ * See {@link MnemonicCodeVectorsTest} test vectors.
+ */
 public class MnemonicCodeTest {
-    // These vectors are from https://github.com/trezor/python-mnemonic/blob/master/vectors.json
-    String[] vectors = {
-        "00000000000000000000000000000000",
-        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
-        "c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04",
-
-        "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
-        "legal winner thank year wave sausage worth useful legal winner thank yellow",
-        "2e8905819b8723fe2c1d161860e5ee1830318dbf49a83bd451cfb8440c28bd6fa457fe1296106559a3c80937a1c1069be3a3a5bd381ee6260e8d9739fce1f607",
-
-
-        "80808080808080808080808080808080",
-        "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
-        "d71de856f81a8acc65e6fc851a38d4d7ec216fd0796d0a6827a3ad6ed5511a30fa280f12eb2e47ed2ac03b5c462a0358d18d69fe4f985ec81778c1b370b652a8",
-
-
-        "ffffffffffffffffffffffffffffffff",
-        "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
-        "ac27495480225222079d7be181583751e86f571027b0497b5b5d11218e0a8a13332572917f0f8e5a589620c6f15b11c61dee327651a14c34e18231052e48c069",
-
-
-        "000000000000000000000000000000000000000000000000",
-        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent",
-        "035895f2f481b1b0f01fcf8c289c794660b289981a78f8106447707fdd9666ca06da5a9a565181599b79f53b844d8a71dd9f439c52a3d7b3e8a79c906ac845fa",
-
-
-        "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
-        "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal will",
-        "f2b94508732bcbacbcc020faefecfc89feafa6649a5491b8c952cede496c214a0c7b3c392d168748f2d4a612bada0753b52a1c7ac53c1e93abd5c6320b9e95dd",
-
-
-        "808080808080808080808080808080808080808080808080",
-        "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter always",
-        "107d7c02a5aa6f38c58083ff74f04c607c2d2c0ecc55501dadd72d025b751bc27fe913ffb796f841c49b1d33b610cf0e91d3aa239027f5e99fe4ce9e5088cd65",
-
-
-        "ffffffffffffffffffffffffffffffffffffffffffffffff",
-        "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo when",
-        "0cd6e5d827bb62eb8fc1e262254223817fd068a74b5b449cc2f667c3f1f985a76379b43348d952e2265b4cd129090758b3e3c2c49103b5051aac2eaeb890a528",
-
-
-        "0000000000000000000000000000000000000000000000000000000000000000",
-        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
-        "bda85446c68413707090a52022edd26a1c9462295029f2e60cd7c4f2bbd3097170af7a4d73245cafa9c3cca8d561a7c3de6f5d4a10be8ed2a5e608d68f92fcc8",
-
-
-        "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
-        "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title",
-        "bc09fca1804f7e69da93c2f2028eb238c227f2e9dda30cd63699232578480a4021b146ad717fbb7e451ce9eb835f43620bf5c514db0f8add49f5d121449d3e87",
-
-
-        "8080808080808080808080808080808080808080808080808080808080808080",
-        "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic bless",
-        "c0c519bd0e91a2ed54357d9d1ebef6f5af218a153624cf4f2da911a0ed8f7a09e2ef61af0aca007096df430022f7a2b6fb91661a9589097069720d015e4e982f",
-
-
-        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-        "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo vote",
-        "dd48c104698c30cfe2b6142103248622fb7bb0ff692eebb00089b32d22484e1613912f0a5b694407be899ffd31ed3992c456cdf60f5d4564b8ba3f05a69890ad",
-
-
-        "77c2b00716cec7213839159e404db50d",
-        "jelly better achieve collect unaware mountain thought cargo oxygen act hood bridge",
-        "b5b6d0127db1a9d2226af0c3346031d77af31e918dba64287a1b44b8ebf63cdd52676f672a290aae502472cf2d602c051f3e6f18055e84e4c43897fc4e51a6ff",
-
-
-        "b63a9c59a6e641f288ebc103017f1da9f8290b3da6bdef7b",
-        "renew stay biology evidence goat welcome casual join adapt armor shuffle fault little machine walk stumble urge swap",
-        "9248d83e06f4cd98debf5b6f010542760df925ce46cf38a1bdb4e4de7d21f5c39366941c69e1bdbf2966e0f6e6dbece898a0e2f0a4c2b3e640953dfe8b7bbdc5",
-
-
-        "3e141609b97933b66a060dcddc71fad1d91677db872031e85f4c015c5e7e8982",
-        "dignity pass list indicate nasty swamp pool script soccer toe leaf photo multiply desk host tomato cradle drill spread actor shine dismiss champion exotic",
-        "ff7f3184df8696d8bef94b6c03114dbee0ef89ff938712301d27ed8336ca89ef9635da20af07d4175f2bf5f3de130f39c9d9e8dd0472489c19b1a020a940da67",
-
-
-        "0460ef47585604c5660618db2e6a7e7f",
-        "afford alter spike radar gate glance object seek swamp infant panel yellow",
-        "65f93a9f36b6c85cbe634ffc1f99f2b82cbb10b31edc7f087b4f6cb9e976e9faf76ff41f8f27c99afdf38f7a303ba1136ee48a4c1e7fcd3dba7aa876113a36e4",
-
-
-        "72f60ebac5dd8add8d2a25a797102c3ce21bc029c200076f",
-        "indicate race push merry suffer human cruise dwarf pole review arch keep canvas theme poem divorce alter left",
-        "3bbf9daa0dfad8229786ace5ddb4e00fa98a044ae4c4975ffd5e094dba9e0bb289349dbe2091761f30f382d4e35c4a670ee8ab50758d2c55881be69e327117ba",
-
-
-        "2c85efc7f24ee4573d2b81a6ec66cee209b2dcbd09d8eddc51e0215b0b68e416",
-        "clutch control vehicle tonight unusual clog visa ice plunge glimpse recipe series open hour vintage deposit universe tip job dress radar refuse motion taste",
-        "fe908f96f46668b2d5b37d82f558c77ed0d69dd0e7e043a5b0511c48c2f1064694a956f86360c93dd04052a8899497ce9e985ebe0c8c52b955e6ae86d4ff4449",
-
-
-        "eaebabb2383351fd31d703840b32e9e2",
-        "turtle front uncle idea crush write shrug there lottery flower risk shell",
-        "bdfb76a0759f301b0b899a1e3985227e53b3f51e67e3f2a65363caedf3e32fde42a66c404f18d7b05818c95ef3ca1e5146646856c461c073169467511680876c",
-
-
-        "7ac45cfe7722ee6c7ba84fbc2d5bd61b45cb2fe5eb65aa78",
-        "kiss carry display unusual confirm curtain upgrade antique rotate hello void custom frequent obey nut hole price segment",
-        "ed56ff6c833c07982eb7119a8f48fd363c4a9b1601cd2de736b01045c5eb8ab4f57b079403485d1c4924f0790dc10a971763337cb9f9c62226f64fff26397c79",
-
-
-        "4fa1a8bc3e6d80ee1316050e862c1812031493212b7ec3f3bb1b08f168cabeef",
-        "exile ask congress lamp submit jacket era scheme attend cousin alcohol catch course end lucky hurt sentence oven short ball bird grab wing top",
-        "095ee6f817b4c2cb30a5a797360a81a40ab0f9a4e25ecd672a3f58a0b5ba0687c096a6b14d2c0deb3bdefce4f61d01ae07417d502429352e27695163f7447a8c",
-
-
-        "18ab19a9f54a9274f03e5209a2ac8a91",
-        "board flee heavy tunnel powder denial science ski answer betray cargo cat",
-        "6eff1bb21562918509c73cb990260db07c0ce34ff0e3cc4a8cb3276129fbcb300bddfe005831350efd633909f476c45c88253276d9fd0df6ef48609e8bb7dca8",
-
-
-        "18a2e1d81b8ecfb2a333adcb0c17a5b9eb76cc5d05db91a4",
-        "board blade invite damage undo sun mimic interest slam gaze truly inherit resist great inject rocket museum chief",
-        "f84521c777a13b61564234bf8f8b62b3afce27fc4062b51bb5e62bdfecb23864ee6ecf07c1d5a97c0834307c5c852d8ceb88e7c97923c0a3b496bedd4e5f88a9",
-
-
-        "15da872c95a13dd738fbf50e427583ad61f18fd99f628c417a61cf8343c90419",
-        "beyond stage sleep clip because twist token leaf atom beauty genius food business side grid unable middle armed observe pair crouch tonight away coconut",
-        "b15509eaa2d09d3efd3e006ef42151b30367dc6e3aa5e44caba3fe4d3e352e65101fbdb86a96776b91946ff06f8eac594dc6ee1d3e82a42dfe1b40fef6bcc3fd"
-    };
 
     private MnemonicCode mc;
 
     @Before
     public void setup() throws IOException {
         mc = new MnemonicCode();
-    }
-
-    @Test
-    public void testVectors() throws Exception {
-        for (int ii = 0; ii < vectors.length; ii += 3) {
-            String vecData = vectors[ii];
-            String vecCode = vectors[ii+1];
-            String vecSeed = vectors[ii+2];
-
-            List<String> code = mc.toMnemonic(HEX.decode(vecData));
-            byte[] seed = MnemonicCode.toSeed(code, "TREZOR");
-            byte[] entropy = mc.toEntropy(split(vecCode));
-
-            assertEquals(vecData, HEX.encode(entropy));
-            assertEquals(vecCode, Utils.SPACE_JOINER.join(code));
-            assertEquals(vecSeed, HEX.encode(seed));
-        }
     }
 
     @Test(expected = MnemonicException.MnemonicLengthException.class)
@@ -218,7 +84,7 @@ public class MnemonicCodeTest {
         MnemonicCode.toSeed(code, null);
     }
 
-    public static List<String> split(String words) {
+    static List<String> split(String words) {
         return new ArrayList<>(Arrays.asList(words.split("\\s+")));
     }
 }

--- a/core/src/test/java/org/bitcoinj/crypto/MnemonicCodeTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/MnemonicCodeTest.java
@@ -22,11 +22,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.bitcoinj.core.Utils.HEX;
+import static org.bitcoinj.core.Utils.split;
 
 /**
  * Test the various guard clauses of {@link MnemonicCode}.
@@ -82,9 +81,5 @@ public class MnemonicCodeTest {
     public void testNullPassphrase() throws Exception {
         List<String> code = split("legal winner thank year wave sausage worth useful legal winner thank yellow");
         MnemonicCode.toSeed(code, null);
-    }
-
-    static List<String> split(String words) {
-        return new ArrayList<>(Arrays.asList(words.split("\\s+")));
     }
 }

--- a/core/src/test/java/org/bitcoinj/crypto/MnemonicCodeTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/MnemonicCodeTest.java
@@ -17,12 +17,12 @@
 
 package org.bitcoinj.crypto;
 
+import java.io.IOException;
+import java.util.List;
+
 import com.google.common.collect.Lists;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.IOException;
-import java.util.List;
 
 import static org.bitcoinj.core.Utils.HEX;
 import static org.bitcoinj.core.Utils.split;

--- a/core/src/test/java/org/bitcoinj/crypto/MnemonicCodeVectorsTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/MnemonicCodeVectorsTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2013 Ken Sedgwick
+ * Copyright 2014 Andreas Schildbach
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.bitcoinj.crypto;
 
 import org.bitcoinj.core.Utils;
@@ -221,50 +238,7 @@ public class MnemonicCodeVectorsTest {
                         "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold",
                         "b873212f885ccffbf4692afcb84bc2e55886de2dfa07d90f5c3c239abc31c0a6ce047e30fd8bf6a281e71389aa82d73df74c7bbfb3b06b4639a5cee775cccd3c",
                         ""
-                },
-
-                /*
-                 * The following vectors were created to test character encoding and normalization of the passphrase,
-                 * and were determined using the reference implementation at https://github.com/trezor/python-mnemonic.
-                 *
-                 * Use these vectors to test a resolution to issue #1361.
-                 */
-//                {
-//                        "00000000000000000000000000000000",
-//                        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
-//                        "c8eaf56947690f7505ffae9a08f3c286b5e28adb5db5d2324499979dbe5ecf6009642006593aafeb72cb7314ac47c60fd2710d46674779d6f5872042a228cae3",
-//                        "schön"
-//                }, {
-//                        "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
-//                        "legal winner thank year wave sausage worth useful legal winner thank yellow",
-//                        "d0e74e4615e8697d68a011ac131bef61fb098d07eab20ebe3d2b9034281adb117ffdd5fb78a55661bf4ba4dbab3c805329a454460e74bc8c67e9016fed8ec8e4",
-//                        "schön"
-//                }, {
-//                        "80808080808080808080808080808080",
-//                        "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
-//                        "bb7a3b74623ec791d781055a2a75a253bc14a842a589c0f535ef955730cda04e6d03333e3f7d7dc6b1e6f5d9bed0fcc4714cc80f340c750d60057bff83b82125",
-//                        "schön"
-//                }, {
-//                        "ffffffffffffffffffffffffffffffff",
-//                        "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
-//                        "5f197e8565923b4fd776056ff2d3e5a23c783c1f95ebe91f13166b39a59bd89e20557c33503090be49002a2899c44ab89c2b461e1307443b0d579667dc783d3b",
-//                        "schön"
-//                }, {
-//                        "f30f8c1da665478f49b001d94c5fc452",
-//                        "vessel ladder alter error federal sibling chat ability sun glass valve picture",
-//                        "401e0fcc6974e6fdcb847bd832d9f6e3933d05410f23e882e7c2d027f3ad56e01d38006cd2690930e6f0bab67c75fb269d8bdbe0d1fc125581b78ba0e46c5716",
-//                        "schön"
-//                }, {
-//                        "c10ec20dc3cd9f652c7fac2f1230f7a3c828389a14392f05",
-//                        "scissors invite lock maple supreme raw rapid void congress muscle digital elegant little brisk hair mango congress clump",
-//                        "8f8aef01d3c05f0dbd736158df85f308edff2d3c2428b8e8991336342a2b363e484d6451e24d8b17f1343329c2fbc6b11d35b0ffc89f7f735dae14869aefbd9e",
-//                        "schön"
-//                }, {
-//                        "f585c11aec520db57dd353c69554b21a89b20fb0650966fa0a9d6f74fd989d8f",
-//                        "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold",
-//                        "566beed821c8a4af803aeb0981d48e74ecf247117982f7e055b3b4fb9691f6d870945239bb6045da030b85e0f6397b3c13c3f779d99d3a9f827d177c1adddc01",
-//                        "schön"
-//                }
+                }
         });
     }
 }

--- a/core/src/test/java/org/bitcoinj/crypto/MnemonicCodeVectorsTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/MnemonicCodeVectorsTest.java
@@ -17,17 +17,19 @@
 
 package org.bitcoinj.crypto;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import static org.bitcoinj.core.Utils.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.bitcoinj.core.Utils.HEX;
+import static org.bitcoinj.core.Utils.SPACE_JOINER;
+import static org.bitcoinj.core.Utils.split;
 import static org.junit.Assert.assertEquals;
 
 /**

--- a/core/src/test/java/org/bitcoinj/crypto/MnemonicCodeVectorsTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/MnemonicCodeVectorsTest.java
@@ -17,7 +17,6 @@
 
 package org.bitcoinj.crypto;
 
-import org.bitcoinj.core.Utils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,8 +27,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import static org.bitcoinj.core.Utils.HEX;
-import static org.bitcoinj.crypto.MnemonicCodeTest.split;
+import static org.bitcoinj.core.Utils.*;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -39,16 +37,16 @@ import static org.junit.Assert.assertEquals;
 public class MnemonicCodeVectorsTest {
 
     private MnemonicCode mc;
-    private String entropy;
-    private String mnemonicCode;
-    private String seed;
-    private String passphrase;
+    private String vectorEntropy;
+    private String vectorMnemonicCode;
+    private String vectorSeed;
+    private String vectorPassphrase;
 
-    public MnemonicCodeVectorsTest(String entropy, String mnemonicCode, String seed, String passphrase) {
-        this.entropy = entropy;
-        this.mnemonicCode = mnemonicCode;
-        this.seed = seed;
-        this.passphrase = passphrase;
+    public MnemonicCodeVectorsTest(String vectorEntropy, String vectorMnemonicCode, String vectorSeed, String vectorPassphrase) {
+        this.vectorEntropy = vectorEntropy;
+        this.vectorMnemonicCode = vectorMnemonicCode;
+        this.vectorSeed = vectorSeed;
+        this.vectorPassphrase = vectorPassphrase;
     }
 
     @Before
@@ -58,13 +56,13 @@ public class MnemonicCodeVectorsTest {
 
     @Test
     public void testMnemonicCode() throws Exception {
-        final List<String> mnemonicCode = mc.toMnemonic(HEX.decode(entropy));
-        final byte[] seed = MnemonicCode.toSeed(mnemonicCode, passphrase);
-        final byte[] entropy = mc.toEntropy(split(this.mnemonicCode));
+        final List<String> mnemonicCode = mc.toMnemonic(HEX.decode(vectorEntropy));
+        final byte[] seed = MnemonicCode.toSeed(mnemonicCode, vectorPassphrase);
+        final byte[] entropy = mc.toEntropy(split(vectorMnemonicCode));
 
-        assertEquals(this.entropy, HEX.encode(entropy));
-        assertEquals(this.mnemonicCode, Utils.SPACE_JOINER.join(mnemonicCode));
-        assertEquals(this.seed, HEX.encode(seed));
+        assertEquals(vectorEntropy, HEX.encode(entropy));
+        assertEquals(vectorMnemonicCode, SPACE_JOINER.join(mnemonicCode));
+        assertEquals(vectorSeed, HEX.encode(seed));
     }
 
     /**

--- a/core/src/test/java/org/bitcoinj/crypto/MnemonicCodeVectorsTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/MnemonicCodeVectorsTest.java
@@ -1,0 +1,270 @@
+package org.bitcoinj.crypto;
+
+import org.bitcoinj.core.Utils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.bitcoinj.core.Utils.HEX;
+import static org.bitcoinj.crypto.MnemonicCodeTest.split;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * This is a parametrized test class to execute all {@link MnemonicCode} test vectors.
+ */
+@RunWith(value = Parameterized.class)
+public class MnemonicCodeVectorsTest {
+
+    private MnemonicCode mc;
+    private String entropy;
+    private String mnemonicCode;
+    private String seed;
+    private String passphrase;
+
+    public MnemonicCodeVectorsTest(String entropy, String mnemonicCode, String seed, String passphrase) {
+        this.entropy = entropy;
+        this.mnemonicCode = mnemonicCode;
+        this.seed = seed;
+        this.passphrase = passphrase;
+    }
+
+    @Before
+    public void setup() throws IOException {
+        mc = new MnemonicCode();
+    }
+
+    @Test
+    public void testMnemonicCode() throws Exception {
+        final List<String> mnemonicCode = mc.toMnemonic(HEX.decode(entropy));
+        final byte[] seed = MnemonicCode.toSeed(mnemonicCode, passphrase);
+        final byte[] entropy = mc.toEntropy(split(this.mnemonicCode));
+
+        assertEquals(this.entropy, HEX.encode(entropy));
+        assertEquals(this.mnemonicCode, Utils.SPACE_JOINER.join(mnemonicCode));
+        assertEquals(this.seed, HEX.encode(seed));
+    }
+
+    /**
+     * This method defines and supplies the parameters (test vectors) to be used in the testing of {@link MnemonicCode}.
+     * @return A list of groups of test vectors
+     */
+    @Parameterized.Parameters(name = "Vector set {index} (entropy={0}, passphrase={3})")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                /*
+                 * The following vectors are from https://github.com/trezor/python-mnemonic/blob/master/vectors.json
+                 */
+                {
+                        "00000000000000000000000000000000",
+                        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+                        "c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04",
+                        "TREZOR"
+                }, {
+                        "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
+                        "legal winner thank year wave sausage worth useful legal winner thank yellow",
+                        "2e8905819b8723fe2c1d161860e5ee1830318dbf49a83bd451cfb8440c28bd6fa457fe1296106559a3c80937a1c1069be3a3a5bd381ee6260e8d9739fce1f607",
+                        "TREZOR"
+                }, {
+                        "80808080808080808080808080808080",
+                        "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
+                        "d71de856f81a8acc65e6fc851a38d4d7ec216fd0796d0a6827a3ad6ed5511a30fa280f12eb2e47ed2ac03b5c462a0358d18d69fe4f985ec81778c1b370b652a8",
+                        "TREZOR"
+                }, {
+                        "ffffffffffffffffffffffffffffffff",
+                        "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
+                        "ac27495480225222079d7be181583751e86f571027b0497b5b5d11218e0a8a13332572917f0f8e5a589620c6f15b11c61dee327651a14c34e18231052e48c069",
+                        "TREZOR"
+                }, {
+                        "000000000000000000000000000000000000000000000000",
+                        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent",
+                        "035895f2f481b1b0f01fcf8c289c794660b289981a78f8106447707fdd9666ca06da5a9a565181599b79f53b844d8a71dd9f439c52a3d7b3e8a79c906ac845fa",
+                        "TREZOR"
+                }, {
+                        "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
+                        "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal will",
+                        "f2b94508732bcbacbcc020faefecfc89feafa6649a5491b8c952cede496c214a0c7b3c392d168748f2d4a612bada0753b52a1c7ac53c1e93abd5c6320b9e95dd",
+                        "TREZOR"
+                }, {
+                        "808080808080808080808080808080808080808080808080",
+                        "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter always",
+                        "107d7c02a5aa6f38c58083ff74f04c607c2d2c0ecc55501dadd72d025b751bc27fe913ffb796f841c49b1d33b610cf0e91d3aa239027f5e99fe4ce9e5088cd65",
+                        "TREZOR"
+                }, {
+                        "ffffffffffffffffffffffffffffffffffffffffffffffff",
+                        "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo when",
+                        "0cd6e5d827bb62eb8fc1e262254223817fd068a74b5b449cc2f667c3f1f985a76379b43348d952e2265b4cd129090758b3e3c2c49103b5051aac2eaeb890a528",
+                        "TREZOR"
+                }, {
+                        "0000000000000000000000000000000000000000000000000000000000000000",
+                        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
+                        "bda85446c68413707090a52022edd26a1c9462295029f2e60cd7c4f2bbd3097170af7a4d73245cafa9c3cca8d561a7c3de6f5d4a10be8ed2a5e608d68f92fcc8",
+                        "TREZOR"
+                }, {
+                        "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
+                        "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title",
+                        "bc09fca1804f7e69da93c2f2028eb238c227f2e9dda30cd63699232578480a4021b146ad717fbb7e451ce9eb835f43620bf5c514db0f8add49f5d121449d3e87",
+                        "TREZOR"
+                }, {
+                        "8080808080808080808080808080808080808080808080808080808080808080",
+                        "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic bless",
+                        "c0c519bd0e91a2ed54357d9d1ebef6f5af218a153624cf4f2da911a0ed8f7a09e2ef61af0aca007096df430022f7a2b6fb91661a9589097069720d015e4e982f",
+                        "TREZOR"
+                }, {
+                        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                        "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo vote",
+                        "dd48c104698c30cfe2b6142103248622fb7bb0ff692eebb00089b32d22484e1613912f0a5b694407be899ffd31ed3992c456cdf60f5d4564b8ba3f05a69890ad",
+                        "TREZOR"
+                }, {
+                        "9e885d952ad362caeb4efe34a8e91bd2",
+                        "ozone drill grab fiber curtain grace pudding thank cruise elder eight picnic",
+                        "274ddc525802f7c828d8ef7ddbcdc5304e87ac3535913611fbbfa986d0c9e5476c91689f9c8a54fd55bd38606aa6a8595ad213d4c9c9f9aca3fb217069a41028",
+                        "TREZOR"
+                }, {
+                        "6610b25967cdcca9d59875f5cb50b0ea75433311869e930b",
+                        "gravity machine north sort system female filter attitude volume fold club stay feature office ecology stable narrow fog",
+                        "628c3827a8823298ee685db84f55caa34b5cc195a778e52d45f59bcf75aba68e4d7590e101dc414bc1bbd5737666fbbef35d1f1903953b66624f910feef245ac",
+                        "TREZOR"
+                }, {
+                        "68a79eaca2324873eacc50cb9c6eca8cc68ea5d936f98787c60c7ebc74e6ce7c",
+                        "hamster diagram private dutch cause delay private meat slide toddler razor book happy fancy gospel tennis maple dilemma loan word shrug inflict delay length",
+                        "64c87cde7e12ecf6704ab95bb1408bef047c22db4cc7491c4271d170a1b213d20b385bc1588d9c7b38f1b39d415665b8a9030c9ec653d75e65f847d8fc1fc440",
+                        "TREZOR"
+                }, {
+                        "c0ba5a8e914111210f2bd131f3d5e08d",
+                        "scheme spot photo card baby mountain device kick cradle pact join borrow",
+                        "ea725895aaae8d4c1cf682c1bfd2d358d52ed9f0f0591131b559e2724bb234fca05aa9c02c57407e04ee9dc3b454aa63fbff483a8b11de949624b9f1831a9612",
+                        "TREZOR"
+                }, {
+                        "6d9be1ee6ebd27a258115aad99b7317b9c8d28b6d76431c3",
+                        "horn tenant knee talent sponsor spell gate clip pulse soap slush warm silver nephew swap uncle crack brave",
+                        "fd579828af3da1d32544ce4db5c73d53fc8acc4ddb1e3b251a31179cdb71e853c56d2fcb11aed39898ce6c34b10b5382772db8796e52837b54468aeb312cfc3d",
+                        "TREZOR"
+                }, {
+                        "9f6a2878b2520799a44ef18bc7df394e7061a224d2c33cd015b157d746869863",
+                        "panda eyebrow bullet gorilla call smoke muffin taste mesh discover soft ostrich alcohol speed nation flash devote level hobby quick inner drive ghost inside",
+                        "72be8e052fc4919d2adf28d5306b5474b0069df35b02303de8c1729c9538dbb6fc2d731d5f832193cd9fb6aeecbc469594a70e3dd50811b5067f3b88b28c3e8d",
+                        "TREZOR"
+                }, {
+                        "23db8160a31d3e0dca3688ed941adbf3",
+                        "cat swing flag economy stadium alone churn speed unique patch report train",
+                        "deb5f45449e615feff5640f2e49f933ff51895de3b4381832b3139941c57b59205a42480c52175b6efcffaa58a2503887c1e8b363a707256bdd2b587b46541f5",
+                        "TREZOR"
+                }, {
+                        "8197a4a47f0425faeaa69deebc05ca29c0a5b5cc76ceacc0",
+                        "light rule cinnamon wrap drastic word pride squirrel upgrade then income fatal apart sustain crack supply proud access",
+                        "4cbdff1ca2db800fd61cae72a57475fdc6bab03e441fd63f96dabd1f183ef5b782925f00105f318309a7e9c3ea6967c7801e46c8a58082674c860a37b93eda02",
+                        "TREZOR"
+                }, {
+                        "066dca1a2bb7e8a1db2832148ce9933eea0f3ac9548d793112d9a95c9407efad",
+                        "all hour make first leader extend hole alien behind guard gospel lava path output census museum junior mass reopen famous sing advance salt reform",
+                        "26e975ec644423f4a4c4f4215ef09b4bd7ef924e85d1d17c4cf3f136c2863cf6df0a475045652c57eb5fb41513ca2a2d67722b77e954b4b3fc11f7590449191d",
+                        "TREZOR"
+                }, {
+                        "f30f8c1da665478f49b001d94c5fc452",
+                        "vessel ladder alter error federal sibling chat ability sun glass valve picture",
+                        "2aaa9242daafcee6aa9d7269f17d4efe271e1b9a529178d7dc139cd18747090bf9d60295d0ce74309a78852a9caadf0af48aae1c6253839624076224374bc63f",
+                        "TREZOR"
+                }, {
+                        "c10ec20dc3cd9f652c7fac2f1230f7a3c828389a14392f05",
+                        "scissors invite lock maple supreme raw rapid void congress muscle digital elegant little brisk hair mango congress clump",
+                        "7b4a10be9d98e6cba265566db7f136718e1398c71cb581e1b2f464cac1ceedf4f3e274dc270003c670ad8d02c4558b2f8e39edea2775c9e232c7cb798b069e88",
+                        "TREZOR"
+                }, {
+                        "f585c11aec520db57dd353c69554b21a89b20fb0650966fa0a9d6f74fd989d8f",
+                        "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold",
+                        "01f5bced59dec48e362f2c45b5de68b9fd6c92c6634f44d6d40aab69056506f0e35524a518034ddc1192e1dacd32c1ed3eaa3c3b131c88ed8e7e54c49a5d0998",
+                        "TREZOR"
+                },
+
+                /*
+                 * The following vectors were created to test the absence of a passphrase,
+                 * and were determined using the reference implementation at https://github.com/trezor/python-mnemonic.
+                 */
+                {
+                        "00000000000000000000000000000000",
+                        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+                        "5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4",
+                        ""
+                }, {
+                        "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
+                        "legal winner thank year wave sausage worth useful legal winner thank yellow",
+                        "878386efb78845b3355bd15ea4d39ef97d179cb712b77d5c12b6be415fffeffe5f377ba02bf3f8544ab800b955e51fbff09828f682052a20faa6addbbddfb096",
+                        ""
+                }, {
+                        "80808080808080808080808080808080",
+                        "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
+                        "77d6be9708c8218738934f84bbbb78a2e048ca007746cb764f0673e4b1812d176bbb173e1a291f31cf633f1d0bad7d3cf071c30e98cd0688b5bcce65ecaceb36",
+                        ""
+                }, {
+                        "ffffffffffffffffffffffffffffffff",
+                        "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
+                        "b6a6d8921942dd9806607ebc2750416b289adea669198769f2e15ed926c3aa92bf88ece232317b4ea463e84b0fcd3b53577812ee449ccc448eb45e6f544e25b6",
+                        ""
+                }, {
+                        "f30f8c1da665478f49b001d94c5fc452",
+                        "vessel ladder alter error federal sibling chat ability sun glass valve picture",
+                        "e2d7f9a462875c1325f44f321392edc8eaafebf1547c89d72d10b41b4ee23af3fb0ab010f39f5cbea3b3aa671161b58262b6a508bcbe2d34ee272a942534d45f",
+                        ""
+                }, {
+                        "c10ec20dc3cd9f652c7fac2f1230f7a3c828389a14392f05",
+                        "scissors invite lock maple supreme raw rapid void congress muscle digital elegant little brisk hair mango congress clump",
+                        "a555426999448df9022c3afc2ed0e4aebff3a0ac37d8a395f81412e14994efc960ed168d39a80478e0467a3d5cfc134fef2767c1d3a27f18e3afeb11bfc8e6ad",
+                        ""
+                }, {
+                        "f585c11aec520db57dd353c69554b21a89b20fb0650966fa0a9d6f74fd989d8f",
+                        "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold",
+                        "b873212f885ccffbf4692afcb84bc2e55886de2dfa07d90f5c3c239abc31c0a6ce047e30fd8bf6a281e71389aa82d73df74c7bbfb3b06b4639a5cee775cccd3c",
+                        ""
+                },
+
+                /*
+                 * The following vectors were created to test character encoding and normalization of the passphrase,
+                 * and were determined using the reference implementation at https://github.com/trezor/python-mnemonic.
+                 *
+                 * Use these vectors to test a resolution to issue #1361.
+                 */
+//                {
+//                        "00000000000000000000000000000000",
+//                        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+//                        "c8eaf56947690f7505ffae9a08f3c286b5e28adb5db5d2324499979dbe5ecf6009642006593aafeb72cb7314ac47c60fd2710d46674779d6f5872042a228cae3",
+//                        "schön"
+//                }, {
+//                        "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
+//                        "legal winner thank year wave sausage worth useful legal winner thank yellow",
+//                        "d0e74e4615e8697d68a011ac131bef61fb098d07eab20ebe3d2b9034281adb117ffdd5fb78a55661bf4ba4dbab3c805329a454460e74bc8c67e9016fed8ec8e4",
+//                        "schön"
+//                }, {
+//                        "80808080808080808080808080808080",
+//                        "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
+//                        "bb7a3b74623ec791d781055a2a75a253bc14a842a589c0f535ef955730cda04e6d03333e3f7d7dc6b1e6f5d9bed0fcc4714cc80f340c750d60057bff83b82125",
+//                        "schön"
+//                }, {
+//                        "ffffffffffffffffffffffffffffffff",
+//                        "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
+//                        "5f197e8565923b4fd776056ff2d3e5a23c783c1f95ebe91f13166b39a59bd89e20557c33503090be49002a2899c44ab89c2b461e1307443b0d579667dc783d3b",
+//                        "schön"
+//                }, {
+//                        "f30f8c1da665478f49b001d94c5fc452",
+//                        "vessel ladder alter error federal sibling chat ability sun glass valve picture",
+//                        "401e0fcc6974e6fdcb847bd832d9f6e3933d05410f23e882e7c2d027f3ad56e01d38006cd2690930e6f0bab67c75fb269d8bdbe0d1fc125581b78ba0e46c5716",
+//                        "schön"
+//                }, {
+//                        "c10ec20dc3cd9f652c7fac2f1230f7a3c828389a14392f05",
+//                        "scissors invite lock maple supreme raw rapid void congress muscle digital elegant little brisk hair mango congress clump",
+//                        "8f8aef01d3c05f0dbd736158df85f308edff2d3c2428b8e8991336342a2b363e484d6451e24d8b17f1343329c2fbc6b11d35b0ffc89f7f735dae14869aefbd9e",
+//                        "schön"
+//                }, {
+//                        "f585c11aec520db57dd353c69554b21a89b20fb0650966fa0a9d6f74fd989d8f",
+//                        "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold",
+//                        "566beed821c8a4af803aeb0981d48e74ecf247117982f7e055b3b4fb9691f6d870945239bb6045da030b85e0f6397b3c13c3f779d99d3a9f827d177c1adddc01",
+//                        "schön"
+//                }
+        });
+    }
+}


### PR DESCRIPTION
The pull request consists of a split of the MnemonicCodeTest into two test classes, the addition of test vectors for an empty passphrase, and disabled test vectors for a normalized passphrase.

The test vectors portion of MnemonicCodeTest was split into another test class called MnemonicCodeVectorsTest. This new class uses the Parameterization feature of JUnit to execute multiple vectors through the same test. The MnemonicCodeTest class now contains tests predominantly for guard clauses (i.e. throw exception if input not valid).

There could be mistakes with handling an empty passphrase, (e.g. is the prefix of "mnemonic" still used) so test vectors for an empty passphrase were generated and added.

Test vectors for passphrase normalization are included, however they are disabled due to Issue #1361. These can be enabled for the testing and merging of that issue's resolution.