### PR TITLE
Introduce SignatureDecodeException

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AlertMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/AlertMessage.java
@@ -115,7 +115,11 @@ public class AlertMessage extends Message {
      * doesn't verify, because that would allow arbitrary attackers to spam your users.
      */
     public boolean isSignatureValid() {
-        return ECKey.verify(Sha256Hash.hashTwice(content), signature, params.getAlertSigningKey());
+        try {
+            return ECKey.verify(Sha256Hash.hashTwice(content), signature, params.getAlertSigningKey());
+        } catch (SignatureDecodeException e) {
+            return false;
+        }
     }
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/java/org/bitcoinj/core/SignatureDecodeException.java
+++ b/core/src/main/java/org/bitcoinj/core/SignatureDecodeException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Andreas Schildbach
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.core;
+
+public class SignatureDecodeException extends Exception {
+    public SignatureDecodeException() {
+        super();
+    }
+
+    public SignatureDecodeException(String message) {
+        super(message);
+    }
+
+    public SignatureDecodeException(Throwable cause) {
+        super(cause);
+    }
+
+    public SignatureDecodeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/core/src/main/java/org/bitcoinj/crypto/TransactionSignature.java
+++ b/core/src/main/java/org/bitcoinj/crypto/TransactionSignature.java
@@ -161,20 +161,6 @@ public class TransactionSignature extends ECKey.ECDSASignature {
      *
      * @param requireCanonicalEncoding if the encoding of the signature must
      * be canonical.
-     * @throws RuntimeException if the signature is invalid or unparseable in some way.
-     * @deprecated use {@link #decodeFromBitcoin(byte[], boolean, boolean)} instead}.
-     */
-    @Deprecated
-    public static TransactionSignature decodeFromBitcoin(byte[] bytes,
-                                                         boolean requireCanonicalEncoding) throws VerificationException {
-        return decodeFromBitcoin(bytes, requireCanonicalEncoding, false);
-    }
-
-    /**
-     * Returns a decoded signature.
-     *
-     * @param requireCanonicalEncoding if the encoding of the signature must
-     * be canonical.
      * @param requireCanonicalSValue if the S-value must be canonical (below half
      * the order of the curve).
      * @throws RuntimeException if the signature is invalid or unparseable in some way.

--- a/core/src/main/java/org/bitcoinj/crypto/TransactionSignature.java
+++ b/core/src/main/java/org/bitcoinj/crypto/TransactionSignature.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.crypto;
 
+import org.bitcoinj.core.SignatureDecodeException;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.VerificationException;
@@ -163,20 +164,15 @@ public class TransactionSignature extends ECKey.ECDSASignature {
      * be canonical.
      * @param requireCanonicalSValue if the S-value must be canonical (below half
      * the order of the curve).
-     * @throws RuntimeException if the signature is invalid or unparseable in some way.
+     * @throws SignatureDecodeException if the signature is unparseable in some way.
+     * @throws VerificationException if the signature is invalid.
      */
-    public static TransactionSignature decodeFromBitcoin(byte[] bytes,
-                                                         boolean requireCanonicalEncoding,
-                                                         boolean requireCanonicalSValue) throws VerificationException {
+    public static TransactionSignature decodeFromBitcoin(byte[] bytes, boolean requireCanonicalEncoding,
+            boolean requireCanonicalSValue) throws SignatureDecodeException, VerificationException {
         // Bitcoin encoding is DER signature + sighash byte.
         if (requireCanonicalEncoding && !isEncodingCanonical(bytes))
             throw new VerificationException("Signature encoding is not canonical.");
-        ECKey.ECDSASignature sig;
-        try {
-            sig = ECKey.ECDSASignature.decodeFromDER(bytes);
-        } catch (IllegalArgumentException e) {
-            throw new VerificationException("Could not decode DER", e);
-        }
+        ECKey.ECDSASignature sig = ECKey.ECDSASignature.decodeFromDER(bytes);
         if (requireCanonicalSValue && !sig.isCanonical())
             throw new VerificationException("S-value is not canonical.");
 

--- a/core/src/main/java/org/bitcoinj/net/discovery/HttpDiscovery.java
+++ b/core/src/main/java/org/bitcoinj/net/discovery/HttpDiscovery.java
@@ -114,7 +114,8 @@ public class HttpDiscovery implements PeerDiscovery {
     }
 
     @VisibleForTesting
-    public InetSocketAddress[] protoToAddrs(PeerSeedProtos.SignedPeerSeeds proto) throws PeerDiscoveryException, InvalidProtocolBufferException, SignatureException {
+    public InetSocketAddress[] protoToAddrs(PeerSeedProtos.SignedPeerSeeds proto) throws PeerDiscoveryException,
+            InvalidProtocolBufferException, SignatureDecodeException, SignatureException {
         if (details.pubkey != null) {
             if (!Arrays.equals(proto.getPubkey().toByteArray(), details.pubkey.getPubKey()))
                 throw new PeerDiscoveryException("Public key mismatch");

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClient.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClient.java
@@ -349,7 +349,8 @@ public class PaymentChannelClient implements IPaymentChannelClient {
     }
 
     @GuardedBy("lock")
-    private void receiveRefund(Protos.TwoWayChannelMessage refundMsg, @Nullable KeyParameter userKey) throws VerificationException {
+    private void receiveRefund(Protos.TwoWayChannelMessage refundMsg, @Nullable KeyParameter userKey)
+            throws SignatureDecodeException, VerificationException {
         checkState(majorVersion == 1);
         checkState(step == InitStep.WAITING_FOR_REFUND_RETURN && refundMsg.hasReturnRefund());
         log.info("Got RETURN_REFUND message, providing signed contract");
@@ -469,7 +470,7 @@ public class PaymentChannelClient implements IPaymentChannelClient {
                         closeReason = CloseReason.REMOTE_SENT_INVALID_MESSAGE;
                         break;
                 }
-            } catch (VerificationException e) {
+            } catch (SignatureDecodeException | VerificationException e) {
                 log.error("Caught verification exception handling message from server", e);
                 errorBuilder = Protos.Error.newBuilder()
                         .setCode(Protos.Error.ErrorCode.BAD_TRANSACTION);

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServer.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServer.java
@@ -373,7 +373,7 @@ public class PaymentChannelServer {
             state.storeChannelInWallet(PaymentChannelServer.this);
             try {
                 receiveUpdatePaymentMessage(providedContract.getInitialPayment(), false /* no ack msg */);
-            } catch (VerificationException e) {
+            } catch (SignatureDecodeException | VerificationException e) {
                 log.error("Initial payment failed to verify", e);
                 error(e.getMessage(), Protos.Error.ErrorCode.BAD_TRANSACTION, CloseReason.REMOTE_SENT_INVALID_MESSAGE);
                 return;
@@ -424,7 +424,8 @@ public class PaymentChannelServer {
     }
 
     @GuardedBy("lock")
-    private void receiveUpdatePaymentMessage(Protos.UpdatePayment msg, boolean sendAck) throws VerificationException, ValueOutOfRangeException, InsufficientMoneyException {
+    private void receiveUpdatePaymentMessage(Protos.UpdatePayment msg, boolean sendAck) throws SignatureDecodeException,
+            VerificationException, ValueOutOfRangeException, InsufficientMoneyException {
         log.info("Got a payment update");
 
         Coin lastBestPayment = state.getBestValueToMe();
@@ -513,7 +514,7 @@ public class PaymentChannelServer {
             } catch (InsufficientMoneyException e) {
                 log.error("Caught insufficient money exception handling message from client", e);
                 error(e.getMessage(), Protos.Error.ErrorCode.BAD_TRANSACTION, CloseReason.REMOTE_SENT_INVALID_MESSAGE);
-            } catch (IllegalStateException e) {
+            } catch (SignatureDecodeException e) {
                 log.error("Caught illegal state exception handling message from client", e);
                 error(e.getMessage(), Protos.Error.ErrorCode.SYNTAX_ERROR, CloseReason.REMOTE_SENT_INVALID_MESSAGE);
             }

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerState.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerState.java
@@ -240,7 +240,7 @@ public abstract class PaymentChannelServerState {
         stateMachine.checkState(State.READY);
         checkNotNull(refundSize);
         checkNotNull(signatureBytes);
-        TransactionSignature signature = TransactionSignature.decodeFromBitcoin(signatureBytes, true);
+        TransactionSignature signature = TransactionSignature.decodeFromBitcoin(signatureBytes, true, false);
         // We allow snapping to zero for the payment amount because it's treated specially later, but not less than
         // the dust level because that would prevent the transaction from being relayed/mined.
         final boolean fullyUsedUp = refundSize.equals(Coin.ZERO);

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerState.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelServerState.java
@@ -236,7 +236,9 @@ public abstract class PaymentChannelServerState {
      * @throws VerificationException If the signature does not verify or size is out of range (incl being rejected by the network as dust).
      * @return true if there is more value left on the channel, false if it is now fully used up.
      */
-    public synchronized boolean incrementPayment(Coin refundSize, byte[] signatureBytes) throws VerificationException, ValueOutOfRangeException, InsufficientMoneyException {
+    public synchronized boolean incrementPayment(Coin refundSize, byte[] signatureBytes)
+            throws SignatureDecodeException, VerificationException, ValueOutOfRangeException,
+            InsufficientMoneyException {
         stateMachine.checkState(State.READY);
         checkNotNull(refundSize);
         checkNotNull(signatureBytes);

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelV1ClientState.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelV1ClientState.java
@@ -230,7 +230,7 @@ public class PaymentChannelV1ClientState extends PaymentChannelClientState {
             throws VerificationException {
         checkNotNull(theirSignature);
         stateMachine.checkState(State.WAITING_FOR_SIGNED_REFUND);
-        TransactionSignature theirSig = TransactionSignature.decodeFromBitcoin(theirSignature, true);
+        TransactionSignature theirSig = TransactionSignature.decodeFromBitcoin(theirSignature, true, false);
         if (theirSig.sigHashMode() != Transaction.SigHash.NONE || !theirSig.anyoneCanPay())
             throw new VerificationException("Refund signature was not SIGHASH_NONE|SIGHASH_ANYONECANPAY");
         // Sign the refund transaction ourselves.

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelV1ClientState.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelV1ClientState.java
@@ -227,7 +227,7 @@ public class PaymentChannelV1ClientState extends PaymentChannelClientState {
      * the appropriate time if necessary.</p>
      */
     public synchronized void provideRefundSignature(byte[] theirSignature, @Nullable KeyParameter userKey)
-            throws VerificationException {
+            throws SignatureDecodeException, VerificationException {
         checkNotNull(theirSignature);
         stateMachine.checkState(State.WAITING_FOR_SIGNED_REFUND);
         TransactionSignature theirSig = TransactionSignature.decodeFromBitcoin(theirSignature, true, false);

--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -470,7 +470,7 @@ public class Script {
     private int findSigInRedeem(byte[] signatureBytes, Sha256Hash hash) {
         checkArgument(chunks.get(0).isOpCode()); // P2SH scriptSig
         int numKeys = Script.decodeFromOpN(chunks.get(chunks.size() - 2).opcode);
-        TransactionSignature signature = TransactionSignature.decodeFromBitcoin(signatureBytes, true);
+        TransactionSignature signature = TransactionSignature.decodeFromBitcoin(signatureBytes, true, false);
         for (int i = 0 ; i < numKeys ; i++) {
             if (ECKey.fromPublicOnly(chunks.get(i + 1).data).verify(hash, signature)) {
                 return i;
@@ -1484,7 +1484,7 @@ public class Script {
             // We could reasonably move this out of the loop, but because signature verification is significantly
             // more expensive than hashing, its not a big deal.
             try {
-                TransactionSignature sig = TransactionSignature.decodeFromBitcoin(sigs.getFirst(), requireCanonical);
+                TransactionSignature sig = TransactionSignature.decodeFromBitcoin(sigs.getFirst(), requireCanonical, false);
                 Sha256Hash hash = txContainingThis.hashForSignature(index, connectedScript, (byte) sig.sighashFlags);
                 if (ECKey.verify(hash.getBytes(), sig, pubKey))
                     sigs.pollFirst();

--- a/core/src/main/java/org/bitcoinj/wallet/DefaultRiskAnalysis.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DefaultRiskAnalysis.java
@@ -21,6 +21,7 @@ import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.ECKey.ECDSASignature;
 import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.SignatureDecodeException;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionConfidence;
 import org.bitcoinj.core.TransactionInput;
@@ -190,7 +191,7 @@ public class DefaultRiskAnalysis implements RiskAnalysis {
                 ECDSASignature signature;
                 try {
                     signature = ECKey.ECDSASignature.decodeFromDER(chunk.data);
-                } catch (IllegalArgumentException x) {
+                } catch (SignatureDecodeException x) {
                     // Doesn't look like a signature.
                     signature = null;
                 }

--- a/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
@@ -176,7 +176,7 @@ public class DefaultRiskAnalysisTest {
     }
 
     @Test
-    public void canonicalSignatureLowS() {
+    public void canonicalSignatureLowS() throws Exception {
         // First, a synthetic test.
         TransactionSignature sig = TransactionSignature.dummy();
         Script scriptHighS = ScriptBuilder

--- a/examples/src/main/java/org/bitcoinj/examples/GenerateLowSTests.java
+++ b/examples/src/main/java/org/bitcoinj/examples/GenerateLowSTests.java
@@ -28,10 +28,12 @@ import org.bitcoinj.core.LegacyAddress;
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.SignatureDecodeException;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionInput;
 import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.core.Utils;
+import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.script.Script;
@@ -54,7 +56,8 @@ import org.bitcoinj.wallet.RedeemData;
 public class GenerateLowSTests {
     public static final BigInteger HIGH_S_DIFFERENCE = new BigInteger("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141", 16);
 
-    public static void main(final String[] argv) throws NoSuchAlgorithmException, IOException {
+    public static void main(final String[] argv)
+            throws NoSuchAlgorithmException, IOException, VerificationException, SignatureDecodeException {
         final NetworkParameters params = new MainNetParams();
         final LocalTransactionSigner signer = new LocalTransactionSigner();
         final SecureRandom secureRandom = SecureRandom.getInstanceStrong();


### PR DESCRIPTION
ECKey: If DER-encoded signatures cannot be parsed, throw SignatureDecodeException rather than RuntimeException.