### PR TITLE
GithubActions: Use ‘temurin’ JDK 8 + 11

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,14 +8,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        java: [ '8', '11', '15' ]
+        java: [ '8', '11']
       fail-fast: false
     name: JAVA ${{ matrix.java }} OS ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v1


### PR DESCRIPTION
Temurin is the Eclipse Foundation’s successor to AdoptOpenJDK
and is likely to continue to be the most widely-used community
distribution.

Unfortunately, Temurin only provides JDK 8, 11, and 16,
and since bitcoinj can’t yet be built with JDK 16, we’ll
drop the JDK 15 build without replacing it with JDK 16.