### PR TITLE
Fix incorrect AppDataDirectory tests on Windows

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,9 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # windows-latest currently fails on some tests
-        # TODO: Fix windows issues and add `windows-latest`
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         java: [ '8', '11', '14' ]
       fail-fast: false
     name: JAVA ${{ matrix.java }} OS ${{ matrix.os }}

--- a/core/src/test/java/org/bitcoinj/utils/AppDataDirectoryTest.java
+++ b/core/src/test/java/org/bitcoinj/utils/AppDataDirectoryTest.java
@@ -61,24 +61,23 @@ public class AppDataDirectoryTest {
 
     @Test(expected = RuntimeException.class)
     public void throwsIOExceptionIfPathNotFound() {
-        // The null character is non printable and an ASCII control character
-        // Forbidden on all OSs
+        // Force exceptions with illegal characters
         if (Utils.isWindows()) {
-            AppDataDirectory.get("/");
+            AppDataDirectory.get(":");  // Illegal character for Windows
         }
         if (Utils.isMac()) {
             // NUL character
-            AppDataDirectory.get("\0");
+            AppDataDirectory.get("\0"); // Illegal character for Mac
         }
         if (Utils.isLinux()) {
             // NUL character
-            AppDataDirectory.get("\0");
+            AppDataDirectory.get("\0"); // Illegal character for Linux
         }
     }
 
 
     private static String winPath(String appName) {
-        return WINAPPDATA + "\\." + appName.toLowerCase();
+        return WINAPPDATA + "\\" + appName.toLowerCase();
     }
 
     private static String macPath(String appName) {


### PR DESCRIPTION
These tests were failing on Windows. This PR, plus PR #2028 will fix all the failures I'm seeing on `windows-latest` except one (`SPVBlockStoreTest.oneStoreDelete()` which has a comment "Used to fail on Widows")