### PR TITLE
Github Actions: Re-enable windows-latest

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,9 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # windows-latest currently fails on some tests
-        # TODO: Fix windows issues and add `windows-latest`
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         java: [ '8', '11', '14' ]
       fail-fast: false
     name: JAVA ${{ matrix.java }} OS ${{ matrix.os }}


### PR DESCRIPTION
This is a draft PR that we can keep re-basing against `master` until all the Windows-blockers are fixed.
