### PR TITLE
Make Guava an `api` dependency using java-library

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -9,7 +9,7 @@ version = '0.16-SNAPSHOT'
 
 dependencies {
     compile 'org.bouncycastle:bcprov-jdk15to18:1.64'
-    implementation 'com.google.guava:guava:28.2-android'
+    api 'com.google.guava:guava:28.2-android'
     compile 'com.google.protobuf:protobuf-java:3.9.2'
     implementation 'com.squareup.okhttp3:okhttp:3.12.8'
     implementation 'org.slf4j:slf4j-api:1.7.30'

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 dependencies {
     implementation project(':bitcoinj-core')
-    implementation 'com.google.guava:guava:28.2-android'
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     implementation 'org.slf4j:slf4j-jdk14:1.7.30'
     implementation 'org.fusesource.leveldbjni:leveldbjni-all:1.8'

--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 dependencies {
     implementation project(':bitcoinj-core')
-    implementation 'com.google.guava:guava:28.2-android'
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
     implementation 'org.slf4j:slf4j-jdk14:1.7.30'
 }

--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -7,7 +7,6 @@ plugins {
 
 dependencies {
     implementation project(':bitcoinj-core')
-    implementation 'com.google.guava:guava:28.2-android'
     implementation 'de.jensd:fontawesomefx:8.0.0'
     implementation 'com.google.zxing:core:3.3.3'
     implementation 'org.slf4j:slf4j-jdk14:1.7.30'


### PR DESCRIPTION
Use the Gradle java-library plugin to make Guava an `api`
dependency since Guava types are used in the bitcoinj public API.

This is supported in Gradle 4.4.x: https://docs.gradle.org/4.4.1/userguide/java_library_plugin.html
