### PR TITLE
Choose Gradle Protobuf Plugin by Gradle version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,17 @@
+import org.gradle.util.GradleVersion
+
 buildscript {
     repositories {
         mavenCentral()
     }
-
+    // If using Gradle 7, use the compatible protobuf plugin, else use the one that works with oldest supported Gradle
+    boolean isGradle7 = GradleVersion.current().compareTo(GradleVersion.version("7.0")) >= 0
+    def gradleProtobufVersion = isGradle7 ? "0.8.11" : "0.8.10"
+    if (isGradle7) {
+        System.err.println "Warning: Using com.google.protobuf:protobuf-gradle-plugin:${gradleProtobufVersion} because ${GradleVersion.current()}"
+    }
     dependencies {
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.10'
+        classpath "com.google.protobuf:protobuf-gradle-plugin:${gradleProtobufVersion}"
     }
 }
 


### PR DESCRIPTION
If Gradle version > 5.6 use latest Gradle Protobuf Plugin (currently 0.8.17), else use 0.8.10.

This should allow us to rebase PR #2112 and add support for Gradle 7.