### PR TITLE
Upgrade Gradle Protobuf Plugin to 0.8.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.6'
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.10'
     }
 }
 


### PR DESCRIPTION
The current latest version is 0.8.12, but version 0.8.11
and later require Gradle 5.6 or later which will change our
build requirements and documentation.

See:
https://github.com/google/protobuf-gradle-plugin/releases/tag/v0.8.11