### PR TITLE
Opcode names: accept OP_FALSE and OP_TRUE

### DIFF
--- a/core/src/main/java/org/bitcoinj/script/ScriptOpCodes.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptOpCodes.java
@@ -281,6 +281,8 @@ public class ScriptOpCodes {
 
     private static final Map<String, Integer> opCodeNameMap = ImmutableMap.<String, Integer>builder()
             .putAll(opCodeMap.inverse())
+            .put("OP_FALSE", OP_FALSE)
+            .put("OP_TRUE", OP_TRUE)
             .put("NOP2", OP_NOP2)
             .put("NOP3", OP_NOP3)
             .build();


### PR DESCRIPTION
Previously, only `OP_0` was accepted as the name for the 0x00 opcode.