### PR TITLE
DRMWorkaround: Skip workaround on OpenJDK.

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DRMWorkaround.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DRMWorkaround.java
@@ -39,7 +39,7 @@ public class DRMWorkaround {
         if (done) return;
         done = true;
 
-        if (Utils.isAndroidRuntime())
+        if (Utils.isAndroidRuntime() || Utils.isOpenJDKRuntime())
             return;
         try {
             Field gate = Class.forName("javax.crypto.JceSecurity").getDeclaredField("isRestricted");


### PR DESCRIPTION
According to https://stackoverflow.com/questions/1179672/how-to-avoid-installing-unlimited-strength-jce-policy-files-when-deploying-an the workaround is not needed on OpenJDK.

@oscarguindzberg What do you think?