### PR TITLE
Require JDK 11, use `javac --release` to validate Java API (Java 11+, Gradle 4.4+)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        java: ['8', '11', '17']
+        java: ['11', '17']
         distribution: ['temurin']
         gradle: ['7.2']
         include:

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ To get started, it is best to have the latest JDK and Gradle installed. The HEAD
 
 #### Building from the command line
 
-Official builds are currently using with JDK 8, even though the `core` module is compatible with JDK 7 and later.
+Official builds are currently using JDK 11.  (Our GitHub Actions build and test with JDK 11 and JDK 17)
 
-To perform a full build (*including* JavaDocs and unit/integration *tests*) use JDK 8+
+To perform a full build (*including* JavaDocs and unit/integration *tests*) use JDK 11+
 ```
 gradle clean build
 ```
-If you are running JDK 11 or later and Gradle 4.10 or later, the build will automatically include the JavaFX-based `wallettemplate` module. The outputs are under the `build` directory.
+If you are using Gradle 4.10 or later, the build will automatically include the JavaFX-based `wallettemplate` module. The outputs are under the `build` directory.
 
 To perform a full build *without* unit/integration *tests* use:
 ```

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.util.GradleVersion
+
 plugins {
     id 'java-library'
     id 'com.google.protobuf'
@@ -25,11 +27,15 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
 }
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.8
+sourceCompatibility = 8
+targetCompatibility = 8
 compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
 javadoc.options.encoding = 'UTF-8'
+
+compileJava {
+    options.compilerArgs.addAll(['--release', '8'])
+}
 
 protobuf {
     protoc {
@@ -47,7 +53,7 @@ protobuf {
     generatedFilesBaseDir = new File(projectDir, '/src') // workaround for '$projectDir/src'
 }
 
-test {
+tasks.withType(Test) {
     exclude 'org/bitcoinj/core/PeerTest*'
     exclude 'org/bitcoinj/core/TransactionBroadcastTest*'
     exclude 'org/bitcoinj/net/discovery/DnsDiscoveryTest*'
@@ -55,6 +61,10 @@ test {
         events "failed"
         exceptionFormat "full"
     }
+}
+
+// Test with default Java toolchain
+test {
 }
 
 ext.moduleName = 'org.bitcoinj.core'

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -10,7 +10,11 @@ dependencies {
     implementation 'org.fusesource.leveldbjni:leveldbjni-all:1.8'
 }
 
-sourceCompatibility = 1.8
+sourceCompatibility = 8
 compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
 javadoc.options.encoding = 'UTF-8'
+
+compileJava {
+    options.compilerArgs.addAll(['--release', '8'])
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 import org.gradle.util.GradleVersion
 import org.gradle.api.GradleScriptException
 
-// Minimum Gradle version for main build
+// Minimum Gradle version for build
 def minGradleVersion = GradleVersion.version("4.4")
 // Minimum Gradle version for builds of JavaFX 11 module
 def minFxGradleVersion = GradleVersion.version("4.10")
@@ -10,6 +10,10 @@ rootProject.name = 'bitcoinj-parent'
 
 if (GradleVersion.current().compareTo(minGradleVersion) < 0) {
     throw new GradleScriptException("bitcoinj build requires Gradle ${minGradleVersion} or later", null)
+}
+
+if (!JavaVersion.current().isJava11Compatible()) {
+    throw new GradleScriptException("bitcoinj build requires Java 11 or later", null)
 }
 
 include 'core'
@@ -21,10 +25,9 @@ project(':tools').name = 'bitcoinj-tools'
 include 'examples'
 project(':examples').name = 'bitcoinj-examples'
 
-if (GradleVersion.current().compareTo(minFxGradleVersion) >= 0 && JavaVersion.current().isJava11Compatible()) {
-    System.err.println "Including wallettemplate because ${GradleVersion.current()} and Java ${JavaVersion.current()}"
+if (GradleVersion.current().compareTo(minFxGradleVersion) > 0) {
+    System.err.println "Including wallettemplate because ${GradleVersion.current()}"
     include 'wallettemplate'
     project(':wallettemplate').name = 'bitcoinj-wallettemplate'
-} else {
-    System.err.println "Skipping wallettemplate, requires ${minFxGradleVersion}+ and Java 11+, currently running: ${GradleVersion.current()} and Java ${JavaVersion.current()}"
 }
+

--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -10,10 +10,14 @@ dependencies {
     implementation 'org.slf4j:slf4j-jdk14:1.7.32'
 }
 
-sourceCompatibility = 1.8
+sourceCompatibility = 8
 compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
 javadoc.options.encoding = 'UTF-8'
+
+compileJava {
+    options.compilerArgs.addAll(['--release', '8'])
+}
 
 mainClassName = "org.bitcoinj.tools.WalletTool"
 applicationName = "wallet-tool"

--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -17,9 +17,13 @@ javafx {
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 
-sourceCompatibility = 1.11
+sourceCompatibility = 11
 compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
 javadoc.options.encoding = 'UTF-8'
+
+compileJava {
+    options.compilerArgs.addAll(['--release', '11'])
+}
 
 mainClassName = 'wallettemplate.Main'


### PR DESCRIPTION
See Issue #2149. This PR updates the minimum JDK to 11, but the build **still works with Debian Gradle** 4.4.1.

By taking advantages of features in JDK 11+ we get better validation and (in a future commit using Gradle 6.7+) test coverage for the older JDKs.

* Require JDK 11 for the build
* Use `javac -release` option to validate API for older JDK when compiling. (e.g. for —release 8, no JDK 9+ APIs will be allowed)
* Simplify settings.gradle now that we require JDK 11
* Remove JDK 8 from Github Actions matrix

With newer Gradle versions the build is progressively enhanced:

* Gradle 4.4+ Minimum Gradle required
* Gradle 4.10+ wallettemplate is built (JavaFX)

UPDATE: The following are removed from this PR and will be added in a subsequent PR:

* If Gradle 6.7+, use javaToolchains to test on older JDKs (Tests will be run on Gradle’s JDK and also JDK 7, JDK 8)


