### PR TITLE
Try connecting orphans when previous block not found

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
@@ -461,18 +461,20 @@ public abstract class AbstractBlockChain {
                 checkState(tryConnecting, "bug in tryConnectingOrphans");
                 log.warn("Block does not connect: {} prev {}", block.getHashAsString(), block.getPrevBlockHash());
                 orphanBlocks.put(block.getHash(), new OrphanBlock(block, filteredTxHashList, filteredTxn));
+                if (tryConnecting) {
+                    tryConnectingOrphans();
+                }
                 return false;
             } else {
                 checkState(lock.isHeldByCurrentThread());
                 // It connects to somewhere on the chain. Not necessarily the top of the best known chain.
                 params.checkDifficultyTransitions(storedPrev, block, blockStore);
                 connectBlock(block, storedPrev, shouldVerifyTransactions(), filteredTxHashList, filteredTxn);
+                if (tryConnecting) {
+                    tryConnectingOrphans();
+                }
+                return true;
             }
-
-            if (tryConnecting)
-                tryConnectingOrphans();
-
-            return true;
         } finally {
             lock.unlock();
         }


### PR DESCRIPTION
I'm not sure if this is the right way to fix this but I have let it run for about a week and it got into a state when last block connected into blockchain was ~5 days old and all the following ones were in orphanBlocks. I'm not sure how this happened but then all the new blocks were added to orphans and orphans were never connected (tryConnectingOrphans was never called). I tried to call tryConnectingOrphans() in debug which resolved the issue and it recovered without a need to restart and all orphans were connected to the chain. 

I found this because it causes a big memory consumption/leak as orphanBlocks takes much more memory and were never cleared, see #997