### PR TITLE
Remove unused mock sleep support from Utils

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -567,7 +567,6 @@ public class PeerGroupTest extends TestWithPeerGroup {
         });
         peerGroup.setMaxConnections(3);
 
-        Utils.setMockSleep(true);
         blockJobs = true;
 
         jobBlocks.release(2);   // startup + first peer discovery

--- a/core/src/test/java/org/bitcoinj/testing/TestWithPeerGroup.java
+++ b/core/src/test/java/org/bitcoinj/testing/TestWithPeerGroup.java
@@ -74,7 +74,6 @@ public class TestWithPeerGroup extends TestWithNetworkConnections {
         try {
             super.tearDown();
             blockJobs = false;
-            Utils.finishMockSleep();
             if (peerGroup.isRunning())
                 peerGroup.stopAsync();
         } catch (Exception e) {


### PR DESCRIPTION
This is apparently unused, so I think it should be removed. If we need such a capability I recommend injecting it via a constructor rather than using a Utils object and static variables/methods.

(The mock time capability is causing problems in the unit tests that I'm currently debugging and it should probably also be removed/refactored, but it is more widely used so I intend to fix/workaround the issue instead)
