### PR TITLE
Use protocolVersion in MessageSerializer

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AddressMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressMessage.java
@@ -75,6 +75,7 @@ public class AddressMessage extends Message {
         if (numAddresses > MAX_ADDRESSES)
             throw new ProtocolException("Address message too large.");
         addresses = new ArrayList<>((int) numAddresses);
+        int protocolVersion = serializer.getProtocolVersion();
         for (int i = 0; i < numAddresses; i++) {
             PeerAddress addr = new PeerAddress(params, payload, cursor, protocolVersion, this, serializer);
             addresses.add(addr);

--- a/core/src/main/java/org/bitcoinj/core/ChildMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/ChildMessage.java
@@ -43,7 +43,7 @@ public abstract class ChildMessage extends Message {
         super(params, payload, offset, protocolVersion);
     }
 
-    public ChildMessage(NetworkParameters params, byte[] payload, int offset, int protocolVersion, Message parent, MessageSerializer setSerializer, int length) throws ProtocolException {
+    public ChildMessage(NetworkParameters params, byte[] payload, int offset, int protocolVersion, @Nullable Message parent, MessageSerializer setSerializer, int length) throws ProtocolException {
         super(params, payload, offset, protocolVersion, setSerializer, length);
         this.parent = parent;
     }

--- a/core/src/main/java/org/bitcoinj/core/DummySerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/DummySerializer.java
@@ -34,6 +34,16 @@ class DummySerializer extends MessageSerializer {
     }
 
     @Override
+    public DummySerializer withProtocolVersion(int protocolVersion) {
+        return this;
+    }
+
+    @Override
+    public int getProtocolVersion() {
+        return 0;
+    }
+
+    @Override
     public Message deserialize(ByteBuffer in) throws UnsupportedOperationException {
         throw new UnsupportedOperationException(DEFAULT_EXCEPTION_MESSAGE);
     }

--- a/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
@@ -34,7 +34,7 @@ public class GetBlocksMessage extends Message {
 
     public GetBlocksMessage(NetworkParameters params, BlockLocator locator, Sha256Hash stopHash) {
         super(params);
-        this.version = protocolVersion;
+        this.version = serializer.getProtocolVersion();
         this.locator = locator;
         this.stopHash = stopHash;
     }
@@ -74,7 +74,7 @@ public class GetBlocksMessage extends Message {
     @Override
     protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         // Version, for some reason.
-        Utils.uint32ToByteStreamLE(params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.CURRENT), stream);
+        Utils.uint32ToByteStreamLE(serializer.getProtocolVersion(), stream);
         // Then a vector of block hashes. This is actually a "block locator", a set of block
         // identifiers that spans the entire chain with exponentially increasing gaps between
         // them, until we end up at the genesis block. See CBlockLocator::Set()

--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -58,8 +58,6 @@ public abstract class Message {
     protected boolean recached = false;
     protected MessageSerializer serializer;
 
-    protected int protocolVersion;
-
     protected NetworkParameters params;
 
     protected Message() {
@@ -68,7 +66,6 @@ public abstract class Message {
 
     protected Message(NetworkParameters params) {
         this.params = params;
-        this.protocolVersion = params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.CURRENT);
         this.serializer = params.getDefaultSerializer();
     }
 
@@ -88,8 +85,7 @@ public abstract class Message {
      * @throws ProtocolException
      */
     protected Message(NetworkParameters params, byte[] payload, int offset, int protocolVersion, MessageSerializer serializer, int length) throws ProtocolException {
-        this.serializer = serializer;
-        this.protocolVersion = protocolVersion;
+        this.serializer = serializer.withProtocolVersion(protocolVersion);
         this.params = params;
         this.payload = payload;
         this.cursor = this.offset = offset;
@@ -122,13 +118,12 @@ public abstract class Message {
     }
 
     protected Message(NetworkParameters params, byte[] payload, int offset) throws ProtocolException {
-        this(params, payload, offset, params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.CURRENT),
+        this(params, payload, offset, params.getDefaultSerializer().getProtocolVersion(),
              params.getDefaultSerializer(), UNKNOWN_LENGTH);
     }
 
     protected Message(NetworkParameters params, byte[] payload, int offset, MessageSerializer serializer, int length) throws ProtocolException {
-        this(params, payload, offset, params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.CURRENT),
-             serializer, length);
+        this(params, payload, offset, serializer.getProtocolVersion(), serializer, length);
     }
 
     // These methods handle the serialization/deserialization using the custom Bitcoin protocol.
@@ -171,6 +166,17 @@ public abstract class Message {
 
     public boolean isRecached() {
         return recached;
+    }
+
+    /**
+     * Overrides the message serializer.
+     * @param serializer the new serializer
+     */
+    public void setSerializer(MessageSerializer serializer) {
+        if (!this.serializer.equals(serializer)) {
+            this.serializer = serializer;
+            unCache();
+        }
     }
 
     /**
@@ -330,9 +336,7 @@ public abstract class Message {
     }
 
     protected byte[] readBytes(int length) throws ProtocolException {
-        if ((length > MAX_SIZE) || (cursor + length > payload.length)) {
-            throw new ProtocolException("Claimed value length too large: " + length);
-        }
+        checkReadLength(length);
         try {
             byte[] b = new byte[length];
             System.arraycopy(payload, cursor, b, 0, length);
@@ -342,7 +346,18 @@ public abstract class Message {
             throw new ProtocolException(e);
         }
     }
-    
+
+    protected byte readByte() throws ProtocolException {
+        checkReadLength(1);
+        return payload[cursor++];
+    }
+
+    private void checkReadLength(int length) throws ProtocolException {
+        if ((length > MAX_SIZE) || (cursor + length > payload.length)) {
+            throw new ProtocolException("Claimed value length too large: " + length);
+        }
+    }
+
     protected byte[] readByteArray() throws ProtocolException {
         long len = readVarInt();
         return readBytes((int)len);

--- a/core/src/main/java/org/bitcoinj/core/MessageSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/MessageSerializer.java
@@ -18,6 +18,8 @@
 
 package org.bitcoinj.core;
 
+import com.google.common.annotations.Beta;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.BufferUnderflowException;
@@ -28,6 +30,39 @@ import java.nio.ByteBuffer;
  * classes should be immutable.
  */
 public abstract class MessageSerializer {
+
+    /**
+     * <p>
+     * Create a new serializer with a specific protocol version. Mainly used to disable SegWit when parsing transactions
+     * </p>
+     * <p>
+     * Note: this is an experimental "beta" API and could change in future releases
+     * </p>
+     */
+    @Beta
+    public abstract MessageSerializer withProtocolVersion(int protocolVersion);
+
+    @Beta
+    public MessageSerializer withProtocolVersionFlag(int flag, boolean set) {
+        int newProtocolVersion = getProtocolVersion();
+        if (set) {
+            newProtocolVersion |= flag;
+        } else {
+            newProtocolVersion &= ~flag;
+        }
+        return withProtocolVersion(newProtocolVersion);
+    }
+
+    /**
+     * <p>
+     * Get the protocol version of this serializer
+     * </p>
+     * <p>
+     * Note: this is an experimental "beta" API and could change in future releases
+     * </p>
+     */
+    @Beta
+    public abstract int getProtocolVersion();
 
     /**
      * Reads a message from the given ByteBuffer and returns it.

--- a/core/src/main/java/org/bitcoinj/core/PeerAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerAddress.java
@@ -71,7 +71,7 @@ public class PeerAddress extends ChildMessage {
         super(params);
         this.addr = checkNotNull(addr);
         this.port = port;
-        this.protocolVersion = protocolVersion;
+        setSerializer(serializer.withProtocolVersion(protocolVersion));
         this.services = services;
         length = isSerializeTime() ? MESSAGE_SIZE : MESSAGE_SIZE - 4;
     }
@@ -107,7 +107,6 @@ public class PeerAddress extends ChildMessage {
         super(params);
         this.hostname = hostname;
         this.port = port;
-        this.protocolVersion = params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.CURRENT);
         this.services = BigInteger.ZERO;
     }
 
@@ -140,7 +139,7 @@ public class PeerAddress extends ChildMessage {
     }
 
     private boolean isSerializeTime() {
-        return protocolVersion >= 31402 && !(parent instanceof VersionMessage);
+        return serializer.getProtocolVersion() >= 31402 && !(parent instanceof VersionMessage);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -1421,7 +1421,7 @@ public class Transaction extends ChildMessage {
     @Override
     protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         boolean useSegwit = hasWitnesses()
-                && protocolVersion >= NetworkParameters.ProtocolVersion.WITNESS_VERSION.getBitcoinProtocolVersion();
+                && serializer.getProtocolVersion() >= NetworkParameters.ProtocolVersion.WITNESS_VERSION.getBitcoinProtocolVersion();
         bitcoinSerializeToStream(stream, useSegwit);
     }
 

--- a/core/src/main/java/org/bitcoinj/core/Utils.java
+++ b/core/src/main/java/org/bitcoinj/core/Utils.java
@@ -417,6 +417,14 @@ public class Utils {
     }
 
     /**
+     * Clears the mock clock and sleep
+     */
+    public static void resetMocking() {
+        mockTime = null;
+        mockSleepQueue = null;
+    }
+
+    /**
      * Returns the current time, or a mocked out equivalent.
      */
     public static Date now() {

--- a/core/src/main/java/org/bitcoinj/core/VersionMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionMessage.java
@@ -103,7 +103,7 @@ public class VersionMessage extends Message {
     
     public VersionMessage(NetworkParameters params, int newBestHeight) {
         super(params);
-        clientVersion = params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.CURRENT);
+        clientVersion = serializer.getProtocolVersion();
         localServices = 0;
         time = Utils.currentTimeSeconds();
         // Note that the Bitcoin Core doesn't do anything with these, and finding out your own external IP address

--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -65,6 +65,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
     @Before
     public void setUp() throws Exception {
         BriefLogFormatter.init();
+        Utils.resetMocking();
         Context.propagate(new Context(PARAMS, 100, Coin.ZERO, false));
     }
 

--- a/core/src/test/java/org/bitcoinj/core/CheckpointManagerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/CheckpointManagerTest.java
@@ -23,6 +23,7 @@ import org.junit.runner.RunWith;
 
 import java.io.IOException;
 
+import static org.bitcoinj.core.NetworkParameters.ProtocolVersion.CURRENT;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 
@@ -57,9 +58,9 @@ public class CheckpointManagerTest {
     public void canReadTextualStream() throws IOException {
         expect(params.getId()).andReturn("org/bitcoinj/core/checkpointmanagertest/validTextualFormat");
         expect(params.getSerializer(false)).andReturn(
-                new BitcoinSerializer(params, false));
-        expect(params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.CURRENT))
-                .andReturn(NetworkParameters.ProtocolVersion.CURRENT.getBitcoinProtocolVersion());
+                new BitcoinSerializer(params, CURRENT.getBitcoinProtocolVersion(), false));
+        expect(params.getProtocolVersionNum(CURRENT))
+                .andReturn(CURRENT.getBitcoinProtocolVersion());
         replay(params);
         new CheckpointManager(params, null);
     }

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -576,7 +576,8 @@ public class TransactionTest {
 
         public HugeDeclaredSizeTransaction(NetworkParameters params, boolean hackInputsSize, boolean hackOutputsSize, boolean hackWitnessPushCountSize) {
             super(params);
-            this.protocolVersion = NetworkParameters.ProtocolVersion.WITNESS_VERSION.getBitcoinProtocolVersion();
+            setSerializer(serializer.withProtocolVersion(
+                    NetworkParameters.ProtocolVersion.WITNESS_VERSION.getBitcoinProtocolVersion()));
             Transaction inputTx = new Transaction(params);
             inputTx.addOutput(Coin.FIFTY_COINS, LegacyAddress.fromKey(params, ECKey.fromPrivate(BigInteger.valueOf(123456))));
             this.addInput(inputTx.getOutput(0));


### PR DESCRIPTION
This change moves protocolVersion from Message to MessageSerializer.
The main reason is to support parsing transactions as non-segwit.
This is impossible to do otherwise, as MessageSerializer#makeTransaction
does not accept a protocolVersion parameter.
Additionally this change makes the MessageSerializer similar to the
Stream in BitcoinCore, where the protocol version can be modified.

I marked the API as beta so we can discuss a potentially better implementation.