### PR TITLE
Require Gradle 4.4 (or above) for building.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ The bitcoinj library is a Java implementation of the Bitcoin protocol, which all
 
 ### Technologies
 
-* Java 7+ and Gradle 3.4+ for the `core` module
-* Java 8+ and Gradle 3.4+ for `tools` and `examples`
+* Java 7+ and Gradle 4.4+ for the `core` module
+* Java 8+ and Gradle 4.4+ for `tools` and `examples`
 * Java 11+ and Gradle 4.10+ for the JavaFX-based `wallettemplate`
 * [Gradle](https://gradle.org/) - for building the project
 * [Google Protocol Buffers](https://github.com/google/protobuf) - for use with serialization and hardware communications

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,7 @@ import org.gradle.util.GradleVersion
 import org.gradle.api.GradleScriptException
 
 // Minimum Gradle version for main build
-def minGradleVersion = GradleVersion.version("3.4")
+def minGradleVersion = GradleVersion.version("4.4")
 // Minimum Gradle version for builds of JavaFX 11 module
 def minFxGradleVersion = GradleVersion.version("4.10")
 


### PR DESCRIPTION
Debian Buster and Ubuntu Bionic, Cosmic and Disco now come with Gradle 4.4.1. Thus, I propose we raise the build requirement to Gradle 4.4.

This will allow us to use Gradle syntax and features that have become available between versions 3.4 and 4.4.
