### PR TITLE
ECKey: Track compression state in ECKey rather than ECPoint.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -8,7 +8,7 @@ plugins {
 version = '0.16-SNAPSHOT'
 
 dependencies {
-    compile 'org.bouncycastle:bcprov-jdk15to18:1.63'
+    compile 'org.bouncycastle:bcprov-jdk15to18:1.64'
     implementation 'com.google.guava:guava:28.1-android'
     compile 'com.google.protobuf:protobuf-java:3.9.2'
     implementation 'com.squareup.okhttp3:okhttp:3.12.6'

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -67,7 +67,7 @@ public class DeterministicKey extends ECKey {
                             LazyECPoint publicAsPoint,
                             @Nullable BigInteger priv,
                             @Nullable DeterministicKey parent) {
-        super(priv, compressPoint(checkNotNull(publicAsPoint)));
+        super(priv, checkNotNull(publicAsPoint), true);
         checkArgument(chainCode.length == 32);
         this.parent = parent;
         this.childNumberPath = HDPath.M(checkNotNull(childNumberPath));
@@ -89,7 +89,7 @@ public class DeterministicKey extends ECKey {
                             byte[] chainCode,
                             BigInteger priv,
                             @Nullable DeterministicKey parent) {
-        super(priv, compressPoint(ECKey.publicPointFromPrivate(priv)));
+        super(priv, ECKey.publicPointFromPrivate(priv), true);
         checkArgument(chainCode.length == 32);
         this.parent = parent;
         this.childNumberPath = HDPath.M(checkNotNull(childNumberPath));
@@ -137,7 +137,7 @@ public class DeterministicKey extends ECKey {
                             @Nullable DeterministicKey parent,
                             int depth,
                             int parentFingerprint) {
-        super(null, compressPoint(checkNotNull(publicAsPoint)));
+        super(null, checkNotNull(publicAsPoint), true);
         checkArgument(chainCode.length == 32);
         this.parent = parent;
         this.childNumberPath = HDPath.M(checkNotNull(childNumberPath));
@@ -157,7 +157,7 @@ public class DeterministicKey extends ECKey {
                             @Nullable DeterministicKey parent,
                             int depth,
                             int parentFingerprint) {
-        super(priv, compressPoint(ECKey.publicPointFromPrivate(priv)));
+        super(priv, ECKey.publicPointFromPrivate(priv), true);
         checkArgument(chainCode.length == 32);
         this.parent = parent;
         this.childNumberPath = HDPath.M(checkNotNull(childNumberPath));
@@ -169,7 +169,7 @@ public class DeterministicKey extends ECKey {
     
     /** Clones the key */
     public DeterministicKey(DeterministicKey keyToClone, DeterministicKey newParent) {
-        super(keyToClone.priv, keyToClone.pub.get());
+        super(keyToClone.priv, keyToClone.pub.get(), true);
         this.parent = newParent;
         this.childNumberPath = keyToClone.childNumberPath;
         this.chainCode = keyToClone.chainCode;
@@ -628,7 +628,7 @@ public class DeterministicKey extends ECKey {
     @Override
     public String toString() {
         final MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this).omitNullValues();
-        helper.add("pub", Utils.HEX.encode(pub.getEncoded()));
+        helper.add("pub", Utils.HEX.encode(pub.getEncoded(isCompressed())));
         helper.add("chainCode", HEX.encode(chainCode));
         helper.add("path", getPathAsString());
         if (parent != null)

--- a/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
+++ b/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
@@ -65,13 +65,6 @@ public class LazyECPoint {
         return get().getDetachedPoint();
     }
 
-    public byte[] getEncoded() {
-        if (bits != null)
-            return Arrays.copyOf(bits, bits.length);
-        else
-            return get().getEncoded();
-    }
-
     public boolean isInfinity() {
         return get().isInfinity();
     }
@@ -90,13 +83,6 @@ public class LazyECPoint {
 
     public boolean isNormalized() {
         return get().isNormalized();
-    }
-
-    public boolean isCompressed() {
-        if (bits != null)
-            return bits[0] == 2 || bits[0] == 3;
-        else
-            return get().isCompressed();
     }
 
     public ECPoint multiply(BigInteger k) {
@@ -140,7 +126,7 @@ public class LazyECPoint {
     }
 
     public byte[] getEncoded(boolean compressed) {
-        if (compressed == isCompressed() && bits != null)
+        if (bits != null)
             return Arrays.copyOf(bits, bits.length);
         else
             return get().getEncoded(compressed);

--- a/core/src/test/java/org/bitcoinj/core/BloomFilterTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BloomFilterTest.java
@@ -79,7 +79,7 @@ public class BloomFilterTest {
 
         KeyChainGroup group = KeyChainGroup.builder(MAINNET).build();
         // Add a random key which happens to have been used in a recent generation
-        group.importKeys(ECKey.fromPublicOnly(privKey.getKey().getPubKeyPoint()), ECKey.fromPublicOnly(HEX.decode("03cb219f69f1b49468bd563239a86667e74a06fcba69ac50a08a5cbc42a5808e99")));
+        group.importKeys(ECKey.fromPublicOnly(privKey.getKey().getPubKeyPoint(), false), ECKey.fromPublicOnly(HEX.decode("03cb219f69f1b49468bd563239a86667e74a06fcba69ac50a08a5cbc42a5808e99")));
         Wallet wallet = new Wallet(MAINNET, group);
         wallet.commitTx(new Transaction(MAINNET, HEX.decode("01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0d038754030114062f503253482fffffffff01c05e559500000000232103cb219f69f1b49468bd563239a86667e74a06fcba69ac50a08a5cbc42a5808e99ac00000000")));
         


### PR DESCRIPTION
The reason is BouncyCastle 1.64 removed compression state tracking.

This PR also updates BouncyCastle to version 1.64.