### PR TITLE
Fixed potential locking error in TxConfidenceTable

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TxConfidenceFactory.java
+++ b/core/src/main/java/org/bitcoinj/core/TxConfidenceFactory.java
@@ -1,0 +1,7 @@
+package org.bitcoinj.core;
+
+class TxConfidenceFactory {
+    TransactionConfidence createConfidence(Sha256Hash hash) {
+        return new TransactionConfidence(hash);
+    }
+}


### PR DESCRIPTION
There was an incorrect lock release in `org.bitcoinj.core.TxConfidenceTable#seen`, so i made an attempt to fix this and implemented a unit test