### PR TITLE
added performance test for block message

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,14 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
 
     dependencies {
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.6'
+        classpath 'me.champeau.gradle:jmh-gradle-plugin:0.4.8'
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'com.google.protobuf'
     id 'maven'
     id 'eclipse'
+    id 'me.champeau.gradle.jmh'
 }
 
 version = '0.16-SNAPSHOT'

--- a/core/src/jmh/java/or/GetBlocksMessageBenchmark.java
+++ b/core/src/jmh/java/or/GetBlocksMessageBenchmark.java
@@ -1,0 +1,21 @@
+package or;
+
+import org.openjdk.jmh.annotations.*;
+import org.bitcoinj.params.UnitTestParams;
+
+
+public class GetBlocksMessageBenchmark {
+
+
+    @org.openjdk.jmh.annotations.Benchmark
+    @BenchmarkMode(Mode.All)
+    @Warmup(iterations = 10)
+    @Measurement(iterations = 10)
+    public void test() throws IOException {
+        NetworkParameters params = UnitTestParams.get();
+        for (int i=0 ; i < 10 ; i++) {
+            GetBlocksMessage Message = new GetBlocksMessage(params, i);
+            Message.parse();
+        }
+    }
+}


### PR DESCRIPTION
This will add JMH test coverage for the block get message class. In this way we will be sure that the performance across getting block information is always constant.