### PR TITLE
MainNetParams: Add seed.bitcoin.wiz.biz to DNS seeds

### DIFF
--- a/core/src/main/java/org/bitcoinj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/MainNetParams.java
@@ -79,6 +79,7 @@ public class MainNetParams extends AbstractBitcoinNetParams {
                 "seed.btc.petertodd.org",       // Peter Todd
                 "seed.bitcoin.sprovoost.nl",    // Sjors Provoost
                 "dnsseed.emzy.de",              // Stephan Oeste
+                "seed.bitcoin.wiz.biz",         // Jason Maurice
         };
         httpSeeds = new HttpDiscovery.Details[] {
                 // Andreas Schildbach


### PR DESCRIPTION
DNS seed was added to Bitcoin Core in https://github.com/bitcoin/bitcoin/pull/19284

Documentation: https://wiz.biz/bitcoin/seed