### PR TITLE
Correct the docstring on ScriptPattern.isMultisig

### DIFF
--- a/core/src/main/java/org/bitcoinj/script/ScriptPattern.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptPattern.java
@@ -197,8 +197,8 @@ public class ScriptPattern {
     }
 
     /**
-     * Returns whether this script matches the format used for multisig outputs:
-     * {@code [n] [keys...] [m] CHECKMULTISIG}
+     * Returns whether this script matches the format used for m-of-n multisig outputs:
+     * {@code [m] [keys...] [n] CHECKMULTISIG}
      */
     public static boolean isSentToMultisig(Script script) {
         List<ScriptChunk> chunks = script.chunks;


### PR DESCRIPTION
Also uses the term "m of n" multisig for clarity.

See conversation at https://github.com/bitcoinj/bitcoinj/pull/1867#discussion_r287012684