### PR TITLE
Upgrade to JavaFX 14, JavaFX Plugin 0.0.8

### DIFF
--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'eclipse'
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.7'
+    id 'org.openjfx.javafxplugin' version '0.0.8'
 }
 
 dependencies {
@@ -13,6 +13,7 @@ dependencies {
 }
 
 javafx {
+    version = '14'
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 


### PR DESCRIPTION
OpenJFX 14 has critical fixes for macOS Catalina.

More info here on version 14:
https://jaxenter.com/javafx-14-mobile-java-release-169554.html
