### PR TITLE
BIP-39 normalize passphrase and words

### DIFF
--- a/core/src/test/java/org/bitcoinj/crypto/MnemonicCodeTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/MnemonicCodeTest.java
@@ -17,15 +17,16 @@
 
 package org.bitcoinj.crypto;
 
+import org.junit.Before;
+import org.junit.Test;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import static org.bitcoinj.core.Utils.HEX;
 import static org.bitcoinj.core.Utils.WHITESPACE_SPLITTER;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test the various guard clauses of {@link MnemonicCode}.
@@ -45,7 +46,7 @@ public class MnemonicCodeTest {
     public void testBadEntropyLength() throws Exception {
         byte[] entropy = HEX.decode("7f7f7f7f7f7f7f7f7f7f7f7f7f7f");
         mc.toMnemonic(entropy);
-    }    
+    }
 
     @Test(expected = MnemonicException.MnemonicLengthException.class)
     public void testBadLength() throws Exception {
@@ -78,8 +79,22 @@ public class MnemonicCodeTest {
     }
 
     @Test(expected = NullPointerException.class)
-    public void testNullPassphrase() throws Exception {
+    public void testNullPassphrase() {
         List<String> code = WHITESPACE_SPLITTER.splitToList("legal winner thank year wave sausage worth useful legal winner thank yellow");
         MnemonicCode.toSeed(code, null);
+    }
+
+    /**
+     * Test data from: https://iancoleman.io/bip39/#english
+     */
+    @Test
+    public void testWithPassphraseSpecialChars() {
+        List<String> code = WHITESPACE_SPLITTER.splitToList(
+                "smart deer exclude episode famous inside post inmate rocket analyst soccer mammal");
+        final byte[] seed = MnemonicCode.toSeed(code, "BananoweŻycie");
+
+        assertEquals(
+                "2e9c82dde1ed6e8ce61bb9403b570ff5021843638d589100796b40b513b7f82fa0306037321e13a237fb04016daaa94b4c2c6e23453a2f500e3b6fa1e0ee7c99",
+                HEX.encode(seed));
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,4 @@
 import org.gradle.util.GradleVersion
-import org.gradle.api.GradleScriptException
 
 // Minimum Gradle version for main build
 def minGradleVersion = GradleVersion.version("4.4")
@@ -8,7 +7,7 @@ def minFxGradleVersion = GradleVersion.version("4.10")
 
 rootProject.name = 'bitcoinj-parent'
 
-if (GradleVersion.current().compareTo(minGradleVersion) < 0) {
+if (GradleVersion.current() < minGradleVersion) {
     throw new GradleScriptException("bitcoinj build requires Gradle ${minGradleVersion} or later", null)
 }
 
@@ -21,7 +20,7 @@ project(':tools').name = 'bitcoinj-tools'
 include 'examples'
 project(':examples').name = 'bitcoinj-examples'
 
-if (GradleVersion.current().compareTo(minFxGradleVersion) >= 0 && JavaVersion.current().isJava11Compatible()) {
+if (GradleVersion.current() >= minFxGradleVersion && JavaVersion.current().isJava11Compatible()) {
     System.err.println "Including wallettemplate because ${GradleVersion.current()} and Java ${JavaVersion.current()}"
     include 'wallettemplate'
     project(':wallettemplate').name = 'bitcoinj-wallettemplate'


### PR DESCRIPTION
Fix for: https://github.com/bitcoinj/bitcoinj/issues/10

Added NKFD normalization for passphrase and words too. At this moment only english words are supported in bitcoinj, but after this fix, I am going to add support for other languages too (available in BIP-39).