### PR TITLE
Use lower-case appName for data dir on Windows/Linux/Unix

### DIFF
--- a/wallettemplate/src/main/java/wallettemplate/utils/AppDataDirectory.java
+++ b/wallettemplate/src/main/java/wallettemplate/utils/AppDataDirectory.java
@@ -49,14 +49,14 @@ public class AppDataDirectory {
         final Path applicationDataDirectory;
 
         if (Utils.isWindows()) {
-            applicationDataDirectory = Path.of(System.getenv("APPDATA"), appName);
+            applicationDataDirectory = Path.of(System.getenv("APPDATA"), appName.toLowerCase());
         } else if (Utils.isMac()) {
             applicationDataDirectory = Path.of(System.getProperty("user.home"),"Library/Application Support", appName);
         } else if (Utils.isLinux()) {
-            applicationDataDirectory = Path.of(System.getProperty("user.home"), "." + appName);
+            applicationDataDirectory = Path.of(System.getProperty("user.home"), "." + appName.toLowerCase());
         } else {
             // Unknown, assume unix-like
-            applicationDataDirectory = Path.of(System.getProperty("user.home"), "." + appName);
+            applicationDataDirectory = Path.of(System.getProperty("user.home"), "." + appName.toLowerCase());
         }
         return applicationDataDirectory;
     }


### PR DESCRIPTION
This is a bug fix, since `AppDataDirectory` was intended to match the directory names used by Bitcoin Core. Thus we need to convert `appName` to lowercase on Windows, Linux, and Unix.

See PR #1878 for previous discussion.