### PR TITLE
ScriptChunk.decodeOpN: remove checkState

### DIFF
--- a/core/src/main/java/org/bitcoinj/script/ScriptChunk.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptChunk.java
@@ -68,7 +68,6 @@ public class ScriptChunk {
 
     /** If this chunk is an OP_N opcode returns the equivalent integer value. */
     public int decodeOpN() {
-        checkState(isOpCode());
         return Script.decodeFromOpN(opcode);
     }
 


### PR DESCRIPTION
The `checkState` on `ScriptChunk.decodeOpN()` was excessively strict: it excluded `OP_0`. As the method calls `Script.decodeFromOpN()`, which itself has a check on the passed-in opcode, we simply remove the check entirely.

No code in bitcoinj was calling `ScriptChunk.decodeOpN()`.