### PR TITLE
build.gradle: Migrate from maven to maven-publish plugin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.10'
+        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.16'
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-library'
     id 'com.google.protobuf'
-    id 'maven'
+    id 'maven-publish'
     id 'eclipse'
 }
 


### PR DESCRIPTION
To publish to the local Maven repository, use `gradle publishToMavenLocal` rather than `gradle install`.