### PR TITLE
writeBinaryCheckpoints method

### DIFF
--- a/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
@@ -172,27 +172,26 @@ public class BuildCheckpoints {
     }
 
     private static void writeBinaryCheckpoints(TreeMap<Integer, StoredBlock> checkpoints, File file) throws Exception {
-        try (FileOutputStream fileOutputStream = new FileOutputStream(file, false)) {
-            MessageDigest digest = Sha256Hash.newDigest();
-            try (
-                    DigestOutputStream digestOutputStream = new DigestOutputStream(fileOutputStream, digest);
-                    DataOutputStream dataOutputStream = new DataOutputStream(digestOutputStream)
-            ) {
-                digestOutputStream.on(false);
-                dataOutputStream.writeBytes("CHECKPOINTS 1");
-                dataOutputStream.writeInt(0);  // Number of signatures to read. Do this later.
-                digestOutputStream.on(true);
-                dataOutputStream.writeInt(checkpoints.size());
-                ByteBuffer buffer = ByteBuffer.allocate(StoredBlock.COMPACT_SERIALIZED_SIZE);
-                for (StoredBlock block : checkpoints.values()) {
-                    block.serializeCompact(buffer);
-                    dataOutputStream.write(buffer.array());
-                    buffer.position(0);
-                }
-                Sha256Hash checkpointsHash = Sha256Hash.wrap(digest.digest());
-                System.out.println("Hash of checkpoints data is " + checkpointsHash);
-                System.out.println("Checkpoints written to '" + file.getCanonicalPath() + "'.");
+        MessageDigest digest = Sha256Hash.newDigest();
+        try (
+                FileOutputStream fileOutputStream = new FileOutputStream(file, false);
+                DigestOutputStream digestOutputStream = new DigestOutputStream(fileOutputStream, digest);
+                DataOutputStream dataOutputStream = new DataOutputStream(digestOutputStream)
+        ) {
+            digestOutputStream.on(false);
+            dataOutputStream.writeBytes("CHECKPOINTS 1");
+            dataOutputStream.writeInt(0);  // Number of signatures to read. Do this later.
+            digestOutputStream.on(true);
+            dataOutputStream.writeInt(checkpoints.size());
+            ByteBuffer buffer = ByteBuffer.allocate(StoredBlock.COMPACT_SERIALIZED_SIZE);
+            for (StoredBlock block : checkpoints.values()) {
+                block.serializeCompact(buffer);
+                dataOutputStream.write(buffer.array());
+                buffer.position(0);
             }
+            Sha256Hash checkpointsHash = Sha256Hash.wrap(digest.digest());
+            System.out.println("Hash of checkpoints data is " + checkpointsHash);
+            System.out.println("Checkpoints written to '" + file.getCanonicalPath() + "'.");
         }
     }
 

--- a/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
@@ -175,24 +175,27 @@ public class BuildCheckpoints {
         final FileOutputStream fileOutputStream = new FileOutputStream(file, false);
         MessageDigest digest = Sha256Hash.newDigest();
         final DigestOutputStream digestOutputStream = new DigestOutputStream(fileOutputStream, digest);
-        digestOutputStream.on(false);
         final DataOutputStream dataOutputStream = new DataOutputStream(digestOutputStream);
-        dataOutputStream.writeBytes("CHECKPOINTS 1");
-        dataOutputStream.writeInt(0);  // Number of signatures to read. Do this later.
-        digestOutputStream.on(true);
-        dataOutputStream.writeInt(checkpoints.size());
-        ByteBuffer buffer = ByteBuffer.allocate(StoredBlock.COMPACT_SERIALIZED_SIZE);
-        for (StoredBlock block : checkpoints.values()) {
-            block.serializeCompact(buffer);
-            dataOutputStream.write(buffer.array());
-            buffer.position(0);
+        try {
+            digestOutputStream.on(false);
+            dataOutputStream.writeBytes("CHECKPOINTS 1");
+            dataOutputStream.writeInt(0);  // Number of signatures to read. Do this later.
+            digestOutputStream.on(true);
+            dataOutputStream.writeInt(checkpoints.size());
+            ByteBuffer buffer = ByteBuffer.allocate(StoredBlock.COMPACT_SERIALIZED_SIZE);
+            for (StoredBlock block : checkpoints.values()) {
+                block.serializeCompact(buffer);
+                dataOutputStream.write(buffer.array());
+                buffer.position(0);
+            }
+            Sha256Hash checkpointsHash = Sha256Hash.wrap(digest.digest());
+            System.out.println("Hash of checkpoints data is " + checkpointsHash);
+            System.out.println("Checkpoints written to '" + file.getCanonicalPath() + "'.");
+        } finally {
+            dataOutputStream.close();
+            digestOutputStream.close();
+            fileOutputStream.close();
         }
-        dataOutputStream.close();
-        Sha256Hash checkpointsHash = Sha256Hash.wrap(digest.digest());
-        System.out.println("Hash of checkpoints data is " + checkpointsHash);
-        digestOutputStream.close();
-        fileOutputStream.close();
-        System.out.println("Checkpoints written to '" + file.getCanonicalPath() + "'.");
     }
 
     private static void writeTextualCheckpoints(TreeMap<Integer, StoredBlock> checkpoints, File file) throws IOException {

--- a/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
@@ -172,45 +172,43 @@ public class BuildCheckpoints {
     }
 
     private static void writeBinaryCheckpoints(TreeMap<Integer, StoredBlock> checkpoints, File file) throws Exception {
-        final FileOutputStream fileOutputStream = new FileOutputStream(file, false);
-        MessageDigest digest = Sha256Hash.newDigest();
-        final DigestOutputStream digestOutputStream = new DigestOutputStream(fileOutputStream, digest);
-        final DataOutputStream dataOutputStream = new DataOutputStream(digestOutputStream);
-        try {
-            digestOutputStream.on(false);
-            dataOutputStream.writeBytes("CHECKPOINTS 1");
-            dataOutputStream.writeInt(0);  // Number of signatures to read. Do this later.
-            digestOutputStream.on(true);
-            dataOutputStream.writeInt(checkpoints.size());
-            ByteBuffer buffer = ByteBuffer.allocate(StoredBlock.COMPACT_SERIALIZED_SIZE);
-            for (StoredBlock block : checkpoints.values()) {
-                block.serializeCompact(buffer);
-                dataOutputStream.write(buffer.array());
-                buffer.position(0);
+        try (FileOutputStream fileOutputStream = new FileOutputStream(file, false)) {
+            MessageDigest digest = Sha256Hash.newDigest();
+            try (
+                    DigestOutputStream digestOutputStream = new DigestOutputStream(fileOutputStream, digest);
+                    DataOutputStream dataOutputStream = new DataOutputStream(digestOutputStream)
+            ) {
+                digestOutputStream.on(false);
+                dataOutputStream.writeBytes("CHECKPOINTS 1");
+                dataOutputStream.writeInt(0);  // Number of signatures to read. Do this later.
+                digestOutputStream.on(true);
+                dataOutputStream.writeInt(checkpoints.size());
+                ByteBuffer buffer = ByteBuffer.allocate(StoredBlock.COMPACT_SERIALIZED_SIZE);
+                for (StoredBlock block : checkpoints.values()) {
+                    block.serializeCompact(buffer);
+                    dataOutputStream.write(buffer.array());
+                    buffer.position(0);
+                }
+                Sha256Hash checkpointsHash = Sha256Hash.wrap(digest.digest());
+                System.out.println("Hash of checkpoints data is " + checkpointsHash);
+                System.out.println("Checkpoints written to '" + file.getCanonicalPath() + "'.");
             }
-            Sha256Hash checkpointsHash = Sha256Hash.wrap(digest.digest());
-            System.out.println("Hash of checkpoints data is " + checkpointsHash);
-            System.out.println("Checkpoints written to '" + file.getCanonicalPath() + "'.");
-        } finally {
-            dataOutputStream.close();
-            digestOutputStream.close();
-            fileOutputStream.close();
         }
     }
 
     private static void writeTextualCheckpoints(TreeMap<Integer, StoredBlock> checkpoints, File file) throws IOException {
-        PrintWriter writer = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.US_ASCII));
-        writer.println("TXT CHECKPOINTS 1");
-        writer.println("0"); // Number of signatures to read. Do this later.
-        writer.println(checkpoints.size());
-        ByteBuffer buffer = ByteBuffer.allocate(StoredBlock.COMPACT_SERIALIZED_SIZE);
-        for (StoredBlock block : checkpoints.values()) {
-            block.serializeCompact(buffer);
-            writer.println(CheckpointManager.BASE64.encode(buffer.array()));
-            buffer.position(0);
+        try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.US_ASCII))) {
+            writer.println("TXT CHECKPOINTS 1");
+            writer.println("0"); // Number of signatures to read. Do this later.
+            writer.println(checkpoints.size());
+            ByteBuffer buffer = ByteBuffer.allocate(StoredBlock.COMPACT_SERIALIZED_SIZE);
+            for (StoredBlock block : checkpoints.values()) {
+                block.serializeCompact(buffer);
+                writer.println(CheckpointManager.BASE64.encode(buffer.array()));
+                buffer.position(0);
+            }
+            System.out.println("Checkpoints written to '" + file.getCanonicalPath() + "'.");
         }
-        writer.close();
-        System.out.println("Checkpoints written to '" + file.getCanonicalPath() + "'.");
     }
 
     private static void sanityCheck(File file, int expectedSize) throws IOException {


### PR DESCRIPTION
- wrapped fileOutputStream in try/finally block and moved .close() calls  to avoid possible resource leaks