### PR TITLE
Breaking: New HDPath type to replace ImmutableList<ChildNumber>

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicHierarchy.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicHierarchy.java
@@ -16,7 +16,6 @@
 
 package org.bitcoinj.crypto;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 
 import java.util.List;
@@ -41,10 +40,10 @@ import static com.google.common.base.Preconditions.checkArgument;
  * is a list of {@link ChildNumber}s.</p>
  */
 public class DeterministicHierarchy {
-    private final Map<ImmutableList<ChildNumber>, DeterministicKey> keys = Maps.newHashMap();
-    private final ImmutableList<ChildNumber> rootPath;
+    private final Map<HDPath, DeterministicKey> keys = Maps.newHashMap();
+    private final HDPath rootPath;
     // Keep track of how many child keys each node has. This is kind of weak.
-    private final Map<ImmutableList<ChildNumber>, ChildNumber> lastChildNumbers = Maps.newHashMap();
+    private final Map<HDPath, ChildNumber> lastChildNumbers = Maps.newHashMap();
 
     public static final int BIP32_STANDARDISATION_TIME_SECS = 1369267200;
 
@@ -62,7 +61,7 @@ public class DeterministicHierarchy {
      * inserted in order.
      */
     public final void putKey(DeterministicKey key) {
-        ImmutableList<ChildNumber> path = key.getPath();
+        HDPath path = key.getPath();
         // Update our tracking of what the next child in each branch of the tree should be. Just assume that keys are
         // inserted in order here.
         final DeterministicKey parent = key.getParent();
@@ -81,9 +80,9 @@ public class DeterministicHierarchy {
      * @throws IllegalArgumentException if create is false and the path was not found.
      */
     public DeterministicKey get(List<ChildNumber> path, boolean relativePath, boolean create) {
-        ImmutableList<ChildNumber> absolutePath = relativePath
-                ? ImmutableList.<ChildNumber>builder().addAll(rootPath).addAll(path).build()
-                : ImmutableList.copyOf(path);
+        HDPath absolutePath = relativePath
+                ? rootPath.extend(path)
+                : HDPath.of(path);
         if (!keys.containsKey(absolutePath)) {
             if (!create)
                 throw new IllegalArgumentException(String.format(Locale.US, "No key found for %s path %s.",
@@ -106,7 +105,7 @@ public class DeterministicHierarchy {
      * @return next newly created key using the child derivation funtcion
      * @throws IllegalArgumentException if the parent doesn't exist and createParent is false.
      */
-    public DeterministicKey deriveNextChild(ImmutableList<ChildNumber> parentPath, boolean relative, boolean createParent, boolean privateDerivation) {
+    public DeterministicKey deriveNextChild(List<ChildNumber> parentPath, boolean relative, boolean createParent, boolean privateDerivation) {
         DeterministicKey parent = get(parentPath, relative, createParent);
         int nAttempts = 0;
         while (nAttempts++ < HDKeyDerivation.MAX_CHILD_DERIVATION_ATTEMPTS) {
@@ -118,14 +117,14 @@ public class DeterministicHierarchy {
         throw new HDDerivationException("Maximum number of child derivation attempts reached, this is probably an indication of a bug.");
     }
 
-    private ChildNumber getNextChildNumberToDerive(ImmutableList<ChildNumber> path, boolean privateDerivation) {
+    private ChildNumber getNextChildNumberToDerive(List<ChildNumber> path, boolean privateDerivation) {
         ChildNumber lastChildNumber = lastChildNumbers.get(path);
         ChildNumber nextChildNumber = new ChildNumber(lastChildNumber != null ? lastChildNumber.num() + 1 : 0, privateDerivation);
-        lastChildNumbers.put(path, nextChildNumber);
+        lastChildNumbers.put(HDPath.of(path), nextChildNumber);
         return nextChildNumber;
     }
 
-    public int getNumChildren(ImmutableList<ChildNumber> path) {
+    public int getNumChildren(List<ChildNumber> path) {
         final ChildNumber cn = lastChildNumbers.get(path);
         if (cn == null)
             return 0;

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -21,7 +21,6 @@ import org.bitcoinj.core.*;
 import org.bitcoinj.script.Script;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableList;
 import org.bouncycastle.crypto.params.KeyParameter;
 import org.bouncycastle.math.ec.ECPoint;
 
@@ -29,7 +28,9 @@ import javax.annotation.Nullable;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
 
 import static org.bitcoinj.core.Utils.HEX;
@@ -54,7 +55,7 @@ public class DeterministicKey extends ECKey {
     };
 
     private final DeterministicKey parent;
-    private final ImmutableList<ChildNumber> childNumberPath;
+    private final HDPath childNumberPath;
     private final int depth;
     private int parentFingerprint; // 0 if this key is root node of key hierarchy
 
@@ -62,7 +63,7 @@ public class DeterministicKey extends ECKey {
     private final byte[] chainCode;
 
     /** Constructs a key from its components. This is not normally something you should use. */
-    public DeterministicKey(ImmutableList<ChildNumber> childNumberPath,
+    public DeterministicKey(List<ChildNumber> childNumberPath,
                             byte[] chainCode,
                             LazyECPoint publicAsPoint,
                             @Nullable BigInteger priv,
@@ -70,13 +71,13 @@ public class DeterministicKey extends ECKey {
         super(priv, compressPoint(checkNotNull(publicAsPoint)));
         checkArgument(chainCode.length == 32);
         this.parent = parent;
-        this.childNumberPath = checkNotNull(childNumberPath);
+        this.childNumberPath = HDPath.of(checkNotNull(childNumberPath));
         this.chainCode = Arrays.copyOf(chainCode, chainCode.length);
         this.depth = parent == null ? 0 : parent.depth + 1;
         this.parentFingerprint = (parent != null) ? parent.getFingerprint() : 0;
     }
 
-    public DeterministicKey(ImmutableList<ChildNumber> childNumberPath,
+    public DeterministicKey(List<ChildNumber> childNumberPath,
                             byte[] chainCode,
                             ECPoint publicAsPoint,
                             @Nullable BigInteger priv,
@@ -85,21 +86,21 @@ public class DeterministicKey extends ECKey {
     }
 
     /** Constructs a key from its components. This is not normally something you should use. */
-    public DeterministicKey(ImmutableList<ChildNumber> childNumberPath,
+    public DeterministicKey(List<ChildNumber> childNumberPath,
                             byte[] chainCode,
                             BigInteger priv,
                             @Nullable DeterministicKey parent) {
         super(priv, compressPoint(ECKey.publicPointFromPrivate(priv)));
         checkArgument(chainCode.length == 32);
         this.parent = parent;
-        this.childNumberPath = checkNotNull(childNumberPath);
+        this.childNumberPath = HDPath.of(checkNotNull(childNumberPath));
         this.chainCode = Arrays.copyOf(chainCode, chainCode.length);
         this.depth = parent == null ? 0 : parent.depth + 1;
         this.parentFingerprint = (parent != null) ? parent.getFingerprint() : 0;
     }
 
     /** Constructs a key from its components. This is not normally something you should use. */
-    public DeterministicKey(ImmutableList<ChildNumber> childNumberPath,
+    public DeterministicKey(List<ChildNumber> childNumberPath,
                             byte[] chainCode,
                             KeyCrypter crypter,
                             LazyECPoint pub,
@@ -131,7 +132,7 @@ public class DeterministicKey extends ECKey {
      * information about its parent key.  Invoked when deserializing, but otherwise not something that
      * you normally should use.
      */
-    public DeterministicKey(ImmutableList<ChildNumber> childNumberPath,
+    public DeterministicKey(List<ChildNumber> childNumberPath,
                             byte[] chainCode,
                             LazyECPoint publicAsPoint,
                             @Nullable DeterministicKey parent,
@@ -140,7 +141,7 @@ public class DeterministicKey extends ECKey {
         super(null, compressPoint(checkNotNull(publicAsPoint)));
         checkArgument(chainCode.length == 32);
         this.parent = parent;
-        this.childNumberPath = checkNotNull(childNumberPath);
+        this.childNumberPath = HDPath.of(checkNotNull(childNumberPath));
         this.chainCode = Arrays.copyOf(chainCode, chainCode.length);
         this.depth = depth;
         this.parentFingerprint = ascertainParentFingerprint(parent, parentFingerprint);
@@ -151,7 +152,7 @@ public class DeterministicKey extends ECKey {
      * information about its parent key.  Invoked when deserializing, but otherwise not something that
      * you normally should use.
      */
-    public DeterministicKey(ImmutableList<ChildNumber> childNumberPath,
+    public DeterministicKey(List<ChildNumber> childNumberPath,
                             byte[] chainCode,
                             BigInteger priv,
                             @Nullable DeterministicKey parent,
@@ -160,7 +161,7 @@ public class DeterministicKey extends ECKey {
         super(priv, compressPoint(ECKey.publicPointFromPrivate(priv)));
         checkArgument(chainCode.length == 32);
         this.parent = parent;
-        this.childNumberPath = checkNotNull(childNumberPath);
+        this.childNumberPath = HDPath.of(checkNotNull(childNumberPath));
         this.chainCode = Arrays.copyOf(chainCode, chainCode.length);
         this.depth = depth;
         this.parentFingerprint = ascertainParentFingerprint(parent, parentFingerprint);
@@ -183,7 +184,7 @@ public class DeterministicKey extends ECKey {
      * A path can be written as 0/1/0 which means the first child of the root, the second child of that node, then
      * the first child of that node.
      */
-    public ImmutableList<ChildNumber> getPath() {
+    public HDPath getPath() {
         return childNumberPath;
     }
 
@@ -436,7 +437,7 @@ public class DeterministicKey extends ECKey {
                 cursor.pub, new BigInteger(1, parentalPrivateKeyBytes), cursor.parent);
         // Now we have to rederive the keys along the path back to ourselves. That path can be found by just truncating
         // our path with the length of the parents path.
-        ImmutableList<ChildNumber> path = childNumberPath.subList(cursor.getPath().size(), childNumberPath.size());
+        List<ChildNumber> path = childNumberPath.subList(cursor.getPath().size(), childNumberPath.size());
         for (ChildNumber num : path) {
             downCursor = HDKeyDerivation.deriveChildKey(downCursor, num);
         }
@@ -552,7 +553,7 @@ public class DeterministicKey extends ECKey {
         final int parentFingerprint = buffer.getInt();
         final int i = buffer.getInt();
         final ChildNumber childNumber = new ChildNumber(i);
-        ImmutableList<ChildNumber> path;
+        HDPath path;
         if (parent != null) {
             if (parentFingerprint == 0)
                 throw new IllegalArgumentException("Parent was provided but this key doesn't have one");
@@ -567,8 +568,8 @@ public class DeterministicKey extends ECKey {
                 // This can happen when deserializing an account key for a watching wallet.  In this case, we assume that
                 // the client wants to conceal the key's position in the hierarchy.  The path is truncated at the
                 // parent's node.
-                path = ImmutableList.of(childNumber);
-            else path = ImmutableList.of();
+                path = HDPath.of(childNumber);
+            else path = HDPath.of();
         }
         byte[] chainCode = new byte[32];
         buffer.get(chainCode);

--- a/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
@@ -16,7 +16,6 @@
 
 package org.bitcoinj.crypto;
 
-import com.google.common.collect.*;
 import org.bitcoinj.core.*;
 import org.bouncycastle.math.ec.*;
 
@@ -84,14 +83,14 @@ public final class HDKeyDerivation {
     public static DeterministicKey createMasterPrivKeyFromBytes(byte[] privKeyBytes, byte[] chainCode)
             throws HDDerivationException {
         // childNumberPath is an empty list because we are creating the root key.
-        return createMasterPrivKeyFromBytes(privKeyBytes, chainCode, ImmutableList.<ChildNumber> of());
+        return createMasterPrivKeyFromBytes(privKeyBytes, chainCode, HDPath.of());
     }
 
     /**
      * @throws HDDerivationException if privKeyBytes is invalid (not between 0 and n inclusive).
      */
     public static DeterministicKey createMasterPrivKeyFromBytes(byte[] privKeyBytes, byte[] chainCode,
-            ImmutableList<ChildNumber> childNumberPath) throws HDDerivationException {
+            List<ChildNumber> childNumberPath) throws HDDerivationException {
         BigInteger priv = new BigInteger(1, privKeyBytes);
         assertNonZero(priv, "Generated master key is invalid.");
         assertLessThanN(priv, "Generated master key is invalid.");
@@ -99,7 +98,7 @@ public final class HDKeyDerivation {
     }
 
     public static DeterministicKey createMasterPubKeyFromBytes(byte[] pubKeyBytes, byte[] chainCode) {
-        return new DeterministicKey(ImmutableList.<ChildNumber>of(), chainCode, new LazyECPoint(ECKey.CURVE.getCurve(), pubKeyBytes), null, null);
+        return new DeterministicKey(HDPath.of(), chainCode, new LazyECPoint(ECKey.CURVE.getCurve(), pubKeyBytes), null, null);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/crypto/HDPath.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDPath.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2019 Michael Sean Gilligan.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.crypto;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * HD Key derivation path. {@code HDPath} can be used to represent a full path or a relative path.
+ * The {@code hasPrivateKey} {@code boolean} is used for rendering to {@code String}
+ * but (at present) not much else. It defaults to {@code false} which will also be the setting for a relative path.
+ * <p>
+ * {@code HDPath} is immutable and uses the {@code Collections.UnmodifiableList} type internally.
+ * <p>
+ * It implements {@code java.util.List<ChildNumber>} to ease migration
+ * from the previous Guava {@code ImmutableList<ChildNumber>}. It should be a minor breaking change
+ * to replace {@code ImmutableList<ChildNumber>} with {@code List<ChildNumber>} where necessary in your code. Although
+ * it is recommended to use the {@code HDPath} type for clarity and for access to {@code HDPath}-specific functionality.
+ */
+public class HDPath extends AbstractList<ChildNumber> {
+    private static final char PREFIX_PRIVATE = 'm';
+    private static final char PREFIX_PUBLIC = 'M';
+    private static final char SEPARATOR = '/';
+    protected final boolean hasPrivateKey;
+    protected final List<ChildNumber> unmodifiableList;
+
+    public HDPath(boolean hasPrivateKey, List<ChildNumber> list) {
+        this.hasPrivateKey = hasPrivateKey;
+        this.unmodifiableList = Collections.unmodifiableList(list);
+    }
+
+    public HDPath(List<ChildNumber> list) {
+        this(false, list);
+    }
+
+    static HDPath of(boolean hasPrivateKey, List<ChildNumber> list) {
+        return new HDPath(hasPrivateKey, list);
+    }
+
+    static public HDPath of(List<ChildNumber> list) {
+        return HDPath.of(false, list);
+    }
+
+    static public HDPath of(ChildNumber childNumber) {
+        return HDPath.of(Collections.singletonList(childNumber));
+    }
+
+    static public HDPath of() {
+        return HDPath.of(Collections.<ChildNumber>emptyList());
+    }
+
+    /**
+     * Is this a path to a private key?
+     *
+     * @return true if yes, false if no or a partial path
+     */
+    public boolean hasPrivateKey() {
+        return hasPrivateKey;
+    }
+
+    /**
+     * Extend the path by appending a ChildNumber
+     *
+     * @param child the child to append
+     * @return A new immutable path
+     */
+    public HDPath extend(ChildNumber child) {
+        List<ChildNumber> mutable = new ArrayList<>(this.unmodifiableList); // Mutable copy
+        mutable.add(child);
+        return new HDPath(this.hasPrivateKey, mutable);
+    }
+
+    /**
+     * Extend the path by appending two ChildNumber objects.
+     *
+     * @param child1 the first child to append
+     * @param child2 the second child to append
+     * @return A new immutable path
+     */
+    public HDPath extend(ChildNumber child1, ChildNumber child2) {
+        List<ChildNumber> mutable = new ArrayList<>(this.unmodifiableList); // Mutable copy
+        mutable.add(child1);
+        mutable.add(child2);
+        return new HDPath(this.hasPrivateKey, mutable);
+    }
+
+    /**
+     * Extend the path by appending a relative path.
+     *
+     * @param path2 the relative path to append
+     * @return A new immutable path
+     */
+    public HDPath extend(HDPath path2) {
+        List<ChildNumber> mutable = new ArrayList<>(this.unmodifiableList); // Mutable copy
+        mutable.addAll(path2);
+        return new HDPath(this.hasPrivateKey, mutable);
+    }
+
+    /**
+     * Extend the path by appending a relative path.
+     *
+     * @param path2 the relative path to append
+     * @return A new immutable path
+     */
+    public HDPath extend(List<ChildNumber> path2) {
+        return this.extend(HDPath.of(path2));
+    }
+
+    @Override
+    public ChildNumber get(int index) {
+        return unmodifiableList.get(index);
+    }
+
+    @Override
+    public int size() {
+        return unmodifiableList.size();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder b = new StringBuilder();
+        b.append(hasPrivateKey ? HDPath.PREFIX_PRIVATE : HDPath.PREFIX_PUBLIC);
+        for (ChildNumber segment : unmodifiableList) {
+            b.append(HDPath.SEPARATOR);
+            b.append(segment.toString());
+        }
+        return b.toString();
+    }
+}

--- a/core/src/main/java/org/bitcoinj/crypto/HDUtils.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDUtils.java
@@ -19,7 +19,6 @@ package org.bitcoinj.crypto;
 
 import org.bitcoinj.core.ECKey;
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import org.bouncycastle.crypto.digests.SHA512Digest;
 import org.bouncycastle.crypto.macs.HMac;
@@ -68,13 +67,13 @@ public final class HDUtils {
     }
 
     /** Append a derivation level to an existing path */
-    public static ImmutableList<ChildNumber> append(List<ChildNumber> path, ChildNumber childNumber) {
-        return ImmutableList.<ChildNumber>builder().addAll(path).add(childNumber).build();
+    public static HDPath append(List<ChildNumber> path, ChildNumber childNumber) {
+        return new HDPath(path).extend(childNumber);
     }
 
     /** Concatenate two derivation paths */
-    public static ImmutableList<ChildNumber> concat(List<ChildNumber> path, List<ChildNumber> path2) {
-        return ImmutableList.<ChildNumber>builder().addAll(path).addAll(path2).build();
+    public static HDPath concat(List<ChildNumber> path, List<ChildNumber> path2) {
+        return new HDPath(path).extend(path2);
     }
 
     /** Convert to a string path, starting with "M/" */
@@ -89,7 +88,7 @@ public final class HDUtils {
      *
      * Where a letter "H" means hardened key. Spaces are ignored.
      */
-    public static List<ChildNumber> parsePath(@Nonnull String path) {
+    public static HDPath parsePath(@Nonnull String path) {
         String[] parsedNodes = path.replace("M", "").split("/");
         List<ChildNumber> nodes = new ArrayList<>();
 
@@ -102,6 +101,6 @@ public final class HDUtils {
             nodes.add(new ChildNumber(nodeNumber, isHard));
         }
 
-        return nodes;
+        return new HDPath(nodes);
     }
 }

--- a/core/src/main/java/org/bitcoinj/wallet/DefaultKeyChainFactory.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DefaultKeyChainFactory.java
@@ -20,7 +20,7 @@ package org.bitcoinj.wallet;
 import org.bitcoinj.crypto.*;
 import org.bitcoinj.script.Script;
 
-import com.google.common.collect.ImmutableList;
+import java.util.List;
 
 /**
  * Default factory for creating keychains while de-serializing.
@@ -28,7 +28,7 @@ import com.google.common.collect.ImmutableList;
 public class DefaultKeyChainFactory implements KeyChainFactory {
     @Override
     public DeterministicKeyChain makeKeyChain(DeterministicSeed seed, KeyCrypter crypter, boolean isMarried,
-            Script.ScriptType outputScriptType, ImmutableList<ChildNumber> accountPath) {
+            Script.ScriptType outputScriptType, List<ChildNumber> accountPath) {
         DeterministicKeyChain chain;
         if (isMarried)
             chain = new MarriedKeyChain(seed, crypter, outputScriptType, accountPath);

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -107,7 +107,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
     @Nullable private DeterministicKey rootKey;
     @Nullable private DeterministicSeed seed;
     private final Script.ScriptType outputScriptType;
-    private final ImmutableList<ChildNumber> accountPath;
+    private final HDPath accountPath;
 
     // Paths through the key tree. External keys are ones that are communicated to other parties. Internal keys are
     // keys created for change addresses, coinbases, mixing, etc - anything that isn't communicated. The distinction
@@ -116,14 +116,14 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
     // a payment request that can generate lots of addresses independently.
     // The account path may be overridden by subclasses.
     // m / 0'
-    public static final ImmutableList<ChildNumber> ACCOUNT_ZERO_PATH = ImmutableList.of(ChildNumber.ZERO_HARDENED);
+    public static final HDPath ACCOUNT_ZERO_PATH = HDPath.of(ChildNumber.ZERO_HARDENED);
     // m / 1'
-    public static final ImmutableList<ChildNumber> ACCOUNT_ONE_PATH = ImmutableList.of(ChildNumber.ONE_HARDENED);
+    public static final HDPath ACCOUNT_ONE_PATH = HDPath.of(ChildNumber.ONE_HARDENED);
     // m / 44' / 0' / 0'
-    public static final ImmutableList<ChildNumber> BIP44_ACCOUNT_ZERO_PATH = ImmutableList.of(new ChildNumber(44, true),
-            ChildNumber.ZERO_HARDENED, ChildNumber.ZERO_HARDENED);
-    public static final ImmutableList<ChildNumber> EXTERNAL_SUBPATH = ImmutableList.of(ChildNumber.ZERO);
-    public static final ImmutableList<ChildNumber> INTERNAL_SUBPATH = ImmutableList.of(ChildNumber.ONE);
+    public static final HDPath BIP44_ACCOUNT_ZERO_PATH = HDPath.of(new ChildNumber(44, true))
+                        .extend(ChildNumber.ZERO_HARDENED, ChildNumber.ZERO_HARDENED);
+    public static final HDPath EXTERNAL_SUBPATH = HDPath.of(ChildNumber.ZERO);
+    public static final HDPath INTERNAL_SUBPATH = HDPath.of(ChildNumber.ONE);
 
     // We try to ensure we have at least this many keys ready and waiting to be handed out via getKey().
     // See docs for getLookaheadSize() for more info on what this is for. The -1 value means it hasn't been calculated
@@ -176,7 +176,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
         protected DeterministicKey watchingKey = null;
         protected boolean isFollowing = false;
         protected DeterministicKey spendingKey = null;
-        protected ImmutableList<ChildNumber> accountPath = null;
+        protected HDPath accountPath = null;
 
         protected Builder() {
         }
@@ -276,9 +276,9 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
         /**
          * Use an account path other than the default {@link DeterministicKeyChain#ACCOUNT_ZERO_PATH}.
          */
-        public T accountPath(ImmutableList<ChildNumber> accountPath) {
+        public T accountPath(List<ChildNumber> accountPath) {
             checkState(watchingKey == null, "either watch or accountPath");
-            this.accountPath = checkNotNull(accountPath);
+            this.accountPath = HDPath.of(checkNotNull(accountPath));
             return self();
         }
 
@@ -360,11 +360,11 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
      * </p>
      */
     protected DeterministicKeyChain(DeterministicSeed seed, @Nullable KeyCrypter crypter,
-            Script.ScriptType outputScriptType, ImmutableList<ChildNumber> accountPath) {
+            Script.ScriptType outputScriptType, List<ChildNumber> accountPath) {
         checkArgument(outputScriptType == null || outputScriptType == Script.ScriptType.P2PKH
                 || outputScriptType == Script.ScriptType.P2WPKH, "Only P2PKH or P2WPKH allowed.");
         this.outputScriptType = outputScriptType != null ? outputScriptType : Script.ScriptType.P2PKH;
-        this.accountPath = accountPath;
+        this.accountPath = HDPath.of(accountPath);
         this.seed = seed;
         basicKeyChain = new BasicKeyChain(crypter);
         if (!seed.isEncrypted()) {
@@ -386,7 +386,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
      * For use in encryption when {@link #toEncrypted(KeyCrypter, KeyParameter)} is called, so that
      * subclasses can override that method and create an instance of the right class.
      *
-     * See also {@link #makeKeyChainFromSeed(DeterministicSeed, ImmutableList, Script.ScriptType)}
+     * See also {@link #makeKeyChainFromSeed(DeterministicSeed, List, Script.ScriptType)}
      */
     protected DeterministicKeyChain(KeyCrypter crypter, KeyParameter aesKey, DeterministicKeyChain chain) {
         // Can't encrypt a watching chain.
@@ -430,7 +430,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
         }
     }
 
-    public ImmutableList<ChildNumber> getAccountPath() {
+    public HDPath getAccountPath() {
         return accountPath;
     }
 
@@ -439,7 +439,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
     }
 
     private DeterministicKey encryptNonLeaf(KeyParameter aesKey, DeterministicKeyChain chain,
-                                            DeterministicKey parent, ImmutableList<ChildNumber> path) {
+                                            DeterministicKey parent, List<ChildNumber> path) {
         DeterministicKey key = chain.hierarchy.get(path, false, false);
         key = key.encrypt(checkNotNull(basicKeyChain.getKeyCrypter()), aesKey, parent);
         hierarchy.putKey(key);
@@ -505,7 +505,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
             basicKeyChain.importKeys(lookahead);
             List<DeterministicKey> keys = new ArrayList<>(numberOfKeys);
             for (int i = 0; i < numberOfKeys; i++) {
-                ImmutableList<ChildNumber> path = HDUtils.append(parentKey.getPath(), new ChildNumber(index - numberOfKeys + i, false));
+                HDPath path = HDUtils.append(parentKey.getPath(), new ChildNumber(index - numberOfKeys + i, false));
                 DeterministicKey k = hierarchy.get(path, false, false);
                 // Just a last minute sanity check before we hand the key out to the app for usage. This isn't inspired
                 // by any real problem reports from bitcoinj users, but I've heard of cases via the grapevine of
@@ -615,7 +615,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
 
     /** Returns the deterministic key for the given absolute path in the hierarchy. */
     protected DeterministicKey getKeyByPath(ChildNumber... path) {
-        return getKeyByPath(ImmutableList.copyOf(path));
+        return getKeyByPath(HDPath.of(Arrays.asList(path)));
     }
 
     /** Returns the deterministic key for the given absolute path in the hierarchy. */
@@ -860,7 +860,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
                     path.add(new ChildNumber(i));
                 // Deserialize the public key and path.
                 LazyECPoint pubkey = new LazyECPoint(ECKey.CURVE.getCurve(), key.getPublicKey().toByteArray());
-                final ImmutableList<ChildNumber> immutablePath = ImmutableList.copyOf(path);
+                final HDPath immutablePath = HDPath.of(path);
                 if (key.hasOutputScriptType())
                     outputScriptType = Script.ScriptType.valueOf(key.getOutputScriptType().name());
                 // Possibly create the chain, if we didn't already do so yet.
@@ -898,7 +898,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
                         isWatchingAccountKey = true;
                     } else {
                         chain = factory.makeKeyChain(seed, crypter, isMarried,
-                                outputScriptType, ImmutableList.<ChildNumber> builder().addAll(accountPath).build());
+                                outputScriptType, HDPath.of(accountPath));
                         chain.lookaheadSize = LAZY_CALCULATE_LOOKAHEAD;
                         // If the seed is encrypted, then the chain is incomplete at this point. However, we will load
                         // it up below as we parse in the keys. We just need to check at the end that we've loaded
@@ -1043,7 +1043,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
      * Subclasses should override this to create an instance of the subclass instead of a plain DKC.
      * This is used in encryption/decryption.
      */
-    protected DeterministicKeyChain makeKeyChainFromSeed(DeterministicSeed seed, ImmutableList<ChildNumber> accountPath,
+    protected DeterministicKeyChain makeKeyChainFromSeed(DeterministicSeed seed, List<ChildNumber> accountPath,
             Script.ScriptType outputScriptType) {
         return new DeterministicKeyChain(seed, null, outputScriptType, accountPath);
     }

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainFactory.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainFactory.java
@@ -17,11 +17,12 @@
 
 package org.bitcoinj.wallet;
 
-import com.google.common.collect.ImmutableList;
 import org.bitcoinj.crypto.ChildNumber;
 import org.bitcoinj.crypto.DeterministicKey;
 import org.bitcoinj.crypto.KeyCrypter;
 import org.bitcoinj.script.Script;
+
+import java.util.List;
 
 /**
  * Factory interface for creation keychains while de-serializing a wallet.
@@ -37,7 +38,7 @@ public interface KeyChainFactory {
      * @param accountPath account path to generate receiving addresses on
      */
     DeterministicKeyChain makeKeyChain(DeterministicSeed seed, KeyCrypter crypter, boolean isMarried,
-            Script.ScriptType outputScriptType, ImmutableList<ChildNumber> accountPath);
+            Script.ScriptType outputScriptType, List<ChildNumber> accountPath);
 
     /**
      * Make a watching keychain.

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroupStructure.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroupStructure.java
@@ -16,20 +16,18 @@
 
 package org.bitcoinj.wallet;
 
-import org.bitcoinj.crypto.ChildNumber;
+import org.bitcoinj.crypto.HDPath;
 import org.bitcoinj.script.Script;
-
-import com.google.common.collect.ImmutableList;
 
 /** Defines a structure for hierarchical deterministic wallets. */
 public interface KeyChainGroupStructure {
     /** Map desired output script type to an account path */
-    ImmutableList<ChildNumber> accountPathFor(Script.ScriptType outputScriptType);
+    HDPath accountPathFor(Script.ScriptType outputScriptType);
 
     /** Default {@link KeyChainGroupStructure} implementation. Based on BIP32 "Wallet structure". */
     public static final KeyChainGroupStructure DEFAULT = new KeyChainGroupStructure() {
         @Override
-        public ImmutableList<ChildNumber> accountPathFor(Script.ScriptType outputScriptType) {
+        public HDPath accountPathFor(Script.ScriptType outputScriptType) {
             if (outputScriptType == null || outputScriptType == Script.ScriptType.P2PKH)
                 return DeterministicKeyChain.ACCOUNT_ZERO_PATH;
             else if (outputScriptType == Script.ScriptType.P2WPKH)

--- a/core/src/main/java/org/bitcoinj/wallet/MarriedKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/MarriedKeyChain.java
@@ -133,7 +133,7 @@ public class MarriedKeyChain extends DeterministicKeyChain {
      * This constructor is not stable across releases! If you need a stable API, use {@link #builder()} to use a
      * {@link Builder}.
      */
-    protected MarriedKeyChain(DeterministicSeed seed, KeyCrypter crypter, Script.ScriptType outputScriptType, ImmutableList<ChildNumber> accountPath) {
+    protected MarriedKeyChain(DeterministicSeed seed, KeyCrypter crypter, Script.ScriptType outputScriptType, List<ChildNumber> accountPath) {
         super(seed, crypter, outputScriptType, accountPath);
     }
 

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -333,7 +333,7 @@ public class Wallet extends BaseTaggableObject
      * @return an instance of a wallet from a deterministic seed.
      */
     public static Wallet fromSeed(NetworkParameters params, DeterministicSeed seed, Script.ScriptType outputScriptType,
-            ImmutableList<ChildNumber> accountPath) {
+            List<ChildNumber> accountPath) {
         DeterministicKeyChain chain = DeterministicKeyChain.builder().seed(seed).outputScriptType(outputScriptType)
                 .accountPath(accountPath).build();
         return new Wallet(params, KeyChainGroup.builder(params).addChain(chain).build());
@@ -344,10 +344,10 @@ public class Wallet extends BaseTaggableObject
      * @param seed deterministic seed
      * @param accountPath account path
      * @return an instance of a wallet from a deterministic seed.
-     * @deprecated Use {@link #fromSeed(NetworkParameters, DeterministicSeed, ScriptType, ImmutableList)}
+     * @deprecated Use {@link #fromSeed(NetworkParameters, DeterministicSeed, ScriptType, List)}
      */
     @Deprecated
-    public static Wallet fromSeed(NetworkParameters params, DeterministicSeed seed, ImmutableList<ChildNumber> accountPath) {
+    public static Wallet fromSeed(NetworkParameters params, DeterministicSeed seed, List<ChildNumber> accountPath) {
         return fromSeed(params, seed, Script.ScriptType.P2PKH, accountPath);
     }
 

--- a/core/src/test/java/org/bitcoinj/testing/KeyChainTransactionSigner.java
+++ b/core/src/test/java/org/bitcoinj/testing/KeyChainTransactionSigner.java
@@ -44,7 +44,7 @@ public class KeyChainTransactionSigner extends CustomTransactionSigner {
 
     @Override
     protected SignatureAndKey getSignature(Sha256Hash sighash, List<ChildNumber> derivationPath) {
-        ImmutableList<ChildNumber> keyPath = ImmutableList.copyOf(derivationPath);
+        List<ChildNumber> keyPath = ImmutableList.copyOf(derivationPath);
         DeterministicKey key = keyChain.getKeyByPath(keyPath, true);
         return new SignatureAndKey(key.sign(sighash), key.dropPrivateBytes().dropParent());
     }

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -56,7 +56,7 @@ public class DeterministicKeyChainTest {
     private final byte[] ENTROPY = Sha256Hash.hash("don't use a string seed like this in real life".getBytes());
     private static final NetworkParameters UNITTEST = UnitTestParams.get();
     private static final NetworkParameters MAINNET = MainNetParams.get();
-    private static final ImmutableList<ChildNumber> BIP44_COIN_1_ACCOUNT_ZERO_PATH = ImmutableList.of(new ChildNumber(44, true),
+    private static final List<ChildNumber> BIP44_COIN_1_ACCOUNT_ZERO_PATH = ImmutableList.of(new ChildNumber(44, true),
             new ChildNumber(1, true), ChildNumber.ZERO_HARDENED);
 
     @Before
@@ -112,7 +112,7 @@ public class DeterministicKeyChainTest {
     @Test
     public void deriveAccountOne() throws Exception {
         final long secs = 1389353062L;
-        final ImmutableList<ChildNumber> accountOne = ImmutableList.of(ChildNumber.ONE);
+        final List<ChildNumber> accountOne = ImmutableList.of(ChildNumber.ONE);
         DeterministicKeyChain chain1 = DeterministicKeyChain.builder().accountPath(accountOne)
                 .entropy(ENTROPY, secs).build();
         ECKey key1 = chain1.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
@@ -134,7 +134,7 @@ public class DeterministicKeyChainTest {
     @Test
     public void serializeAccountOne() throws Exception {
         final long secs = 1389353062L;
-        final ImmutableList<ChildNumber> accountOne = ImmutableList.of(ChildNumber.ONE);
+        final List<ChildNumber> accountOne = ImmutableList.of(ChildNumber.ONE);
         DeterministicKeyChain chain1 = DeterministicKeyChain.builder().accountPath(accountOne)
                 .entropy(ENTROPY, secs).build();
         ECKey key1 = chain1.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
@@ -468,7 +468,7 @@ public class DeterministicKeyChainTest {
     @Test
     public void watchingChainAccountOne() throws UnreadableWalletException {
         Utils.setMockClock();
-        final ImmutableList<ChildNumber> accountOne = ImmutableList.of(ChildNumber.ONE);
+        final List<ChildNumber> accountOne = ImmutableList.of(ChildNumber.ONE);
         DeterministicKeyChain chain1 = DeterministicKeyChain.builder().accountPath(accountOne)
                 .seed(chain.getSeed()).build();
         DeterministicKey key1 = chain1.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
@@ -591,7 +591,7 @@ public class DeterministicKeyChainTest {
     public void spendingChainAccountTwo() throws UnreadableWalletException {
         Utils.setMockClock();
         final long secs = 1389353062L;
-        final ImmutableList<ChildNumber> accountTwo = ImmutableList.of(new ChildNumber(2, true));
+        final List<ChildNumber> accountTwo = ImmutableList.of(new ChildNumber(2, true));
         chain = DeterministicKeyChain.builder().accountPath(accountTwo).entropy(ENTROPY, secs).build();
         DeterministicKey firstReceiveKey = chain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         DeterministicKey secondReceiveKey = chain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -3033,7 +3033,7 @@ public class WalletTest extends TestWithWallet {
         int numIssuedExternal = activeKeyChain.getIssuedExternalKeys();
         DeterministicKey rootKey = wallet.getActiveKeyChain().getRootKey();
         DeterministicKey watchingKey = activeKeyChain.getWatchingKey();
-        ImmutableList<ChildNumber> accountPath = activeKeyChain.getAccountPath();
+        HDPath accountPath = activeKeyChain.getAccountPath();
         Script.ScriptType outputScriptType = activeKeyChain.getOutputScriptType();
 
         Protos.Wallet protos = new WalletProtobufSerializer().walletToProto(wallet);


### PR DESCRIPTION
`HDPath` replaces `ImmutableList<ChildNumber>` as the preferred representation for a hierarchical deterministic path.

Some methods take `List<ChildNumber>` as a parameter which will accept `ImmutableList<ChildNumber>`. Since `HDPath` implements `List<ChildNumber>`, if you're calling a method that now returns `HDPath`, you can change the receiving variable from `ImmutableList<ChildNumber>` to `List<ChildNumber>` or even call `ImmutableList.copyOf()` if necessary.