### PR TITLE
DRMWorkaround: JceSecurity.isRestricted remove final modifier

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DRMWorkaround.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DRMWorkaround.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 
 public class DRMWorkaround {
     private static Logger log = LoggerFactory.getLogger(DRMWorkaround.class);
@@ -43,6 +44,9 @@ public class DRMWorkaround {
         try {
             Field gate = Class.forName("javax.crypto.JceSecurity").getDeclaredField("isRestricted");
             gate.setAccessible(true);
+            Field modifiersField = Field.class.getDeclaredField("modifiers");
+            modifiersField.setAccessible(true);
+            modifiersField.setInt(gate, gate.getModifiers() & ~Modifier.FINAL);
             gate.setBoolean(null, false);
             final Field allPerm = Class.forName("javax.crypto.CryptoAllPermission").getDeclaredField("INSTANCE");
             allPerm.setAccessible(true);


### PR DESCRIPTION
On Oracle's jdk8 (u192) JceSecurity.isRestricted is declared final so the code without this fix fails.

See https://stackoverflow.com/questions/1179672/how-to-avoid-installing-unlimited-strength-jce-policy-files-when-deploying-an