### PR TITLE
NetworkParameters: make double-checked locking safe with volatile

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -107,7 +107,7 @@ public abstract class NetworkParameters {
     protected int[] addrSeeds;
     protected HttpDiscovery.Details[] httpSeeds = {};
     protected Map<Integer, Sha256Hash> checkpoints = new HashMap<>();
-    protected transient MessageSerializer defaultSerializer = null;
+    protected volatile transient MessageSerializer defaultSerializer = null;
 
     protected NetworkParameters() {
         alertSigningKey = SATOSHI_KEY;


### PR DESCRIPTION
In `NetworkParameters`, double-checked locking is performed during lazy initialization of `defaultSerializer` in `getDefaultSerializer`: https://github.com/matthewleon/bitcoinj/blob/ee8f86aaaa00efbf580eeb20e45df55f228e1ead/core/src/main/java/org/bitcoinj/core/NetworkParameters.java#L398

For this to actually be safe, `defaultSerializer` must be marked `volatile`.