### PR TITLE
Refactor/legacyaddresstest redundant throws

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
@@ -60,7 +60,7 @@ public class LegacyAddressTest {
     }
 
     @Test
-    public void stringification() throws Exception {
+    public void stringification() {
         // Test a testnet address.
         LegacyAddress a = LegacyAddress.fromPubKeyHash(TESTNET, HEX.decode("fda79a24e50ff70ff42f7d89585da5bd19d9e5cc"));
         assertEquals("n4eA2nbYqErp7H6jebchxAN59DmNpksexv", a.toString());
@@ -72,7 +72,7 @@ public class LegacyAddressTest {
     }
 
     @Test
-    public void decoding() throws Exception {
+    public void decoding() {
         LegacyAddress a = LegacyAddress.fromBase58(TESTNET, "n4eA2nbYqErp7H6jebchxAN59DmNpksexv");
         assertEquals("fda79a24e50ff70ff42f7d89585da5bd19d9e5cc", Utils.HEX.encode(a.getHash()));
 
@@ -114,7 +114,7 @@ public class LegacyAddressTest {
     }
 
     @Test
-    public void getNetwork() throws Exception {
+    public void getNetwork() {
         NetworkParameters params = LegacyAddress.getParametersFromAddress("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL");
         assertEquals(MAINNET.getId(), params.getId());
         params = LegacyAddress.getParametersFromAddress("n4eA2nbYqErp7H6jebchxAN59DmNpksexv");
@@ -122,7 +122,7 @@ public class LegacyAddressTest {
     }
 
     @Test
-    public void getAltNetwork() throws Exception {
+    public void getAltNetwork() {
         // An alternative network
         class AltNetwork extends MainNetParams {
             AltNetwork() {
@@ -150,7 +150,7 @@ public class LegacyAddressTest {
     }
 
     @Test
-    public void p2shAddress() throws Exception {
+    public void p2shAddress() {
         // Test that we can construct P2SH addresses
         LegacyAddress mainNetP2SHAddress = LegacyAddress.fromBase58(MainNetParams.get(), "35b9vsyH1KoFT5a5KtrKusaCcPLkiSo1tU");
         assertEquals(mainNetP2SHAddress.getVersion(), MAINNET.p2shHeader);
@@ -177,7 +177,7 @@ public class LegacyAddressTest {
     }
 
     @Test
-    public void p2shAddressCreationFromKeys() throws Exception {
+    public void p2shAddressCreationFromKeys() {
         // import some keys from this example: https://gist.github.com/gavinandresen/3966071
         ECKey key1 = DumpedPrivateKey.fromBase58(MAINNET, "5JaTXbAUmfPYZFRwrYaALK48fN6sFJp4rHqq2QSXs8ucfpE4yQU").getKey();
         key1 = ECKey.fromPrivate(key1.getPrivKeyBytes());
@@ -203,7 +203,7 @@ public class LegacyAddressTest {
     }
 
     @Test
-    public void roundtripBase58() throws Exception {
+    public void roundtripBase58() {
         String base58 = "17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL";
         assertEquals(base58, LegacyAddress.fromBase58(null, base58).toBase58());
     }
@@ -218,7 +218,7 @@ public class LegacyAddressTest {
     }
 
     @Test
-    public void comparisonLessThan() throws Exception {
+    public void comparisonLessThan() {
         LegacyAddress a = LegacyAddress.fromBase58(MAINNET, "1Dorian4RoXcnBv9hnQ4Y2C1an6NJ4UrjX");
         LegacyAddress b = LegacyAddress.fromBase58(MAINNET, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P");
 
@@ -227,7 +227,7 @@ public class LegacyAddressTest {
     }
 
     @Test
-    public void comparisonGreaterThan() throws Exception {
+    public void comparisonGreaterThan() {
         LegacyAddress a = LegacyAddress.fromBase58(MAINNET, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P");
         LegacyAddress b = LegacyAddress.fromBase58(MAINNET, "1Dorian4RoXcnBv9hnQ4Y2C1an6NJ4UrjX");
 


### PR DESCRIPTION
These redundant `throws` exist in many tests, but this PR removes them from `LegacyAddressTest` with a view to removing distractions from the diff in https://github.com/bitcoinj/bitcoinj/pull/1801