### PR TITLE
Simplify BaseTaggableObject

### DIFF
--- a/core/src/main/java/org/bitcoinj/utils/BaseTaggableObject.java
+++ b/core/src/main/java/org/bitcoinj/utils/BaseTaggableObject.java
@@ -16,7 +16,6 @@
 
 package org.bitcoinj.utils;
 
-import com.google.common.collect.Maps;
 import com.google.protobuf.ByteString;
 
 import javax.annotation.Nullable;
@@ -26,19 +25,16 @@ import java.util.Map;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * A simple implementation of {@link TaggableObject} that just uses a lazily created hashmap that is
- * synchronized on this objects Java monitor.
+ * A simple implementation of {@link TaggableObject} that uses a hashmap that is
+ * synchronized on this object's Java monitor.
  */
 public class BaseTaggableObject implements TaggableObject {
-    @Nullable protected Map<String, ByteString> tags;
+    protected final Map<String, ByteString> tags = new HashMap<>();
 
     @Override
     @Nullable
     public synchronized ByteString maybeGetTag(String tag) {
-        if (tags == null)
-            return null;
-        else
-            return tags.get(tag);
+        return tags.get(tag);
     }
 
     @Override
@@ -51,18 +47,14 @@ public class BaseTaggableObject implements TaggableObject {
 
     @Override
     public synchronized void setTag(String tag, ByteString value) {
+        // HashMap allows null keys and values, but we don't
         checkNotNull(tag);
         checkNotNull(value);
-        if (tags == null)
-            tags = new HashMap<>();
         tags.put(tag, value);
     }
 
     @Override
     public synchronized Map<String, ByteString> getTags() {
-        if (tags != null)
-            return Maps.newHashMap(tags);
-        else
-            return Maps.newHashMap();
+        return new HashMap<>(tags);
     }
 }


### PR DESCRIPTION
* Make the tags member non-nullable and final by initializing it
* Remove comment about being lazily-created (it doesn’t need to be)
* Remove now unnecessary null-handling code
* Eliminate dependency on Guava (`Maps.newHashMap()`)