### PR TITLE
TestWithPeerGroup — increase timeout to 15 seconds

### DIFF
--- a/core/src/test/java/org/bitcoinj/testing/TestWithPeerGroup.java
+++ b/core/src/test/java/org/bitcoinj/testing/TestWithPeerGroup.java
@@ -49,7 +49,7 @@ public class TestWithPeerGroup extends TestWithNetworkConnections {
     }
 
     @Rule
-    public Timeout globalTimeout = Timeout.seconds(10);
+    public Timeout globalTimeout = Timeout.seconds(15);
 
     @Override
     public void setUp() throws Exception {


### PR DESCRIPTION
PeerGroup tests intermittently failing with timeout errors on CI. [example](https://github.com/bitcoinj/bitcoinj/pull/2047/checks?check_run_id=1120297345)

Let's increase the timeout from 10 seconds to 20 seconds to reduce or eliminate these random failures.
