### PR TITLE
Github Actions: Upload test results as artifact

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,3 +21,11 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Build with Gradle
         run: gradle build --stacktrace
+      - name: Upload Test Results and Reports
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: bitcoinj-core-test-results-jdk${{ matrix.java }}-${{ matrix.os }}
+          path: |
+            core/build/reports/tests/test/
+            core/build/test-results/test/


### PR DESCRIPTION
Upload tests results and reports for the `bitcoinj-core` subproject whether the build succeeds or fails. (There are no tests for the other modules yet)

