### PR TITLE
kill an unnecessary instance variable in TransactionOutput

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -55,8 +55,6 @@ public class TransactionOutput extends ChildMessage {
     private boolean availableForSpending;
     @Nullable private TransactionInput spentBy;
 
-    private int scriptLen;
-
     /**
      * Deserializes a transaction output message. This is usually part of a transaction message.
      */
@@ -139,7 +137,7 @@ public class TransactionOutput extends ChildMessage {
     @Override
     protected void parse() throws ProtocolException {
         value = readInt64();
-        scriptLen = (int) readVarInt();
+        int scriptLen = (int) readVarInt();
         length = cursor - offset + scriptLen;
         scriptBytes = readBytes(scriptLen);
     }


### PR DESCRIPTION
This seems to have been left over from earlier code changes and now serves no purpose.