### PR TITLE
Github Actions: Build with Gradle 6.9

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,7 +18,10 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Build with Gradle
-        run: gradle build --stacktrace
+        uses: gradle/gradle-build-action@v1
+        with:
+          gradle-version: 6.9
+          arguments: build --stacktrace
       - name: Upload Test Results and Reports
         uses: actions/upload-artifact@v2
         if: always()


### PR DESCRIPTION
Use the `gradle/gradle-build-action` to build with a specified
version of Gradle. In our case, let’s use Gradle 6.9.