### PR TITLE
Upgrade to ProtoBuf plugin 0.8.12 (and require Gradle 5.6 or later)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,13 +1,13 @@
 image: ubuntu:bionic
 
 variables:
-  GRADLE_VERSION: "4.10.3"
+  GRADLE_VERSION: "5.6"
 
 before_script:
   - apt-get update
   - apt-get -y upgrade
   - apt-get -y install openjdk-11-jdk gradle
-  - gradle wrapper --gradle-version=$GRADLE_VERSION --stacktrace
+  - gradle -c empty-settings.gradle wrapper --gradle-version=$GRADLE_VERSION --stacktrace
 
 build:
   script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,12 @@ language: java
 matrix:
   include:
   - jdk: openjdk8
-    env: GRADLE_VERSION=4.4.1
-  - jdk: openjdk8
-    env: GRADLE_VERSION=4.10.3
+    env: GRADLE_VERSION=5.6
   - jdk: openjdk11
-    env: GRADLE_VERSION=4.10.3
+    env: GRADLE_VERSION=5.6
 install: true
 before_script:
-  - gradle wrapper --gradle-version=$GRADLE_VERSION
+  - gradle -c empty-settings.gradle wrapper --gradle-version=$GRADLE_VERSION
 script:
   - ./gradlew clean build
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.10'
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.12'
     }
 }
 

--- a/empty-settings.gradle
+++ b/empty-settings.gradle
@@ -1,0 +1,3 @@
+// Empty settings file. Used to run the `wrapper` task to upgrade Gradle on CI. See .travis.yml
+// and .gitlab-ci.yml
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,10 +1,8 @@
 import org.gradle.util.GradleVersion
 import org.gradle.api.GradleScriptException
 
-// Minimum Gradle version for main build
-def minGradleVersion = GradleVersion.version("4.4")
-// Minimum Gradle version for builds of JavaFX 11 module
-def minFxGradleVersion = GradleVersion.version("4.10")
+// Minimum Gradle version for build
+def minGradleVersion = GradleVersion.version("5.6")
 
 rootProject.name = 'bitcoinj-parent'
 
@@ -21,10 +19,10 @@ project(':tools').name = 'bitcoinj-tools'
 include 'examples'
 project(':examples').name = 'bitcoinj-examples'
 
-if (GradleVersion.current().compareTo(minFxGradleVersion) >= 0 && JavaVersion.current().isJava11Compatible()) {
-    System.err.println "Including wallettemplate because ${GradleVersion.current()} and Java ${JavaVersion.current()}"
+if (JavaVersion.current().isJava11Compatible()) {
+    System.err.println "Including wallettemplate because Java ${JavaVersion.current()}"
     include 'wallettemplate'
     project(':wallettemplate').name = 'bitcoinj-wallettemplate'
 } else {
-    System.err.println "Skipping wallettemplate, requires ${minFxGradleVersion}+ and Java 11+, currently running: ${GradleVersion.current()} and Java ${JavaVersion.current()}"
+    System.err.println "Skipping wallettemplate, requires Java 11+, currently running: Java ${JavaVersion.current()}"
 }


### PR DESCRIPTION
Resolves Issue #1985 

* Upgrade to ProtoBuf Gradle Plugin 0.8.12 which requires Gradle 5.6+
* Require Gradle 5.6 or later in `settings.gradle`
* Simplify `settings.gradle` since minimum Gradle version is the same for `wallettemplate` and the rest of the build
* Use Gradle 5.6 in Travis CI build
* Use Gradle 5.6 in Gitlab CI build
* Use `empty-settings.gradle` for Gradle wrapper updates on Travis/Gitlab