### PR TITLE
Fix failing tests on certain systems and intoduce Utils::resetMocking()

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Utils.java
+++ b/core/src/main/java/org/bitcoinj/core/Utils.java
@@ -417,6 +417,14 @@ public class Utils {
     }
 
     /**
+     * Clears the mock clock and sleep
+     */
+    public static void resetMocking() {
+        mockTime = null;
+        mockSleepQueue = null;
+    }
+
+    /**
      * Returns the current time, or a mocked out equivalent.
      */
     public static Date now() {

--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -65,6 +65,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
     @Before
     public void setUp() throws Exception {
         BriefLogFormatter.init();
+        Utils.resetMocking();
         Context.propagate(new Context(PARAMS, 100, Coin.ZERO, false));
     }
 


### PR DESCRIPTION
It appears that the tests do not run in the same order or the static variables
are not reset between runs on all systemsi or gradle versions.
So it happened that the test UtilsTest::testRollMockClock was messing up
the time for the H2FullPrunedBlockChainTest (and the LevelDB one).

This fixes the issue by resetting the mock time for the
AbstractFullPrunedBlockChainTest.