### PR TITLE
settings.gradle: Prefix project names by 'bitcoinj-'.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -4,8 +4,6 @@ apply plugin: 'maven'
 apply plugin: 'eclipse'
 
 version = '0.16-SNAPSHOT'
-archivesBaseName = 'bitcoinj-core'
-eclipse.project.name = 'bitcoinj-core'
 
 dependencies {
     compile 'org.bouncycastle:bcprov-jdk15on:1.60'

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,10 +1,8 @@
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
-eclipse.project.name = 'bitcoinj-examples'
-
 dependencies {
-    implementation project(':core')
+    implementation project(':bitcoinj-core')
     implementation 'com.google.guava:guava:27.0.1-android'
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     implementation 'org.slf4j:slf4j-jdk14:1.7.25'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,13 +1,21 @@
 import org.gradle.util.GradleVersion
 
+rootProject.name = 'bitcoinj-parent'
+
 include 'core'
+project(':core').name = 'bitcoinj-core'
+
 include 'tools'
+project(':tools').name = 'bitcoinj-tools'
+
 include 'examples'
+project(':examples').name = 'bitcoinj-examples'
 
 def minGradleVersion = GradleVersion.version("4.10")
 if (GradleVersion.current().compareTo(minGradleVersion) >= 0 && JavaVersion.current().isJava11Compatible()) {
     println "Including wallettemplate because ${GradleVersion.current()} and Java ${JavaVersion.current()}"
     include 'wallettemplate'
+    project(':wallettemplate').name = 'bitcoinj-wallettemplate'
 } else {
     println "Skipping wallettemplate: ${GradleVersion.current()} and Java ${JavaVersion.current()}"
 }

--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -1,10 +1,8 @@
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
-eclipse.project.name = 'bitcoinj-tools'
-
 dependencies {
-    implementation project(':core')
+    implementation project(':bitcoinj-core')
     implementation 'com.google.guava:guava:27.0.1-android'
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     implementation 'org.slf4j:slf4j-jdk14:1.7.25'

--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -7,10 +7,8 @@ apply plugin: 'eclipse'
 apply plugin: 'application'
 apply plugin: 'org.openjfx.javafxplugin'
 
-eclipse.project.name = 'bitcoinj-wallettemplate'
-
 dependencies {
-    implementation project(':core')
+    implementation project(':bitcoinj-core')
     implementation 'com.google.guava:guava:27.0.1-android'
     implementation 'org.fxmisc.easybind:easybind:1.0.2'
     implementation 'de.jensd:fontawesomefx:8.0.0'


### PR DESCRIPTION
This lets us get rid of archivesBaseName and eclipse.project.name configurations.