### PR TITLE
ScriptChunk: add equalsContract test and fix mutability

### DIFF
--- a/core/src/main/java/org/bitcoinj/script/ScriptChunk.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptChunk.java
@@ -42,7 +42,7 @@ public class ScriptChunk {
      */
     @Nullable
     public final byte[] data;
-    private int startLocationInProgram;
+    private final int startLocationInProgram;
 
     public ScriptChunk(int opcode, byte[] data) {
         this(opcode, data, -1);

--- a/core/src/test/java/org/bitcoinj/script/ScriptChunkTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptChunkTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Random;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 import com.google.common.primitives.Bytes;
@@ -34,6 +35,13 @@ import com.google.common.primitives.Bytes;
 public class ScriptChunkTest {
 
     private static final Random RANDOM = new Random(42);
+
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.forClass(ScriptChunk.class)
+                .usingGetClass()
+                .verify();
+    }
 
     @Test
     public void testShortestPossibleDataPush() {


### PR DESCRIPTION
Adds an `EqualsVerifier` test for `ScriptChunk`. The test fails unless `startLocationInProgram` is marked `final`.