### PR TITLE
GitLabCI: Use Debian Bullseye-slim

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,15 +1,10 @@
-image: ubuntu:bionic
-
-variables:
-  GRADLE_VERSION: "4.10.3"
+image: debian:bullseye-slim
 
 before_script:
   - apt-get update
   - apt-get -y upgrade
   - apt-get -y install openjdk-11-jdk gradle
-  - gradle wrapper --gradle-version=$GRADLE_VERSION --stacktrace
 
 build:
   script:
-    - java -version
-    - ./gradlew build --stacktrace
+    - gradle build --stacktrace


### PR DESCRIPTION
This change to `.gitlab-ci.yml` will allow us to test our "oldest build tools" use case on **Debian Bullseye** (and hopefully on other **Debian** versions with additional modifications to `.gitlab-ci.yml`)

The changes include: 

* Move from `ubuntu:bionic` to `debian:bullseye-slim`
* Use Gradle version included in distro (currently 4.4.1)
* Remove unneeded `java -version` command

Related Issues:

* https://github.com/bitcoinj/bitcoinj/issues/2145
* https://github.com/bitcoinj/bitcoinj/issues/2049 (Another occurrence of this failure popped up in tests on GitLab CI)