### PR TITLE
replace AESFastEngine with AESEngine

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/KeyCrypterScrypt.java
+++ b/core/src/main/java/org/bitcoinj/crypto/KeyCrypterScrypt.java
@@ -25,10 +25,10 @@ import org.bitcoinj.core.Utils;
 import org.bitcoinj.wallet.Protos;
 import org.bitcoinj.wallet.Protos.ScryptParameters;
 import org.bitcoinj.wallet.Protos.Wallet.EncryptionType;
+import org.bouncycastle.crypto.engines.AESEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.bouncycastle.crypto.BufferedBlockCipher;
-import org.bouncycastle.crypto.engines.AESFastEngine;
 import org.bouncycastle.crypto.modes.CBCBlockCipher;
 import org.bouncycastle.crypto.paddings.PaddedBufferedBlockCipher;
 import org.bouncycastle.crypto.params.KeyParameter;
@@ -186,7 +186,7 @@ public class KeyCrypterScrypt implements KeyCrypter {
             ParametersWithIV keyWithIv = new ParametersWithIV(aesKey, iv);
 
             // Encrypt using AES.
-            BufferedBlockCipher cipher = new PaddedBufferedBlockCipher(new CBCBlockCipher(new AESFastEngine()));
+            BufferedBlockCipher cipher = new PaddedBufferedBlockCipher(new CBCBlockCipher(new AESEngine()));
             cipher.init(true, keyWithIv);
             byte[] encryptedBytes = new byte[cipher.getOutputSize(plainBytes.length)];
             final int length1 = cipher.processBytes(plainBytes, 0, plainBytes.length, encryptedBytes, 0);
@@ -215,7 +215,7 @@ public class KeyCrypterScrypt implements KeyCrypter {
             ParametersWithIV keyWithIv = new ParametersWithIV(new KeyParameter(aesKey.getKey()), dataToDecrypt.initialisationVector);
 
             // Decrypt the message.
-            BufferedBlockCipher cipher = new PaddedBufferedBlockCipher(new CBCBlockCipher(new AESFastEngine()));
+            BufferedBlockCipher cipher = new PaddedBufferedBlockCipher(new CBCBlockCipher(new AESEngine()));
             cipher.init(false, keyWithIv);
 
             byte[] cipherBytes = dataToDecrypt.encryptedBytes;


### PR DESCRIPTION
AESFastEngine raises a deprecation warning.

see https://nvd.nist.gov/vuln/detail/CVE-2016-1000339

Also see the bouncycastle 2.6.4 release notes regarding `AESFastEngine` deprecation.

First time contribution here: Not sure how worthwhile the perf vs. security tradeoff here is. My naive impression is that AES operations aren't generally on a hot path. Is this correct?

I searched through discussions here and didn't see this particular vuln come up.