### PR TITLE
build.gradle: Exclude the same set of integration tests as we did for Maven.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -36,7 +36,10 @@ protobuf {
 }
 
 test {
+    exclude 'org/bitcoinj/core/PeerTest*'
+    exclude 'org/bitcoinj/core/TransactionBroadcastTest*'
     exclude 'org/bitcoinj/net/NetworkAbstractionTests*'
+    exclude 'org/bitcoinj/protocols/channels/ChannelConnectionTest*'
     testLogging {
         events "failed"
         exceptionFormat "full"


### PR DESCRIPTION
This should fix the 'address already in use' error.