### PR TITLE
Make travis to print failed tests on the console

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
   - gradle -q clean install
   - jdk_switcher use openjdk7
   - cd core
-  - gradle -q clean build
+  - gradle clean build
 
 notifications:
   irc:

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -34,6 +34,10 @@ protobuf {
 
 test {
     exclude 'org/bitcoinj/net/NetworkAbstractionTests*'
+    testLogging {
+        events "failed"
+        exceptionFormat "full"
+    }
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {


### PR DESCRIPTION
HTML test reports were not accessible on Travis.

See https://guides.gradle.org/executing-gradle-builds-on-travisci/ "Travis CI doesn’t not provide built-in options to post-process produced artifacts of the build e.g. host the JAR file or the HTML test reports. You will have to use external services (like S3) to transfer the files."

Fix based on:
https://stackoverflow.com/questions/28614865/how-to-read-test-result-reports-on-travis-ci

Useful links: 
https://github.com/lhotari/travis-gradle-test-failures-to-console (does not work anymore)
https://stackoverflow.com/questions/36558340/during-gradle-test-show-standard-out-and-err-only-for-failed-tests

