### PR TITLE
HDKeyDerivation: Remove bogus precondition from deriveChildKeyBytesFromPublic().

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
@@ -186,7 +186,6 @@ public final class HDKeyDerivation {
     }
 
     public static RawKeyBytes deriveChildKeyBytesFromPublic(DeterministicKey parent, ChildNumber childNumber, PublicDeriveMode mode) throws HDDerivationException {
-        checkArgument(!childNumber.isHardened(), "Can't use private derivation with public keys only.");
         byte[] parentPublicKey = parent.getPubKeyPoint().getEncoded(true);
         checkState(parentPublicKey.length == 33, "Parent pubkey must be 33 bytes, but is " + parentPublicKey.length);
         ByteBuffer data = ByteBuffer.allocate(37);


### PR DESCRIPTION
The precondition was added in c3fd83e511057943f89ef63f6b5b7fc7252d3434 and then refactored in 5638387d3a9b01bcc470d95d29e266507fc1f796. But I think it simply doesn't make sense.