### PR TITLE
Removed the limit of parsing blocks of max 2,000,000 bytes. Some bloc…

### DIFF
--- a/core/src/main/java/org/bitcoinj/utils/BlockFileLoader.java
+++ b/core/src/main/java/org/bitcoinj/utils/BlockFileLoader.java
@@ -158,7 +158,7 @@ public class BlockFileLoader implements Iterable<Block>, Iterator<Block> {
                 currentFileStream.read(bytes, 0, 4);
                 long size = Utils.readUint32BE(Utils.reverseBytes(bytes), 0);
                 // We allow larger than MAX_BLOCK_SIZE because test code uses this as well.
-                if (size > Block.MAX_BLOCK_SIZE*2 || size <= 0)
+                if (size > Block.MAX_BLOCK_SIZE*5 || size <= 0)
                     continue;
                 bytes = new byte[(int) size];
                 currentFileStream.read(bytes, 0, (int) size);


### PR DESCRIPTION
…ks from 2020 are larger and weren't imported