### PR TITLE
Move AppDataDirectory.java to o.b.utils in core

### DIFF
--- a/core/src/main/java/org/bitcoinj/utils/BlockFileLoader.java
+++ b/core/src/main/java/org/bitcoinj/utils/BlockFileLoader.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -71,15 +72,9 @@ public class BlockFileLoader implements Iterable<Block>, Iterator<Block> {
     }
 
     public static File defaultBlocksDir() {
-        final File defaultBlocksDir;
-        if (Utils.isWindows()) {
-            defaultBlocksDir = new File(System.getenv("APPDATA") + "\\.bitcoin\\blocks\\");
-        } else if (Utils.isMac()) {
-            defaultBlocksDir = new File(System.getProperty("user.home") + "/Library/Application Support/Bitcoin/blocks/");
-        } else if (Utils.isLinux()) {
-            defaultBlocksDir = new File(System.getProperty("user.home") + "/.bitcoin/blocks/");
-        } else {
-            throw new RuntimeException("Unsupported system");
+        File defaultBlocksDir = AppDataDirectory.getPath("Bitcoin").resolve("blocks").toFile();
+        if (!defaultBlocksDir.isDirectory()) {
+            throw new RuntimeException("Default blocks directory not found");
         }
         return defaultBlocksDir;
     }

--- a/core/src/test/java/org/bitcoinj/utils/AppDataDirectoryTest.java
+++ b/core/src/test/java/org/bitcoinj/utils/AppDataDirectoryTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Michael Sean Gilligan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.utils;
+
+import org.bitcoinj.core.Utils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Basic test of AppDataDirectory
+ */
+public class AppDataDirectoryTest {
+    static final String HOMEDIR = System.getProperty("user.home");
+    static final String WINAPPDATA = System.getenv("APPDATA");
+
+    @Test
+    public void worksOnCurrentPlatform() {
+        final String appName = "bitcoinj";
+        String path = AppDataDirectory.get(appName).toString();
+        if (Utils.isWindows()) {
+            assertEquals("Path wrong on Mac", winPath(appName), path);
+        } else if (Utils.isMac()) {
+            assertEquals("Path wrong on Mac",  macPath(appName), path);
+        } else if (Utils.isLinux()) {
+            assertEquals("Path wrong on Linux",  unixPath(appName), path);
+        } else {
+            assertEquals("Path wrong on unknown/default",  unixPath(appName), path);
+        }
+    }
+
+    @Test
+    public void worksOnCurrentPlatformForBitcoinCore() {
+        final String appName = "Bitcoin";
+        String path = AppDataDirectory.get(appName).toString();
+        if (Utils.isWindows()) {
+            assertEquals("Path wrong on Mac", winPath(appName), path);
+        } else if (Utils.isMac()) {
+            assertEquals("Path wrong on Mac",  macPath(appName), path);
+        } else if (Utils.isLinux()) {
+            assertEquals("Path wrong on Linux",  unixPath(appName), path);
+        } else {
+            assertEquals("Path wrong on unknown/default",  unixPath(appName), path);
+        }
+    }
+
+    private static String winPath(String appName) {
+        return WINAPPDATA + "\\." + appName.toLowerCase();
+    }
+
+    private static String macPath(String appName) {
+        return HOMEDIR + "/Library/Application Support/" + appName;
+    }
+
+    private static String unixPath(String appName) {
+        return HOMEDIR + "/." + appName.toLowerCase();
+    }
+}

--- a/wallettemplate/src/main/java/wallettemplate/Main.java
+++ b/wallettemplate/src/main/java/wallettemplate/Main.java
@@ -18,6 +18,7 @@ package wallettemplate;
 
 import com.google.common.util.concurrent.*;
 import javafx.scene.input.*;
+import org.bitcoinj.utils.AppDataDirectory;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Utils;
 import org.bitcoinj.kits.WalletAppKit;
@@ -35,7 +36,6 @@ import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import wallettemplate.controls.NotificationBarPane;
-import wallettemplate.utils.AppDataDirectory;
 import wallettemplate.utils.GuiUtils;
 import wallettemplate.utils.TextFieldValidator;
 


### PR DESCRIPTION
This will allow usage in both `wallettemplate` and `tools` and to replace
similar code in `BlockFileLoader.java` in `core`.
Required minor back-port of `Path.of()` functionality from JDK11.