### PR TITLE
Refactor PrefixedChecksummedBytesTest.java

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/PrefixedChecksummedBytesTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PrefixedChecksummedBytesTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2014 bitcoinj project
+ * Copyright 2019 Tim Strasser
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,18 +17,22 @@
 
 package org.bitcoinj.core;
 
-import org.bitcoinj.params.MainNetParams;
-import org.bitcoinj.params.TestNet3Params;
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import static org.bitcoinj.core.Utils.HEX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
 
+@RunWith(EasyMockRunner.class)
 public class PrefixedChecksummedBytesTest {
-    private static final NetworkParameters TESTNET = TestNet3Params.get();
-    private static final NetworkParameters MAINNET = MainNetParams.get();
+
+    @Mock
+    NetworkParameters params;
 
     private static class PrefixedChecksummedBytesToTest extends PrefixedChecksummedBytes {
         public PrefixedChecksummedBytesToTest(NetworkParameters params, byte[] bytes) {
@@ -41,18 +46,24 @@ public class PrefixedChecksummedBytesTest {
     }
 
     @Test
-    public void stringification() throws Exception {
+    public void stringification() {
         // Test a testnet address.
-        PrefixedChecksummedBytes a = new PrefixedChecksummedBytesToTest(TESTNET, HEX.decode("fda79a24e50ff70ff42f7d89585da5bd19d9e5cc"));
+        expect(params.getAddressHeader()).andReturn(111).andReturn(0);
+        replay(params);
+
+        PrefixedChecksummedBytes a = new PrefixedChecksummedBytesToTest(params, HEX.decode("fda79a24e50ff70ff42f7d89585da5bd19d9e5cc"));
         assertEquals("n4eA2nbYqErp7H6jebchxAN59DmNpksexv", a.toString());
 
-        PrefixedChecksummedBytes b = new PrefixedChecksummedBytesToTest(MAINNET, HEX.decode("4a22c3c4cbb31e4d03b15550636762bda0baf85a"));
+        PrefixedChecksummedBytes b = new PrefixedChecksummedBytesToTest(params, HEX.decode("4a22c3c4cbb31e4d03b15550636762bda0baf85a"));
         assertEquals("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL", b.toString());
     }
 
     @Test
     public void cloning() throws Exception {
-        PrefixedChecksummedBytes a = new PrefixedChecksummedBytesToTest(TESTNET, HEX.decode("fda79a24e50ff70ff42f7d89585da5bd19d9e5cc"));
+        expect(params.getAddressHeader()).andReturn(111);
+        replay(params);
+
+        PrefixedChecksummedBytes a = new PrefixedChecksummedBytesToTest(params, HEX.decode("fda79a24e50ff70ff42f7d89585da5bd19d9e5cc"));
         PrefixedChecksummedBytes b = a.clone();
 
         assertEquals(a, b);
@@ -61,9 +72,13 @@ public class PrefixedChecksummedBytesTest {
 
     @Test
     public void comparisonCloneEqualTo() throws Exception {
-        PrefixedChecksummedBytes a = new PrefixedChecksummedBytesToTest(TESTNET, HEX.decode("fda79a24e50ff70ff42f7d89585da5bd19d9e5cc"));
+        expect(params.getAddressHeader()).andReturn(111);
+        expect(params.getId()).andReturn("org.bitcoin.test").times(2);
+        replay(params);
+
+        PrefixedChecksummedBytes a = new PrefixedChecksummedBytesToTest(params, HEX.decode("fda79a24e50ff70ff42f7d89585da5bd19d9e5cc"));
         PrefixedChecksummedBytes b = a.clone();
 
-        assertTrue(a.compareTo(b) == 0);
+        assertEquals(0, a.compareTo(b));
     }
 }


### PR DESCRIPTION
Changes:
- Replaced real instances of testnet and mainnet NetworkParameters with a mocked instance
- Removed unnecessary throw declaration
- Refactored assertTrue to assertEquals

Otherwise, this test covers exactly the same things as before.