### PR TITLE
Simplify wallettemplate/build.gradle

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,7 +1,9 @@
-apply plugin: 'java'
-apply plugin: 'com.google.protobuf'
-apply plugin: 'maven'
-apply plugin: 'eclipse'
+plugins {
+    id 'java'
+    id 'com.google.protobuf'
+    id 'maven'
+    id 'eclipse'
+}
 
 version = '0.16-SNAPSHOT'
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'java'
-apply plugin: 'eclipse'
+plugins {
+    id 'java'
+    id 'eclipse'
+}
 
 dependencies {
     implementation project(':bitcoinj-core')

--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'java'
-apply plugin: 'eclipse'
+plugins {
+    id 'java'
+    id 'eclipse'
+}
 
 dependencies {
     implementation project(':bitcoinj-core')

--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -18,7 +18,7 @@ javafx {
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 
-sourceCompatibility = 11
+sourceCompatibility = 1.11
 compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
 

--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -1,11 +1,9 @@
 plugins {
-    id 'org.openjfx.javafxplugin' version '0.0.7' apply false
+    id 'java'
+    id 'eclipse'
+    id 'application'
+    id 'org.openjfx.javafxplugin' version '0.0.7'
 }
-
-apply plugin: 'java'
-apply plugin: 'eclipse'
-apply plugin: 'application'
-apply plugin: 'org.openjfx.javafxplugin'
 
 dependencies {
     implementation project(':bitcoinj-core')
@@ -20,7 +18,7 @@ javafx {
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 
-sourceCompatibility = 1.11
+sourceCompatibility = 11
 compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
 


### PR DESCRIPTION
* Put all Gradle plugins in plugins block
* Use “11” for sourceCompatibility (not “1.11”)