### PR TITLE
Added back coveralls integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ before_script:
   - gradle wrapper --gradle-version=$GRADLE_VERSION
 script:
   - ./gradlew clean build
+after_success:
+  - ./gradlew jacocoTestReport coveralls
 
 notifications:
   irc:

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
 
     dependencies {
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.6'
+        classpath "org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.0"
     }
 }
 
@@ -14,4 +15,21 @@ allprojects {
     }
 
     group = 'org.bitcoinj'
+}
+
+subprojects {
+    apply plugin: 'java'
+    apply plugin: 'jacoco'
+    apply plugin: 'com.github.kt3k.coveralls'
+
+    jacoco {
+        toolVersion = '0.8.4'
+    }
+
+    jacocoTestReport {
+        reports {
+            xml.enabled = true
+            html.enabled = true
+        }
+    }
 }


### PR DESCRIPTION
Hello,
I noticed that coveralls report is not updated since 1 May 2018, checked build scripts and looks like after this commit
 https://github.com/bitcoinj/bitcoinj/commit/aaa5262ef42c084406db09bb55f02fb58bfc9789#diff-354f30a63fb0907d4ad57269548329e3L15  coveralls support was removed

In this PR I updated gradle script to report jacoco coverage to coveralls, example results:
https://coveralls.io/builds/26122261  ~60% coverage

Included changes:
 * coveralls-gradle-plugin added to buildscript section;
 * jacoco configuration to generate xml reports;
 * travis `after_success` step to collect jacoco report and publish coveralls data;