### PR TITLE
KeyChainGroup: Migrate constructors to builder pattern.

### DIFF
--- a/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
+++ b/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
@@ -434,17 +434,17 @@ public class WalletAppKit extends AbstractIdleService {
     }
 
     protected Wallet createWallet() {
-        KeyChainGroup kcg;
+        KeyChainGroup.Builder kcg = KeyChainGroup.builder(params);
         if (restoreFromSeed != null)
-            kcg = new KeyChainGroup(params, restoreFromSeed);
+            kcg.addChain(DeterministicKeyChain.builder().seed(restoreFromSeed).build());
         else if (restoreFromKey != null)
-            kcg = new KeyChainGroup(params, restoreFromKey, false);
+            kcg.addChain(DeterministicKeyChain.builder().spend(restoreFromKey).build());
         else
-            kcg = new KeyChainGroup(params);
+            kcg.fromRandom();
         if (walletFactory != null) {
-            return walletFactory.create(params, kcg);
+            return walletFactory.create(params, kcg.build());
         } else {
-            return new Wallet(params, kcg);  // default
+            return new Wallet(params, kcg.build()); // default
         }
     }
 

--- a/core/src/test/java/org/bitcoinj/core/BloomFilterTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BloomFilterTest.java
@@ -77,7 +77,7 @@ public class BloomFilterTest {
         Address addr = LegacyAddress.fromKey(MAINNET, privKey.getKey());
         assertTrue(addr.toString().equals("17Wx1GQfyPTNWpQMHrTwRSMTCAonSiZx9e"));
 
-        KeyChainGroup group = new KeyChainGroup(MAINNET);
+        KeyChainGroup group = KeyChainGroup.builder(MAINNET).build();
         // Add a random key which happens to have been used in a recent generation
         group.importKeys(ECKey.fromPublicOnly(privKey.getKey().getPubKeyPoint()), ECKey.fromPublicOnly(HEX.decode("03cb219f69f1b49468bd563239a86667e74a06fcba69ac50a08a5cbc42a5808e99")));
         Wallet wallet = new Wallet(MAINNET, group);

--- a/core/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTests.java
+++ b/core/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTests.java
@@ -56,7 +56,7 @@ public class FilteredBlockAndPartialMerkleTreeTests extends TestWithPeerGroup {
                 BigInteger.valueOf(1), 100000));
         store.setChainHead(store.get(Sha256Hash.wrap("000000000003ba27aa200b1cecaad478d2b00432346c3f1f3986da1afd33e506")));
 
-        KeyChainGroup group = new KeyChainGroup(UNITTEST);
+        KeyChainGroup group = KeyChainGroup.builder(UNITTEST).build();
         group.importKeys(ECKey.fromPublicOnly(HEX.decode("04b27f7e9475ccf5d9a431cb86d665b8302c140144ec2397fce792f4a4e7765fecf8128534eaa71df04f93c74676ae8279195128a1506ebf7379d23dab8fca0f63")),
                 ECKey.fromPublicOnly(HEX.decode("04732012cb962afa90d31b25d8fb0e32c94e513ab7a17805c14ca4c3423e18b4fb5d0e676841733cb83abaf975845c9f6f2a8097b7d04f4908b18368d6fc2d68ec")),
                 ECKey.fromPublicOnly(HEX.decode("04cfb4113b3387637131ebec76871fd2760fc430dd16de0110f0eb07bb31ffac85e2607c189cb8582ea1ccaeb64ffd655409106589778f3000fdfe3263440b0350")),

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -44,6 +44,7 @@ import org.bitcoinj.utils.BriefLogFormatter;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.DeterministicKeyChain;
 import org.bitcoinj.wallet.KeyChain;
+import org.bitcoinj.wallet.KeyChainGroup;
 
 import com.google.common.io.ByteStreams;
 import com.google.protobuf.ByteString;
@@ -92,12 +93,10 @@ public class WalletProtobufSerializerTest {
         BriefLogFormatter.initVerbose();
         Context ctx = new Context(UNITTEST);
         myWatchedKey = new ECKey();
-        myWallet = new Wallet(UNITTEST);
         myKey = new ECKey();
         myKey.setCreationTimeSeconds(123456789L);
-        myWallet.importKey(myKey);
         myAddress = LegacyAddress.fromKey(UNITTEST, myKey);
-        myWallet = new Wallet(UNITTEST);
+        myWallet = new Wallet(UNITTEST, KeyChainGroup.builder(UNITTEST).build());
         myWallet.importKey(myKey);
         mScriptCreationTime = new Date().getTime() / 1000 - 1234;
         myWallet.addWatchedAddress(LegacyAddress.fromKey(UNITTEST, myWatchedKey), mScriptCreationTime);

--- a/core/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
+++ b/core/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
@@ -26,6 +26,7 @@ import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.utils.BriefLogFormatter;
 import org.bitcoinj.utils.Threading;
+import org.bitcoinj.wallet.KeyChainGroup;
 import org.bitcoinj.wallet.Wallet;
 
 import com.google.common.util.concurrent.SettableFuture;
@@ -88,7 +89,7 @@ public class TestWithNetworkConnections {
         this.blockStore = blockStore;
         // Allow subclasses to override the wallet object with their own.
         if (wallet == null) {
-            wallet = new Wallet(UNITTEST);
+            wallet = new Wallet(UNITTEST, KeyChainGroup.builder(UNITTEST).build());
             key = wallet.freshReceiveKey();
             address = LegacyAddress.fromKey(UNITTEST, key);
         }

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -555,7 +555,8 @@ public class DeterministicKeyChainTest {
         DeterministicKey accountKey = HDKeyDerivation.deriveChildKey(coinLevelKey, new ChildNumber(0, true));
         accountKey = accountKey.dropParent();
         accountKey.setCreationTimeSeconds(watchingKey.getCreationTimeSeconds());
-        KeyChainGroup group = new KeyChainGroup(params, accountKey, false);
+        KeyChainGroup group = KeyChainGroup.builder(params)
+                .addChain(DeterministicKeyChain.builder().spend(accountKey).build()).build();
         DeterministicKeyChain fromMasterKeyChain = group.getActiveKeyChain();
         assertEquals(BIP44_ACCOUNT_ONE_PATH, fromMasterKeyChain.getAccountPath());
         assertEquals(secs, fromMasterKeyChain.getEarliestKeyCreationTime());


### PR DESCRIPTION
KeyChainGroup: Remove most constructors. Those that remain are considered an unstable API.

Migrate all use of constructors to use a builder instead.