### PR TITLE
Replace use of currentTimeMillis() with currentTimeSeconds() where appropriate.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Utils.java
+++ b/core/src/main/java/org/bitcoinj/core/Utils.java
@@ -427,12 +427,16 @@ public class Utils {
         return mockTime != null ? mockTime : new Date();
     }
 
-    // TODO: Replace usages of this where the result is / 1000 with currentTimeSeconds.
-    /** Returns the current time in milliseconds since the epoch, or a mocked out equivalent. */
+    /**
+     * Returns the current time in milliseconds since the epoch, or a mocked out equivalent.
+     */
     public static long currentTimeMillis() {
         return mockTime != null ? mockTime.getTime() : System.currentTimeMillis();
     }
 
+    /**
+     * Returns the current time in seconds since the epoch, or a mocked out equivalent.
+     */
     public static long currentTimeSeconds() {
         return currentTimeMillis() / 1000;
     }

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -990,7 +990,7 @@ public class Wallet extends BaseTaggableObject
      * Same as {@link #addWatchedAddress(Address, long)} with the current time as the creation time.
      */
     public boolean addWatchedAddress(final Address address) {
-        long now = Utils.currentTimeMillis() / 1000;
+        long now = Utils.currentTimeSeconds();
         return addWatchedAddresses(Lists.newArrayList(address), now) == 1;
     }
 

--- a/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelStateTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/channels/PaymentChannelStateTest.java
@@ -351,7 +351,7 @@ public class PaymentChannelStateTest extends TestWithWallet {
         wallet.addOrUpdateExtension(stateStorage);
 
         Utils.setMockClock(); // Use mock clock
-        final long EXPIRE_TIME = Utils.currentTimeMillis()/1000 + 60*60*24;
+        final long EXPIRE_TIME = Utils.currentTimeSeconds() + 60*60*24;
 
         serverState = makeServerState(mockBroadcaster, serverWallet, serverKey, EXPIRE_TIME);
         assertEquals(getInitialServerState(), serverState.getState());
@@ -702,7 +702,7 @@ public class PaymentChannelStateTest extends TestWithWallet {
         assertEquals(CENT.add(Transaction.REFERENCE_DEFAULT_MIN_TX_FEE), wallet.getBalance());
 
         Utils.setMockClock(); // Use mock clock
-        final long EXPIRE_TIME = Utils.currentTimeMillis()/1000 + 60*60*24;
+        final long EXPIRE_TIME = Utils.currentTimeSeconds() + 60*60*24;
 
         serverState = makeServerState(mockBroadcaster, serverWallet, serverKey, EXPIRE_TIME);
         assertEquals(getInitialServerState(), serverState.getState());
@@ -815,7 +815,7 @@ public class PaymentChannelStateTest extends TestWithWallet {
         Context.propagate(new Context(UNITTEST, 100, Coin.ZERO, true));
 
         Utils.setMockClock(); // Use mock clock
-        final long EXPIRE_TIME = Utils.currentTimeMillis()/1000 + 60*60*24;
+        final long EXPIRE_TIME = Utils.currentTimeSeconds() + 60*60*24;
 
         serverState = makeServerState(mockBroadcaster, serverWallet, serverKey, EXPIRE_TIME);
         assertEquals(getInitialServerState(), serverState.getState());


### PR DESCRIPTION
Completing ToDo, to replace remaining statements of `Utils.currentTimeMillis() / 1000` with `Utils. currentTimeSeconds()`.