### PR TITLE
Remove wallet_template Gradle task (in favor of run task)

### DIFF
--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -25,7 +25,3 @@ compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
 
 mainClassName = 'wallettemplate.Main'
-
-// task wallet_template can be replaced with the 'run' task
-task wallet_template(dependsOn: 'run') {
-}


### PR DESCRIPTION
The `run` task is standard (`application` plugin) and does what we need.
I don’t think anything else depends on the `wallet_template` task.