### PR TITLE
null pointer exception happens when adding witness program

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4640,7 +4640,7 @@ public class Wallet extends BaseTaggableObject
                     // Only add long (at least 64 bit) data to the bloom filter.
                     // If any long constants become popular in scripts, we will need logic
                     // here to exclude them.
-                    if (!chunk.isOpCode() && chunk.data.length >= MINIMUM_BLOOM_DATA_LENGTH) {
+                    if (!chunk.isOpCode() && (chunk.data != null) && chunk.data.length >= MINIMUM_BLOOM_DATA_LENGTH) {
                         filter.insert(chunk.data);
                     }
                 }


### PR DESCRIPTION
Using `addWatchedAddress()` to adding witness program happens NullPointerException.

```
SegwitAddress watchAddr = SegwitAddress.fromBech32(params, "tb1....");
wallet.addWatchedAddress(watchAddr);
```