### PR TITLE
ECKey: Clean up compress/decompress helpers

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/core/ECKey.java
@@ -176,12 +176,12 @@ public class ECKey implements EncryptableItem {
         ECPrivateKeyParameters privParams = (ECPrivateKeyParameters) keypair.getPrivate();
         ECPublicKeyParameters pubParams = (ECPublicKeyParameters) keypair.getPublic();
         priv = privParams.getD();
-        pub = getPointWithCompression(pubParams.getQ(), true);
+        pub = new LazyECPoint(pubParams.getQ(), true);
         creationTimeSeconds = Utils.currentTimeSeconds();
     }
 
     protected ECKey(@Nullable BigInteger priv, ECPoint pub, boolean compressed) {
-        this(priv, getPointWithCompression(checkNotNull(pub), compressed));
+        this(priv, new LazyECPoint(checkNotNull(pub), compressed));
     }
 
     protected ECKey(@Nullable BigInteger priv, LazyECPoint pub) {
@@ -202,7 +202,7 @@ public class ECKey implements EncryptableItem {
      * See the ECKey class docs for a discussion of point compression.
      */
     public static LazyECPoint compressPoint(LazyECPoint point) {
-        return point.isCompressed() ? point : getPointWithCompression(point.get(), true);
+        return point.isCompressed() ? point : new LazyECPoint(point.get(), true);
     }
 
     /**
@@ -210,11 +210,7 @@ public class ECKey implements EncryptableItem {
      * See the ECKey class docs for a discussion of point compression.
      */
     public static LazyECPoint decompressPoint(LazyECPoint point) {
-        return !point.isCompressed() ? point : getPointWithCompression(point.get(), false);
-    }
-
-    private static LazyECPoint getPointWithCompression(ECPoint point, boolean compressed) {
-        return new LazyECPoint(point, compressed);
+        return !point.isCompressed() ? point : new LazyECPoint(point.get(), false);
     }
 
     /**
@@ -239,7 +235,7 @@ public class ECKey implements EncryptableItem {
      */
     public static ECKey fromPrivate(BigInteger privKey, boolean compressed) {
         ECPoint point = publicPointFromPrivate(privKey);
-        return new ECKey(privKey, getPointWithCompression(point, compressed));
+        return new ECKey(privKey, new LazyECPoint(point, compressed));
     }
 
     /**
@@ -307,7 +303,7 @@ public class ECKey implements EncryptableItem {
         if (!pub.isCompressed())
             return this;
         else
-            return new ECKey(priv, getPointWithCompression(pub.get(), false));
+            return new ECKey(priv, new LazyECPoint(pub.get(), false));
     }
 
     /**
@@ -362,7 +358,7 @@ public class ECKey implements EncryptableItem {
         if (pubKey == null) {
             // Derive public from private.
             ECPoint point = publicPointFromPrivate(privKey);
-            this.pub = getPointWithCompression(point, compressed);
+            this.pub = new LazyECPoint(point, compressed);
         } else {
             // We expect the pubkey to be in regular encoded form, just as a BigInteger. Therefore the first byte is
             // a special marker byte.

--- a/core/src/main/java/org/bitcoinj/core/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/core/ECKey.java
@@ -299,6 +299,7 @@ public class ECKey implements EncryptableItem {
      * Returns a copy of this key, but with the public point represented in uncompressed form. Normally you would
      * never need this: it's for specialised scenarios or when backwards compatibility in encoded form is necessary.
      */
+    @Deprecated
     public ECKey decompress() {
         if (!pub.isCompressed())
             return this;

--- a/core/src/main/java/org/bitcoinj/core/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/core/ECKey.java
@@ -198,19 +198,19 @@ public class ECKey implements EncryptableItem {
     }
 
     /**
-     * Utility for compressing an elliptic curve point. Returns the same point if it's already compressed.
-     * See the ECKey class docs for a discussion of point compression.
+     * @deprecated Use {@link LazyECPoint#compress()}
      */
+    @Deprecated
     public static LazyECPoint compressPoint(LazyECPoint point) {
-        return point.isCompressed() ? point : new LazyECPoint(point.get(), true);
+        return point.compress();
     }
 
     /**
-     * Utility for decompressing an elliptic curve point. Returns the same point if it's already uncompressed.
-     * See the ECKey class docs for a discussion of point compression.
+     * @deprecated Use {@link LazyECPoint#decompress()}
      */
+    @Deprecated
     public static LazyECPoint decompressPoint(LazyECPoint point) {
-        return !point.isCompressed() ? point : new LazyECPoint(point.get(), false);
+        return point.decompress();
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -67,7 +67,7 @@ public class DeterministicKey extends ECKey {
                             LazyECPoint publicAsPoint,
                             @Nullable BigInteger priv,
                             @Nullable DeterministicKey parent) {
-        super(priv, compressPoint(checkNotNull(publicAsPoint)));
+        super(priv, publicAsPoint.compress());
         checkArgument(chainCode.length == 32);
         this.parent = parent;
         this.childNumberPath = HDPath.M(checkNotNull(childNumberPath));
@@ -138,7 +138,7 @@ public class DeterministicKey extends ECKey {
                             @Nullable DeterministicKey parent,
                             int depth,
                             int parentFingerprint) {
-        super(null, compressPoint(checkNotNull(publicAsPoint)));
+        super(null, publicAsPoint.compress());
         checkArgument(chainCode.length == 32);
         this.parent = parent;
         this.childNumberPath = HDPath.M(checkNotNull(childNumberPath));

--- a/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
+++ b/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
@@ -70,6 +70,22 @@ public class LazyECPoint {
         this.bits = null;
     }
 
+    /**
+     * Returns a compressed version of this elliptic curve point. Returns the same point if it's already compressed.
+     * See the {@link ECKey} class docs for a discussion of point compression.
+     */
+    public LazyECPoint compress() {
+        return compressed ? this : new LazyECPoint(get(), true);
+    }
+
+    /**
+     * Returns a decompressed version of this elliptic curve point. Returns the same point if it's already compressed.
+     * See the {@link ECKey} class docs for a discussion of point compression.
+     */
+    public LazyECPoint decompress() {
+        return !compressed ? this : new LazyECPoint(get(), false);
+    }
+
     public ECPoint get() {
         if (point == null)
             point = curve.decodePoint(bits);

--- a/core/src/test/java/org/bitcoinj/core/DumpedPrivateKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/core/DumpedPrivateKeyTest.java
@@ -106,7 +106,7 @@ public class DumpedPrivateKeyTest {
 
     @Test
     public void roundtripBase58_getKey() throws Exception {
-        ECKey k = new ECKey().decompress();
+        ECKey k = ECKey.fromPrivate(new ECKey().getPrivKey(), false);
         assertFalse(k.isCompressed());
         assertEquals(k.getPrivKey(),
                 DumpedPrivateKey.fromBase58(null, k.getPrivateKeyAsWiF(MAINNET)).getKey().getPrivKey());

--- a/core/src/test/java/org/bitcoinj/core/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ECKeyTest.java
@@ -357,7 +357,7 @@ public class ECKeyTest {
 
     @Test
     public void testToString() throws Exception {
-        ECKey key = ECKey.fromPrivate(BigInteger.TEN).decompress(); // An example private key.
+        ECKey key = ECKey.fromPrivate(BigInteger.TEN, false); // An example private key.
         NetworkParameters params = MAINNET;
         assertEquals("ECKey{pub HEX=04a0434d9e47f3c86235477c7b1ae6ae5d3442d49b1943c2b752a68e2a47e247c7893aba425419bc27a3b6c7e693a24c696f794c2ed877a1593cbee53b037368d7, isEncrypted=false, isPubKeyOnly=false}", key.toString());
         assertEquals("ECKey{pub HEX=04a0434d9e47f3c86235477c7b1ae6ae5d3442d49b1943c2b752a68e2a47e247c7893aba425419bc27a3b6c7e693a24c696f794c2ed877a1593cbee53b037368d7, priv HEX=000000000000000000000000000000000000000000000000000000000000000a, priv WIF=5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreBoNWTw6, isEncrypted=false, isPubKeyOnly=false}", key.toStringWithPrivate(null, params));
@@ -365,13 +365,13 @@ public class ECKeyTest {
 
     @Test
     public void testGetPrivateKeyAsHex() throws Exception {
-        ECKey key = ECKey.fromPrivate(BigInteger.TEN).decompress(); // An example private key.
+        ECKey key = ECKey.fromPrivate(BigInteger.TEN, false); // An example private key.
         assertEquals("000000000000000000000000000000000000000000000000000000000000000a", key.getPrivateKeyAsHex());
     }
 
     @Test
     public void testGetPublicKeyAsHex() throws Exception {
-        ECKey key = ECKey.fromPrivate(BigInteger.TEN).decompress(); // An example private key.
+        ECKey key = ECKey.fromPrivate(BigInteger.TEN, false); // An example private key.
         assertEquals("04a0434d9e47f3c86235477c7b1ae6ae5d3442d49b1943c2b752a68e2a47e247c7893aba425419bc27a3b6c7e693a24c696f794c2ed877a1593cbee53b037368d7", key.getPublicKeyAsHex());
     }
 
@@ -520,9 +520,10 @@ public class ECKeyTest {
     @Test
     public void testPublicKeysAreEqual() {
         ECKey key = new ECKey();
-        ECKey pubKey1 = ECKey.fromPublicOnly(key);
+        ECKey pubKey1 = ECKey.fromPublicOnly(key.getPubKeyPoint(), true);
         assertTrue(pubKey1.isCompressed());
-        ECKey pubKey2 = pubKey1.decompress();
+        ECKey pubKey2 = ECKey.fromPublicOnly(key.getPubKeyPoint(), false);
+        assertFalse(pubKey2.isCompressed());
         assertEquals(pubKey1, pubKey2);
         assertEquals(pubKey1.hashCode(), pubKey2.hashCode());
     }


### PR DESCRIPTION
These commits aim at deprecating and eventually removing ECKey helpers that deal with public key compression. For normal users of this library, there should not be a reason to need this.