### PR TITLE
equals and hashcode tests for address hierarchy

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     compileOnly 'org.fusesource.leveldbjni:leveldbjni-all:1.8'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.easymock:easymock:3.2'
+    testImplementation 'com.google.guava:guava-testlib:27.1-jre'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.5.2'
     testImplementation 'org.slf4j:slf4j-jdk14:1.7.25'
     testImplementation 'com.h2database:h2:1.3.167'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -17,11 +17,11 @@ dependencies {
     compileOnly 'org.fusesource.leveldbjni:leveldbjni-all:1.8'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.easymock:easymock:3.2'
-    testImplementation 'com.google.guava:guava-testlib:27.1-jre'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.5.2'
     testImplementation 'org.slf4j:slf4j-jdk14:1.7.25'
     testImplementation 'com.h2database:h2:1.3.167'
     testImplementation 'org.fusesource.leveldbjni:leveldbjni-all:1.8'
+    testImplementation 'nl.jqno.equalsverifier:equalsverifier:2.5.2'
 }
 
 sourceCompatibility = 1.7

--- a/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
@@ -17,7 +17,8 @@
 
 package org.bitcoinj.core;
 
-import com.google.common.testing.ClassSanityTester;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.Networks;
 import org.bitcoinj.params.TestNet3Params;
@@ -44,10 +45,13 @@ public class LegacyAddressTest {
     private static final NetworkParameters MAINNET = MainNetParams.get();
 
     @Test
-    public void equalsAndHashCode() {
-        new ClassSanityTester()
-                .setDistinctValues(NetworkParameters.class, TESTNET, MAINNET)
-                .testEquals(LegacyAddress.class);
+    public void equalsContract() {
+        EqualsVerifier.forClass(LegacyAddress.class)
+                .withPrefabValues(NetworkParameters.class, MAINNET, TESTNET)
+                .suppress(Warning.NULL_FIELDS)
+                .suppress(Warning.TRANSIENT_FIELDS)
+                .usingGetClass()
+                .verify();
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
@@ -17,6 +17,7 @@
 
 package org.bitcoinj.core;
 
+import com.google.common.testing.ClassSanityTester;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.Networks;
 import org.bitcoinj.params.TestNet3Params;
@@ -41,6 +42,13 @@ import static org.junit.Assert.*;
 public class LegacyAddressTest {
     private static final NetworkParameters TESTNET = TestNet3Params.get();
     private static final NetworkParameters MAINNET = MainNetParams.get();
+
+    @Test
+    public void equalsAndHashCode() {
+        new ClassSanityTester()
+                .setDistinctValues(NetworkParameters.class, TESTNET, MAINNET)
+                .testEquals(LegacyAddress.class);
+    }
 
     @Test
     public void testJavaSerialization() throws Exception {

--- a/core/src/test/java/org/bitcoinj/core/PrefixedChecksummedBytesTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PrefixedChecksummedBytesTest.java
@@ -17,13 +17,16 @@
 
 package org.bitcoinj.core;
 
-import com.google.common.testing.ClassSanityTester;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.TestNet3Params;
 import org.easymock.EasyMockRunner;
 import org.easymock.Mock;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import javax.annotation.ParametersAreNonnullByDefault;
 
 import static org.bitcoinj.core.Utils.HEX;
 import static org.junit.Assert.assertEquals;
@@ -49,10 +52,13 @@ public class PrefixedChecksummedBytesTest {
     }
 
     @Test
-    public void equalsAndHashCode() {
-        new ClassSanityTester()
-                .setDistinctValues(NetworkParameters.class, TestNet3Params.get(), MainNetParams.get())
-                .testEquals(PrefixedChecksummedBytesToTest.class);
+    public void equalsContract() {
+        EqualsVerifier.forClass(PrefixedChecksummedBytes.class)
+                .withPrefabValues(NetworkParameters.class, MainNetParams.get(), TestNet3Params.get())
+                .suppress(Warning.NULL_FIELDS)
+                .suppress(Warning.TRANSIENT_FIELDS)
+                .usingGetClass()
+                .verify();
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/core/PrefixedChecksummedBytesTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PrefixedChecksummedBytesTest.java
@@ -17,6 +17,9 @@
 
 package org.bitcoinj.core;
 
+import com.google.common.testing.ClassSanityTester;
+import org.bitcoinj.params.MainNetParams;
+import org.bitcoinj.params.TestNet3Params;
 import org.easymock.EasyMockRunner;
 import org.easymock.Mock;
 import org.junit.Test;
@@ -43,6 +46,13 @@ public class PrefixedChecksummedBytesTest {
         public String toString() {
             return Base58.encodeChecked(params.getAddressHeader(), bytes);
         }
+    }
+
+    @Test
+    public void equalsAndHashCode() {
+        new ClassSanityTester()
+                .setDistinctValues(NetworkParameters.class, TestNet3Params.get(), MainNetParams.get())
+                .testEquals(PrefixedChecksummedBytesToTest.class);
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/core/SegwitAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/SegwitAddressTest.java
@@ -26,7 +26,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Locale;
 
-import com.google.common.testing.ClassSanityTester;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.script.Script;
@@ -42,10 +43,13 @@ public class SegwitAddressTest {
     private static final TestNet3Params TESTNET = TestNet3Params.get();
 
     @Test
-    public void equalsAndHashCode() {
-        new ClassSanityTester()
-                .setDistinctValues(NetworkParameters.class, TESTNET, MAINNET)
-                .testEquals(SegwitAddress.class);
+    public void equalsContract() {
+        EqualsVerifier.forClass(SegwitAddress.class)
+                .withPrefabValues(NetworkParameters.class, MAINNET, TESTNET)
+                .suppress(Warning.NULL_FIELDS)
+                .suppress(Warning.TRANSIENT_FIELDS)
+                .usingGetClass()
+                .verify();
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/core/SegwitAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/SegwitAddressTest.java
@@ -26,6 +26,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Locale;
 
+import com.google.common.testing.ClassSanityTester;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.script.Script;
@@ -39,6 +40,13 @@ import com.google.common.base.MoreObjects;
 public class SegwitAddressTest {
     private static final MainNetParams MAINNET = MainNetParams.get();
     private static final TestNet3Params TESTNET = TestNet3Params.get();
+
+    @Test
+    public void equalsAndHashCode() {
+        new ClassSanityTester()
+                .setDistinctValues(NetworkParameters.class, TESTNET, MAINNET)
+                .testEquals(SegwitAddress.class);
+    }
 
     @Test
     public void example_p2wpkh_mainnet() {


### PR DESCRIPTION
Wanted to add these as a precaution before proceeding with refactors in the address hierarchy.