### PR TITLE
Always use ConfidenceChange listener

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
@@ -141,9 +141,7 @@ public class TransactionBroadcast {
             // a big effect.
             List<Peer> peers = peerGroup.getConnectedPeers();    // snapshots
             // Prepare to send the transaction by adding a listener that'll be called when confidence changes.
-            // Only bother with this if we might actually hear back:
-            if (minConnections > 1)
-                tx.getConfidence().addEventListener(new ConfidenceChange());
+            tx.getConfidence().addEventListener(new ConfidenceChange());
             // Bitcoin Core sends an inv in this case and then lets the peer request the tx data. We just
             // blast out the TX here for a couple of reasons. Firstly it's simpler: in the case where we have
             // just a single connection we don't have to wait for getdata to be received and handled before


### PR DESCRIPTION
If connected to 1 peer, it will be disconnected and reconnected after the broadcast, so we in fact will hear the inv from that peer.

Otherwise, when connected to just 1 peer, the future is never set.