### PR TITLE
Replace deprecated Guava `Maps.newHashMap()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicHierarchy.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicHierarchy.java
@@ -16,8 +16,7 @@
 
 package org.bitcoinj.crypto;
 
-import com.google.common.collect.Maps;
-
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -40,10 +39,10 @@ import static com.google.common.base.Preconditions.checkArgument;
  * is a list of {@link ChildNumber}s.</p>
  */
 public class DeterministicHierarchy {
-    private final Map<HDPath, DeterministicKey> keys = Maps.newHashMap();
+    private final Map<HDPath, DeterministicKey> keys = new HashMap<>();
     private final HDPath rootPath;
     // Keep track of how many child keys each node has. This is kind of weak.
-    private final Map<HDPath, ChildNumber> lastChildNumbers = Maps.newHashMap();
+    private final Map<HDPath, ChildNumber> lastChildNumbers = new HashMap<>();
 
     public static final int BIP32_STANDARDISATION_TIME_SECS = 1369267200;
 


### PR DESCRIPTION
For JDK7+ `new` with the diamond syntax is preferred.