### PR TITLE
Add satoshi denomination

### DIFF
--- a/core/src/main/java/org/bitcoinj/utils/MonetaryFormat.java
+++ b/core/src/main/java/org/bitcoinj/utils/MonetaryFormat.java
@@ -62,7 +62,7 @@ public final class MonetaryFormat {
     public static final String CODE_MBTC = "mBTC";
     /** Currency code for base 1/1000000 Bitcoin. */
     public static final String CODE_UBTC = "µBTC";
-    /** Currency symbol for base 1 Bitcoin. */
+    /** Currency symbol for base 1/100000000 Bitcoin. */
     public static final String CODE_SAT = "sat";
     /** Currency symbol for base 1 Bitcoin. */
     public static final String SYMBOL_BTC = "\u20bf";
@@ -70,7 +70,7 @@ public final class MonetaryFormat {
     public static final String SYMBOL_MBTC = "m" + SYMBOL_BTC;
     /** Currency symbol for base 1/1000000 Bitcoin. */
     public static final String SYMBOL_UBTC = "µ" + SYMBOL_BTC;
-    /** Currency symbol for base 1/100 000 000 Bitcoin (satoshi). */
+    /** Currency symbol for base 1/100000000 Bitcoin (satoshi). */
     public static final String SYMBOL_UBTC = "sat";
 
     public static final int MAX_DECIMALS = 8;

--- a/core/src/main/java/org/bitcoinj/utils/MonetaryFormat.java
+++ b/core/src/main/java/org/bitcoinj/utils/MonetaryFormat.java
@@ -70,8 +70,6 @@ public final class MonetaryFormat {
     public static final String SYMBOL_MBTC = "m" + SYMBOL_BTC;
     /** Currency symbol for base 1/1000000 Bitcoin. */
     public static final String SYMBOL_UBTC = "µ" + SYMBOL_BTC;
-    /** Currency symbol for base 1/100000000 Bitcoin (satoshi). */
-    public static final String SYMBOL_SAT = "sat";
 
     public static final int MAX_DECIMALS = 8;
 

--- a/core/src/main/java/org/bitcoinj/utils/MonetaryFormat.java
+++ b/core/src/main/java/org/bitcoinj/utils/MonetaryFormat.java
@@ -71,7 +71,7 @@ public final class MonetaryFormat {
     /** Currency symbol for base 1/1000000 Bitcoin. */
     public static final String SYMBOL_UBTC = "µ" + SYMBOL_BTC;
     /** Currency symbol for base 1/100000000 Bitcoin (satoshi). */
-    public static final String SYMBOL_UBTC = "sat";
+    public static final String SYMBOL_SAT = "sat";
 
     public static final int MAX_DECIMALS = 8;
 

--- a/core/src/main/java/org/bitcoinj/utils/MonetaryFormat.java
+++ b/core/src/main/java/org/bitcoinj/utils/MonetaryFormat.java
@@ -52,6 +52,8 @@ public final class MonetaryFormat {
     public static final MonetaryFormat MBTC = new MonetaryFormat().shift(3).minDecimals(2).optionalDecimals(2);
     /** Standard format for the µBTC denomination. */
     public static final MonetaryFormat UBTC = new MonetaryFormat().shift(6).minDecimals(0).optionalDecimals(2);
+    /** Standard format for the SAT denomination. */
+    public static final MonetaryFormat SAT = new MonetaryFormat().shift(8).minDecimals(0).optionalDecimals(0);
     /** Standard format for fiat amounts. */
     public static final MonetaryFormat FIAT = new MonetaryFormat().shift(0).minDecimals(2).repeatOptionalDecimals(2, 1);
     /** Currency code for base 1 Bitcoin. */
@@ -61,11 +63,15 @@ public final class MonetaryFormat {
     /** Currency code for base 1/1000000 Bitcoin. */
     public static final String CODE_UBTC = "µBTC";
     /** Currency symbol for base 1 Bitcoin. */
+    public static final String CODE_SAT = "sat";
+    /** Currency symbol for base 1 Bitcoin. */
     public static final String SYMBOL_BTC = "\u20bf";
     /** Currency symbol for base 1/1000 Bitcoin. */
     public static final String SYMBOL_MBTC = "m" + SYMBOL_BTC;
     /** Currency symbol for base 1/1000000 Bitcoin. */
     public static final String SYMBOL_UBTC = "µ" + SYMBOL_BTC;
+    /** Currency symbol for base 1/100 000 000 Bitcoin (satoshi). */
+    public static final String SYMBOL_UBTC = "sat";
 
     public static final int MAX_DECIMALS = 8;
 

--- a/core/src/test/java/org/bitcoinj/utils/MonetaryFormatTest.java
+++ b/core/src/test/java/org/bitcoinj/utils/MonetaryFormatTest.java
@@ -214,6 +214,7 @@ public class MonetaryFormatTest {
         assertEquals("BTC 0.00", MonetaryFormat.BTC.format(Coin.ZERO).toString());
         assertEquals("mBTC 0.00", MonetaryFormat.MBTC.format(Coin.ZERO).toString());
         assertEquals("µBTC 0", MonetaryFormat.UBTC.format(Coin.ZERO).toString());
+        assertEquals("sat 0", MonetaryFormat.SAT.format(Coin.ZERO).toString());
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/utils/MonetaryFormatTest.java
+++ b/core/src/test/java/org/bitcoinj/utils/MonetaryFormatTest.java
@@ -214,7 +214,6 @@ public class MonetaryFormatTest {
         assertEquals("BTC 0.00", MonetaryFormat.BTC.format(Coin.ZERO).toString());
         assertEquals("mBTC 0.00", MonetaryFormat.MBTC.format(Coin.ZERO).toString());
         assertEquals("µBTC 0", MonetaryFormat.UBTC.format(Coin.ZERO).toString());
-        assertEquals("sat 0", MonetaryFormat.SAT.format(Coin.ZERO).toString());
     }
 
     @Test


### PR DESCRIPTION
* Related: https://github.com/bitcoin-wallet/bitcoin-wallet/pull/594#issuecomment-552184448
* Add satoshi denomination for bitcoinj
* Regular definition (1/10000000th bitcoin)
* Display as sat (so this does not include the bitcoin symbol)