### PR TITLE
Build wallettemplate with JDK 11+ and OpenJFX downloaded from Maven Central

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ jdk:
   - openjdk11
 install: true
 script:
-    # excluding wallet-template because of the unreliable JavaFX dependency
-  - gradle clean build -x :wallettemplate:compileJava
+  # wallettemplate subproject is conditionally built if JDK 11+ is installed
+  - gradle clean build
 
 notifications:
   irc:

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ The bitcoinj library is a Java implementation of the Bitcoin protocol, which all
 
 ### Technologies
 
-* Java 7 for the core modules, Java 8 for everything else
-* [Gradle 3.4+](https://gradle.org/) - for building the project
+* Java 7 for the `core` module
+* Java 8 for `tools` and `examples`
+* Java 11 for the JavaFX-based `wallettemplate`
+* [Gradle 3.4+](https://gradle.org/) - for building the project (Gradle 4.10.2 or later is recommended)
 * [Google Protocol Buffers](https://github.com/google/protobuf) - for use with serialization and hardware communications
 
 ### Getting started
@@ -18,17 +20,20 @@ To get started, it is best to have the latest JDK and Gradle installed. The HEAD
 
 #### Building from the command line
 
-To perform a full build use
+Official builds are currently using with JDK 8, even though the `core` module is compatible with JDK 7 and later.
+
+To perform a full build (*including* JavaDocs and unit/integration *tests*) use JDK 8+
 ```
 gradle clean build
 ```
-You can also run
-```
-gradle javadoc
-```
-to generate the JavaDocs.
+If you are running JDK 11 or later the build will automatically include the JavaFX-based `wallettemplate` module. The outputs are under the `build` directory.
 
-The outputs are under the `build` directory.
+To perform a full build *without* unit/integration *tests* use:
+```
+gradle clean assemble
+```
+
+
 
 #### Building from an IDE
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,12 @@
+import org.gradle.util.GradleVersion
+
 include 'core'
 include 'tools'
 include 'examples'
-include 'wallettemplate'
+def minGradleVersion = GradleVersion.version("4.10")
+if (GradleVersion.current().compareTo(minGradleVersion) >= 0 &&  JavaVersion.current().isJava11Compatible()) {
+    println "Including wallettemplate because ${GradleVersion.current()} and Java ${JavaVersion.current()}"
+    include 'wallettemplate'
+} else {
+    println "Skipping wallettemplate: ${GradleVersion.current()} and Java ${JavaVersion.current()}"
+}

--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -1,5 +1,11 @@
+plugins {
+    id 'org.openjfx.javafxplugin' version '0.0.7' apply false
+}
+
 apply plugin: 'java'
 apply plugin: 'eclipse'
+apply plugin: 'application'
+apply plugin: 'org.openjfx.javafxplugin'
 
 eclipse.project.name = 'bitcoinj-wallettemplate'
 
@@ -12,11 +18,16 @@ dependencies {
     implementation 'org.slf4j:slf4j-jdk14:1.7.25'
 }
 
-sourceCompatibility = 1.8
+javafx {
+    modules = [ 'javafx.controls', 'javafx.fxml' ]
+}
+
+sourceCompatibility = 1.11
 compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
 
-task wallet_template(type: JavaExec) {
-    main = 'wallettemplate.Main'
-    classpath = sourceSets.main.runtimeClasspath
+mainClassName = 'wallettemplate.Main'
+
+// task wallet_template can be replaced with the 'run' task
+task wallet_template(dependsOn: 'run') {
 }


### PR DESCRIPTION
Possible resolution to Issue #1713 

* Create new `settings-jdk11.gradle` Gradle settings file
* Update `.travis.yml` to use `-c settings-jdk11.gradle` when building with JDK11
* Update build instructions in README
