### PR TITLE
Github Actions: Cache Gradle packages

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,6 +17,12 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
       - name: Build with Gradle
         run: gradle build --stacktrace
       - name: Upload Test Results and Reports

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![Visit our IRC channel](https://kiwiirc.com/buttons/irc.freenode.net/bitcoinj.png)](https://kiwiirc.com/client/irc.freenode.net/bitcoinj)
 
-### Welcome to bitcoinj
+### Welcome to bitcoinj 
 
 The bitcoinj library is a Java implementation of the Bitcoin protocol, which allows it to maintain a wallet and send/receive transactions without needing a local copy of Bitcoin Core. It comes with full documentation and some example apps showing how to use it.
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.10'
     }
 }
-
+ 
 allprojects {
     repositories {
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -15,3 +15,5 @@ allprojects {
 
     group = 'org.bitcoinj'
 }
+
+/* Trivial, non-whitespace change. Delete me */


### PR DESCRIPTION
This should speed up the builds.

See: https://docs.github.com/en/actions/language-and-framework-guides/building-and-testing-java-with-gradle#caching-dependencies