### PR TITLE
Add benchmark for LevelDBFullPrunedBlockStore

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,14 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
 
     dependencies {
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.6'
+        classpath 'me.champeau.gradle:jmh-gradle-plugin:0.4.8'
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'com.google.protobuf'
     id 'maven'
     id 'eclipse'
+    id 'me.champeau.gradle.jmh'
 }
 
 version = '0.16-SNAPSHOT'

--- a/core/src/jmh/java/org/bitcoinj/core/LevelDBFullPrunedBlockStoreBenchmark.java
+++ b/core/src/jmh/java/org/bitcoinj/core/LevelDBFullPrunedBlockStoreBenchmark.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Tim Strasser
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.core;
+
+import org.bitcoinj.params.UnitTestParams;
+import org.bitcoinj.store.BlockStoreException;
+import org.bitcoinj.store.FullPrunedBlockStore;
+import org.bitcoinj.store.LevelDBFullPrunedBlockStore;
+import org.openjdk.jmh.annotations.*;
+
+public class LevelDBFullPrunedBlockStoreBenchmark {
+
+    public static int NUM_BLOCKS = 10;
+
+    @State(Scope.Benchmark)
+    public static class BenchmarkParams {
+        @Param({"true", "false"})
+        boolean instrument;
+    }
+
+    @org.openjdk.jmh.annotations.Benchmark
+    @BenchmarkMode(Mode.All)
+    @Warmup(iterations = 5)
+    @Measurement(iterations = 5)
+    public void benchmark(BenchmarkParams benchmarkParams) throws PrunedException, BlockStoreException {
+        NetworkParameters params = UnitTestParams.get();
+        Context context = new Context(params);
+        FullPrunedBlockStore store = new LevelDBFullPrunedBlockStore(
+                params, "test-leveldb", 10, 100 * 1024 * 1024l,
+                10 * 1024 * 1024, 100000, benchmarkParams.instrument, Integer.MAX_VALUE);
+        FullPrunedBlockChain fullPrunedBlockChain = new FullPrunedBlockChain(context, store);
+        ECKey ecKey = new ECKey();
+        int height = 1;
+        for (int i = 0; i < NUM_BLOCKS; i++) {
+            Block block = params.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, ecKey.getPubKey(), height++);
+            fullPrunedBlockChain.add(block);
+        }
+
+        store.close();
+    }
+}


### PR DESCRIPTION
Hi,

I think I already said that I'm doing the work on the tests as part of an university assignment about software testing. As part of this assigmnent, I have to work on performance testing in form of benchmarks for the open source project I chose.

I don't know if introducing benchmarks for this project makes sense. I searched the project for comments about benchmarking and performance tests and found a comment in the class LevelDBFullPrunedBlockstore:
```        // Called to prime cache.
        // Might be idea to call periodically to flush out removed keys.
        // Would need to benchmark 1st though.
        public void reloadCache(DB db) {
            // LevelDB is great at scanning consecutive keys.
            // This take seconds even with 20m keys to add.
```

So I decided to include a jmh gradle plugin and start writing a simple benchmark for the LevelDB implementation.

Maybe it would make sense to benchmark all different DB implementations in order to be able to compare them.

Benchmarks can be run with ```./gradlew jmh``` from a terminal or inside the IDE by running the ```jmh``` task. Results are stored under the build folder. Currently, the output looks like this:

```
Benchmark                                                         (instrument)    Mode   Cnt   Score    Error  Units
LevelDBFullPrunedBlockStoreBenchmark.benchmark                            true   thrpt     6  74.373 ±  4.326  ops/s
LevelDBFullPrunedBlockStoreBenchmark.benchmark                           false   thrpt     8  73.303 ±  2.715  ops/s
LevelDBFullPrunedBlockStoreBenchmark.benchmark                            true    avgt     7   0.013 ±  0.001   s/op
LevelDBFullPrunedBlockStoreBenchmark.benchmark                           false    avgt     8   0.015 ±  0.005   s/op
LevelDBFullPrunedBlockStoreBenchmark.benchmark                            true  sample  7247   0.014 ±  0.001   s/op
LevelDBFullPrunedBlockStoreBenchmark.benchmark:benchmark·p0.00            true  sample         0.010            s/op
LevelDBFullPrunedBlockStoreBenchmark.benchmark:benchmark·p0.50            true  sample         0.013            s/op
LevelDBFullPrunedBlockStoreBenchmark.benchmark:benchmark·p0.90            true  sample         0.017            s/op
LevelDBFullPrunedBlockStoreBenchmark.benchmark:benchmark·p0.95            true  sample         0.020            s/op
LevelDBFullPrunedBlockStoreBenchmark.benchmark:benchmark·p0.99            true  sample         0.030            s/op
LevelDBFullPrunedBlockStoreBenchmark.benchmark:benchmark·p0.999           true  sample         0.048            s/op
LevelDBFullPrunedBlockStoreBenchmark.benchmark:benchmark·p0.9999          true  sample         0.064            s/op
LevelDBFullPrunedBlockStoreBenchmark.benchmark:benchmark·p1.00            true  sample         0.064            s/op
LevelDBFullPrunedBlockStoreBenchmark.benchmark                           false  sample  5201   0.013 ±  0.001   s/op
LevelDBFullPrunedBlockStoreBenchmark.benchmark:benchmark·p0.00           false  sample         0.010            s/op
LevelDBFullPrunedBlockStoreBenchmark.benchmark:benchmark·p0.50           false  sample         0.013            s/op
LevelDBFullPrunedBlockStoreBenchmark.benchmark:benchmark·p0.90           false  sample         0.016            s/op
LevelDBFullPrunedBlockStoreBenchmark.benchmark:benchmark·p0.95           false  sample         0.020            s/op
LevelDBFullPrunedBlockStoreBenchmark.benchmark:benchmark·p0.99           false  sample         0.028            s/op
LevelDBFullPrunedBlockStoreBenchmark.benchmark:benchmark·p0.999          false  sample         0.038            s/op
LevelDBFullPrunedBlockStoreBenchmark.benchmark:benchmark·p0.9999         false  sample         0.064            s/op
LevelDBFullPrunedBlockStoreBenchmark.benchmark:benchmark·p1.00           false  sample         0.064            s/op
LevelDBFullPrunedBlockStoreBenchmark.benchmark                            true      ss    25   0.044 ±  0.007   s/op
LevelDBFullPrunedBlockStoreBenchmark.benchmark                           false      ss    25   0.051 ±  0.012   s/op
```

Please let me know your thoughts about this!