### PR TITLE
WalletTool: Implement two coin selection options for sending

### DIFF
--- a/tools/src/main/java/org/bitcoinj/tools/WalletTool.java
+++ b/tools/src/main/java/org/bitcoinj/tools/WalletTool.java
@@ -628,11 +628,12 @@ public class WalletTool implements Callable<Integer> {
         for (String spec : outputs) {
             try {
                 OutputSpec outputSpec = new OutputSpec(spec);
-                if (outputSpec.isAddress()) {
-                    t.addOutput(outputSpec.value, outputSpec.addr);
-                } else {
-                    t.addOutput(outputSpec.value, outputSpec.key);
-                }
+                Coin value = outputSpec.value != null ? outputSpec.value :
+                        wallet.getBalance(allowUnconfirmed ? BalanceType.ESTIMATED : BalanceType.AVAILABLE);
+                if (outputSpec.isAddress())
+                    t.addOutput(value, outputSpec.addr);
+                else
+                    t.addOutput(value, outputSpec.key);
             } catch (AddressFormatException.WrongNetwork e) {
                 System.err.println("Malformed output specification, address is for a different network: " + spec);
                 return;
@@ -716,7 +717,7 @@ public class WalletTool implements Callable<Integer> {
             }
             String destination = parts[0];
             if ("ALL".equalsIgnoreCase(parts[1]))
-                value = wallet.getBalance(BalanceType.ESTIMATED);
+                value = null;
             else
                 value = parseCoin(parts[1]);
             if (destination.startsWith("0")) {


### PR DESCRIPTION
WalletTool: Implement two coin selection options for sending, `--select-addr=<address>` and `--select-output=<txid>:<index>`.

