### PR TITLE
Remove use of bounded wildcard in Networks.networks

### DIFF
--- a/core/src/main/java/org/bitcoinj/params/Networks.java
+++ b/core/src/main/java/org/bitcoinj/params/Networks.java
@@ -31,9 +31,9 @@ import java.util.Set;
  */
 public class Networks {
     /** Registered networks */
-    private static Set<? extends NetworkParameters> networks = ImmutableSet.of(TestNet3Params.get(), MainNetParams.get());
+    private static Set<NetworkParameters> networks = ImmutableSet.<NetworkParameters>of(TestNet3Params.get(), MainNetParams.get());
 
-    public static Set<? extends NetworkParameters> get() {
+    public static Set<NetworkParameters> get() {
         return networks;
     }
 


### PR DESCRIPTION
The use of a bounded wildcard type in `Networks.networks` is unnecessary and not a best practice.

This is a subset of #1998. 

It is based upon guidelines in Effective Java, 3rd Edition[1]. In general if you have a `List` of some type (e.g. `NetworkParameters`) it perfectly legal to put subclasses in the `List`. The `? extends` is used when you want to refer to an arbitrary generic list that _may_ have been declared with a subtype of `NetworkParameters` (e.g. a `List<AbstractBitcoinNetParams>` for which client code may expect all objects in the list to support the methods of the subclass.)

In the case of `Networks` there is only one _type of List_: a list of objects that implement `NetworkParameters`. So we can simplify the internal code and API by dropping the `? extends`.

[1] "Do not use bounded wildcard types as return types" and "If the user of a class has to think about wildcard types, there is probably something wrong with its API", p. 142.