### PR TITLE
build.gradle: Migrate repository from JCenter to Maven Central.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -10,7 +10,7 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     group = 'org.bitcoinj'


### PR DESCRIPTION
JCenter will stop accepting submission on February 28th and the repo will no longer be available on May 1st.

https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/