### PR TITLE
Modify inappropriate message length check

### DIFF
--- a/core/src/main/java/org/bitcoinj/net/ProtobufConnection.java
+++ b/core/src/main/java/org/bitcoinj/net/ProtobufConnection.java
@@ -162,7 +162,7 @@ public class ProtobufConnection<MessageType extends MessageLite> extends Abstrac
 
             // If length is larger than the maximum message size (or is negative/overflows) throw an exception and close the
             // connection
-            if (len > maxMessageSize || len + 4 < 4)
+            if (len > maxMessageSize || len < 0)
                 throw new IllegalStateException("Message too large or length underflowed");
 
             // If the buffer's capacity is less than the next messages length + 4 (length prefix), we must use messageBytes


### PR DESCRIPTION
I think it is more appropriate to do this length check, because the above comment explains that the maximum message length refers to the length without the prefix, so here is only the verification of the true length of the message, I think it should not involve the length of the prefix. 
This code can be more easily understood, and the comments above this line of code also write to verify that the length is out of range or negative, so I think this is more readable.