### PR TITLE
.travis.yml: Specify exact Gradle version to use.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ jdk:
   - openjdk8
   - openjdk11
 install: true
+before_script:
+  - gradle wrapper --gradle-version=4.10.3
 script:
-  - gradle clean build
+  - ./gradlew clean build
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,17 @@
 sudo: false
 dist: xenial
 language: java
-jdk:
-  - openjdk8
-  - openjdk11
+matrix:
+  include:
+  - jdk: openjdk8
+    env: GRADLE_VERSION=4.4.1
+  - jdk: openjdk8
+    env: GRADLE_VERSION=4.10.3
+  - jdk: openjdk11
+    env: GRADLE_VERSION=4.10.3
 install: true
 before_script:
-  - gradle wrapper --gradle-version=4.10.3
+  - gradle wrapper --gradle-version=$GRADLE_VERSION
 script:
   - ./gradlew clean build
 


### PR DESCRIPTION
- Specify exact Gradle to use by running the Gradle wrapper in before_script.
- Pick several combinations of JDK version and Gradle version by building a matrix. See this example build: https://travis-ci.org/bitcoinj/bitcoinj/builds/521380652

@msgilligan What do you think of this? Would you pick other combinations?