### PR TITLE
Update a bit of outdated documentation in the ECKey code

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/core/ECKey.java
@@ -146,8 +146,7 @@ public class ECKey implements EncryptableItem {
         secureRandom = new SecureRandom();
     }
 
-    // The two parts of the key. If "priv" is set, "pub" can always be calculated. If "pub" is set but not "priv", we
-    // can only verify signatures not make them.
+    // The two parts of the key. If "pub" is set but not "priv", we can only verify signatures, not make them.
     @Nullable protected final BigInteger priv;  // A field element.
     protected final LazyECPoint pub;
 


### PR DESCRIPTION
From what I can tell, `pub` is _always_ set. It just uses a lazy class.