### PR TITLE
Make zero inputs/outputs transactions parsable.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -335,10 +335,14 @@ public abstract class Message {
         }
     }
 
-    protected byte[] readBytes(int length) throws ProtocolException {
+    private void checkReadLength(int length) throws ProtocolException {
         if ((length > MAX_SIZE) || (cursor + length > payload.length)) {
             throw new ProtocolException("Claimed value length too large: " + length);
         }
+    }
+
+    protected byte[] readBytes(int length) throws ProtocolException {
+        checkReadLength(length);
         try {
             byte[] b = new byte[length];
             System.arraycopy(payload, cursor, b, 0, length);
@@ -347,6 +351,11 @@ public abstract class Message {
         } catch (IndexOutOfBoundsException e) {
             throw new ProtocolException(e);
         }
+    }
+
+    protected byte readByte() throws ProtocolException {
+        checkReadLength(1);
+        return payload[cursor++];
     }
 
     protected byte[] readByteArray() throws ProtocolException {

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -665,4 +665,23 @@ public class TransactionTest {
         assertEquals(542, tx.getWeight());
         assertEquals(136, tx.getVsize());
     }
+
+    @Test
+    public void nonSegwitZeroInputZeroOutputTx() {
+        // Non SegWit tx with zero input and outputs
+        String txHex = "010000000000f1f2f3f4";
+        Transaction tx = UNITTEST.getDefaultSerializer().makeTransaction(HEX.decode(txHex));
+        assertEquals(txHex, HEX.encode(tx.bitcoinSerialize()));
+    }
+
+    @Test
+    public void nonSegwitZeroInputOneOutputTx() {
+        // Non SegWit tx with zero input and one output that has an amount of `0100000000000000` that could confuse
+        // a naive segwit parser. This can only be read with SegWit disabled
+        MessageSerializer serializer = UNITTEST.getDefaultSerializer();
+        String txHex = "0100000000010100000000000000016af1f2f3f4";
+        int protoVersionNoWitness = serializer.getProtocolVersion() | Transaction.SERIALIZE_TRANSACTION_NO_WITNESS;
+        tx = serializer.withProtocolVersion(protoVersionNoWitness).makeTransaction(HEX.decode(txHex));
+        assertEquals(txHex, HEX.encode(tx.bitcoinSerialize()));
+    }
 }

--- a/core/src/test/java/org/bitcoinj/script/ScriptTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptTest.java
@@ -41,6 +41,7 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
+import static org.bitcoinj.core.Transaction.SERIALIZE_TRANSACTION_NO_WITNESS;
 import static org.bitcoinj.core.Utils.HEX;
 import static org.bitcoinj.script.ScriptOpCodes.OP_0;
 import static org.bitcoinj.script.ScriptOpCodes.OP_INVALIDOPCODE;
@@ -394,7 +395,17 @@ public class ScriptTest {
             if (test.isArray() && test.size() == 1 && test.get(0).isTextual())
                 continue; // This is a comment.
             Map<TransactionOutPoint, Script> scriptPubKeys = parseScriptPubKeys(test.get(0));
-            Transaction transaction = TESTNET.getDefaultSerializer().makeTransaction(HEX.decode(test.get(1).asText().toLowerCase()));
+            byte[] txBytes = HEX.decode(test.get(1).asText().toLowerCase());
+            MessageSerializer serializer = TESTNET.getDefaultSerializer();
+            Transaction transaction;
+            try {
+                transaction = serializer.makeTransaction(txBytes);
+            } catch (ProtocolException ignore) {
+                // Try to parse as a no-witness transaction because some vectors are 0-input, 1-output txs that fail
+                // to correctly parse as witness transactions.
+                int protoVersionNoWitness = serializer.getProtocolVersion() | SERIALIZE_TRANSACTION_NO_WITNESS;
+                transaction = serializer.withProtocolVersion(protoVersionNoWitness).makeTransaction(txBytes);
+            }
             Set<VerifyFlag> verifyFlags = parseVerifyFlags(test.get(2).asText());
 
             boolean valid = true;


### PR DESCRIPTION
Switch to the bitcoin core reference segwit parsing algorithm because
some no-segwit transactions with no inputs are incorrectly parsed as
segwit.

This change is to be 100% compatible with the reference implementation
and to be compatible with the PSBT implementation.