### PR TITLE
ECKey: Deprecate method decompress().

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/core/ECKey.java
@@ -303,6 +303,7 @@ public class ECKey implements EncryptableItem {
      * Returns a copy of this key, but with the public point represented in uncompressed form. Normally you would
      * never need this: it's for specialised scenarios or when backwards compatibility in encoded form is necessary.
      */
+    @Deprecated
     public ECKey decompress() {
         if (!pub.isCompressed())
             return this;

--- a/core/src/test/java/org/bitcoinj/core/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ECKeyTest.java
@@ -357,7 +357,7 @@ public class ECKeyTest {
 
     @Test
     public void testToString() throws Exception {
-        ECKey key = ECKey.fromPrivate(BigInteger.TEN).decompress(); // An example private key.
+        ECKey key = ECKey.fromPrivate(BigInteger.TEN, false); // An example private key.
         NetworkParameters params = MAINNET;
         assertEquals("ECKey{pub HEX=04a0434d9e47f3c86235477c7b1ae6ae5d3442d49b1943c2b752a68e2a47e247c7893aba425419bc27a3b6c7e693a24c696f794c2ed877a1593cbee53b037368d7, isEncrypted=false, isPubKeyOnly=false}", key.toString());
         assertEquals("ECKey{pub HEX=04a0434d9e47f3c86235477c7b1ae6ae5d3442d49b1943c2b752a68e2a47e247c7893aba425419bc27a3b6c7e693a24c696f794c2ed877a1593cbee53b037368d7, priv HEX=000000000000000000000000000000000000000000000000000000000000000a, priv WIF=5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreBoNWTw6, isEncrypted=false, isPubKeyOnly=false}", key.toStringWithPrivate(null, params));
@@ -365,13 +365,13 @@ public class ECKeyTest {
 
     @Test
     public void testGetPrivateKeyAsHex() throws Exception {
-        ECKey key = ECKey.fromPrivate(BigInteger.TEN).decompress(); // An example private key.
+        ECKey key = ECKey.fromPrivate(BigInteger.TEN, false); // An example private key.
         assertEquals("000000000000000000000000000000000000000000000000000000000000000a", key.getPrivateKeyAsHex());
     }
 
     @Test
     public void testGetPublicKeyAsHex() throws Exception {
-        ECKey key = ECKey.fromPrivate(BigInteger.TEN).decompress(); // An example private key.
+        ECKey key = ECKey.fromPrivate(BigInteger.TEN, false); // An example private key.
         assertEquals("04a0434d9e47f3c86235477c7b1ae6ae5d3442d49b1943c2b752a68e2a47e247c7893aba425419bc27a3b6c7e693a24c696f794c2ed877a1593cbee53b037368d7", key.getPublicKeyAsHex());
     }
 


### PR DESCRIPTION
The idea is to slowly remove API that allows to deal with uncompressed keys (except for the absolute minimum that is necessary for legacy keys).