### PR TITLE
bugfix: ScriptPattern.isSentToMultisig throws

### DIFF
--- a/core/src/main/java/org/bitcoinj/script/ScriptPattern.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptPattern.java
@@ -210,7 +210,6 @@ public class ScriptPattern {
         try {
             // Second to last chunk must be an OP_N opcode and there should be that many data chunks (keys).
             ScriptChunk m = chunks.get(chunks.size() - 2);
-            if (!m.isOpCode()) return false;
             int numKeys = decodeFromOpN(m.opcode);
             if (numKeys < 1 || chunks.size() != 3 + numKeys) return false;
             for (int i = 1; i < chunks.size() - 2; i++) {

--- a/core/src/main/java/org/bitcoinj/script/ScriptPattern.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptPattern.java
@@ -218,7 +218,7 @@ public class ScriptPattern {
             }
             // First chunk must be an OP_N opcode too.
             if (decodeFromOpN(chunks.get(0).opcode) < 1) return false;
-        } catch (IllegalStateException e) {
+        } catch (RuntimeException e) {
             return false;   // Not an OP_N opcode.
         }
         return true;

--- a/core/src/test/java/org/bitcoinj/script/ScriptPatternTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptPatternTest.java
@@ -26,7 +26,8 @@ import org.junit.Test;
 import java.math.BigInteger;
 import java.util.List;
 
-import static org.junit.Assert.assertTrue;
+import static org.bitcoinj.script.ScriptOpCodes.OP_CHECKMULTISIG;
+import static org.junit.Assert.*;
 
 public class ScriptPatternTest {
     private List<ECKey> keys = Lists.newArrayList(new ECKey(), new ECKey(), new ECKey());
@@ -71,6 +72,19 @@ public class ScriptPatternTest {
         assertTrue(ScriptPattern.isSentToMultisig(
                 ScriptBuilder.createMultiSigOutputScript(2, keys)
         ));
+    }
+
+    @Test
+    public void testIsSentToMultisigFailure() {
+        // at the time this test was written, the following script would result in throwing
+        // put a non OP_N opcode first and second-to-last positions
+        Script evil = new ScriptBuilder()
+                .op(0xff)
+                .op(0xff)
+                .op(0xff)
+                .op(OP_CHECKMULTISIG)
+                .build();
+        assertFalse(ScriptPattern.isSentToMultisig(evil));
     }
 
     @Test


### PR DESCRIPTION
`ScriptPattern.isSentToMultisig()` is meant to be a safe function returning a `boolean`. It was catching the wrong exception, causing it to throw when given crafted scripts.