### PR TITLE
fix a possible NPE in peer discovery

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -495,7 +495,9 @@ public class PeerGroup implements TransactionBroadcaster {
                 if (retryTime > now) {
                     long delay = retryTime - now;
                     log.info("Waiting {} ms before next connect attempt {}", delay, addrToTry == null ? "" : "to " + addrToTry);
-                    inactives.add(addrToTry);
+                    if (addrToTry != null) {
+                        inactives.add(addrToTry);
+                    }
                     executor.schedule(this, delay, TimeUnit.MILLISECONDS);
                     return;
                 }

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -501,7 +501,9 @@ public class PeerGroup implements TransactionBroadcaster {
                     executor.schedule(this, delay, TimeUnit.MILLISECONDS);
                     return;
                 }
-                connectTo(addrToTry, false, vConnectTimeoutMillis);
+                if (addrToTry != null) {
+                    connectTo(addrToTry, false, vConnectTimeoutMillis);
+                }
             } finally {
                 lock.unlock();
             }

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -490,20 +490,21 @@ public class PeerGroup implements TransactionBroadcaster {
                 do {
                     addrToTry = inactives.poll();
                 } while (ipv6Unreachable && addrToTry.getAddr() instanceof Inet6Address);
+                if (addrToTry == null) {
+                    // We have exhausted the queue of reachable peers, so just settle down.
+                    // Most likely we were given a fixed set of addresses in some test scenario.
+                    return;
+                }
                 long retryTime = backoffMap.get(addrToTry).getRetryTime();
                 retryTime = Math.max(retryTime, groupBackoff.getRetryTime());
                 if (retryTime > now) {
                     long delay = retryTime - now;
-                    log.info("Waiting {} ms before next connect attempt {}", delay, addrToTry == null ? "" : "to " + addrToTry);
-                    if (addrToTry != null) {
-                        inactives.add(addrToTry);
-                    }
+                    log.info("Waiting {} ms before next connect attempt to {}", delay, addrToTry);
+                    inactives.add(addrToTry);
                     executor.schedule(this, delay, TimeUnit.MILLISECONDS);
                     return;
                 }
-                if (addrToTry != null) {
-                    connectTo(addrToTry, false, vConnectTimeoutMillis);
-                }
+                connectTo(addrToTry, false, vConnectTimeoutMillis);
             } finally {
                 lock.unlock();
             }


### PR DESCRIPTION
Attempting to `add` `null` to a `PriorityQueue` will cause an NPE. It seems possible for `addrToTry` to be null at this point in the code, or at least this possibility is quite hard to reason about. The log line above guards against it.