### PR TITLE
Use TestNet3 in WalletTemplate

### DIFF
--- a/wallettemplate/src/main/java/wallettemplate/Main.java
+++ b/wallettemplate/src/main/java/wallettemplate/Main.java
@@ -46,7 +46,7 @@ import java.net.URL;
 import static wallettemplate.utils.GuiUtils.*;
 
 public class Main extends Application {
-    public static NetworkParameters params = MainNetParams.get();
+    public static NetworkParameters params = TestNet3Params.get();
     public static final Script.ScriptType PREFERRED_OUTPUT_SCRIPT_TYPE = Script.ScriptType.P2WPKH;
     public static final String APP_NAME = "WalletTemplate";
     private static final String WALLET_FILE_NAME = APP_NAME.replaceAll("[^a-zA-Z0-9.-]", "_") + "-"


### PR DESCRIPTION
WalletTemplate is not a production-ready wallet and (for now, at least)
should default (currently hard-coded) to TestNet3.