### PR TITLE
add dnsseed.emzy.de to DNS seeds

### DIFF
--- a/core/src/main/java/org/bitcoinj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/MainNetParams.java
@@ -79,6 +79,7 @@ public class MainNetParams extends AbstractBitcoinNetParams {
                 "seed.btc.petertodd.org",       // Peter Todd
                 "seed.bitcoin.sprovoost.nl",    // Sjors Provoost
                 "seed.bitnodes.io",             // Addy Yeow
+                "dnsseed.emzy.de",              // Stephan Oeste
         };
         httpSeeds = new HttpDiscovery.Details[] {
                 // Andreas Schildbach


### PR DESCRIPTION
ACK https://github.com/bitcoin/bitcoin/blob/master/doc/dnsseed-policy.md

I'm willing to keep it up and running, unless something bad happens.
I have 15+ years experience running dns servers.

About my setup:

- the server may change over time, but the service will be up all the time
- running [sipa/bitcoin-seeder](https://github.com/sipa/bitcoin-seeder) with default settings (and the non-root port redirect)