### PR TITLE
Make wallettemplate use Java Module System, native jlink and jpackage builds.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+systemProp.org.gradle.java.compile-classpath-packaging=true

--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -2,13 +2,15 @@ plugins {
     id 'java'
     id 'eclipse'
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin'           version '0.0.8'
+    id 'org.beryx.jlink'                    version '2.17.7'
 }
 
 dependencies {
     implementation project(':bitcoinj-core')
     implementation 'de.jensd:fontawesomefx:8.0.0'
     implementation 'com.google.zxing:core:3.4.0'
+    implementation 'org.slf4j:slf4j-api:1.7.30'
     implementation 'org.slf4j:slf4j-jdk14:1.7.30'
 }
 
@@ -17,9 +19,30 @@ javafx {
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 
-sourceCompatibility = 1.11
+sourceCompatibility = 11
 compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
 javadoc.options.encoding = 'UTF-8'
 
-mainClassName = 'wallettemplate.Main'
+mainClassName = "$moduleName/wallettemplate.Main"
+
+jlink {
+    addExtraDependencies("javafx")
+    options = ['--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages']
+    launcher {
+        name = 'WalletTemplate'
+        jvmArgs = []
+    }
+    mergedModule {
+        requires 'java.logging'
+        requires 'java.desktop'
+
+        requires 'javafx.graphics'
+        requires 'javafx.controls'
+    }
+    jpackage {
+        // See https://badass-jlink-plugin.beryx.org/releases/latest/#_jpackage for
+        // where the plugin's jpackage task finds the path to the jpackage tool by default
+        skipInstaller = false
+    }
+}

--- a/wallettemplate/src/main/java/module-info.java
+++ b/wallettemplate/src/main/java/module-info.java
@@ -1,0 +1,34 @@
+/**
+ * Module Info for Wallet Template
+ * Note: relies upon several filename-based Automatic Modules and the
+ * BadAss JLink Gradle Plugin for correct operation
+ *
+ * if you are using IntelliJ and it isn't finding the org.bitcoinj.core, see:
+ * https://blog.jetbrains.com/idea/2017/03/support-for-java-9-modules-in-intellij-idea-2017-1/
+ * I made it work by adding a filename-based JAR dependency on the output JAR of the 'core' module.
+ */
+module wallettemplate {
+        requires java.logging;
+        requires java.desktop;
+
+        requires javafx.controls;
+        requires javafx.fxml;
+
+        requires org.slf4j;
+
+        requires org.bitcoinj.core;     // Automatic module
+
+        requires org.bouncycastle.provider;
+        requires com.google.common;
+
+        requires protobuf.java;
+        requires com.google.zxing;
+        requires fontawesomefx;         // Filename-based automatic module name
+        requires jsr305;
+
+        opens wallettemplate to javafx.fxml;
+        opens wallettemplate.controls to javafx.fxml;
+        exports wallettemplate;
+        exports wallettemplate.controls;
+
+}


### PR DESCRIPTION
* Upgrade dependencies
* Use [BadAss JLink Plugin](https://badass-jlink-plugin.beryx.org/releases/latest/)
* `jlink` and `jpackage` tasks are now both working

`jpackage` requires an early-access build of the [jpackage Packaging Tool](https://jdk.java.net/jpackage/) from OpenJDK 13 to be installed (and typically located via the `BADASS_JLINK_JPACKAGE_HOME` environment variable.)

You can run the `jlink` generated image with: `./wallettemplate/build/image/bin/WalletTemplate` or `./wallettemplate/build/image/bin/WalletTemplate.bat` for Windows (Windows not tested)

The **macOS** app is at `wallettemplate/build/jpackage/WalletTemplate.app` and is double-clickable. Windows and Linux apps should be in the same directory when built under those OSes.

Tested on **macOS**.  Output sizes are:
```
$ du -s -m wallettemplate/build/image wallettemplate/build/jpackage/WalletTemplate*
53	wallettemplate/build/image
57	wallettemplate/build/jpackage/WalletTemplate-1.0.dmg
111	wallettemplate/build/jpackage/WalletTemplate-1.0.pkg
71	wallettemplate/build/jpackage/WalletTemplate.app
```

If I recall correctly, under Java 8 these files would be around 200 MB each.