### PR TITLE
simplify TX verification error checking

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -158,11 +158,7 @@ public class TransactionOutput extends ChildMessage {
      * receives.
      */
     public Coin getValue() {
-        try {
-            return Coin.valueOf(value);
-        } catch (IllegalArgumentException e) {
-            throw new IllegalStateException(e.getMessage(), e);
-        }
+        return Coin.valueOf(value);
     }
 
     /**


### PR DESCRIPTION
This simplifies some of the error checking in `Transaction.verify()` and `TransactionOutput.getValue()`. It seems that some of the calls in these methods used to throw exceptions, but no longer do so, leaving some stale code for checking errors that cannot be thrown.