### PR TITLE
Exclude SeedPeersTest.java from normal test build

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -39,6 +39,7 @@ test {
     exclude 'org/bitcoinj/core/PeerTest*'
     exclude 'org/bitcoinj/core/TransactionBroadcastTest*'
     exclude 'org/bitcoinj/net/NetworkAbstractionTests*'
+    exclude 'org/bitcoinj/net/discovery/SeedPeersTest*'
     exclude 'org/bitcoinj/protocols/channels/ChannelConnectionTest*'
     testLogging {
         events "failed"


### PR DESCRIPTION
SeedPeersTest.java seems to also use the network, so it should probably be exluded from the test build as well