### PR TITLE
wallettemplate: upgrade JavaFX to version 15

### DIFF
--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 }
 
 javafx {
-    version = '14.0.1'
+    version = '15'
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 


### PR DESCRIPTION
JavaFX 15 is released and is the now the latest supported version. It supports JDK 11 and later — same as the previous release.

Release notes are here:
https://github.com/openjdk/jfx/blob/jfx15/doc-files/release-notes-15.md#release-notes-for-javafx-15