### PR TITLE
breaking: kill PrefixedChecksummedBytes Comparable implementation

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/LegacyAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/LegacyAddress.java
@@ -21,10 +21,13 @@ package org.bitcoinj.core;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Objects;
 
 import javax.annotation.Nullable;
 
+import com.google.common.collect.ComparisonChain;
+import com.google.common.primitives.UnsignedBytes;
 import org.bitcoinj.params.Networks;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.Script.ScriptType;
@@ -50,6 +53,17 @@ public class LegacyAddress extends Address {
 
     /** True if P2SH, false if P2PKH. */
     public final boolean p2sh;
+
+    public static final Comparator<LegacyAddress> byteComparator = new Comparator<LegacyAddress>() {
+        @Override
+        public int compare(LegacyAddress o1, LegacyAddress o2) {
+            return ComparisonChain.start()
+                    .compare(o1.params.getId(), o2.params.getId())
+                    .compareFalseFirst(o1.p2sh, o2.p2sh)
+                    .compare(o1.bytes, o2.bytes, UnsignedBytes.lexicographicalComparator())
+                    .result();
+        }
+    };
 
     /**
      * Private constructor. Use {@link #fromBase58(NetworkParameters, String)},

--- a/core/src/main/java/org/bitcoinj/core/PrefixedChecksummedBytes.java
+++ b/core/src/main/java/org/bitcoinj/core/PrefixedChecksummedBytes.java
@@ -23,6 +23,7 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Objects;
 
 import com.google.common.primitives.UnsignedBytes;
@@ -41,9 +42,17 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * keys exported using Bitcoin Core's dumpprivkey command.
  * </p>
  */
-public abstract class PrefixedChecksummedBytes implements Serializable, Cloneable, Comparable<PrefixedChecksummedBytes> {
+public abstract class PrefixedChecksummedBytes implements Serializable, Cloneable {
     protected final transient NetworkParameters params;
     protected final byte[] bytes;
+
+    public static final Comparator<PrefixedChecksummedBytes> comparator = new Comparator<PrefixedChecksummedBytes>() {
+        @Override
+        public int compare(PrefixedChecksummedBytes o1, PrefixedChecksummedBytes o2) {
+            int result = o1.params.getId().compareTo(o2.params.getId());
+            return result != 0 ? result : UnsignedBytes.lexicographicalComparator().compare(o1.bytes, o2.bytes);
+        }
+    };
 
     protected PrefixedChecksummedBytes(NetworkParameters params, byte[] bytes) {
         this.params = checkNotNull(params);
@@ -78,15 +87,6 @@ public abstract class PrefixedChecksummedBytes implements Serializable, Cloneabl
     @Override
     public PrefixedChecksummedBytes clone() throws CloneNotSupportedException {
         return (PrefixedChecksummedBytes) super.clone();
-    }
-
-    /**
-     * This implementation uses an optimized Google Guava method to compare {@code bytes}.
-     */
-    @Override
-    public int compareTo(PrefixedChecksummedBytes o) {
-        int result = this.params.getId().compareTo(o.params.getId());
-        return result != 0 ? result : UnsignedBytes.lexicographicalComparator().compare(this.bytes, o.bytes);
     }
 
     // Java serialization

--- a/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
@@ -35,6 +35,7 @@ import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.bitcoinj.core.LegacyAddress.byteComparator;
 import static org.bitcoinj.core.Utils.HEX;
 import static org.junit.Assert.*;
 
@@ -213,7 +214,7 @@ public class LegacyAddressTest {
         LegacyAddress a = LegacyAddress.fromBase58(MAINNET, "1Dorian4RoXcnBv9hnQ4Y2C1an6NJ4UrjX");
         LegacyAddress b = a.clone();
 
-        int result = a.compareTo(b);
+        int result = byteComparator.compare(a, b);
         assertEquals(0, result);
     }
 
@@ -222,7 +223,7 @@ public class LegacyAddressTest {
         LegacyAddress a = LegacyAddress.fromBase58(MAINNET, "1Dorian4RoXcnBv9hnQ4Y2C1an6NJ4UrjX");
         LegacyAddress b = LegacyAddress.fromBase58(MAINNET, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P");
 
-        int result = a.compareTo(b);
+        int result = byteComparator.compare(a, b);
         assertTrue(result < 0);
     }
 
@@ -231,7 +232,7 @@ public class LegacyAddressTest {
         LegacyAddress a = LegacyAddress.fromBase58(MAINNET, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P");
         LegacyAddress b = LegacyAddress.fromBase58(MAINNET, "1Dorian4RoXcnBv9hnQ4Y2C1an6NJ4UrjX");
 
-        int result = a.compareTo(b);
+        int result = byteComparator.compare(a, b);
         assertTrue(result > 0);
     }
 
@@ -244,7 +245,7 @@ public class LegacyAddressTest {
             String addr[] = line.split(",");
             LegacyAddress first = LegacyAddress.fromBase58(MAINNET, addr[0]);
             LegacyAddress second = LegacyAddress.fromBase58(MAINNET, addr[1]);
-            assertTrue(first.compareTo(second) < 0);
+            assertTrue(byteComparator.compare(first, second) < 0);
             assertTrue(first.toString().compareTo(second.toString()) < 0);
         }
     }

--- a/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
@@ -237,6 +237,17 @@ public class LegacyAddressTest {
     }
 
     @Test
+    public void equalsComparisonConsistency() {
+        byte[] fakeHash160 = HEX.decode("18a0e827269b5211eb51a4af1b2fa69333efa722");
+        LegacyAddress a = LegacyAddress.fromPubKeyHash(MAINNET, fakeHash160);
+        LegacyAddress b = LegacyAddress.fromScriptHash(MAINNET, fakeHash160);
+        assertNotEquals(a, b);
+
+        // ordering is not important for this test, we merely care that comparison does not result in equality
+        assertFalse(byteComparator.compare(a, b) == 0);
+    }
+
+    @Test
     public void comparisonBytesVsString() throws Exception {
         BufferedReader dataSetReader = new BufferedReader(
                 new InputStreamReader(getClass().getResourceAsStream("LegacyAddressTestDataset.txt")));

--- a/core/src/test/java/org/bitcoinj/core/PrefixedChecksummedBytesTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PrefixedChecksummedBytesTest.java
@@ -22,6 +22,7 @@ import org.easymock.Mock;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.bitcoinj.core.PrefixedChecksummedBytes.comparator;
 import static org.bitcoinj.core.Utils.HEX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
@@ -79,6 +80,6 @@ public class PrefixedChecksummedBytesTest {
         PrefixedChecksummedBytes a = new PrefixedChecksummedBytesToTest(params, HEX.decode("fda79a24e50ff70ff42f7d89585da5bd19d9e5cc"));
         PrefixedChecksummedBytes b = a.clone();
 
-        assertEquals(0, a.compareTo(b));
+        assertEquals(0, comparator.compare(a, b));
     }
 }


### PR DESCRIPTION
Sadly, this implementation falls prey to the problem explained here: http://www.javapractices.com/topic/TopicAction.do?Id=10

> When a class extends a concrete Comparable class and adds a significant field, a correct implementation of compareTo cannot be constructed. The only alternative is to use composition instead of inheritance.

Currently, `LegacyAddress` behaves this way. My proposed changes to `SegwitAddress` add significant fields. `Bip38PrivateKey` has a number of such fields.

Besides this, the implementation of `equals` used throughout these classes checks for class equality, making it inconsistent with `compareTo` _even_ in cases where significant fields are not added. This is nasty for reasons explained well in the `Comparable` javadoc:

> It is strongly recommended (though not required) that natural orderings be consistent with equals. This is so because sorted sets (and sorted maps) without explicit comparators behave "strangely" when they are used with elements (or keys) whose natural ordering is inconsistent with equals. In particular, such a sorted set (or sorted map) violates the general contract for set (or map), which is defined in terms of the equals method.

This PR kills the `Comparable` implementation and replaces it with public static `Comparator`s that are, in the case of `LegacyAddress`, covariant. I've added a test case that demonstrates a bit of the issue.