### PR TITLE
core jar: Automatic module name org.bitcoinj.core

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -45,6 +45,15 @@ test {
     }
 }
 
+ext.moduleName = 'org.bitcoinj.core'
+
+jar {
+    inputs.property("moduleName", moduleName)
+    manifest {
+        attributes  'Automatic-Module-Name': moduleName
+    }
+}
+
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
     from javadoc.destinationDir


### PR DESCRIPTION
See: http://branchandbound.net/blog/java/2017/12/automatic-module-name/