### PR TITLE
fix NPEs on wallet encryption

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
@@ -667,17 +667,19 @@ public class KeyChainGroup implements KeyBag {
     public void encrypt(KeyCrypter keyCrypter, KeyParameter aesKey) {
         checkNotNull(keyCrypter);
         checkNotNull(aesKey);
-        checkState(chains == null || !chains.isEmpty() || basic.numKeys() != 0, "can't encrypt entirely empty wallet");
+        checkState((chains != null && !chains.isEmpty()) || basic.numKeys() != 0, "can't encrypt entirely empty wallet");
         // This code must be exception safe.
+
         BasicKeyChain newBasic = basic.toEncrypted(keyCrypter, aesKey);
+        basic = newBasic;
         List<DeterministicKeyChain> newChains = new ArrayList<>();
-        if (chains != null)
+        if (chains != null) {
             for (DeterministicKeyChain chain : chains)
                 newChains.add(chain.toEncrypted(keyCrypter, aesKey));
+            this.chains.clear();
+            this.chains.addAll(newChains);
+        }
         this.keyCrypter = keyCrypter;
-        basic = newBasic;
-        this.chains.clear();
-        this.chains.addAll(newChains);
     }
 
     /**

--- a/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
@@ -713,4 +713,14 @@ public class KeyChainGroupTest {
                 group.currentAddress(KeyPurpose.RECEIVE_FUNDS).toString());
         assertEquals("bc1qw8sf3mwuwn74qnhj83gjg0cwkk78fun2pxl9t2", group.currentAddress(KeyPurpose.CHANGE).toString());
     }
+
+    @Test
+    public void onlyBasicKeyEncryption() {
+        group = KeyChainGroup.createBasic(MAINNET);
+        final ECKey key = ECKey.fromPrivate(BigInteger.TEN);
+        group.importKeys(key);
+        KeyCrypterScrypt scrypt = new KeyCrypterScrypt(2);
+        KeyParameter aesKey = scrypt.deriveKey("password");
+        group.encrypt(scrypt, aesKey);
+    }
 }


### PR DESCRIPTION
The `checkState` logic here was somewhat backward, allowing NPEs to be thrown in the code below. Further, two operations on `chains` were not protected by a nullity check.