### PR TITLE
HDPath M() and m() factory methods

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicHierarchy.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicHierarchy.java
@@ -79,7 +79,7 @@ public class DeterministicHierarchy {
      * @throws IllegalArgumentException if create is false and the path was not found.
      */
     public DeterministicKey get(List<ChildNumber> path, boolean relativePath, boolean create) {
-        HDPath inputPath = HDPath.of(path);
+        HDPath inputPath = HDPath.M(path);
         HDPath absolutePath = relativePath
                 ? rootPath.extend(path)
                 : inputPath;

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -70,7 +70,7 @@ public class DeterministicKey extends ECKey {
         super(priv, compressPoint(checkNotNull(publicAsPoint)));
         checkArgument(chainCode.length == 32);
         this.parent = parent;
-        this.childNumberPath = HDPath.of(checkNotNull(childNumberPath));
+        this.childNumberPath = HDPath.M(checkNotNull(childNumberPath));
         this.chainCode = Arrays.copyOf(chainCode, chainCode.length);
         this.depth = parent == null ? 0 : parent.depth + 1;
         this.parentFingerprint = (parent != null) ? parent.getFingerprint() : 0;
@@ -92,7 +92,7 @@ public class DeterministicKey extends ECKey {
         super(priv, compressPoint(ECKey.publicPointFromPrivate(priv)));
         checkArgument(chainCode.length == 32);
         this.parent = parent;
-        this.childNumberPath = HDPath.of(checkNotNull(childNumberPath));
+        this.childNumberPath = HDPath.M(checkNotNull(childNumberPath));
         this.chainCode = Arrays.copyOf(chainCode, chainCode.length);
         this.depth = parent == null ? 0 : parent.depth + 1;
         this.parentFingerprint = (parent != null) ? parent.getFingerprint() : 0;
@@ -140,7 +140,7 @@ public class DeterministicKey extends ECKey {
         super(null, compressPoint(checkNotNull(publicAsPoint)));
         checkArgument(chainCode.length == 32);
         this.parent = parent;
-        this.childNumberPath = HDPath.of(checkNotNull(childNumberPath));
+        this.childNumberPath = HDPath.M(checkNotNull(childNumberPath));
         this.chainCode = Arrays.copyOf(chainCode, chainCode.length);
         this.depth = depth;
         this.parentFingerprint = ascertainParentFingerprint(parent, parentFingerprint);
@@ -160,7 +160,7 @@ public class DeterministicKey extends ECKey {
         super(priv, compressPoint(ECKey.publicPointFromPrivate(priv)));
         checkArgument(chainCode.length == 32);
         this.parent = parent;
-        this.childNumberPath = HDPath.of(checkNotNull(childNumberPath));
+        this.childNumberPath = HDPath.M(checkNotNull(childNumberPath));
         this.chainCode = Arrays.copyOf(chainCode, chainCode.length);
         this.depth = depth;
         this.parentFingerprint = ascertainParentFingerprint(parent, parentFingerprint);
@@ -567,8 +567,8 @@ public class DeterministicKey extends ECKey {
                 // This can happen when deserializing an account key for a watching wallet.  In this case, we assume that
                 // the client wants to conceal the key's position in the hierarchy.  The path is truncated at the
                 // parent's node.
-                path = HDPath.of(childNumber);
-            else path = HDPath.of();
+                path = HDPath.M(childNumber);
+            else path = HDPath.M();
         }
         byte[] chainCode = new byte[32];
         buffer.get(chainCode);

--- a/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
@@ -83,7 +83,7 @@ public final class HDKeyDerivation {
     public static DeterministicKey createMasterPrivKeyFromBytes(byte[] privKeyBytes, byte[] chainCode)
             throws HDDerivationException {
         // childNumberPath is an empty list because we are creating the root key.
-        return createMasterPrivKeyFromBytes(privKeyBytes, chainCode, HDPath.of());
+        return createMasterPrivKeyFromBytes(privKeyBytes, chainCode, HDPath.M());
     }
 
     /**
@@ -98,7 +98,7 @@ public final class HDKeyDerivation {
     }
 
     public static DeterministicKey createMasterPubKeyFromBytes(byte[] pubKeyBytes, byte[] chainCode) {
-        return new DeterministicKey(HDPath.of(), chainCode, new LazyECPoint(ECKey.CURVE.getCurve(), pubKeyBytes), null, null);
+        return new DeterministicKey(HDPath.M(), chainCode, new LazyECPoint(ECKey.CURVE.getCurve(), pubKeyBytes), null, null);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/crypto/HDPath.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDPath.java
@@ -26,7 +26,7 @@ import java.util.List;
 /**
  * HD Key derivation path. {@code HDPath} can be used to represent a full path or a relative path.
  * The {@code hasPrivateKey} {@code boolean} is used for rendering to {@code String}
- * but (at present) not much else. It defaults to {@code false} which will also be the setting for a relative path.
+ * but (at present) not much else. It defaults to {@code false} which is the preferred setting for a relative path.
  * <p>
  * {@code HDPath} is immutable and uses the {@code Collections.UnmodifiableList} type internally.
  * <p>
@@ -34,6 +34,9 @@ import java.util.List;
  * from the previous Guava {@code ImmutableList<ChildNumber>}. It should be a minor breaking change
  * to replace {@code ImmutableList<ChildNumber>} with {@code List<ChildNumber>} where necessary in your code. Although
  * it is recommended to use the {@code HDPath} type for clarity and for access to {@code HDPath}-specific functionality.
+ * <p>
+ * Take note of the overloaded factory methods {@link HDPath#M()} and {@link HDPath#m()}. These can be used to very
+ * concisely create HDPath objects (especially when statically imported.)
  */
 public class HDPath extends AbstractList<ChildNumber> {
     private static final char PREFIX_PRIVATE = 'm';
@@ -42,29 +45,102 @@ public class HDPath extends AbstractList<ChildNumber> {
     protected final boolean hasPrivateKey;
     protected final List<ChildNumber> unmodifiableList;
 
+    /**
+     * Constructs a path for a public or private key.
+     *
+     * @param hasPrivateKey Whether it is a path to a private key or not
+     * @param list List of children in the path
+     */
     public HDPath(boolean hasPrivateKey, List<ChildNumber> list) {
         this.hasPrivateKey = hasPrivateKey;
         this.unmodifiableList = Collections.unmodifiableList(list);
     }
 
+    /**
+     * Constructs a path for a public key.
+     *
+     * @param list List of children in the path
+     */
     public HDPath(List<ChildNumber> list) {
         this(false, list);
     }
 
+    /**
+     * Returns a path for a public or private key.
+     *
+     * @param hasPrivateKey Whether it is a path to a private key or not
+     * @param list List of children in the path
+     */
     private static HDPath of(boolean hasPrivateKey, List<ChildNumber> list) {
         return new HDPath(hasPrivateKey, list);
     }
 
-    public static HDPath of(List<ChildNumber> list) {
+    /**
+     * Returns a path for a public key.
+     *
+     * @param list List of children in the path
+     */
+    public static HDPath M(List<ChildNumber> list) {
         return HDPath.of(false, list);
     }
 
-    public static HDPath of(ChildNumber childNumber) {
-        return HDPath.of(Collections.singletonList(childNumber));
+    /**
+     * Returns an empty path for a public key.
+     */
+    public static HDPath M() {
+        return HDPath.M(Collections.<ChildNumber>emptyList());
     }
 
-    public static HDPath of() {
-        return HDPath.of(Collections.<ChildNumber>emptyList());
+    /**
+     * Returns a path for a public key.
+     *
+     * @param childNumber Single child in path
+     */
+    public static HDPath M(ChildNumber childNumber) {
+        return HDPath.M(Collections.singletonList(childNumber));
+    }
+
+    /**
+     * Returns a path for a public key.
+     *
+     * @param children Children in the path
+     */
+    public static HDPath M(ChildNumber... children) {
+        return HDPath.M(Arrays.asList(children));
+    }
+
+    /**
+     * Returns a path for a private key.
+     *
+     * @param list List of children in the path
+     */
+    public static HDPath m(List<ChildNumber> list) {
+        return HDPath.of(true, list);
+    }
+
+    /**
+     * Returns an empty path for a private key.
+     */
+    public static HDPath m() {
+        return HDPath.m(Collections.<ChildNumber>emptyList());
+    }
+
+    /**
+     * Returns a path for a private key.
+     *
+     * @param childNumber Single child in path
+     */
+    public static HDPath m(ChildNumber childNumber) {
+        return HDPath.m(Collections.singletonList(childNumber));
+    }
+
+    /**
+     * Returns a path for a private key.
+     *
+     * @param children Children in the path
+     */
+    public static HDPath m(ChildNumber... children) {
+        return HDPath.m(Arrays.asList(children));
     }
 
     /**
@@ -132,7 +208,7 @@ public class HDPath extends AbstractList<ChildNumber> {
      * @return A new immutable path
      */
     public HDPath extend(List<ChildNumber> path2) {
-        return this.extend(HDPath.of(path2));
+        return this.extend(HDPath.M(path2));
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/crypto/HDUtils.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDUtils.java
@@ -88,7 +88,7 @@ public final class HDUtils {
      */
     @Deprecated
     public static String formatPath(List<ChildNumber> path) {
-        return HDPath.of(path).toString();
+        return HDPath.M(path).toString();
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -114,14 +114,14 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
     // a payment request that can generate lots of addresses independently.
     // The account path may be overridden by subclasses.
     // m / 0'
-    public static final HDPath ACCOUNT_ZERO_PATH = HDPath.of(ChildNumber.ZERO_HARDENED);
+    public static final HDPath ACCOUNT_ZERO_PATH = HDPath.M(ChildNumber.ZERO_HARDENED);
     // m / 1'
-    public static final HDPath ACCOUNT_ONE_PATH = HDPath.of(ChildNumber.ONE_HARDENED);
+    public static final HDPath ACCOUNT_ONE_PATH = HDPath.M(ChildNumber.ONE_HARDENED);
     // m / 44' / 0' / 0'
-    public static final HDPath BIP44_ACCOUNT_ZERO_PATH = HDPath.of(new ChildNumber(44, true))
+    public static final HDPath BIP44_ACCOUNT_ZERO_PATH = HDPath.M(new ChildNumber(44, true))
                         .extend(ChildNumber.ZERO_HARDENED, ChildNumber.ZERO_HARDENED);
-    public static final HDPath EXTERNAL_SUBPATH = HDPath.of(ChildNumber.ZERO);
-    public static final HDPath INTERNAL_SUBPATH = HDPath.of(ChildNumber.ONE);
+    public static final HDPath EXTERNAL_SUBPATH = HDPath.M(ChildNumber.ZERO);
+    public static final HDPath INTERNAL_SUBPATH = HDPath.M(ChildNumber.ONE);
 
     // We try to ensure we have at least this many keys ready and waiting to be handed out via getKey().
     // See docs for getLookaheadSize() for more info on what this is for. The -1 value means it hasn't been calculated
@@ -276,7 +276,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
          */
         public T accountPath(List<ChildNumber> accountPath) {
             checkState(watchingKey == null, "either watch or accountPath");
-            this.accountPath = HDPath.of(checkNotNull(accountPath));
+            this.accountPath = HDPath.M(checkNotNull(accountPath));
             return self();
         }
 
@@ -362,7 +362,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
         checkArgument(outputScriptType == null || outputScriptType == Script.ScriptType.P2PKH
                 || outputScriptType == Script.ScriptType.P2WPKH, "Only P2PKH or P2WPKH allowed.");
         this.outputScriptType = outputScriptType != null ? outputScriptType : Script.ScriptType.P2PKH;
-        this.accountPath = HDPath.of(accountPath);
+        this.accountPath = HDPath.M(accountPath);
         this.seed = seed;
         basicKeyChain = new BasicKeyChain(crypter);
         if (!seed.isEncrypted()) {
@@ -613,7 +613,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
 
     /** Returns the deterministic key for the given absolute path in the hierarchy. */
     protected DeterministicKey getKeyByPath(ChildNumber... path) {
-        return getKeyByPath(HDPath.of(Arrays.asList(path)));
+        return getKeyByPath(HDPath.M(Arrays.asList(path)));
     }
 
     /** Returns the deterministic key for the given absolute path in the hierarchy. */
@@ -858,7 +858,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
                     path.add(new ChildNumber(i));
                 // Deserialize the public key and path.
                 LazyECPoint pubkey = new LazyECPoint(ECKey.CURVE.getCurve(), key.getPublicKey().toByteArray());
-                final HDPath immutablePath = HDPath.of(path);
+                final HDPath immutablePath = HDPath.M(path);
                 if (key.hasOutputScriptType())
                     outputScriptType = Script.ScriptType.valueOf(key.getOutputScriptType().name());
                 // Possibly create the chain, if we didn't already do so yet.
@@ -896,7 +896,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
                         isWatchingAccountKey = true;
                     } else {
                         chain = factory.makeKeyChain(seed, crypter, isMarried,
-                                outputScriptType, HDPath.of(accountPath));
+                                outputScriptType, HDPath.M(accountPath));
                         chain.lookaheadSize = LAZY_CALCULATE_LOOKAHEAD;
                         // If the seed is encrypted, then the chain is incomplete at this point. However, we will load
                         // it up below as we parse in the keys. We just need to check at the end that we've loaded


### PR DESCRIPTION
Refactor existing `of()` factory methods to `M()` (for public key) and
add `m()` methods for private keys. Also add methods taking varargs.

(This should probably be rebased on top of PR #1895 or merged with it.)