### PR TITLE
Message hierarchy: Remove constructors that take a separate protocolVersion argument.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AddressMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressMessage.java
@@ -77,7 +77,7 @@ public class AddressMessage extends Message {
         addresses = new ArrayList<>((int) numAddresses);
         int protocolVersion = serializer.getProtocolVersion();
         for (int i = 0; i < numAddresses; i++) {
-            PeerAddress addr = new PeerAddress(params, payload, cursor, protocolVersion, this, serializer);
+            PeerAddress addr = new PeerAddress(params, payload, cursor, this, serializer);
             addresses.add(addr);
             cursor += addr.getMessageSize();
         }

--- a/core/src/main/java/org/bitcoinj/core/ChildMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/ChildMessage.java
@@ -39,23 +39,13 @@ public abstract class ChildMessage extends Message {
         super(params);
     }
 
-    public ChildMessage(NetworkParameters params, byte[] payload, int offset, int protocolVersion) throws ProtocolException {
-        super(params, payload, offset, protocolVersion);
-    }
-
-    public ChildMessage(NetworkParameters params, byte[] payload, int offset, int protocolVersion,
-                        @Nullable Message parent, MessageSerializer setSerializer, int length) throws ProtocolException {
-        super(params, payload, offset, protocolVersion, setSerializer, length);
-        this.parent = parent;
-    }
-
     public ChildMessage(NetworkParameters params, byte[] payload, int offset) throws ProtocolException {
         super(params, payload, offset);
     }
 
-    public ChildMessage(NetworkParameters params, byte[] payload, int offset, @Nullable Message parent, MessageSerializer setSerializer, int length)
-            throws ProtocolException {
-        super(params, payload, offset, setSerializer, length);
+    public ChildMessage(NetworkParameters params, byte[] payload, int offset, @Nullable Message parent,
+                        MessageSerializer serializer, int length) throws ProtocolException {
+        super(params, payload, offset, serializer, length);
         this.parent = parent;
     }
 

--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -65,23 +65,18 @@ public abstract class Message {
         this.serializer = params.getDefaultSerializer();
     }
 
-    protected Message(NetworkParameters params, byte[] payload, int offset, int protocolVersion) throws ProtocolException {
-        this(params, payload, offset, protocolVersion, params.getDefaultSerializer(), UNKNOWN_LENGTH);
-    }
-
     /**
      * 
      * @param params NetworkParameters object.
      * @param payload Bitcoin protocol formatted byte array containing message content.
      * @param offset The location of the first payload byte within the array.
-     * @param protocolVersion Bitcoin protocol version.
      * @param serializer the serializer to use for this message.
      * @param length The length of message payload if known.  Usually this is provided when deserializing of the wire
      * as the length will be provided as part of the header.  If unknown then set to Message.UNKNOWN_LENGTH
      * @throws ProtocolException
      */
-    protected Message(NetworkParameters params, byte[] payload, int offset, int protocolVersion, MessageSerializer serializer, int length) throws ProtocolException {
-        this.serializer = serializer.withProtocolVersion(protocolVersion);
+    protected Message(NetworkParameters params, byte[] payload, int offset, MessageSerializer serializer, int length) throws ProtocolException {
+        this.serializer = serializer;
         this.params = params;
         this.payload = payload;
         this.cursor = this.offset = offset;
@@ -98,12 +93,7 @@ public abstract class Message {
     }
 
     protected Message(NetworkParameters params, byte[] payload, int offset) throws ProtocolException {
-        this(params, payload, offset, params.getDefaultSerializer().getProtocolVersion(),
-             params.getDefaultSerializer(), UNKNOWN_LENGTH);
-    }
-
-    protected Message(NetworkParameters params, byte[] payload, int offset, MessageSerializer serializer, int length) throws ProtocolException {
-        this(params, payload, offset, serializer.getProtocolVersion(), serializer, length);
+        this(params, payload, offset, params.getDefaultSerializer(), UNKNOWN_LENGTH);
     }
 
     // These methods handle the serialization/deserialization using the custom Bitcoin protocol.

--- a/core/src/main/java/org/bitcoinj/core/PeerAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerAddress.java
@@ -46,32 +46,24 @@ public class PeerAddress extends ChildMessage {
 
     /**
      * Construct a peer address from a serialized payload.
-     */
-    public PeerAddress(NetworkParameters params, byte[] payload, int offset, int protocolVersion) throws ProtocolException {
-        super(params, payload, offset, protocolVersion);
-    }
-
-    /**
-     * Construct a peer address from a serialized payload.
      * @param params NetworkParameters object.
      * @param payload Bitcoin protocol formatted byte array containing message content.
      * @param offset The location of the first payload byte within the array.
-     * @param protocolVersion Bitcoin protocol version.
      * @param serializer the serializer to use for this message.
      * @throws ProtocolException
      */
-    public PeerAddress(NetworkParameters params, byte[] payload, int offset, int protocolVersion, Message parent, MessageSerializer serializer) throws ProtocolException {
-        super(params, payload, offset, protocolVersion, parent, serializer, UNKNOWN_LENGTH);
+    public PeerAddress(NetworkParameters params, byte[] payload, int offset, Message parent, MessageSerializer serializer) throws ProtocolException {
+        super(params, payload, offset, parent, serializer, UNKNOWN_LENGTH);
     }
 
     /**
      * Construct a peer address from a memorized or hardcoded address.
      */
-    public PeerAddress(NetworkParameters params, InetAddress addr, int port, int protocolVersion, BigInteger services) {
+    public PeerAddress(NetworkParameters params, InetAddress addr, int port, BigInteger services, MessageSerializer serializer) {
         super(params);
         this.addr = checkNotNull(addr);
         this.port = port;
-        setSerializer(serializer.withProtocolVersion(protocolVersion));
+        setSerializer(serializer);
         this.services = services;
         length = isSerializeTime() ? MESSAGE_SIZE : MESSAGE_SIZE - 4;
     }
@@ -80,8 +72,7 @@ public class PeerAddress extends ChildMessage {
      * Constructs a peer address from the given IP address and port. Version number is default for the given parameters.
      */
     public PeerAddress(NetworkParameters params, InetAddress addr, int port) {
-        this(params, addr, port, params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.CURRENT),
-                BigInteger.ZERO);
+        this(params, addr, port, BigInteger.ZERO, params.getDefaultSerializer());
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/VersionMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionMessage.java
@@ -112,9 +112,9 @@ public class VersionMessage extends Message {
         // Note that the Bitcoin Core doesn't do anything with these, and finding out your own external IP address
         // is kind of tricky anyway, so we just put nonsense here for now.
         InetAddress localhost = InetAddresses.forString("127.0.0.1");
-        receivingAddr = new PeerAddress(params, localhost, params.getPort(), clientVersion, BigInteger.ZERO);
+        receivingAddr = new PeerAddress(params, localhost, params.getPort(), BigInteger.ZERO, serializer);
         receivingAddr.setParent(this);
-        fromAddr = new PeerAddress(params, localhost, params.getPort(), clientVersion, BigInteger.ZERO);
+        fromAddr = new PeerAddress(params, localhost, params.getPort(), BigInteger.ZERO, serializer);
         fromAddr.setParent(this);
         subVer = LIBRARY_SUBVER;
         bestHeight = newBestHeight;
@@ -129,10 +129,10 @@ public class VersionMessage extends Message {
         clientVersion = (int) readUint32();
         localServices = readUint64().longValue();
         time = readUint64().longValue();
-        receivingAddr = new PeerAddress(params, payload, cursor, 0, this, serializer);
+        receivingAddr = new PeerAddress(params, payload, cursor, this, serializer.withProtocolVersion(0));
         cursor += receivingAddr.getMessageSize();
         if (clientVersion >= 106) {
-            fromAddr = new PeerAddress(params, payload, cursor, 0, this, serializer);
+            fromAddr = new PeerAddress(params, payload, cursor, this, serializer.withProtocolVersion(0));
             cursor += fromAddr.getMessageSize();
             // uint64 localHostNonce (random data)
             // We don't care about the localhost nonce. It's used to detect connecting back to yourself in cases where

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -804,9 +804,8 @@ public class WalletProtobufSerializer {
                 throw new UnreadableWalletException("Peer IP address does not have the right length", e);
             }
             int port = proto.getPort();
-            int protocolVersion = params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.CURRENT);
             BigInteger services = BigInteger.valueOf(proto.getServices());
-            PeerAddress address = new PeerAddress(params, ip, port, protocolVersion, services);
+            PeerAddress address = new PeerAddress(params, ip, port, services, params.getDefaultSerializer());
             confidence.markBroadcastBy(address);
         }
         if (confidenceProto.hasLastBroadcastedAt())

--- a/core/src/test/java/org/bitcoinj/core/PeerAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerAddressTest.java
@@ -34,7 +34,8 @@ public class PeerAddressTest {
     public void parse_ancientProtocolVersion() throws Exception {
         // copied from https://en.bitcoin.it/wiki/Protocol_documentation#Network_address
         String hex = "010000000000000000000000000000000000ffff0a000001208d";
-        PeerAddress pa = new PeerAddress(MAINNET, HEX.decode(hex), 0, 0);
+        PeerAddress pa = new PeerAddress(MAINNET, HEX.decode(hex), 0, null,
+                MAINNET.getDefaultSerializer().withProtocolVersion(0));
         assertEquals(26, pa.length);
         assertEquals(VersionMessage.NODE_NETWORK, pa.getServices().longValue());
         assertEquals("10.0.0.1", pa.getAddr().getHostAddress());
@@ -43,7 +44,8 @@ public class PeerAddressTest {
 
     @Test
     public void bitcoinSerialize_ancientProtocolVersion() throws Exception {
-        PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName(null), 8333, 0, BigInteger.ZERO);
+        PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName(null), 8333, BigInteger.ZERO,
+                MAINNET.getDefaultSerializer().withProtocolVersion(0));
         assertEquals(26, pa.length);        
         assertEquals("000000000000000000000000000000000000ffff7f000001208d", Utils.HEX.encode(pa.bitcoinSerialize()));
     }
@@ -51,11 +53,10 @@ public class PeerAddressTest {
     @Test
     public void roundtrip_ipv4_currentProtocolVersion() throws Exception {
         long time = Utils.currentTimeSeconds();
-        PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName("1.2.3.4"), 1234,
-                NetworkParameters.ProtocolVersion.CURRENT.getBitcoinProtocolVersion(), BigInteger.ZERO);
+        PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName("1.2.3.4"), 1234, BigInteger.ZERO,
+                MAINNET.getDefaultSerializer());
         byte[] serialized = pa.bitcoinSerialize();
-        PeerAddress pa2 = new PeerAddress(MAINNET, serialized, 0,
-                NetworkParameters.ProtocolVersion.CURRENT.getBitcoinProtocolVersion());
+        PeerAddress pa2 = new PeerAddress(MAINNET, serialized, 0, null, MAINNET.getDefaultSerializer());
         assertEquals("1.2.3.4", pa2.getAddr().getHostAddress());
         assertEquals(1234, pa2.getPort());
         assertEquals(BigInteger.ZERO, pa2.getServices());
@@ -64,9 +65,11 @@ public class PeerAddressTest {
 
     @Test
     public void roundtrip_ipv4_ancientProtocolVersion() throws Exception {
-        PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName("1.2.3.4"), 1234, 0, BigInteger.ZERO);
+        PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName("1.2.3.4"), 1234, BigInteger.ZERO,
+                MAINNET.getDefaultSerializer().withProtocolVersion(0));
         byte[] serialized = pa.bitcoinSerialize();
-        PeerAddress pa2 = new PeerAddress(MAINNET, serialized, 0, 0);
+        PeerAddress pa2 = new PeerAddress(MAINNET, serialized, 0, null,
+                MAINNET.getDefaultSerializer().withProtocolVersion(0));
         assertEquals("1.2.3.4", pa2.getAddr().getHostAddress());
         assertEquals(1234, pa2.getPort());
         assertEquals(BigInteger.ZERO, pa2.getServices());
@@ -77,10 +80,9 @@ public class PeerAddressTest {
     public void roundtrip_ipv6_currentProtocolVersion() throws Exception {
         long time = Utils.currentTimeSeconds();
         PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334"), 1234,
-                NetworkParameters.ProtocolVersion.CURRENT.getBitcoinProtocolVersion(), BigInteger.ZERO);
+                BigInteger.ZERO, MAINNET.getDefaultSerializer());
         byte[] serialized = pa.bitcoinSerialize();
-        PeerAddress pa2 = new PeerAddress(MAINNET, serialized, 0,
-                NetworkParameters.ProtocolVersion.CURRENT.getBitcoinProtocolVersion());
+        PeerAddress pa2 = new PeerAddress(MAINNET, serialized, 0, null, MAINNET.getDefaultSerializer());
         assertEquals("2001:db8:85a3:0:0:8a2e:370:7334", pa2.getAddr().getHostAddress());
         assertEquals(1234, pa2.getPort());
         assertEquals(BigInteger.ZERO, pa2.getServices());
@@ -89,10 +91,11 @@ public class PeerAddressTest {
 
     @Test
     public void roundtrip_ipv6_ancientProtocolVersion() throws Exception {
-        PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334"), 1234, 0,
-                BigInteger.ZERO);
+        PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334"), 1234,
+                BigInteger.ZERO, MAINNET.getDefaultSerializer().withProtocolVersion(0));
         byte[] serialized = pa.bitcoinSerialize();
-        PeerAddress pa2 = new PeerAddress(MAINNET, serialized, 0, 0);
+        PeerAddress pa2 = new PeerAddress(MAINNET, serialized, 0, null,
+                MAINNET.getDefaultSerializer().withProtocolVersion(0));
         assertEquals("2001:db8:85a3:0:0:8a2e:370:7334", pa2.getAddr().getHostAddress());
         assertEquals(1234, pa2.getPort());
         assertEquals(BigInteger.ZERO, pa2.getServices());


### PR DESCRIPTION
It's contained in the MessageSerializer since a while.