### PR TITLE
Add “Legacy Gradle CI” Github Actions workflow

### DIFF
--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -1,4 +1,5 @@
-name: Gradle CI
+name: Legacy Gradle CI
+# Build with JDK 8 and Gradle 4.4.1 (for Debian package support)
 
 on: [push, pull_request]
 
@@ -8,25 +9,27 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        java: [ '8', '11', '15' ]
+        java: [ '8' ]
+        gradle: [ '4.4.1' ]
       fail-fast: false
-    name: JAVA ${{ matrix.java }} OS ${{ matrix.os }}
+    name: Gradle ${{ matrix.gradle }} JAVA ${{ matrix.java }} OS ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v1
         with:
-          gradle-version: 6.9
+          gradle-version: ${{ matrix.gradle }}
           arguments: build --stacktrace
       - name: Upload Test Results and Reports
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: bitcoinj-core-test-results-jdk${{ matrix.java }}-${{ matrix.os }}
+          name: bitcoinj-core-legacy-gradle-test-results-jdk${{ matrix.java }}-${{ matrix.os }}
           path: |
             core/build/reports/tests/test/
             core/build/test-results/test/


### PR DESCRIPTION
This workflow currently builds with: JDK 8 (Temurin), Gradle 4.4.1
on macOS, Windows, and Linux.

It is meant to be a test of what a Debian package targeted for
inclusion in Debian would use.

Note: This comment was updated to match force push that uses JDK 8/Gradle 4.4.1