### PR TITLE
Bugfix/monetary format equality

### DIFF
--- a/core/src/main/java/org/bitcoinj/utils/MonetaryFormat.java
+++ b/core/src/main/java/org/bitcoinj/utils/MonetaryFormat.java
@@ -489,7 +489,7 @@ public final class MonetaryFormat {
             return false;
         if (!Objects.equals(this.roundingMode, other.roundingMode))
             return false;
-        if (!Objects.equals(this.codes, other.codes))
+        if (!Arrays.equals(this.codes, other.codes))
             return false;
         if (!Objects.equals(this.codeSeparator, other.codeSeparator))
             return false;

--- a/core/src/main/java/org/bitcoinj/utils/MonetaryFormat.java
+++ b/core/src/main/java/org/bitcoinj/utils/MonetaryFormat.java
@@ -501,6 +501,6 @@ public final class MonetaryFormat {
     @Override
     public int hashCode() {
         return Objects.hash(negativeSign, positiveSign, zeroDigit, decimalMark, minDecimals, decimalGroups, shift,
-                roundingMode, codes, codeSeparator, codePrefixed);
+                roundingMode, Arrays.hashCode(codes), codeSeparator, codePrefixed);
     }
 }

--- a/core/src/test/java/org/bitcoinj/utils/MonetaryFormatTest.java
+++ b/core/src/test/java/org/bitcoinj/utils/MonetaryFormatTest.java
@@ -359,4 +359,11 @@ public class MonetaryFormatTest {
         MonetaryFormat mf2 = new MonetaryFormat(true);
         assertEquals(mf1, mf2);
     }
+
+    @Test
+    public void testHashCode() {
+        MonetaryFormat mf1 = new MonetaryFormat(true);
+        MonetaryFormat mf2 = new MonetaryFormat(true);
+        assertEquals(mf1.hashCode(), mf2.hashCode());
+    }
 }

--- a/core/src/test/java/org/bitcoinj/utils/MonetaryFormatTest.java
+++ b/core/src/test/java/org/bitcoinj/utils/MonetaryFormatTest.java
@@ -352,4 +352,11 @@ public class MonetaryFormatTest {
     public void fiat() throws Exception {
         assertEquals(ONE_EURO, NO_CODE.parseFiat("EUR", "1"));
     }
+
+    @Test
+    public void testEquality() {
+        MonetaryFormat mf1 = new MonetaryFormat(true);
+        MonetaryFormat mf2 = new MonetaryFormat(true);
+        assertEquals(mf1, mf2);
+    }
 }


### PR DESCRIPTION
`equals` and `hashCode` for `MonetaryFormat` were broken. This fixes them.