### PR TITLE
Github Actions: Add Ubuntu/JDK 11/Gradle 4.10.3

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,6 +11,12 @@ jobs:
         java: [ '8', '11']
         distribution: ['temurin']
         gradle: ['7.2']
+        include:
+          # Special case to test something close to Debian config with the oldest supported (standard) Gradle on Ubuntu
+          - os: ubuntu-latest
+            java: '11'
+            distribution: 'temurin'
+            gradle: '4.10.3'
       fail-fast: false
     name: JAVA ${{ matrix.distribution }} ${{ matrix.java }} OS ${{ matrix.os }} Gradle ${{ matrix.gradle }}
     steps:


### PR DESCRIPTION
Github Actions allows adding special cases to the matrix.  See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix

Using the `include:` option, we can add a special case for Ubuntu, JDK 11, and Gradle 4.10.3