### PR TITLE
fix broken SegwitAddress javadoc links

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/SegwitAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/SegwitAddress.java
@@ -129,7 +129,7 @@ public class SegwitAddress extends Address {
 
     /**
      * Get the type of output script that will be used for sending to the address. This is either
-     * {@link ScriptType#P2WPKH} or {@link ScriptType#P2WSH}.
+     * {@link Script.ScriptType#P2WPKH} or {@link Script.ScriptType#P2WSH}.
      * 
      * @return type of output script
      */


### PR DESCRIPTION
These were broken by https://github.com/bitcoinj/bitcoinj/commit/d4df1119de3658c813e482d12d3c5436ce962e63