### PR TITLE
Fix NPE in o.b.c.Utils runtime and os detection

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Utils.java
+++ b/core/src/main/java/org/bitcoinj/core/Utils.java
@@ -563,8 +563,8 @@ public class Utils {
     private static Runtime runtime = null;
     private static OS os = null;
     static {
-        String runtimeProp = System.getProperty("java.runtime.name").toLowerCase(Locale.US);
-        if (runtimeProp == null)
+        String runtimeProp = System.getProperty("java.runtime.name", "").toLowerCase(Locale.US);
+        if (runtimeProp.equals(""))
             runtime = null;
         else if (runtimeProp.contains("android"))
             runtime = Runtime.ANDROID;
@@ -575,8 +575,8 @@ public class Utils {
         else
             log.info("Unknown java.runtime.name '{}'", runtimeProp);
 
-        String osProp = System.getProperty("os.name").toLowerCase(Locale.US);
-        if (osProp == null)
+        String osProp = System.getProperty("os.name", "").toLowerCase(Locale.US);
+        if (osProp.equals(""))
             os = null;
         else if (osProp.contains("linux"))
             os = OS.LINUX;


### PR DESCRIPTION
If `getProperty()` returns `null`, calling `.toLowerCase()` results in a `NullPointerException`. Instead
we’ll provide a default fallback value and check for `.equals(“”`) in the following `if` statement.

Note: I found the NPE when compiling/running with native-image/SubstrateVM.