### PR TITLE
DeterministicKey#toString creationTimeSeconds fix for Issue #1899

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -631,8 +631,11 @@ public class DeterministicKey extends ECKey {
         helper.add("pub", Utils.HEX.encode(pub.getEncoded()));
         helper.add("chainCode", HEX.encode(chainCode));
         helper.add("path", getPathAsString());
-        if (creationTimeSeconds > 0)
-            helper.add("creationTimeSeconds", creationTimeSeconds);
+        if (parent != null) {
+            helper.add("creationTimeSeconds (from parent)", getCreationTimeSeconds());
+        } else {
+            helper.add("creationTimeSeconds", getCreationTimeSeconds());
+        }
         helper.add("isEncrypted", isEncrypted());
         helper.add("isPubKeyOnly", isPubKeyOnly());
         return helper.toString();


### PR DESCRIPTION
See Issue #1899

toString() output of creation time now corresponds with
getCreationTimeSeconds(), but we indicate if the creation time came
from the parent.