### PR TITLE
Add JDK 14 to Github Actions build matrix.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         # windows-latest currently fails on some tests
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        java: [ '8', '11' ]
+        java: [ '8', '11', '14' ]
       fail-fast: false
     name: JAVA ${{ matrix.java }} OS ${{ matrix.os }}
     steps:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,4 +1,4 @@
-name: Java CI
+name: Gradle Build
 
 on: [push, pull_request]
 
@@ -8,7 +8,8 @@ jobs:
     strategy:
       matrix:
         # windows-latest currently fails on some tests
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        # TODO: Fix windows issues and add `windows-latest`
+        os: [ubuntu-latest, macOS-latest]
         java: [ '8', '11', '14' ]
       fail-fast: false
     name: JAVA ${{ matrix.java }} OS ${{ matrix.os }}


### PR DESCRIPTION
If JDK 14 works well and we think 3 JDK versions is too many, maybe we could remove 11 from the matrix at a later point...