### PR TITLE
Replace Guava primitive compare() with JDK7+ compare()

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Coin.java
+++ b/core/src/main/java/org/bitcoinj/core/Coin.java
@@ -18,7 +18,6 @@ package org.bitcoinj.core;
 
 import org.bitcoinj.utils.MonetaryFormat;
 import com.google.common.math.LongMath;
-import com.google.common.primitives.Longs;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -312,6 +311,6 @@ public final class Coin implements Monetary, Comparable<Coin>, Serializable {
 
     @Override
     public int compareTo(final Coin other) {
-        return Longs.compare(this.value, other.value);
+        return Long.compare(this.value, other.value);
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -20,7 +20,6 @@ package org.bitcoinj.core;
 import com.google.common.annotations.*;
 import com.google.common.base.*;
 import com.google.common.collect.*;
-import com.google.common.primitives.*;
 import com.google.common.util.concurrent.*;
 import net.jcip.annotations.*;
 import org.bitcoinj.core.listeners.*;
@@ -346,7 +345,7 @@ public class PeerGroup implements TransactionBroadcaster {
                 int result = backoffMap.get(a).compareTo(backoffMap.get(b));
                 // Sort by port if otherwise equals - for testing
                 if (result == 0)
-                    result = Ints.compare(a.getPort(), b.getPort());
+                    result = Integer.compare(a.getPort(), b.getPort());
                 return result;
             }
         });

--- a/core/src/main/java/org/bitcoinj/core/Sha256Hash.java
+++ b/core/src/main/java/org/bitcoinj/core/Sha256Hash.java
@@ -18,7 +18,7 @@
 package org.bitcoinj.core;
 
 import com.google.common.io.ByteStreams;
-import com.google.common.primitives.*;
+import com.google.common.primitives.Ints;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -34,8 +34,6 @@ import org.bitcoinj.wallet.WalletTransaction.Pool;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import com.google.common.primitives.Ints;
-import com.google.common.primitives.Longs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.bouncycastle.crypto.params.KeyParameter;
@@ -75,7 +73,7 @@ public class Transaction extends ChildMessage {
         public int compare(final Transaction tx1, final Transaction tx2) {
             final long time1 = tx1.getUpdateTime().getTime();
             final long time2 = tx2.getUpdateTime().getTime();
-            final int updateTimeComparison = -(Longs.compare(time1, time2));
+            final int updateTimeComparison = -(Long.compare(time1, time2));
             //If time1==time2, compare by tx hash to make comparator consistent with equals
             return updateTimeComparison != 0 ? updateTimeComparison : tx1.getTxId().compareTo(tx2.getTxId());
         }
@@ -90,7 +88,7 @@ public class Transaction extends ChildMessage {
             final TransactionConfidence confidence2 = tx2.getConfidence();
             final int height2 = confidence2.getConfidenceType() == ConfidenceType.BUILDING
                     ? confidence2.getAppearedAtChainHeight() : Block.BLOCK_HEIGHT_UNKNOWN;
-            final int heightComparison = -(Ints.compare(height1, height2));
+            final int heightComparison = -(Integer.compare(height1, height2));
             //If height1==height2, compare by tx hash to make comparator consistent with equals
             return heightComparison != 0 ? heightComparison : tx1.getTxId().compareTo(tx2.getTxId());
         }

--- a/core/src/main/java/org/bitcoinj/core/Utils.java
+++ b/core/src/main/java/org/bitcoinj/core/Utils.java
@@ -44,7 +44,6 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.google.common.io.BaseEncoding;
-import com.google.common.primitives.Ints;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
@@ -515,7 +514,7 @@ public class Utils {
         int item, count;
         public Pair(int item, int count) { this.count = count; this.item = item; }
         // note that in this implementation compareTo() is not consistent with equals()
-        @Override public int compareTo(Pair o) { return -Ints.compare(count, o.count); }
+        @Override public int compareTo(Pair o) { return -Integer.compare(count, o.count); }
     }
 
     public static int maxOfMostFreq(int... items) {

--- a/core/src/main/java/org/bitcoinj/crypto/ChildNumber.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ChildNumber.java
@@ -19,8 +19,6 @@ package org.bitcoinj.crypto;
 import java.util.List;
 import java.util.Locale;
 
-import com.google.common.primitives.Ints;
-
 /**
  * <p>This is just a wrapper for the i (child number) as per BIP 32 with a boolean getter for the most significant bit
  * and a getter for the actual 0-based child number. A {@link List} of these forms a <i>path</i> through a
@@ -95,6 +93,6 @@ public class ChildNumber implements Comparable<ChildNumber> {
     @Override
     public int compareTo(ChildNumber other) {
         // note that in this implementation compareTo() is not consistent with equals()
-        return Ints.compare(this.num(), other.num());
+        return Integer.compare(this.num(), other.num());
     }
 }

--- a/core/src/main/java/org/bitcoinj/utils/ExponentialBackoff.java
+++ b/core/src/main/java/org/bitcoinj/utils/ExponentialBackoff.java
@@ -17,7 +17,6 @@
 package org.bitcoinj.utils;
 
 import org.bitcoinj.core.Utils;
-import com.google.common.primitives.Longs;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -92,7 +91,7 @@ public class ExponentialBackoff implements Comparable<ExponentialBackoff> {
     @Override
     public int compareTo(ExponentialBackoff other) {
         // note that in this implementation compareTo() is not consistent with equals()
-        return Longs.compare(retryTime, other.retryTime);
+        return Long.compare(retryTime, other.retryTime);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/utils/Fiat.java
+++ b/core/src/main/java/org/bitcoinj/utils/Fiat.java
@@ -25,7 +25,6 @@ import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Monetary;
 import com.google.common.base.Objects;
 import com.google.common.math.LongMath;
-import com.google.common.primitives.Longs;
 
 /**
  * Represents a monetary fiat value. It was decided to not fold this into {@link Coin} because of type
@@ -234,6 +233,6 @@ public final class Fiat implements Monetary, Comparable<Fiat>, Serializable {
     public int compareTo(final Fiat other) {
         if (!this.currencyCode.equals(other.currencyCode))
             return this.currencyCode.compareTo(other.currencyCode);
-        return Longs.compare(this.value, other.value);
+        return Long.compare(this.value, other.value);
     }
 }

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -19,7 +19,6 @@ package org.bitcoinj.wallet;
 
 import com.google.common.annotations.*;
 import com.google.common.collect.*;
-import com.google.common.primitives.*;
 import com.google.common.util.concurrent.*;
 import com.google.protobuf.*;
 import net.jcip.annotations.*;
@@ -4551,7 +4550,7 @@ public class Wallet extends BaseTaggableObject
 
         @Override public int compareTo(TxOffsetPair o) {
             // note that in this implementation compareTo() is not consistent with equals()
-            return Ints.compare(offset, o.offset);
+            return Integer.compare(offset, o.offset);
         }
     }
 


### PR DESCRIPTION
In Java 7, Integer.compare() and Long.compare() were added. Use those
methods rather than the Guava equivalents which are “deprecated” for
JDK7+.