### PR TITLE
prevention null pointer exception

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
@@ -28,6 +28,7 @@ import org.slf4j.*;
 
 import javax.annotation.*;
 import java.util.*;
+import java.util.Objects;
 import java.util.concurrent.*;
 import java.util.concurrent.locks.*;
 
@@ -505,7 +506,7 @@ public abstract class AbstractBlockChain {
         if (!params.passesCheckpoint(storedPrev.getHeight() + 1, block.getHash()))
             throw new VerificationException("Block failed checkpoint lockin at " + (storedPrev.getHeight() + 1));
         if (shouldVerifyTransactions()) {
-            for (Transaction tx : block.getTransactions())
+            for (Transaction tx : Objects.requireNonNull(block.getTransactions()))
                 if (!tx.isFinal(storedPrev.getHeight() + 1, block.getTimeSeconds()))
                    throw new VerificationException("Block contains non-final transaction");
         }


### PR DESCRIPTION
Dereference of block.getTransactions() may produce null pointer exception. 