### PR TITLE
Replace Guava Stopwatch with custom utility class

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -18,7 +18,7 @@
 package org.bitcoinj.core;
 
 import com.google.common.annotations.*;
-import com.google.common.base.*;
+import com.google.common.base.Throwables;
 import com.google.common.collect.*;
 import com.google.common.util.concurrent.*;
 import net.jcip.annotations.*;

--- a/core/src/main/java/org/bitcoinj/crypto/KeyCrypterScrypt.java
+++ b/core/src/main/java/org/bitcoinj/crypto/KeyCrypterScrypt.java
@@ -17,7 +17,7 @@
 
 package org.bitcoinj.crypto;
 
-import com.google.common.base.Stopwatch;
+import org.bitcoinj.utils.Stopwatch;
 import com.google.protobuf.ByteString;
 import org.bitcoinj.core.Utils;
 import org.bitcoinj.wallet.Protos;

--- a/core/src/main/java/org/bitcoinj/crypto/MnemonicCode.java
+++ b/core/src/main/java/org/bitcoinj/crypto/MnemonicCode.java
@@ -22,7 +22,7 @@ import org.bitcoinj.core.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Stopwatch;
+import org.bitcoinj.utils.Stopwatch;
 
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;

--- a/core/src/main/java/org/bitcoinj/params/AbstractBitcoinNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/AbstractBitcoinNetParams.java
@@ -20,7 +20,6 @@ package org.bitcoinj.params;
 import static com.google.common.base.Preconditions.checkState;
 
 import java.math.BigInteger;
-import java.util.concurrent.TimeUnit;
 
 import org.bitcoinj.core.Block;
 import org.bitcoinj.core.Coin;
@@ -34,10 +33,9 @@ import org.bitcoinj.utils.MonetaryFormat;
 import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.BlockStoreException;
+import org.bitcoinj.utils.Stopwatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Stopwatch;
 
 import org.bitcoinj.core.BitcoinSerializer;
 
@@ -126,7 +124,7 @@ public abstract class AbstractBitcoinNetParams extends NetworkParameters {
         checkState(cursor != null && isDifficultyTransitionPoint(cursor.getHeight() - 1),
                 "Didn't arrive at a transition point.");
         watch.stop();
-        if (watch.elapsed(TimeUnit.MILLISECONDS) > 50)
+        if (watch.elapsedMillis() > 50)
             log.info("Difficulty transition traversal took {}", watch);
 
         Block blockIntervalAgo = cursor.getHeader();

--- a/core/src/main/java/org/bitcoinj/store/LevelDBFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/LevelDBFullPrunedBlockStore.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
 
 import static org.fusesource.leveldbjni.JniDBFactory.*;
 
-import com.google.common.base.Stopwatch;
+import org.bitcoinj.utils.Stopwatch;
 
 /**
  * <p>
@@ -352,17 +352,17 @@ public class LevelDBFullPrunedBlockStore implements FullPrunedBlockStore {
         if (methodCalls.containsKey(name)) {
             methodCalls.put(name, methodCalls.get(name) + 1);
             methodTotalTime.put(name,
-                    methodTotalTime.get(name) + methodStartTime.get(name).elapsed(TimeUnit.NANOSECONDS));
+                    methodTotalTime.get(name) + methodStartTime.get(name).elapsedNanos());
         } else {
             methodCalls.put(name, 1l);
-            methodTotalTime.put(name, methodStartTime.get(name).elapsed(TimeUnit.NANOSECONDS));
+            methodTotalTime.put(name, methodStartTime.get(name).elapsedNanos());
         }
     }
 
     // Debug method to display stats on runtime of each method
     // and cache hit rates etc..
     void dumpStats() {
-        long wallTimeNanos = totalStopwatch.elapsed(TimeUnit.NANOSECONDS);
+        long wallTimeNanos = totalStopwatch.elapsedNanos();
         long dbtime = 0;
         for (String name : methodCalls.keySet()) {
             long calls = methodCalls.get(name);

--- a/core/src/main/java/org/bitcoinj/utils/Stopwatch.java
+++ b/core/src/main/java/org/bitcoinj/utils/Stopwatch.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Michael Sean Gilligan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.utils;
+
+/**
+ * A simple stopwatch function that is a subset of the Guava stopwatch.
+ * The chosen subset is effectively what bitcoinj was using at the time this
+ * class was created. Uses {@link System#nanoTime()} internally.
+ */
+public class Stopwatch {
+    private boolean isRunning;
+    private final long startTime;
+    private long stopTime;
+
+    private Stopwatch() {
+        isRunning = true;
+        startTime = System.nanoTime();
+    }
+
+    /**
+     * Create and start a Stopwatch
+     *
+     * @return A running stopwatch
+     */
+    public static Stopwatch createStarted() {
+        return new Stopwatch();
+    }
+
+    /**
+     * Stop the stopwatch
+     */
+    public void stop() {
+        stopTime = System.nanoTime();
+        isRunning = false;
+    }
+
+    /**
+     * Return elapsed time in nanoseconds
+     *
+     * @return Elapsed time in nanoseconds
+     */
+    public long elapsedNanos() {
+        return isRunning ? System.nanoTime() - startTime : stopTime - startTime;
+    }
+
+    /**
+     * Return elapsed time in microseconds
+     *
+     * @return Elapsed time in microseconds
+     */
+    public long elapsedMicros() {
+        return elapsedNanos() / 1_000;
+    }
+
+    /**
+     * Return elapsed time in milliseconds
+     *
+     * @return Elapsed time in milliseconds
+     */
+    public long elapsedMillis() {
+        return elapsedNanos() / 1_000_000;
+    }
+
+    /**
+     * Return elapsed time in microseconds as a string
+     *
+     * @return Elapsed time in microseconds
+     */
+    @Override
+    public String toString() {
+        return elapsedMicros() + " \u03bcs";  // time in microseconds
+    }
+}

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -26,7 +26,7 @@ import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.listeners.KeyChainEventListener;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Stopwatch;
+import org.bitcoinj.utils.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.PeekingIterator;

--- a/core/src/main/java/org/bitcoinj/wallet/WalletFiles.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletFiles.java
@@ -21,7 +21,7 @@ import org.bitcoinj.core.*;
 import org.bitcoinj.utils.*;
 import org.slf4j.*;
 
-import com.google.common.base.Stopwatch;
+import org.bitcoinj.utils.Stopwatch;
 
 import javax.annotation.*;
 import java.io.*;

--- a/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -17,7 +17,6 @@
 
 package org.bitcoinj.core;
 
-import com.google.common.base.Stopwatch;
 import com.google.common.collect.*;
 import com.google.common.util.concurrent.*;
 import org.bitcoinj.core.listeners.*;
@@ -540,7 +539,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         // check things after disconnect
         watch.stop();
         assertFalse(peerConnectedFuture.isDone()); // should never have connected
-        assertTrue(watch.elapsed(TimeUnit.MILLISECONDS) >= timeout); // should not disconnect before timeout
+        assertTrue(watch.elapsedMillis() >= timeout); // should not disconnect before timeout
         assertTrue(peerDisconnectedFuture.isDone()); // but should disconnect eventually
     }
 

--- a/core/src/test/java/org/bitcoinj/store/SPVBlockStoreTest.java
+++ b/core/src/test/java/org/bitcoinj/store/SPVBlockStoreTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertNull;
 import java.io.File;
 import java.math.BigInteger;
 import java.util.Collections;
-import java.util.concurrent.TimeUnit;
 
 import org.bitcoinj.core.Address;
 import org.bitcoinj.core.Block;
@@ -35,10 +34,9 @@ import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.StoredBlock;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.params.UnitTestParams;
+import org.bitcoinj.utils.Stopwatch;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.base.Stopwatch;
 
 public class SPVBlockStoreTest {
     private static final NetworkParameters UNITTEST = UnitTestParams.get();
@@ -144,7 +142,7 @@ public class SPVBlockStoreTest {
             store.setChainHead(b);
         }
         assertTrue("took " + watch + " for " + ITERATIONS + " iterations",
-                watch.elapsed(TimeUnit.MILLISECONDS) < THRESHOLD_MS);
+                watch.elapsedMillis() < THRESHOLD_MS);
         store.close();
     }
 

--- a/core/src/test/java/org/bitcoinj/utils/StopwatchTest.java
+++ b/core/src/test/java/org/bitcoinj/utils/StopwatchTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Michael Sean Gilligan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public class StopwatchTest {
+    @Test
+    public void testStartStop() {
+        Stopwatch watch = Stopwatch.createStarted();
+        watch.stop();
+        assertTrue("No time has passed", watch.elapsedNanos() >= 0);
+        assertEquals( "Inconsistent microseconds and nanoseconds", watch.elapsedMicros(), watch.elapsedNanos() / 1000);
+        assertTrue("String without units", watch.toString().endsWith(" \u03bcs"));
+    }
+
+    @Test
+    public void testElapsed() {
+        Stopwatch watch = Stopwatch.createStarted();
+        assertTrue("No time has passed", watch.elapsedNanos() >= 0);
+        assertNotEquals("Clock didn't advance", watch.elapsedNanos(), watch.elapsedNanos());
+        assertTrue("String without units", watch.toString().endsWith(" \u03bcs"));
+    }
+
+    @Test
+    public void testWithShortSleep() throws InterruptedException {
+        Stopwatch watch = Stopwatch.createStarted();
+        Thread.sleep(0, 1000);
+        watch.stop();
+        assertTrue("Not enough time has passed",watch.elapsedNanos() >= 1_000);
+        assertEquals( "Inconsistent microseconds and nanoseconds", watch.elapsedMicros(), watch.elapsedNanos() / 1000);
+        assertTrue("String without units", watch.toString().endsWith(" \u03bcs"));
+    }
+}


### PR DESCRIPTION
We were only using a subset of the Guava Stopwatch functionality so this
simple utility class removes yet another dependency on Guava.