### PR TITLE
Fix AppDataDirectoryTest on macOS

### DIFF
--- a/core/src/test/java/org/bitcoinj/utils/AppDataDirectoryTest.java
+++ b/core/src/test/java/org/bitcoinj/utils/AppDataDirectoryTest.java
@@ -67,8 +67,8 @@ public class AppDataDirectoryTest {
             AppDataDirectory.get("/");
         }
         if (Utils.isMac()) {
-            // The only illegal character for folder names in OSX is the colon
-            AppDataDirectory.get(":");
+            // NUL character
+            AppDataDirectory.get("\0");
         }
         if (Utils.isLinux()) {
             // NUL character


### PR DESCRIPTION
“:” is not an invalid character, but “\0” is.

See discussion in (closed) PR #1891.