### PR TITLE
Refactor/kill Throwables.propagate

### DIFF
--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClientState.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClientState.java
@@ -17,7 +17,6 @@
 package org.bitcoinj.protocols.channels;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;

--- a/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClientState.java
+++ b/core/src/main/java/org/bitcoinj/protocols/channels/PaymentChannelClientState.java
@@ -38,6 +38,7 @@ import org.bouncycastle.crypto.params.KeyParameter;
 import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.*;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 
 /**
  * <p>A payment channel is a method of sending money to someone such that the amount of money you send can be adjusted
@@ -188,7 +189,8 @@ public abstract class PaymentChannelClientState {
 
             @Override
             public void onFailure(Throwable t) {
-                Throwables.propagate(t);
+                throwIfUnchecked(t);
+                throw new RuntimeException(t);
             }
         }, MoreExecutors.directExecutor());
     }

--- a/core/src/main/java/org/bitcoinj/utils/ContextPropagatingThreadFactory.java
+++ b/core/src/main/java/org/bitcoinj/utils/ContextPropagatingThreadFactory.java
@@ -16,7 +16,6 @@
 
 package org.bitcoinj.utils;
 
-import com.google.common.base.*;
 import org.bitcoinj.core.*;
 import org.slf4j.*;
 

--- a/core/src/main/java/org/bitcoinj/utils/ContextPropagatingThreadFactory.java
+++ b/core/src/main/java/org/bitcoinj/utils/ContextPropagatingThreadFactory.java
@@ -51,7 +51,7 @@ public class ContextPropagatingThreadFactory implements ThreadFactory {
                     r.run();
                 } catch (Exception e) {
                     log.error("Exception in thread", e);
-                    Throwables.propagate(e);
+                    throw e;
                 }
             }
         }, name);

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -18,7 +18,6 @@
 package org.bitcoinj.wallet;
 
 import com.google.common.annotations.*;
-import com.google.common.base.*;
 import com.google.common.collect.*;
 import com.google.common.primitives.*;
 import com.google.common.util.concurrent.*;

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4980,7 +4980,7 @@ public class Wallet extends BaseTaggableObject
         } catch (Throwable throwable) {
             log.error("Error during extension deserialization", throwable);
             extensions.remove(extension.getWalletExtensionID());
-            Throwables.propagate(throwable);
+            throw throwable;
         } finally {
             keyChainGroupLock.unlock();
             lock.unlock();


### PR DESCRIPTION
This eliminates all three usages of `Throwables.propagate`, which is giving deprecation warnings. Two of the usages can simply be replaced by a re-`throw`, while one seems to require inlining.

See the Guava project's elaborate wiki page on the subject here: https://github.com/google/guava/wiki/Why-we-deprecated-Throwables.propagate