### PR TITLE
Make missingSigMode member private and final

### DIFF
--- a/core/src/main/java/org/bitcoinj/signers/MissingSigResolutionSigner.java
+++ b/core/src/main/java/org/bitcoinj/signers/MissingSigResolutionSigner.java
@@ -39,9 +39,10 @@ import org.slf4j.LoggerFactory;
 public class MissingSigResolutionSigner implements TransactionSigner {
     private static final Logger log = LoggerFactory.getLogger(MissingSigResolutionSigner.class);
 
-    public Wallet.MissingSigsMode missingSigsMode = Wallet.MissingSigsMode.USE_DUMMY_SIG;
+    private final Wallet.MissingSigsMode missingSigsMode;
 
     public MissingSigResolutionSigner() {
+        this(Wallet.MissingSigsMode.USE_DUMMY_SIG);
     }
 
     public MissingSigResolutionSigner(Wallet.MissingSigsMode missingSigsMode) {


### PR DESCRIPTION
Make the missingSigMode member in MissingSigResolutionSigner private
and final.