### PR TITLE
remove redundant opcode check in ScriptPattern.isSentToMultisig

### DIFF
--- a/core/src/main/java/org/bitcoinj/script/ScriptPattern.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptPattern.java
@@ -205,7 +205,6 @@ public class ScriptPattern {
         if (chunks.size() < 4) return false;
         ScriptChunk chunk = chunks.get(chunks.size() - 1);
         // Must end in OP_CHECKMULTISIG[VERIFY].
-        if (!chunk.isOpCode()) return false;
         if (!(chunk.equalsOpCode(OP_CHECKMULTISIG) || chunk.equalsOpCode(OP_CHECKMULTISIGVERIFY))) return false;
         try {
             // Second to last chunk must be an OP_N opcode and there should be that many data chunks (keys).


### PR DESCRIPTION
The following line has a check that is strictly stronger.