### PR TITLE
don't encode witness version to OP_N when constructing SegwitAddress

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/SegwitAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/SegwitAddress.java
@@ -71,7 +71,7 @@ public class SegwitAddress extends Address {
     private static byte[] encode(int witnessVersion, byte[] witnessProgram) throws AddressFormatException {
         byte[] convertedProgram = convertBits(witnessProgram, 0, witnessProgram.length, 8, 5, true);
         byte[] bytes = new byte[1 + convertedProgram.length];
-        bytes[0] = (byte) (Script.encodeToOpN(witnessVersion) & 0xff);
+        bytes[0] = (byte) (witnessVersion & 0xff);
         System.arraycopy(convertedProgram, 0, bytes, 1, convertedProgram.length);
         return bytes;
     }


### PR DESCRIPTION
This bug was never exposed outside the `SegwitAddress` class (and thus can't be tested) because the `encode` method is only ever called by `fromHash`, where the script version is always set to `0`.

Nevertheless, this bug could result in faults in future code, as other witness program versions begin to be used: The other construction methods, such as `fromBech32`, leave the version byte as a simple representation of the version number. This means that, were the` SegwitAddress` constructor ever called with a non-`0` version number, `getWitnessVersion` would return an incorrect result, and ScriptBuilder.createOutputScript would fail, re-running `encodeToOpN()` on the now greater-than-16 version number.