### PR TITLE
Wallet: Implement witness fee discount.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Context.java
+++ b/core/src/main/java/org/bitcoinj/core/Context.java
@@ -67,7 +67,7 @@ public class Context {
      *
      * @param params The network parameters that will be associated with this context.
      * @param eventHorizon Number of blocks after which the library will delete data and be unable to always process reorgs. See {@link #getEventHorizon()}.
-     * @param feePerKb The default fee per 1000 bytes of transaction data to pay when completing transactions. For details, see {@link SendRequest#feePerKb}.
+     * @param feePerKb The default fee per 1000 virtual bytes of transaction data to pay when completing transactions. For details, see {@link SendRequest#feePerKb}.
      * @param ensureMinRequiredFee Whether to ensure the minimum required fee by default when completing transactions. For details, see {@link SendRequest#ensureMinRequiredFee}.
      */
     public Context(NetworkParameters params, int eventHorizon, Coin feePerKb, boolean ensureMinRequiredFee) {
@@ -181,7 +181,7 @@ public class Context {
     }
 
     /**
-     * The default fee per 1000 bytes of transaction data to pay when completing transactions. For details, see {@link SendRequest#feePerKb}.
+     * The default fee per 1000 virtual bytes of transaction data to pay when completing transactions. For details, see {@link SendRequest#feePerKb}.
      */
     public Coin getFeePerKb() {
         return feePerKb;

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -894,6 +894,8 @@ public class Transaction extends ChildMessage {
         final Coin fee = getFee();
         if (fee != null) {
             s.append(indent).append("   fee  ");
+            if (size != vsize)
+                s.append(fee.multiply(1000).divide(vsize).toFriendlyString()).append("/vkB, ");
             s.append(fee.multiply(1000).divide(size).toFriendlyString()).append("/kB  ");
             s.append(fee.toFriendlyString()).append('\n');
         }

--- a/core/src/main/java/org/bitcoinj/wallet/SendRequest.java
+++ b/core/src/main/java/org/bitcoinj/wallet/SendRequest.java
@@ -85,12 +85,16 @@ public class SendRequest {
      * a way for people to prioritize their transactions over others and is used as a way to make denial of service
      * attacks expensive.</p>
      *
-     * <p>This is a dynamic fee (in satoshis) which will be added to the transaction for each kilobyte in size
+     * <p>This is a dynamic fee (in satoshis) which will be added to the transaction for each virtual kilobyte in size
      * including the first. This is useful as as miners usually sort pending transactions by their fee per unit size
      * when choosing which transactions to add to a block. Note that, to keep this equivalent to Bitcoin Core
-     * definition, a kilobyte is defined as 1000 bytes, not 1024.</p>
+     * definition, a virtual kilobyte is defined as 1000 virtual bytes, not 1024.</p>
      */
     public Coin feePerKb = Context.get().getFeePerKb();
+
+    public void setFeePerVkb(Coin feePerVkb) {
+        this.feePerKb = feePerVkb;
+    }
 
     /**
      * <p>Requires that there be enough fee for a default Bitcoin Core to at least relay the transaction.

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -97,6 +97,7 @@ public class WalletTest extends TestWithWallet {
     private static final CharSequence WRONG_PASSWORD = "nothing noone nobody nowhere";
 
     private final Address OTHER_ADDRESS = LegacyAddress.fromKey(UNITTEST, new ECKey());
+    private final Address OTHER_SEGWIT_ADDRESS = SegwitAddress.fromKey(UNITTEST, new ECKey());
 
     @Before
     @Override
@@ -2715,6 +2716,23 @@ public class WalletTest extends TestWithWallet {
         request.feePerKb = Transaction.DEFAULT_TX_FEE;
         wallet.completeTx(request);
         assertEquals(Coin.valueOf(22700), request.tx.getFee());
+    }
+
+    @Test
+    public void witnessTransactionGetFeeTest() throws Exception {
+        Wallet mySegwitWallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2WPKH);
+        Address mySegwitAddress = mySegwitWallet.freshReceiveAddress(Script.ScriptType.P2WPKH);
+
+        // Prepare wallet to spend
+        StoredBlock block = new StoredBlock(makeSolvedTestBlock(blockStore, OTHER_SEGWIT_ADDRESS), BigInteger.ONE, 1);
+        Transaction tx = createFakeTx(UNITTEST, COIN, mySegwitAddress);
+        mySegwitWallet.receiveFromBlock(tx, block, AbstractBlockChain.NewBlockType.BEST_CHAIN, 0);
+
+        // Create a transaction
+        SendRequest request = SendRequest.to(OTHER_SEGWIT_ADDRESS, CENT);
+        request.feePerKb = Transaction.DEFAULT_TX_FEE;
+        mySegwitWallet.completeTx(request);
+        assertEquals(Coin.valueOf(14000), request.tx.getFee());
     }
 
     @Test

--- a/tools/src/main/java/org/bitcoinj/tools/WalletTool.java
+++ b/tools/src/main/java/org/bitcoinj/tools/WalletTool.java
@@ -255,8 +255,8 @@ public class WalletTool {
         xpubkeysFlag = parser.accepts("xpubkeys").withRequiredArg();
         OptionSpec<String> outputFlag = parser.accepts("output").withRequiredArg();
         parser.accepts("value").withRequiredArg();
-        OptionSpec<String> feePerKbOption = parser.accepts("fee-per-kb").withRequiredArg();
-        OptionSpec<String> feeSatPerByteOption = parser.accepts("fee-sat-per-byte").withRequiredArg();
+        OptionSpec<String> feePerVkbOption = parser.accepts("fee-per-vkb").withRequiredArg();
+        OptionSpec<String> feeSatPerVbyteOption = parser.accepts("fee-sat-per-vbyte").withRequiredArg();
         unixtimeFlag = parser.accepts("unixtime").withRequiredArg().ofType(Long.class);
         OptionSpec<String> conditionFlag = parser.accepts("condition").withRequiredArg();
         parser.accepts("locktime").withRequiredArg();
@@ -392,21 +392,21 @@ public class WalletTool {
                 if (options.has(paymentRequestLocation) && options.has(outputFlag)) {
                     System.err.println("--payment-request and --output cannot be used together.");
                     return;
-                } else if (options.has(feePerKbOption) && options.has(feeSatPerByteOption)) {
+                } else if (options.has(feePerVkbOption) && options.has(feeSatPerVbyteOption)) {
                     System.err.println("--fee-per-kb and --fee-sat-per-byte cannot be used together.");
                     return;
                 } else if (options.has(outputFlag)) {
-                    Coin feePerKb = null;
-                    if (options.has(feePerKbOption))
-                        feePerKb = parseCoin((String) options.valueOf(feePerKbOption));
-                    if (options.has(feeSatPerByteOption))
-                        feePerKb = Coin.valueOf(Long.parseLong(options.valueOf(feeSatPerByteOption)) * 1000);
+                    Coin feePerVkb = null;
+                    if (options.has(feePerVkbOption))
+                        feePerVkb = parseCoin((String) options.valueOf(feePerVkbOption));
+                    if (options.has(feeSatPerVbyteOption))
+                        feePerVkb = Coin.valueOf(Long.parseLong(options.valueOf(feeSatPerVbyteOption)) * 1000);
                     String lockTime = null;
                     if (options.has("locktime")) {
                         lockTime = (String) options.valueOf("locktime");
                     }
                     boolean allowUnconfirmed = options.has("allow-unconfirmed");
-                    send(outputFlag.values(options), feePerKb, lockTime, allowUnconfirmed);
+                    send(outputFlag.values(options), feePerVkb, lockTime, allowUnconfirmed);
                 } else if (options.has(paymentRequestLocation)) {
                     sendPaymentRequest(paymentRequestLocation.value(options), !options.has("no-pki"));
                 } else {
@@ -415,7 +415,7 @@ public class WalletTool {
                 }
                 break;
             case SEND_CLTVPAYMENTCHANNEL: {
-                if (options.has(feePerKbOption) && options.has(feeSatPerByteOption)) {
+                if (options.has(feePerVkbOption) && options.has(feeSatPerVbyteOption)) {
                     System.err.println("--fee-per-kb and --fee-sat-per-byte cannot be used together.");
                     return;
                 }
@@ -423,11 +423,11 @@ public class WalletTool {
                     System.err.println("You must specify a --output=addr:value");
                     return;
                 }
-                Coin feePerKb = null;
-                if (options.has(feePerKbOption))
-                    feePerKb = parseCoin((String) options.valueOf(feePerKbOption));
-                if (options.has(feeSatPerByteOption))
-                    feePerKb = Coin.valueOf(Long.parseLong(options.valueOf(feeSatPerByteOption)) * 1000);
+                Coin feePerVkb = null;
+                if (options.has(feePerVkbOption))
+                    feePerVkb = parseCoin((String) options.valueOf(feePerVkbOption));
+                if (options.has(feeSatPerVbyteOption))
+                    feePerVkb = Coin.valueOf(Long.parseLong(options.valueOf(feeSatPerVbyteOption)) * 1000);
                 if (!options.has("locktime")) {
                     System.err.println("You must specify a --locktime");
                     return;
@@ -438,10 +438,10 @@ public class WalletTool {
                     System.err.println("You must specify an address to refund money to after expiry: --refund-to=addr");
                     return;
                 }
-                sendCLTVPaymentChannel(refundFlag.value(options), outputFlag.value(options), feePerKb, lockTime, allowUnconfirmed);
+                sendCLTVPaymentChannel(refundFlag.value(options), outputFlag.value(options), feePerVkb, lockTime, allowUnconfirmed);
                 } break;
             case SETTLE_CLTVPAYMENTCHANNEL: {
-                if (options.has(feePerKbOption) && options.has(feeSatPerByteOption)) {
+                if (options.has(feePerVkbOption) && options.has(feeSatPerVbyteOption)) {
                     System.err.println("--fee-per-kb and --fee-sat-per-byte cannot be used together.");
                     return;
                 }
@@ -449,20 +449,20 @@ public class WalletTool {
                     System.err.println("You must specify a --output=addr:value");
                     return;
                 }
-                Coin feePerKb = null;
-                if (options.has(feePerKbOption))
-                    feePerKb = parseCoin((String) options.valueOf(feePerKbOption));
-                if (options.has(feeSatPerByteOption))
-                    feePerKb = Coin.valueOf(Long.parseLong(options.valueOf(feeSatPerByteOption)) * 1000);
+                Coin feePerVkb = null;
+                if (options.has(feePerVkbOption))
+                    feePerVkb = parseCoin((String) options.valueOf(feePerVkbOption));
+                if (options.has(feeSatPerVbyteOption))
+                    feePerVkb = Coin.valueOf(Long.parseLong(options.valueOf(feeSatPerVbyteOption)) * 1000);
                 boolean allowUnconfirmed = options.has("allow-unconfirmed");
                 if (!options.has(txHashFlag)) {
                     System.err.println("You must specify the transaction to spend: --txhash=tx-hash");
                     return;
                 }
-                settleCLTVPaymentChannel(txHashFlag.value(options), outputFlag.value(options), feePerKb, allowUnconfirmed);
+                settleCLTVPaymentChannel(txHashFlag.value(options), outputFlag.value(options), feePerVkb, allowUnconfirmed);
                 } break;
             case REFUND_CLTVPAYMENTCHANNEL: {
-                if (options.has(feePerKbOption) && options.has(feeSatPerByteOption)) {
+                if (options.has(feePerVkbOption) && options.has(feeSatPerVbyteOption)) {
                     System.err.println("--fee-per-kb and --fee-sat-per-byte cannot be used together.");
                     return;
                 }
@@ -470,17 +470,17 @@ public class WalletTool {
                     System.err.println("You must specify a --output=addr:value");
                     return;
                 }
-                Coin feePerKb = null;
-                if (options.has(feePerKbOption))
-                    feePerKb = parseCoin((String) options.valueOf(feePerKbOption));
-                if (options.has(feeSatPerByteOption))
-                    feePerKb = Coin.valueOf(Long.parseLong(options.valueOf(feeSatPerByteOption)) * 1000);
+                Coin feePerVkb = null;
+                if (options.has(feePerVkbOption))
+                    feePerVkb = parseCoin((String) options.valueOf(feePerVkbOption));
+                if (options.has(feeSatPerVbyteOption))
+                    feePerVkb = Coin.valueOf(Long.parseLong(options.valueOf(feeSatPerVbyteOption)) * 1000);
                 boolean allowUnconfirmed = options.has("allow-unconfirmed");
                 if (!options.has(txHashFlag)) {
                     System.err.println("You must specify the transaction to spend: --txhash=tx-hash");
                     return;
                 }
-                refundCLTVPaymentChannel(txHashFlag.value(options), outputFlag.value(options), feePerKb, allowUnconfirmed);
+                refundCLTVPaymentChannel(txHashFlag.value(options), outputFlag.value(options), feePerVkb, allowUnconfirmed);
             } break;
             case ENCRYPT: encrypt(); break;
             case DECRYPT: decrypt(); break;
@@ -646,7 +646,7 @@ public class WalletTool {
         }
     }
 
-    private static void send(List<String> outputs, Coin feePerKb, String lockTimeStr, boolean allowUnconfirmed) throws VerificationException {
+    private static void send(List<String> outputs, Coin feePerVkb, String lockTimeStr, boolean allowUnconfirmed) throws VerificationException {
         try {
             // Convert the input strings to outputs.
             Transaction t = new Transaction(params);
@@ -677,8 +677,8 @@ public class WalletTool {
                 log.info("Emptying out wallet, recipient may get less than what you expect");
                 req.emptyWallet = true;
             }
-            if (feePerKb != null)
-                req.feePerKb = feePerKb;
+            if (feePerVkb != null)
+                req.setFeePerVkb(feePerVkb);
             if (allowUnconfirmed) {
                 wallet.allowSpendingUnconfirmedTransactions();
             }
@@ -765,7 +765,7 @@ public class WalletTool {
         }
     }
 
-    private static void sendCLTVPaymentChannel(String refund, String output, Coin feePerKb, String lockTimeStr, boolean allowUnconfirmed) throws VerificationException {
+    private static void sendCLTVPaymentChannel(String refund, String output, Coin feePerVkb, String lockTimeStr, boolean allowUnconfirmed) throws VerificationException {
         try {
             // Convert the input strings to outputs.
             ECKey outputKey, refundKey;
@@ -809,8 +809,8 @@ public class WalletTool {
                 log.info("Emptying out wallet, recipient may get less than what you expect");
                 req.emptyWallet = true;
             }
-            if (feePerKb != null)
-                req.feePerKb = feePerKb;
+            if (feePerVkb != null)
+                req.setFeePerVkb(feePerVkb);
             if (allowUnconfirmed) {
                 wallet.allowSpendingUnconfirmedTransactions();
             }
@@ -853,7 +853,7 @@ public class WalletTool {
     /**
      * Settles a CLTV payment channel transaction given that we own both private keys (ie. for testing).
      */
-    private static void settleCLTVPaymentChannel(String txHash, String output, Coin feePerKb, boolean allowUnconfirmed) {
+    private static void settleCLTVPaymentChannel(String txHash, String output, Coin feePerVkb, boolean allowUnconfirmed) {
         try {
             OutputSpec outputSpec;
             Coin value;
@@ -877,8 +877,8 @@ public class WalletTool {
             SendRequest req = outputSpec.isAddress() ?
                     SendRequest.to(outputSpec.addr, value) :
                     SendRequest.to(params, outputSpec.key, value);
-            if (feePerKb != null)
-                req.feePerKb = feePerKb;
+            if (feePerVkb != null)
+                req.setFeePerVkb(feePerVkb);
 
             Transaction lockTimeVerify = wallet.getTransaction(Sha256Hash.wrap(txHash));
             if (lockTimeVerify == null) {
@@ -957,7 +957,7 @@ public class WalletTool {
     /**
      * Refunds a CLTV payment channel transaction after the lock time has expired.
      */
-    private static void refundCLTVPaymentChannel(String txHash, String output, Coin feePerKb, boolean allowUnconfirmed) {
+    private static void refundCLTVPaymentChannel(String txHash, String output, Coin feePerVkb, boolean allowUnconfirmed) {
         try {
             OutputSpec outputSpec;
             Coin value;
@@ -981,8 +981,8 @@ public class WalletTool {
             SendRequest req = outputSpec.isAddress() ?
                     SendRequest.to(outputSpec.addr, value) :
                     SendRequest.to(params, outputSpec.key, value);
-            if (feePerKb != null)
-                req.feePerKb = feePerKb;
+            if (feePerVkb != null)
+                req.setFeePerVkb(feePerVkb);
 
             Transaction lockTimeVerify = wallet.getTransaction(Sha256Hash.wrap(txHash));
             if (lockTimeVerify == null) {

--- a/tools/src/main/resources/org/bitcoinj/tools/wallet-tool-help.txt
+++ b/tools/src/main/resources/org/bitcoinj/tools/wallet-tool-help.txt
@@ -51,7 +51,7 @@ Usage: wallet-tool --flags action-name
                          --payment-request=http://merchant.com/pay.php?123
 
                        Other options include:
-                          --fee-per-kb or --fee-sat-per-byte sets the network fee, see below
+                          --fee-per-vkb or --fee-sat-per-vbyte sets the network fee, see below
                           --locktime=1234  sets the lock time to block 1234
                           --locktime=2013/01/01  sets the lock time to 1st Jan 2013
                           --allow-unconfirmed will let you create spends of pending non-change outputs.
@@ -77,14 +77,14 @@ Usage: wallet-tool --flags action-name
                        Options:
                           --output=pubkey:value sets the amount to lock and the recipient
                           --refund-to=pubkey sets "our" public key
-                          --fee-per-kb or --fee-sat-per-byte sets the network fee, see below
+                          --fee-per-vkb or --fee-sat-per-vbyte sets the network fee, see below
                           --locktime=YYYY/MM/DD sets the expiry time for the channel
   settle-cltvpaymentchannel
                        Creates and broadcasts a transaction settling a previous micropayment channel.
                        This tool, for testing, requires the presence of both private keys.
                        Options:
                           --output=pubkey:value sets the destination for the money
-                          --fee-per-kb or --fee-sat-per-byte sets the network fee, see below
+                          --fee-per-vkb or --fee-sat-per-vbyte sets the network fee, see below
                           --txhash=hash sets the transaction to spend
   refund-cltvpaymentchannel
                        Creates and broadcasts a transaction refunding a previous micropayment channel.
@@ -92,7 +92,7 @@ Usage: wallet-tool --flags action-name
                        the created transaction won't be accepted into the mempool until that point.
                        Options:
                           --output=pubkey:value sets the destination for the money
-                          --fee-per-kb or --fee-sat-per-byte sets the network fee, see below
+                          --fee-per-vkb or --fee-sat-per-vbyte sets the network fee, see below
                           --txhash=hash sets the transaction to spend
 
 >>> GENERAL OPTIONS
@@ -103,8 +103,8 @@ Usage: wallet-tool --flags action-name
   --chain=<file>       Specifies the name of the file that stores the block chain.
   --force              Overrides any safety checks on the requested action.
   --date               Provide a date in form YYYY/MM/DD to any action that requires one.
-  --fee-per-kb         Sets the network fee in Bitcoin per kilobyte when sending, e.g. --fee-per-kb=0.0005
-  --fee-sat-per-byte   Sets the network fee in satoshi per byte when sending, e.g. --fee-sat-per-byte=50
+  --fee-per-vkb        Sets the network fee in Bitcoin per kilobyte when sending, e.g. --fee-per-vkb=0.0005
+  --fee-sat-per-vbyte  Sets the network fee in satoshi per byte when sending, e.g. --fee-sat-per-vbyte=50
   --output-script-type Provide an output script type to any action that requires one. May be P2PKH or P2WPKH.
   --peers=1.2.3.4      Comma separated IP addresses/domain names for connections instead of peer discovery.
   --offline            If specified when sending, don't try and connect, just write the tx to the wallet.


### PR DESCRIPTION
Fee is now specified in virtual (kilo)bytes. For non-segwit transactions a virtual byte is the same as a byte so the change is backward compatible.