### PR TITLE
Message.readBytes(): Fail fast if length is too large

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -329,7 +329,7 @@ public abstract class Message {
     }
 
     protected byte[] readBytes(int length) throws ProtocolException {
-        if (length > MAX_SIZE) {
+        if ((length > MAX_SIZE) || (cursor + length > payload.length)) {
             throw new ProtocolException("Claimed value length too large: " + length);
         }
         try {


### PR DESCRIPTION
Avoids this DoS attack:
- Sender sends a msg saying it contains 32mb of data (ie a transaction input declaring a 32mb script length), but it does not sends the data.
- bitcoinj node is forced to allocate 32mb of RAM to create a byte[] while the attacker has not "spent" the network resources to send 32mb of data.

This attack is less risky than https://github.com/bitcoinj/bitcoinj/pull/1576 because:
- Allocating 32mb of RAM won't probably take the node down.
- The attack makes sense if the attacker is able to send lots of messages in a short period of time, but a peer is automatically disconnected when an invalid msg is sent.
- The attacker might try to get multiple connections to the node, but it is difficult to get the number of connections required to exploit this problem.
- The garbage collector would eventually free the 32mb arrays.

Summary:
- There is no evident way to exploit this vulnerability, but there is no harm to be cautions.