### PR TITLE
UTF-8 options, java & eclipse plugins in root build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,16 @@ buildscript {
 }
 
 allprojects {
+    apply plugin: 'java'
+    apply plugin: 'eclipse'
+
     repositories {
         jcenter()
     }
 
     group = 'org.bitcoinj'
+
+    compileJava.options.encoding = 'UTF-8'
+    compileTestJava.options.encoding = 'UTF-8'
+    javadoc.options.encoding = 'UTF-8'
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'java-library'
     id 'com.google.protobuf'
     id 'maven'
-    id 'eclipse'
 }
 
 version = '0.16-SNAPSHOT'
@@ -25,9 +24,6 @@ dependencies {
 }
 
 sourceCompatibility = 1.7
-compileJava.options.encoding = 'UTF-8'
-compileTestJava.options.encoding = 'UTF-8'
-javadoc.options.encoding = 'UTF-8'
 
 protobuf {
     protoc {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,8 +1,3 @@
-plugins {
-    id 'java'
-    id 'eclipse'
-}
-
 dependencies {
     implementation project(':bitcoinj-core')
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4'
@@ -11,6 +6,3 @@ dependencies {
 }
 
 sourceCompatibility = 1.8
-compileJava.options.encoding = 'UTF-8'
-compileTestJava.options.encoding = 'UTF-8'
-javadoc.options.encoding = 'UTF-8'

--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -1,7 +1,5 @@
 plugins {
-    id 'java'
     id 'application'
-    id 'eclipse'
 }
 
 dependencies {

--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -1,6 +1,4 @@
 plugins {
-    id 'java'
-    id 'eclipse'
     id 'application'
     id 'org.openjfx.javafxplugin' version '0.0.8'
 }
@@ -18,8 +16,5 @@ javafx {
 }
 
 sourceCompatibility = 1.11
-compileJava.options.encoding = 'UTF-8'
-compileTestJava.options.encoding = 'UTF-8'
-javadoc.options.encoding = 'UTF-8'
 
 mainClassName = 'wallettemplate.Main'


### PR DESCRIPTION
Simplify subproject `build.gradle` files by putting common
settings in root `build.gradle`.