### PR TITLE
Put wallet data files in app data directory

### DIFF
--- a/wallettemplate/src/main/java/wallettemplate/Main.java
+++ b/wallettemplate/src/main/java/wallettemplate/Main.java
@@ -35,6 +35,7 @@ import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import wallettemplate.controls.NotificationBarPane;
+import wallettemplate.utils.AppDataDirectory;
 import wallettemplate.utils.GuiUtils;
 import wallettemplate.utils.TextFieldValidator;
 
@@ -134,7 +135,8 @@ public class Main extends Application {
 
     public void setupWalletKit(@Nullable DeterministicSeed seed) {
         // If seed is non-null it means we are restoring from backup.
-        bitcoin = new WalletAppKit(params, PREFERRED_OUTPUT_SCRIPT_TYPE, null, new File("."), WALLET_FILE_NAME) {
+        File appDataDirectory = AppDataDirectory.get(APP_NAME).toFile();
+        bitcoin = new WalletAppKit(params, PREFERRED_OUTPUT_SCRIPT_TYPE, null, appDataDirectory, WALLET_FILE_NAME) {
             @Override
             protected void onSetupCompleted() {
                 // Don't make the user wait for confirmations for now, as the intention is they're sending it

--- a/wallettemplate/src/main/java/wallettemplate/utils/AppDataDirectory.java
+++ b/wallettemplate/src/main/java/wallettemplate/utils/AppDataDirectory.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wallettemplate.utils;
+
+import org.bitcoinj.core.Utils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Find/create App Data Directory in correct platform-specific location
+ */
+public class AppDataDirectory {
+
+    /**
+     * Get and create if necessary the Path to the application data directory
+     *
+     * @param appName The name of the current application
+     * @return Path to the application data directory
+     */
+    public static Path get(String appName) {
+        final Path applicationDataDirectory = getPath(appName);
+
+        try {
+            Files.createDirectories(applicationDataDirectory);
+        } catch (IOException ioe) {
+            throw new RuntimeException("Couldn't find/create AppDataDirectory", ioe);
+        }
+
+        return applicationDataDirectory;
+    }
+
+    private static Path getPath(String appName) {
+        final Path applicationDataDirectory;
+
+        if (Utils.isWindows()) {
+            applicationDataDirectory = Path.of(System.getenv("APPDATA"), appName);
+        } else if (Utils.isMac()) {
+            applicationDataDirectory = Path.of(System.getProperty("user.home"),"Library/Application Support", appName);
+        } else if (Utils.isLinux()) {
+            applicationDataDirectory = Path.of(System.getProperty("user.home"), "." + appName);
+        } else {
+            // Unknown, assume unix-like
+            applicationDataDirectory = Path.of(System.getProperty("user.home"), "." + appName);
+        }
+        return applicationDataDirectory;
+    }
+}


### PR DESCRIPTION
Previously **WalletTemplate** would store the `.spvchain` and `.wallet` files
in the app’s current working directory which could vary depending upon
how the app was launched.

This PR stores the app’s data files in the “app data directory” which
is always named **WalletTemplate** (`APP_NAME`) and located in the standard
location for application data directories on the current OS platform.

For macOS: `~/Library/Application Support/WalletTemplate`
For Linux/unix: `~/.WalletTemplate`
For Windows: `${APPDATA}/WalletTemplate`  (where `APPDATA` is a standard
Windows environment variable)

Changes:

* Added `OSDetector` class to detect Mac, *Nix, Windows
* Added `AppDataDirectory` class to return current dir Path
* Modified `Main` to use `appDataDirectory` rather than `“.”`