### PR TITLE
Upgrade to JUnit 5 using “Vintage” engine

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     testImplementation 'com.h2database:h2:1.3.176'
     testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.9'
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:5.8.2"
 }
 
 sourceCompatibility = 8
@@ -54,6 +55,7 @@ protobuf {
 }
 
 tasks.withType(Test) {
+    useJUnitPlatform()
     exclude 'org/bitcoinj/core/PeerTest*'
     exclude 'org/bitcoinj/core/TransactionBroadcastTest*'
     exclude 'org/bitcoinj/net/discovery/DnsDiscoveryTest*'


### PR DESCRIPTION
Unfortunately, this requires Gradle 4.6 or later. Upgrading to JUnit 5
allows us to start using JUnit 5 features while still running JUnit 4
tests with the “vintage” engine.

Upgrading to JUnit 5 was one of the proposed steps to improving our testing capability in Issue #1984.   (See idea number 5 on this comment: https://github.com/bitcoinj/bitcoinj/issues/1984#issuecomment-619239187 )