### PR TITLE
kill ScriptChunk.startLocationInProgram

### DIFF
--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -176,10 +176,10 @@ public class Script {
     }
 
     private static final ScriptChunk[] STANDARD_TRANSACTION_SCRIPT_CHUNKS = {
-        new ScriptChunk(ScriptOpCodes.OP_DUP, null, 0),
-        new ScriptChunk(ScriptOpCodes.OP_HASH160, null, 1),
-        new ScriptChunk(ScriptOpCodes.OP_EQUALVERIFY, null, 23),
-        new ScriptChunk(ScriptOpCodes.OP_CHECKSIG, null, 24),
+        new ScriptChunk(ScriptOpCodes.OP_DUP, null),
+        new ScriptChunk(ScriptOpCodes.OP_HASH160, null),
+        new ScriptChunk(ScriptOpCodes.OP_EQUALVERIFY, null),
+        new ScriptChunk(ScriptOpCodes.OP_CHECKSIG, null),
     };
 
     /**
@@ -194,9 +194,7 @@ public class Script {
     private void parse(byte[] program) throws ScriptException {
         chunks = new ArrayList<>(5);   // Common size.
         ByteArrayInputStream bis = new ByteArrayInputStream(program);
-        int initialSize = bis.available();
         while (bis.available() > 0) {
-            int startLocationInProgram = initialSize - bis.available();
             int opcode = bis.read();
 
             long dataToRead = -1;
@@ -219,13 +217,13 @@ public class Script {
 
             ScriptChunk chunk;
             if (dataToRead == -1) {
-                chunk = new ScriptChunk(opcode, null, startLocationInProgram);
+                chunk = new ScriptChunk(opcode, null);
             } else {
                 if (dataToRead > bis.available())
                     throw new ScriptException(ScriptError.SCRIPT_ERR_BAD_OPCODE, "Push of data element that is larger than remaining data");
                 byte[] data = new byte[(int)dataToRead];
                 checkState(dataToRead == 0 || bis.read(data, 0, (int)dataToRead) == dataToRead);
-                chunk = new ScriptChunk(opcode, data, startLocationInProgram);
+                chunk = new ScriptChunk(opcode, data);
             }
             // Save some memory by eliminating redundant copies of the same chunk objects.
             for (ScriptChunk c : STANDARD_TRANSACTION_SCRIPT_CHUNKS) {
@@ -800,10 +798,12 @@ public class Script {
         
         LinkedList<byte[]> altstack = new LinkedList<>();
         LinkedList<Boolean> ifStack = new LinkedList<>();
-        
+
+        int nextLocationInScript = 0;
         for (ScriptChunk chunk : script.chunks) {
             boolean shouldExecute = !ifStack.contains(false);
             int opcode = chunk.opcode;
+            nextLocationInScript += chunk.size();
 
             // Check stack element size
             if (chunk.data != null && chunk.data.length > MAX_SCRIPT_ELEMENT_SIZE)
@@ -1241,7 +1241,7 @@ public class Script {
                     stack.add(Sha256Hash.hashTwice(stack.pollLast()));
                     break;
                 case OP_CODESEPARATOR:
-                    lastCodeSepLocation = chunk.getStartLocationInProgram() + 1;
+                    lastCodeSepLocation = nextLocationInScript;
                     break;
                 case OP_CHECKSIG:
                 case OP_CHECKSIGVERIFY:

--- a/core/src/main/java/org/bitcoinj/script/ScriptChunk.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptChunk.java
@@ -42,16 +42,10 @@ public class ScriptChunk {
      */
     @Nullable
     public final byte[] data;
-    private final int startLocationInProgram;
 
     public ScriptChunk(int opcode, @Nullable byte[] data) {
-        this(opcode, data, -1);
-    }
-
-    public ScriptChunk(int opcode, @Nullable byte[] data, int startLocationInProgram) {
         this.opcode = opcode;
         this.data = data;
-        this.startLocationInProgram = startLocationInProgram;
     }
 
     public boolean equalsOpCode(int opcode) {
@@ -70,11 +64,6 @@ public class ScriptChunk {
      */
     public boolean isPushData() {
         return opcode <= OP_16;
-    }
-
-    public int getStartLocationInProgram() {
-        checkState(startLocationInProgram >= 0);
-        return startLocationInProgram;
     }
 
     /** If this chunk is an OP_N opcode returns the equivalent integer value. */
@@ -150,6 +139,22 @@ public class ScriptChunk {
         return stream.toByteArray();
     }
 
+    /*
+     * The size, in bytes, that this chunk would occupy if serialized into a Script.
+     */
+    public int size() {
+        final int opcodeLength = 1;
+
+        int pushDataSizeLength = 0;
+        if (opcode == OP_PUSHDATA1) pushDataSizeLength = 1;
+        else if (opcode == OP_PUSHDATA2) pushDataSizeLength = 2;
+        else if (opcode == OP_PUSHDATA4) pushDataSizeLength = 4;
+
+        final int dataLength = data == null ? 0 : data.length;
+
+        return opcodeLength + pushDataSizeLength + dataLength;
+    }
+
     @Override
     public String toString() {
         StringBuilder buf = new StringBuilder();
@@ -170,12 +175,11 @@ public class ScriptChunk {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ScriptChunk other = (ScriptChunk) o;
-        return opcode == other.opcode && startLocationInProgram == other.startLocationInProgram
-            && Arrays.equals(data, other.data);
+        return opcode == other.opcode && Arrays.equals(data, other.data);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(opcode, startLocationInProgram, Arrays.hashCode(data));
+        return Objects.hash(opcode, Arrays.hashCode(data));
     }
 }

--- a/core/src/test/java/org/bitcoinj/script/ScriptChunkSizeTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptChunkSizeTest.java
@@ -27,20 +27,20 @@ public class ScriptChunkSizeTest {
     @Parameterized.Parameters
     public static Collection<ScriptChunk> data() {
         ArrayList<ScriptChunk> opcodes = new ArrayList<>(0xff);
-        for (int op = OP_NOP; op < 0xff; op++) opcodes.add(new ScriptChunk(op, null));
+        for (int op = OP_NOP; op < 0xff + 1; op++) opcodes.add(new ScriptChunk(op, null));
 
         ArrayList<ScriptChunk> smallData = new ArrayList<>(OP_PUSHDATA1);
         for (int op = 1; op < OP_PUSHDATA1; op++) smallData.add(new ScriptChunk(op, randomBytes(op)));
 
         ArrayList<ScriptChunk> pushData1 = new ArrayList<>(0xff);
-        for (int i = 0; i < 0xff; i++) pushData1.add(new ScriptChunk(OP_PUSHDATA1, randomBytes(i)));
+        for (int i = 0; i < 0xff + 1; i++) pushData1.add(new ScriptChunk(OP_PUSHDATA1, randomBytes(i)));
 
-        ArrayList<ScriptChunk> pushData2 = new ArrayList<>((int)Script.MAX_SCRIPT_ELEMENT_SIZE);
-        for (int i = 0; i < Script.MAX_SCRIPT_ELEMENT_SIZE; i++)
+        ArrayList<ScriptChunk> pushData2 = new ArrayList<>((int)Script.MAX_SCRIPT_ELEMENT_SIZE + 1);
+        for (int i = 0; i < Script.MAX_SCRIPT_ELEMENT_SIZE + 1; i++)
             pushData2.add(new ScriptChunk(OP_PUSHDATA2, randomBytes(i)));
 
-        ArrayList<ScriptChunk> pushData4 = new ArrayList<>((int)Script.MAX_SCRIPT_ELEMENT_SIZE);
-        for (int i = 0; i < Script.MAX_SCRIPT_ELEMENT_SIZE; i++)
+        ArrayList<ScriptChunk> pushData4 = new ArrayList<>((int)Script.MAX_SCRIPT_ELEMENT_SIZE + 1);
+        for (int i = 0; i < Script.MAX_SCRIPT_ELEMENT_SIZE + 1; i++)
             pushData4.add(new ScriptChunk(OP_PUSHDATA4, randomBytes(i)));
 
         return ImmutableList.<ScriptChunk>builder()

--- a/core/src/test/java/org/bitcoinj/script/ScriptChunkSizeTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptChunkSizeTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Matthew Leon Grinshpun
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.bitcoinj.script;
 
 import com.google.common.collect.ImmutableList;

--- a/core/src/test/java/org/bitcoinj/script/ScriptChunkSizeTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptChunkSizeTest.java
@@ -1,0 +1,65 @@
+package org.bitcoinj.script;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Random;
+
+import static org.bitcoinj.script.ScriptOpCodes.*;
+
+/**
+ * ScriptChunk.size() determines the size of a serialized ScriptChunk without actually performing serialization.
+ * This parameterized test is meant to exhaustively prove that the method does what it promises.
+ */
+@RunWith(value = Parameterized.class)
+public class ScriptChunkSizeTest {
+
+    private static final Random RANDOM = new Random(42);
+
+    @Parameterized.Parameter
+    public ScriptChunk scriptChunk;
+
+    @Parameterized.Parameters
+    public static Collection<ScriptChunk> data() {
+        ArrayList<ScriptChunk> opcodes = new ArrayList<>(0xff);
+        for (int op = OP_NOP; op < 0xff; op++) opcodes.add(new ScriptChunk(op, null));
+
+        ArrayList<ScriptChunk> smallData = new ArrayList<>(OP_PUSHDATA1);
+        for (int op = 1; op < OP_PUSHDATA1; op++) smallData.add(new ScriptChunk(op, randomBytes(op)));
+
+        ArrayList<ScriptChunk> pushData1 = new ArrayList<>(0xff);
+        for (int i = 0; i < 0xff; i++) pushData1.add(new ScriptChunk(OP_PUSHDATA1, randomBytes(i)));
+
+        ArrayList<ScriptChunk> pushData2 = new ArrayList<>((int)Script.MAX_SCRIPT_ELEMENT_SIZE);
+        for (int i = 0; i < Script.MAX_SCRIPT_ELEMENT_SIZE; i++)
+            pushData2.add(new ScriptChunk(OP_PUSHDATA2, randomBytes(i)));
+
+        ArrayList<ScriptChunk> pushData4 = new ArrayList<>((int)Script.MAX_SCRIPT_ELEMENT_SIZE);
+        for (int i = 0; i < Script.MAX_SCRIPT_ELEMENT_SIZE; i++)
+            pushData4.add(new ScriptChunk(OP_PUSHDATA4, randomBytes(i)));
+
+        return ImmutableList.<ScriptChunk>builder()
+                .addAll(opcodes)
+                .addAll(smallData)
+                .addAll(pushData1)
+                .addAll(pushData2)
+                .addAll(pushData4)
+                .build();
+    }
+
+    private static byte[] randomBytes(int size) {
+        byte[] bytes = new byte[size];
+        RANDOM.nextBytes(bytes);
+        return bytes;
+    }
+
+    @Test
+    public void testSize() {
+        Assert.assertEquals(scriptChunk.toByteArray().length, scriptChunk.size());
+    }
+}


### PR DESCRIPTION
The `startLocationInProgram` field of `ScriptChunk` was used as a cacheing mechanism for storing the location of each `ScriptChunk` in a `Script`. This was memory-inefficient, as this integer was only actually used during interpretation of `OP_CODESEPARATOR`. Furthermore, it was dangerous and inconsistent: the `ScriptBuilder` methods, for example, do not properly set `startLocationInProgram`, leading to a potential runtime failure when interpreting `ScriptBuilder`-constructed Scripts.

Rather than cacheing each chunk's location, we add a method called `size()` that efficiently returns the size of a serialized `ScriptChunk`. During `Script` interpretation, we use this method to track the program counter.

Additionally, we add an exhaustive test to ensure that `size()` properly returns the size of a serialized `ScriptChunk`.

This will break any code that relied on `ScriptChunk.getStartLocationInProgram()`.