### PR TITLE
Feature/bip67 compliance

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/LegacyAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/LegacyAddress.java
@@ -19,9 +19,11 @@
 package org.bitcoinj.core;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.bitcoinj.script.ScriptBuilder.createP2SHOutputScript;
 
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 
@@ -110,6 +112,29 @@ public class LegacyAddress extends Address {
      */
     public static LegacyAddress fromScriptHash(NetworkParameters params, byte[] hash160) throws AddressFormatException {
         return new LegacyAddress(params, true, hash160);
+    }
+
+    /**
+     * Construct an n-of-m multisig P2SH {@link LegacyAddress}.
+     *
+     * The resulting address is deterministically generated for the combination of parameters
+     * to this function, independently of the ordering of the keys parameters.
+     *
+     * The algorithm for address generation is described in
+     * <a href="https://github.com/bitcoin/bips/blob/master/bip-0067.mediawiki">BIP 67</a>.
+     *
+     * @param params
+     *            network this address is valid for
+     * @param threshold
+     *            the n in n-of-m: the number of signatures necessary to spend
+     * @param keys
+     *            the m in n-of-m: the keys usable for signing. Ordering is ignored.
+     * @return constructed address
+     */
+    public static LegacyAddress multisigFromKeys(NetworkParameters params, int threshold, Set<ECKey> keys) {
+        Script outputScript = createP2SHOutputScript(threshold, keys);
+        byte[] scriptHash = ScriptPattern.extractHashFromP2SH(outputScript);
+        return LegacyAddress.fromScriptHash(params, scriptHash);
     }
 
     /** @deprecated use {@link #fromScriptHash(NetworkParameters, byte[])} */

--- a/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
@@ -524,9 +524,16 @@ public class ScriptBuilder {
 
     /**
      * Creates redeem script with given public keys and threshold. Given public keys will be placed in
-     * redeem script in the lexicographical sorting order.
+     * redeem script in the lexicographical sorting order, as described in
+     * <a href="https://github.com/bitcoin/bips/blob/master/bip-0067.mediawiki">BIP 67</a>.
      */
     public static Script createRedeemScript(int threshold, List<ECKey> pubkeys) {
+        for (ECKey pubkey : pubkeys) {
+            if (!pubkey.isCompressed()) {
+                throw new IllegalArgumentException("P2SH redeem scripts require compressed public keys");
+            }
+        }
+
         pubkeys = new ArrayList<>(pubkeys);
         Collections.sort(pubkeys, ECKey.PUBKEY_COMPARATOR);
         return ScriptBuilder.createMultiSigOutputScript(threshold, pubkeys);

--- a/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
@@ -534,12 +534,12 @@ public class ScriptBuilder {
             }
         }
 
-        ImmutableList<ECKey> sorted = sortMultisigPubkeys(pubkeys);
+        List<ECKey> sorted = sortMultisigPubkeys(pubkeys);
         return ScriptBuilder.createMultiSigOutputScript(threshold, sorted);
     }
 
     @VisibleForTesting
-    static ImmutableList<ECKey> sortMultisigPubkeys(Collection<ECKey> pubkeys) {
+    static List<ECKey> sortMultisigPubkeys(Collection<ECKey> pubkeys) {
         List<ECKey> sorted = new ArrayList<>(pubkeys);
         Collections.sort(sorted, ECKey.PUBKEY_COMPARATOR);
         return ImmutableList.copyOf(sorted);

--- a/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
@@ -20,8 +20,6 @@ package org.bitcoinj.script;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
 
 import org.bitcoinj.core.Address;

--- a/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
@@ -17,6 +17,7 @@
 
 package org.bitcoinj.core;
 
+import com.google.common.collect.ImmutableSet;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.Networks;
 import org.bitcoinj.params.TestNet3Params;
@@ -34,6 +35,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import static org.bitcoinj.core.Utils.HEX;
 import static org.junit.Assert.*;
@@ -177,7 +179,7 @@ public class LegacyAddressTest {
     }
 
     @Test
-    public void p2shAddressCreationFromKeys() throws Exception {
+    public void multisigFromKeys() {
         // import some keys from this example: https://gist.github.com/gavinandresen/3966071
         ECKey key1 = DumpedPrivateKey.fromBase58(MAINNET, "5JaTXbAUmfPYZFRwrYaALK48fN6sFJp4rHqq2QSXs8ucfpE4yQU").getKey();
         key1 = ECKey.fromPrivate(key1.getPrivKeyBytes());
@@ -186,10 +188,8 @@ public class LegacyAddressTest {
         ECKey key3 = DumpedPrivateKey.fromBase58(MAINNET, "5JFjmGo5Fww9p8gvx48qBYDJNAzR9pmH5S389axMtDyPT8ddqmw").getKey();
         key3 = ECKey.fromPrivate(key3.getPrivKeyBytes());
 
-        List<ECKey> keys = Arrays.asList(key1, key2, key3);
-        Script p2shScript = ScriptBuilder.createP2SHOutputScript(2, keys);
-        LegacyAddress address = LegacyAddress.fromScriptHash(MAINNET,
-                ScriptPattern.extractHashFromP2SH(p2shScript));
+        Set<ECKey> keys = ImmutableSet.of(key1, key2, key3);
+        LegacyAddress address = LegacyAddress.multisigFromKeys(MAINNET, 2, keys);
         assertEquals("3N25saC4dT24RphDAwLtD8LUN4E2gZPJke", address.toString());
     }
 

--- a/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableSet;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.Networks;
 import org.bitcoinj.params.TestNet3Params;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptPattern;
 import org.bitcoinj.script.Script.ScriptType;
@@ -33,8 +32,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStreamReader;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Set;
 
 import static org.bitcoinj.core.Utils.HEX;

--- a/core/src/test/java/org/bitcoinj/script/Bip67Test.java
+++ b/core/src/test/java/org/bitcoinj/script/Bip67Test.java
@@ -1,14 +1,18 @@
 package org.bitcoinj.script;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.LegacyAddress;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.params.MainNetParams;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import static org.bitcoinj.core.Utils.HEX;
 import static org.junit.Assert.assertEquals;
@@ -22,6 +26,8 @@ import static org.junit.Assert.assertEquals;
 public class Bip67Test {
 
     private static final int THRESHOLD = 2;
+
+    private static final NetworkParameters MAINNET = MainNetParams.get();
 
     @Parameterized.Parameters
     public static Collection<Bip67TestVector> data() {
@@ -98,6 +104,13 @@ public class Bip67Test {
         assertEquals(script, outScriptHex);
     }
 
+    @Test
+    public void multisigFromKeys() {
+        Set<ECKey> keys = ImmutableSet.copyOf(list);
+        LegacyAddress createdAddress = LegacyAddress.multisigFromKeys(MAINNET, THRESHOLD, keys);
+        assertEquals(address, createdAddress.toBase58());
+    }
+
     private static ImmutableList<ECKey> pubkeysFromHex(Collection<String> publicKeys) {
         ImmutableList.Builder<ECKey> serialized = new ImmutableList.Builder<>();
         for (String publicKeyHex : publicKeys) {
@@ -107,8 +120,8 @@ public class Bip67Test {
     }
 
     private final static class Bip67TestVector {
-        private final ImmutableList<String> list;
-        private final ImmutableList<String> sorted;
+        private final List<String> list;
+        private final List<String> sorted;
         private final String script;
         private final String address;
 

--- a/core/src/test/java/org/bitcoinj/script/Bip67Test.java
+++ b/core/src/test/java/org/bitcoinj/script/Bip67Test.java
@@ -1,0 +1,113 @@
+package org.bitcoinj.script;
+
+import com.google.common.collect.ImmutableList;
+import org.bitcoinj.core.ECKey;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.bitcoinj.core.Utils.HEX;
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ * Test vectors from
+ * <a href="https://github.com/bitcoin/bips/blob/master/bip-0067.mediawiki">BIP 67</a>.
+ */
+@RunWith(Parameterized.class)
+public class Bip67Test {
+    @Parameterized.Parameters
+    public static Collection<Bip67TestVector> data() {
+        Bip67TestVector test1 = new Bip67TestVector(
+                ImmutableList.of("02ff12471208c14bd580709cb2358d98975247d8765f92bc25eab3b2763ed605f8",
+                        "02fe6f0a5a297eb38c391581c4413e084773ea23954d93f7753db7dc0adc188b2f"),
+                ImmutableList.of("02fe6f0a5a297eb38c391581c4413e084773ea23954d93f7753db7dc0adc188b2f",
+                        "02ff12471208c14bd580709cb2358d98975247d8765f92bc25eab3b2763ed605f8"),
+                "522102fe6f0a5a297eb38c391581c4413e084773ea23954d93f7753db7dc0adc188b2f2102ff12471208c14bd580709cb2358d98975247d8765f92bc25eab3b2763ed605f852ae",
+                "39bgKC7RFbpoCRbtD5KEdkYKtNyhpsNa3Z"
+        );
+
+        Bip67TestVector test2 = new Bip67TestVector(
+                ImmutableList.of("02632b12f4ac5b1d1b72b2a3b508c19172de44f6f46bcee50ba33f3f9291e47ed0",
+                        "027735a29bae7780a9755fae7a1c4374c656ac6a69ea9f3697fda61bb99a4f3e77",
+                        "02e2cc6bd5f45edd43bebe7cb9b675f0ce9ed3efe613b177588290ad188d11b404"),
+                ImmutableList.of("02632b12f4ac5b1d1b72b2a3b508c19172de44f6f46bcee50ba33f3f9291e47ed0",
+                        "027735a29bae7780a9755fae7a1c4374c656ac6a69ea9f3697fda61bb99a4f3e77",
+                        "02e2cc6bd5f45edd43bebe7cb9b675f0ce9ed3efe613b177588290ad188d11b404"),
+                "522102632b12f4ac5b1d1b72b2a3b508c19172de44f6f46bcee50ba33f3f9291e47ed021027735a29bae7780a9755fae7a1c4374c656ac6a69ea9f3697fda61bb99a4f3e772102e2cc6bd5f45edd43bebe7cb9b675f0ce9ed3efe613b177588290ad188d11b40453ae",
+                "3CKHTjBKxCARLzwABMu9yD85kvtm7WnMfH"
+        );
+
+        Bip67TestVector test3 = new Bip67TestVector(
+                ImmutableList.of("030000000000000000000000000000000000004141414141414141414141414141",
+                        "020000000000000000000000000000000000004141414141414141414141414141",
+                        "020000000000000000000000000000000000004141414141414141414141414140",
+                        "030000000000000000000000000000000000004141414141414141414141414140"),
+                ImmutableList.of("020000000000000000000000000000000000004141414141414141414141414140",
+                        "020000000000000000000000000000000000004141414141414141414141414141",
+                        "030000000000000000000000000000000000004141414141414141414141414140",
+                        "030000000000000000000000000000000000004141414141414141414141414141"),
+                "522102000000000000000000000000000000000000414141414141414141414141414021020000000000000000000000000000000000004141414141414141414141414141210300000000000000000000000000000000000041414141414141414141414141402103000000000000000000000000000000000000414141414141414141414141414154ae",
+                "32V85igBri9zcfBRVupVvwK18NFtS37FuD"
+        );
+
+        Bip67TestVector test4 = new Bip67TestVector(
+                ImmutableList.of("022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da",
+                        "03e3818b65bcc73a7d64064106a859cc1a5a728c4345ff0b641209fba0d90de6e9",
+                        "021f2f6e1e50cb6a953935c3601284925decd3fd21bc445712576873fb8c6ebc18"),
+                ImmutableList.of("021f2f6e1e50cb6a953935c3601284925decd3fd21bc445712576873fb8c6ebc18",
+                        "022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da",
+                        "03e3818b65bcc73a7d64064106a859cc1a5a728c4345ff0b641209fba0d90de6e9"),
+                "5221021f2f6e1e50cb6a953935c3601284925decd3fd21bc445712576873fb8c6ebc1821022df8750480ad5b26950b25c7ba79d3e37d75f640f8e5d9bcd5b150a0f85014da2103e3818b65bcc73a7d64064106a859cc1a5a728c4345ff0b641209fba0d90de6e953ae",
+                "3Q4sF6tv9wsdqu2NtARzNCpQgwifm2rAba"
+
+        );
+
+        return ImmutableList.of(test1, test2, test3, test4);
+    }
+
+    private final ImmutableList<String> list;
+    private final ImmutableList<String> sorted;
+    private final String script;
+    private final String address;
+
+    public Bip67Test(Bip67TestVector testVector) {
+        this.list = testVector.list;
+        this.sorted = testVector.sorted;
+        this.script = testVector.script;
+        this.address = testVector.address;
+    }
+
+    @Test
+    public void sorting() {
+        List<ECKey> pubkeys = new ArrayList<>(list.size());
+        for (String pubkeyHex : list) {
+            pubkeys.add(ECKey.fromPublicOnly(HEX.decode(pubkeyHex)));
+        }
+
+        ImmutableList<ECKey> result = ScriptBuilder.sortMultisigPubkeys(pubkeys);
+        List<String> hexKeys = new ArrayList<>(result.size());
+        for (ECKey pubkey : result) {
+            hexKeys.add(pubkey.getPublicKeyAsHex());
+        }
+        assertEquals(sorted, hexKeys);
+    }
+
+    private final static class Bip67TestVector {
+        private final ImmutableList<String> list;
+        private final ImmutableList<String> sorted;
+        private final String script;
+        private final String address;
+
+        private Bip67TestVector(List<String> list, List<String> sorted, String script, String address) {
+            this.list = ImmutableList.copyOf(list);
+            this.sorted = ImmutableList.copyOf(sorted);
+            this.script = script;
+            this.address = address;
+        }
+    }
+}

--- a/core/src/test/java/org/bitcoinj/script/ScriptBuilderTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptBuilderTest.java
@@ -16,13 +16,23 @@
 
 package org.bitcoinj.script;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static org.bitcoinj.core.Utils.HEX;
 import static org.bitcoinj.script.ScriptOpCodes.OP_FALSE;
 import static org.bitcoinj.script.ScriptOpCodes.OP_TRUE;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableList;
+import org.bitcoinj.core.ECKey;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 public class ScriptBuilderTest {
 
@@ -120,4 +130,5 @@ public class ScriptBuilderTest {
         byte[] s = new ScriptBuilder().opFalse().build().getProgram();
         assertArrayEquals(expected, s);
     }
+
 }

--- a/core/src/test/java/org/bitcoinj/script/ScriptBuilderTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptBuilderTest.java
@@ -16,23 +16,13 @@
 
 package org.bitcoinj.script;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-import static org.bitcoinj.core.Utils.HEX;
 import static org.bitcoinj.script.ScriptOpCodes.OP_FALSE;
 import static org.bitcoinj.script.ScriptOpCodes.OP_TRUE;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.collect.ImmutableList;
-import org.bitcoinj.core.ECKey;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
 public class ScriptBuilderTest {
 
@@ -130,5 +120,4 @@ public class ScriptBuilderTest {
         byte[] s = new ScriptBuilder().opFalse().build().getProgram();
         assertArrayEquals(expected, s);
     }
-
 }


### PR DESCRIPTION
This adds the BIP67-compliant `LegacyAddress.multisigFromKeys` factory method. It also adds a (breaking) check to `Script.createRedeemScript` to ensure that all passed-in keys are compressed.

The actual sorting mechanism is unchanged, so this is only breaking in cases where users were passing in uncompressed keys.

The bulk of the new code is the test suite in `core/src/test/java/org/bitcoinj/script/Bip67Test.java`, which uses the vectors from BIP 67: https://github.com/bitcoin/bips/blob/master/bip-0067.mediawiki