### PR TITLE
LegacyAddress: Remove deprecated methods.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/LegacyAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/LegacyAddress.java
@@ -18,18 +18,13 @@
 
 package org.bitcoinj.core;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import java.util.Arrays;
 import java.util.Objects;
 
 import javax.annotation.Nullable;
 
 import org.bitcoinj.params.Networks;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.script.Script.ScriptType;
-import org.bitcoinj.script.ScriptPattern;
-
 
 /**
  * <p>A Bitcoin address looks like 1MsScoe2fTJoq4ZPdQgqyhgWeoNamYPevy and is derived from an elliptic curve public key
@@ -112,22 +107,6 @@ public class LegacyAddress extends Address {
         return new LegacyAddress(params, true, hash160);
     }
 
-    /** @deprecated use {@link #fromScriptHash(NetworkParameters, byte[])} */
-    @Deprecated
-    public static LegacyAddress fromP2SHHash(NetworkParameters params, byte[] hash160) {
-        return fromScriptHash(params, hash160);
-    }
-
-    /**
-     * @deprecated use {@link #fromScriptHash(NetworkParameters, byte[])} in combination with
-     *             {@link ScriptPattern#extractHashFromP2SH(Script)}
-     */
-    @Deprecated
-    public static LegacyAddress fromP2SHScript(NetworkParameters params, Script scriptPubKey) {
-        checkArgument(ScriptPattern.isP2SH(scriptPubKey), "Not a P2SH script");
-        return fromScriptHash(params, ScriptPattern.extractHashFromP2SH(scriptPubKey));
-    }
-
     /**
      * Construct a {@link LegacyAddress} from its base58 form.
      * 
@@ -163,12 +142,6 @@ public class LegacyAddress extends Address {
         }
     }
 
-    /** @deprecated use {@link #fromPubKeyHash(NetworkParameters, byte[])} */
-    @Deprecated
-    public LegacyAddress(NetworkParameters params, byte[] hash160) throws AddressFormatException {
-        this(params, false, hash160);
-    }
-
     /**
      * Get the version header of an address. This is the first byte of a base58 encoded address.
      * 
@@ -187,12 +160,6 @@ public class LegacyAddress extends Address {
         return Base58.encodeChecked(getVersion(), bytes);
     }
 
-    /** @deprecated use {@link #getHash()} */
-    @Deprecated
-    public byte[] getHash160() {
-        return getHash();
-    }
-
     /** The (big endian) 20 byte hash that is the core of a Bitcoin address. */
     @Override
     public byte[] getHash() {
@@ -208,12 +175,6 @@ public class LegacyAddress extends Address {
     @Override
     public ScriptType getOutputScriptType() {
         return p2sh ? ScriptType.P2SH : ScriptType.P2PKH;
-    }
-
-    /** @deprecated Use {@link #getOutputScriptType()} */
-    @Deprecated
-    public boolean isP2SHAddress() {
-        return p2sh;
     }
 
     /**


### PR DESCRIPTION
As far as I can tell, they have all been deprecated in the 0.15 cycle. I propose to remove them to make further refactorings easier/smaller.