### PR TITLE
Add a (currently broken) test that demonstrates the compareTo collision

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
@@ -248,6 +248,15 @@ public class LegacyAddressTest {
     }
 
     @Test
+    public void comparisonNotEqual() {
+        LegacyAddress a = LegacyAddress.fromBase58(MAINNET, "14wivxvNTv9THhewPotsooizZawaWbEKE2");
+        LegacyAddress b = LegacyAddress.fromBase58(MAINNET, "35djrWQp1pTqNsMNWuZUES5vi7EJ74m9Eh");
+
+        int result = a.compareTo(b);
+        assertTrue(result != 0);
+    }
+
+    @Test
     public void comparisonBytesVsString() throws Exception {
         BufferedReader dataSetReader = new BufferedReader(
                 new InputStreamReader(getClass().getResourceAsStream("LegacyAddressTestDataset.txt")));


### PR DESCRIPTION
This test illustrates the problem with compareTo not finding a difference between p2sh and non-p2sh addresses with the same `bytes[]`.