### PR TITLE
Bugfix: ScriptChunk.toString() explosion

### DIFF
--- a/core/src/main/java/org/bitcoinj/script/ScriptChunk.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptChunk.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
 import static org.bitcoinj.script.ScriptOpCodes.*;
 
 /**
@@ -152,17 +153,9 @@ public class ScriptChunk {
 
     @Override
     public String toString() {
-        StringBuilder buf = new StringBuilder();
-        if (isOpCode()) {
-            buf.append(getOpCodeName(opcode));
-        } else if (data != null) {
-            // Data chunk
-            buf.append(getPushDataName(opcode)).append("[").append(Utils.HEX.encode(data)).append("]");
-        } else {
-            // Small num
-            buf.append(Script.decodeFromOpN(opcode));
-        }
-        return buf.toString();
+        if (data == null)
+            return getOpCodeName(opcode);
+        return format("%s[%s]", getPushDataName(opcode), Utils.HEX.encode(data));
     }
 
     @Override

--- a/core/src/test/java/org/bitcoinj/script/ScriptChunkTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptChunkTest.java
@@ -21,9 +21,7 @@ import static org.bitcoinj.script.ScriptOpCodes.OP_IF;
 import static org.bitcoinj.script.ScriptOpCodes.OP_PUSHDATA1;
 import static org.bitcoinj.script.ScriptOpCodes.OP_PUSHDATA2;
 import static org.bitcoinj.script.ScriptOpCodes.OP_PUSHDATA4;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.Random;
 
@@ -51,8 +49,8 @@ public class ScriptChunkTest {
         // until that is the case, toString() should not throw.
         ScriptChunk pushWithoutData = new ScriptChunk(OP_PUSHDATA1, null);
 
-        // all we care about, for now, is that the line below does not throw
-        pushWithoutData.toString();
+        // the chunk is invalid, but at least we can determine its opcode
+        assertEquals("PUSHDATA1", pushWithoutData.toString());
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/script/ScriptChunkTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptChunkTest.java
@@ -44,6 +44,18 @@ public class ScriptChunkTest {
     }
 
     @Test
+    public void testToStringOnInvalidScriptChunk() {
+        // see https://github.com/bitcoinj/bitcoinj/issues/1860
+        // In summary: toString() exploded when given an invalid ScriptChunk.
+        // It should perhaps be impossible to even construct such a ScriptChunk, but
+        // until that is the case, toString() should not throw.
+        ScriptChunk pushWithoutData = new ScriptChunk(OP_PUSHDATA1, null);
+
+        // all we care about, for now, is that the line below does not throw
+        pushWithoutData.toString();
+    }
+
+    @Test
     public void testShortestPossibleDataPush() {
         assertTrue("empty push", new ScriptBuilder().data(new byte[0]).build().getChunks().get(0)
                 .isShortestPossiblePushData());


### PR DESCRIPTION
resolves https://github.com/bitcoinj/bitcoinj/issues/1860

`ScriptChunk.toString()` should no longer throw on invalid `ScriptChunk`s.