### PR TITLE
regtest's Bech32 HRP is "bcrt".

### DIFF
--- a/core/src/main/java/org/bitcoinj/params/RegTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/RegTestParams.java
@@ -36,7 +36,7 @@ public class RegTestParams extends AbstractBitcoinNetParams {
         p2shHeader = 196;
         targetTimespan = TARGET_TIMESPAN;
         dumpedPrivateKeyHeader = 239;
-        segwitAddressHrp = "tb";
+        segwitAddressHrp = "bcrt";
         genesisBlock.setTime(1296688602L);
         genesisBlock.setDifficultyTarget(0x1d07fff8L);
         genesisBlock.setNonce(384568319);


### PR DESCRIPTION
regtest's Bech32 HRP is "bcrt".
[bitcoind code](https://github.com/bitcoin/bitcoin/blob/ace87ea2b00a84b7a76e75f1ec93d1a4dce83f6f/src/chainparams.cpp#L348)