### PR TITLE
VersionMessage: Remove support for protocol versions older than 106.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/VersionMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionMessage.java
@@ -166,22 +166,20 @@ public class VersionMessage extends Message {
         Utils.uint32ToByteStreamLE(time, buf);
         Utils.uint32ToByteStreamLE(time >> 32, buf);
         receivingAddr.bitcoinSerializeToStream(buf);
-        if (clientVersion >= 106) {
-            fromAddr.bitcoinSerializeToStream(buf);
-            // Next up is the "local host nonce", this is to detect the case of connecting
-            // back to yourself. We don't care about this as we won't be accepting inbound
-            // connections.
-            Utils.uint32ToByteStreamLE(0, buf);
-            Utils.uint32ToByteStreamLE(0, buf);
-            // Now comes subVer.
-            byte[] subVerBytes = subVer.getBytes(StandardCharsets.UTF_8);
-            buf.write(new VarInt(subVerBytes.length).encode());
-            buf.write(subVerBytes);
-            // Size of known block chain.
-            Utils.uint32ToByteStreamLE(bestHeight, buf);
-            if (clientVersion >= params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.BLOOM_FILTER)) {
-                buf.write(relayTxesBeforeFilter ? 1 : 0);
-            }
+        fromAddr.bitcoinSerializeToStream(buf);
+        // Next up is the "local host nonce", this is to detect the case of connecting
+        // back to yourself. We don't care about this as we won't be accepting inbound
+        // connections.
+        Utils.uint32ToByteStreamLE(0, buf);
+        Utils.uint32ToByteStreamLE(0, buf);
+        // Now comes subVer.
+        byte[] subVerBytes = subVer.getBytes(StandardCharsets.UTF_8);
+        buf.write(new VarInt(subVerBytes.length).encode());
+        buf.write(subVerBytes);
+        // Size of known block chain.
+        Utils.uint32ToByteStreamLE(bestHeight, buf);
+        if (clientVersion >= params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.BLOOM_FILTER)) {
+            buf.write(relayTxesBeforeFilter ? 1 : 0);
         }
     }
 

--- a/core/src/test/java/org/bitcoinj/core/VersionMessageTest.java
+++ b/core/src/test/java/org/bitcoinj/core/VersionMessageTest.java
@@ -68,7 +68,7 @@ public class VersionMessageTest {
     }
 
     @Test
-    public void roundTrip_ipv4_currentProtocolVersion() throws Exception {
+    public void roundTrip_ipv4() throws Exception {
         VersionMessage ver = new VersionMessage(UNITTEST, 1234);
         ver.time = 23456;
         ver.subVer = "/bitcoinj/";
@@ -92,24 +92,7 @@ public class VersionMessageTest {
     }
 
     @Test
-    public void roundTrip_ipv4_ancientProtocolVersion() throws Exception {
-        VersionMessage ver = new VersionMessage(UNITTEST, 0);
-        ver.time = 23456;
-        ver.clientVersion = 0;
-        ver.localServices = 1;
-        ver.receivingAddr = new PeerAddress(UNITTEST, InetAddress.getByName("4.3.2.1"), 8333);
-        ver.receivingAddr.setParent(ver);
-        byte[] serialized = ver.bitcoinSerialize();
-        VersionMessage ver2 = new VersionMessage(UNITTEST, serialized);
-        assertEquals(23456, ver2.time);
-        assertEquals(0, ver2.clientVersion);
-        assertEquals(1, ver2.localServices);
-        assertEquals("4.3.2.1", ver2.receivingAddr.getAddr().getHostAddress());
-        assertEquals(8333, ver2.receivingAddr.getPort());
-    }
-
-    @Test
-    public void roundTrip_ipv6_currentProtocolVersion() throws Exception {
+    public void roundTrip_ipv6() throws Exception {
         VersionMessage ver = new VersionMessage(UNITTEST, 1234);
         ver.time = 23456;
         ver.subVer = "/bitcoinj/";
@@ -128,26 +111,6 @@ public class VersionMessageTest {
         assertEquals(1, ver2.localServices);
         assertEquals("2001:db8:85a3:0:0:8a2e:370:7334", ver2.fromAddr.getAddr().getHostAddress());
         assertEquals(3888, ver2.fromAddr.getPort());
-        assertEquals("2002:db8:85a3:0:0:8a2e:370:7335", ver2.receivingAddr.getAddr().getHostAddress());
-        assertEquals(8333, ver2.receivingAddr.getPort());
-    }
-
-    @Test
-    public void roundTrip_ipv6_ancientProtocolVersion() throws Exception {
-        VersionMessage ver = new VersionMessage(UNITTEST, 1234);
-        ver.time = 23456;
-        ver.subVer = "/bitcoinj/";
-        ver.clientVersion = 0;
-        ver.localServices = 1;
-        ver.fromAddr = new PeerAddress(UNITTEST, InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334"), 3888);
-        ver.fromAddr.setParent(ver);
-        ver.receivingAddr = new PeerAddress(UNITTEST, InetAddress.getByName("2002:db8:85a3:0:0:8a2e:370:7335"), 8333);
-        ver.receivingAddr.setParent(ver);
-        byte[] serialized = ver.bitcoinSerialize();
-        VersionMessage ver2 = new VersionMessage(UNITTEST, serialized);
-        assertEquals(23456, ver2.time);
-        assertEquals(0, ver2.clientVersion);
-        assertEquals(1, ver2.localServices);
         assertEquals("2002:db8:85a3:0:0:8a2e:370:7335", ver2.receivingAddr.getAddr().getHostAddress());
         assertEquals(8333, ver2.receivingAddr.getPort());
     }


### PR DESCRIPTION
The minimum is 70000 anyway, and I'm pretty sure the code path wasn't properly tested.