### PR TITLE
BlockImporter: use switch statement instead of if/else if for parsing block store argument

### DIFF
--- a/tools/src/main/java/org/bitcoinj/tools/BlockImporter.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BlockImporter.java
@@ -40,18 +40,22 @@ public class BlockImporter {
             params = MainNetParams.get();
 
         BlockStore store;
-        if (args[1].equals("MemFull")) {
-            Preconditions.checkArgument(args.length == 2);
-            store = new MemoryFullPrunedBlockStore(params, 100);
-        } else if (args[1].equals("Mem")) {
-            Preconditions.checkArgument(args.length == 2);
-            store = new MemoryBlockStore(params);
-        } else if (args[1].equals("SPV")) {
-            Preconditions.checkArgument(args.length == 3);
-            store = new SPVBlockStore(params, new File(args[2]));
-        } else {
-            System.err.println("Unknown store " + args[1]);
-            return;
+        switch (args[1]) {
+            case "MemFull":
+                Preconditions.checkArgument(args.length == 2);
+                store = new MemoryFullPrunedBlockStore(params, 100);
+                break;
+            case "Mem":
+                Preconditions.checkArgument(args.length == 2);
+                store = new MemoryBlockStore(params);
+                break;
+            case "SPV":
+                Preconditions.checkArgument(args.length == 3);
+                store = new SPVBlockStore(params, new File(args[2]));
+                break;
+            default:
+                System.err.println("Unknown store " + args[1]);
+                return;
         }
         
         AbstractBlockChain chain = null;


### PR DESCRIPTION
All changes are logically equivalent to old code.

* Use lambdas in a few places
* <>
* Combine catches
* etc.