### PR TITLE
Github Actions: latest JDK ’15’ bump from ’14’

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        java: [ '8', '11', '14' ]
+        java: [ '8', '11', '15' ]
       fail-fast: false
     name: JAVA ${{ matrix.java }} OS ${{ matrix.os }}
     steps:


### PR DESCRIPTION
This is a DRAFT PR so we can see if our build/tests work with the current JDK 15 Early Access. When JDK 15 is released in a few weeks, we should replace JDK 14 in our matrix with JDK 15. We can update this PR at that point.

Thus we'll be building/testing with JDK 8, JDK 11 (LTS), and the latest released JDK.