### PR TITLE
Fix bogus test failures using @BeforeClass initializer for Utils.resetMocking

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -29,6 +29,7 @@ import org.bitcoinj.wallet.SendRequest;
 import org.bitcoinj.wallet.Wallet;
 import org.bitcoinj.wallet.WalletTransaction;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,20 +53,25 @@ public abstract class AbstractFullPrunedBlockChainTest {
 
     private static final Logger log = LoggerFactory.getLogger(AbstractFullPrunedBlockChainTest.class);
 
-    protected static final NetworkParameters PARAMS = new UnitTestParams() {
-        @Override public int getInterval() {
-            return 10000;
-        }
-    };
+    protected static NetworkParameters PARAMS;
     private static final NetworkParameters MAINNET = MainNetParams.get();
 
     protected FullPrunedBlockChain chain;
     protected FullPrunedBlockStore store;
 
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        Utils.resetMocking();
+        PARAMS = new UnitTestParams() {
+            @Override public int getInterval() {
+                return 10000;
+            }
+        };
+    }
+
     @Before
     public void setUp() throws Exception {
         BriefLogFormatter.init();
-        Utils.resetMocking();
         Context.propagate(new Context(PARAMS, 100, Coin.ZERO, false));
     }
 

--- a/core/src/test/java/org/bitcoinj/store/LevelDBBlockStoreTest.java
+++ b/core/src/test/java/org/bitcoinj/store/LevelDBBlockStoreTest.java
@@ -21,6 +21,7 @@ import org.bitcoinj.core.Context;
 import org.bitcoinj.core.LegacyAddress;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.StoredBlock;
+import org.bitcoinj.core.Utils;
 import org.bitcoinj.params.*;
 import org.junit.*;
 
@@ -29,7 +30,13 @@ import java.io.*;
 import static org.junit.Assert.assertEquals;
 
 public class LevelDBBlockStoreTest {
-    private static final NetworkParameters UNITTEST = UnitTestParams.get();
+    private static NetworkParameters UNITTEST;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        Utils.resetMocking();
+        UNITTEST = UnitTestParams.get();
+    }
 
     @Test
     public void basics() throws Exception {

--- a/core/src/test/java/org/bitcoinj/store/SPVBlockStoreTest.java
+++ b/core/src/test/java/org/bitcoinj/store/SPVBlockStoreTest.java
@@ -34,15 +34,23 @@ import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.StoredBlock;
 import org.bitcoinj.core.Transaction;
+import org.bitcoinj.core.Utils;
 import org.bitcoinj.params.UnitTestParams;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.common.base.Stopwatch;
 
 public class SPVBlockStoreTest {
-    private static final NetworkParameters UNITTEST = UnitTestParams.get();
+    private static NetworkParameters UNITTEST;
     private File blockStoreFile;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        Utils.resetMocking();
+        UNITTEST = UnitTestParams.get();
+    }
 
     @Before
     public void setup() throws Exception {

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -60,6 +60,7 @@ import org.bitcoinj.wallet.WalletTransaction;
 import org.bitcoinj.wallet.WalletTransaction.Pool;
 import org.bitcoinj.wallet.listeners.WalletCoinsReceivedEventListener;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -78,7 +79,7 @@ import static org.junit.Assert.*;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class WalletProtobufSerializerTest {
-    private static final NetworkParameters UNITTEST = UnitTestParams.get();
+    private static NetworkParameters UNITTEST;
     private static final NetworkParameters MAINNET = MainNetParams.get();
 
     private ECKey myKey;
@@ -88,6 +89,12 @@ public class WalletProtobufSerializerTest {
 
     public static String WALLET_DESCRIPTION  = "The quick brown fox lives in \u4f26\u6566"; // Beijing in Chinese
     private long mScriptCreationTime;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        Utils.resetMocking();
+        UNITTEST = UnitTestParams.get();
+    }
 
     @Before
     public void setUp() throws Exception {

--- a/core/src/test/java/org/bitcoinj/utils/VersionTallyTest.java
+++ b/core/src/test/java/org/bitcoinj/utils/VersionTallyTest.java
@@ -20,19 +20,27 @@ import org.bitcoinj.core.BlockChain;
 import org.bitcoinj.core.Context;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.StoredBlock;
+import org.bitcoinj.core.Utils;
 import org.bitcoinj.params.UnitTestParams;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.testing.FakeTxBuilder;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.Before;
 
 public class VersionTallyTest {
-    private static final NetworkParameters UNITTEST = UnitTestParams.get();
+    private static NetworkParameters UNITTEST;
 
     public VersionTallyTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        Utils.resetMocking();
+        UNITTEST = UnitTestParams.get();
     }
 
     @Before


### PR DESCRIPTION
This fixes (or works around) the failures we're currently seeing on GitHub Actions Ubuntu and most (but not all) of the failures we were seeing on Github Actions Windows before we disabled testing on Windows.

