### PR TITLE
Make Block a little less mutable

### DIFF
--- a/core/src/main/java/org/bitcoinj/params/AbstractBitcoinNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/AbstractBitcoinNetParams.java
@@ -54,10 +54,17 @@ public abstract class AbstractBitcoinNetParams extends NetworkParameters {
 
     private static final Logger log = LoggerFactory.getLogger(AbstractBitcoinNetParams.class);
 
-    public AbstractBitcoinNetParams() {
-        super();
+    {
         interval = INTERVAL;
-        subsidyDecreaseBlockCount = 210000;
+        subsidyDecreaseBlockCount = REWARD_HALVING_INTERVAL;
+    }
+
+    public AbstractBitcoinNetParams(BigInteger maxTarget, long difficultyTarget, long genesisTime, long genesisNonce) {
+        super(maxTarget, difficultyTarget, genesisTime, genesisNonce);
+    }
+
+    public AbstractBitcoinNetParams(BigInteger maxTarget, long difficultyTarget) {
+        super(maxTarget, difficultyTarget);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/MainNetParams.java
@@ -20,6 +20,7 @@ package org.bitcoinj.params;
 import org.bitcoinj.core.*;
 import org.bitcoinj.net.discovery.*;
 
+import java.math.BigInteger;
 import java.net.*;
 
 import static com.google.common.base.Preconditions.*;
@@ -31,11 +32,15 @@ public class MainNetParams extends AbstractBitcoinNetParams {
     public static final int MAINNET_MAJORITY_WINDOW = 1000;
     public static final int MAINNET_MAJORITY_REJECT_BLOCK_OUTDATED = 950;
     public static final int MAINNET_MAJORITY_ENFORCE_BLOCK_UPGRADE = 750;
+    private static final long DIFFICULTY_TARGET = 0x1d00ffffL;
+    private static final BigInteger MAX_TARGET = Utils.decodeCompactBits(DIFFICULTY_TARGET);
+    private static final long GENESIS_TIME = 1231006505L;
+    private static final long GENESIS_NONCE = 2083236893;
 
     public MainNetParams() {
-        super();
+        super(MAX_TARGET, DIFFICULTY_TARGET, GENESIS_TIME, GENESIS_NONCE);
+        id = ID_MAINNET;
         targetTimespan = TARGET_TIMESPAN;
-        maxTarget = Utils.decodeCompactBits(0x1d00ffffL);
         dumpedPrivateKeyHeader = 128;
         addressHeader = 0;
         p2shHeader = 5;
@@ -51,10 +56,6 @@ public class MainNetParams extends AbstractBitcoinNetParams {
         majorityRejectBlockOutdated = MAINNET_MAJORITY_REJECT_BLOCK_OUTDATED;
         majorityWindow = MAINNET_MAJORITY_WINDOW;
 
-        genesisBlock.setDifficultyTarget(0x1d00ffffL);
-        genesisBlock.setTime(1231006505L);
-        genesisBlock.setNonce(2083236893);
-        id = ID_MAINNET;
         spendableCoinbaseDepth = 100;
         String genesisHash = genesisBlock.getHashAsString();
         checkState(genesisHash.equals("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),

--- a/core/src/main/java/org/bitcoinj/params/RegTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/RegTestParams.java
@@ -28,18 +28,19 @@ import static com.google.common.base.Preconditions.checkState;
  */
 public class RegTestParams extends AbstractBitcoinNetParams {
     private static final BigInteger MAX_TARGET = new BigInteger("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16);
+    private static final long DIFFICULTY_TARGET = 0x1d07fff8L;
+    private static final long GENESIS_TIME = 1296688602L;
+    private static final long GENESIS_NONCE = 384568319;
 
     public RegTestParams() {
-        super();
+        super(MAX_TARGET, DIFFICULTY_TARGET, GENESIS_TIME, GENESIS_NONCE);
+        id = ID_REGTEST;
         packetMagic = 0xfabfb5daL;
         addressHeader = 111;
         p2shHeader = 196;
         targetTimespan = TARGET_TIMESPAN;
         dumpedPrivateKeyHeader = 239;
         segwitAddressHrp = "bcrt";
-        genesisBlock.setTime(1296688602L);
-        genesisBlock.setDifficultyTarget(0x1d07fff8L);
-        genesisBlock.setNonce(384568319);
         spendableCoinbaseDepth = 100;
         String genesisHash = genesisBlock.getHashAsString();
         checkState(genesisHash.equals("00000007199508e34a9ff81e6ec0c477a4cccff2a4767a8eee39c11db367b008"));
@@ -54,10 +55,8 @@ public class RegTestParams extends AbstractBitcoinNetParams {
         // By setting the block interval for difficulty adjustments to Integer.MAX_VALUE we make sure difficulty never
         // changes.
         interval = Integer.MAX_VALUE;
-        maxTarget = MAX_TARGET;
         subsidyDecreaseBlockCount = 150;
         port = 18444;
-        id = ID_REGTEST;
 
         majorityEnforceBlockUpgrade = MainNetParams.MAINNET_MAJORITY_ENFORCE_BLOCK_UPGRADE;
         majorityRejectBlockOutdated = MainNetParams.MAINNET_MAJORITY_REJECT_BLOCK_OUTDATED;

--- a/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
@@ -41,21 +41,21 @@ public class TestNet3Params extends AbstractBitcoinNetParams {
     public static final int TESTNET_MAJORITY_WINDOW = 100;
     public static final int TESTNET_MAJORITY_REJECT_BLOCK_OUTDATED = 75;
     public static final int TESTNET_MAJORITY_ENFORCE_BLOCK_UPGRADE = 51;
+    private static final long DIFFICULTY_TARGET = 0x1d00ffffL;
+    private static final BigInteger MAX_TARGET = Utils.decodeCompactBits(DIFFICULTY_TARGET);
+    private static final long GENESIS_TIME = 1296688602L;
+    private static final long GENESIS_NONCE = 414098458;
 
     public TestNet3Params() {
-        super();
+        super(MAX_TARGET, DIFFICULTY_TARGET, GENESIS_TIME, GENESIS_NONCE);
         id = ID_TESTNET;
         packetMagic = 0x0b110907;
         targetTimespan = TARGET_TIMESPAN;
-        maxTarget = Utils.decodeCompactBits(0x1d00ffffL);
         port = 18333;
         addressHeader = 111;
         p2shHeader = 196;
         dumpedPrivateKeyHeader = 239;
         segwitAddressHrp = "tb";
-        genesisBlock.setTime(1296688602L);
-        genesisBlock.setDifficultyTarget(0x1d00ffffL);
-        genesisBlock.setNonce(414098458);
         spendableCoinbaseDepth = 100;
         String genesisHash = genesisBlock.getHashAsString();
         checkState(genesisHash.equals("000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"));

--- a/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
@@ -29,17 +29,14 @@ public class UnitTestParams extends AbstractBitcoinNetParams {
     public static final int UNITNET_MAJORITY_WINDOW = 8;
     public static final int TESTNET_MAJORITY_REJECT_BLOCK_OUTDATED = 6;
     public static final int TESTNET_MAJORITY_ENFORCE_BLOCK_UPGRADE = 4;
+    public static final BigInteger MAX_TARGET = new BigInteger("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16);
 
     public UnitTestParams() {
-        super();
+        super(MAX_TARGET, Block.EASIEST_DIFFICULTY_TARGET);
         id = ID_UNITTESTNET;
         packetMagic = 0x0b110907;
         addressHeader = 111;
         p2shHeader = 196;
-        maxTarget = new BigInteger("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16);
-        genesisBlock.setTime(Utils.currentTimeSeconds());
-        genesisBlock.setDifficultyTarget(Block.EASIEST_DIFFICULTY_TARGET);
-        genesisBlock.solve();
         port = 18333;
         interval = 10;
         dumpedPrivateKeyHeader = 239;

--- a/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
@@ -186,17 +186,15 @@ public class BlockChainTest {
         assertTrue(testNetChain.add(getBlock1()));
         Block b2 = getBlock2();
         assertTrue(testNetChain.add(b2));
-        Block bad = new Block(TESTNET, Block.BLOCK_VERSION_GENESIS);
+        // We're going to make this block so easy 50% of solutions will pass, and check it gets rejected for having a
+        // bad difficulty target. Unfortunately the encoding mechanism means we cannot make one that accepts all
+        // solutions.
+        Block bad = new Block(TESTNET, Block.BLOCK_VERSION_GENESIS, Block.EASIEST_DIFFICULTY_TARGET, 1279242649);
         // Merkle root can be anything here, doesn't matter.
         bad.setMerkleRoot(Sha256Hash.wrap("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
         // Nonce was just some number that made the hash < difficulty limit set below, it can be anything.
         bad.setNonce(140548933);
-        bad.setTime(1279242649);
         bad.setPrevBlockHash(b2.getHash());
-        // We're going to make this block so easy 50% of solutions will pass, and check it gets rejected for having a
-        // bad difficulty target. Unfortunately the encoding mechanism means we cannot make one that accepts all
-        // solutions.
-        bad.setDifficultyTarget(Block.EASIEST_DIFFICULTY_TARGET);
         try {
             testNetChain.add(bad);
             // The difficulty target above should be rejected on the grounds of being easier than the networks
@@ -397,11 +395,9 @@ public class BlockChainTest {
 
     // Some blocks from the test net.
     private static Block getBlock2() throws Exception {
-        Block b2 = new Block(TESTNET, Block.BLOCK_VERSION_GENESIS);
+        Block b2 = new Block(TESTNET, Block.BLOCK_VERSION_GENESIS, 0x1d00ffff, 1296688946L);
         b2.setMerkleRoot(Sha256Hash.wrap("20222eb90f5895556926c112bb5aa0df4ab5abc3107e21a6950aec3b2e3541e2"));
         b2.setNonce(875942400L);
-        b2.setTime(1296688946L);
-        b2.setDifficultyTarget(0x1d00ffff);
         b2.setPrevBlockHash(Sha256Hash.wrap("00000000b873e79784647a6c82962c70d228557d24a747ea4d1b8bbe878e1206"));
         assertEquals("000000006c02c8ea6e4ff69651f7fcde348fb9d557a06e6957b65552002a7820", b2.getHashAsString());
         b2.verifyHeader();
@@ -409,11 +405,9 @@ public class BlockChainTest {
     }
 
     private static Block getBlock1() throws Exception {
-        Block b1 = new Block(TESTNET, Block.BLOCK_VERSION_GENESIS);
+        Block b1 = new Block(TESTNET, Block.BLOCK_VERSION_GENESIS, 0x1d00ffff, 1296688928);
         b1.setMerkleRoot(Sha256Hash.wrap("f0315ffc38709d70ad5647e22048358dd3745f3ce3874223c80a7c92fab0c8ba"));
         b1.setNonce(1924588547);
-        b1.setTime(1296688928);
-        b1.setDifficultyTarget(0x1d00ffff);
         b1.setPrevBlockHash(Sha256Hash.wrap("000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"));
         assertEquals("00000000b873e79784647a6c82962c70d228557d24a747ea4d1b8bbe878e1206", b1.getHashAsString());
         b1.verifyHeader();

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -906,10 +906,9 @@ public class FullBlockTestGenerator {
         TransactionOutPointWithValue out14 = spendableOutputs.poll();
 
         // A valid block created exactly like b44 to make sure the creation itself works
-        Block b44 = new Block(params, Block.BLOCK_VERSION_GENESIS);
+        Block b44 = new Block(params, Block.BLOCK_VERSION_GENESIS, b43.block.getDifficultyTarget(), b43.block.getTimeSeconds() + 1);
         byte[] outScriptBytes = ScriptBuilder.createP2PKOutputScript(ECKey.fromPublicOnly(coinbaseOutKeyPubKey)).getProgram();
         {
-            b44.setDifficultyTarget(b43.block.getDifficultyTarget());
             b44.addCoinbaseTransaction(coinbaseOutKeyPubKey, ZERO, chainHeadHeight + 15);
 
             Transaction t = new Transaction(params);
@@ -922,7 +921,6 @@ public class FullBlockTestGenerator {
             b44.addTransaction(t);
 
             b44.setPrevBlockHash(b43.getHash());
-            b44.setTime(b43.block.getTimeSeconds() + 1);
         }
         b44.solve();
         blocks.add(new BlockAndValidity(b44, true, false, b44.getHash(), chainHeadHeight + 15, "b44"));
@@ -930,9 +928,8 @@ public class FullBlockTestGenerator {
         TransactionOutPointWithValue out15 = spendableOutputs.poll();
 
         // A block with a non-coinbase as the first tx
-        Block b45 = new Block(params, Block.BLOCK_VERSION_GENESIS);
+        Block b45 = new Block(params, Block.BLOCK_VERSION_GENESIS, b44.getDifficultyTarget(), b44.getTimeSeconds() + 1);
         {
-            b45.setDifficultyTarget(b44.getDifficultyTarget());
             //b45.addCoinbaseTransaction(pubKey, coinbaseValue);
 
             Transaction t = new Transaction(params);
@@ -950,20 +947,17 @@ public class FullBlockTestGenerator {
             b45.addTransaction(t, false);
 
             b45.setPrevBlockHash(b44.getHash());
-            b45.setTime(b44.getTimeSeconds() + 1);
         }
         b45.solve();
         blocks.add(new BlockAndValidity(b45, false, true, b44.getHash(), chainHeadHeight + 15, "b45"));
 
         // A block with no txn
-        Block b46 = new Block(params, Block.BLOCK_VERSION_GENESIS);
+        Block b46 = new Block(params, Block.BLOCK_VERSION_GENESIS, b44.getDifficultyTarget(), b44.getTimeSeconds() + 1);
         {
             b46.transactions = new ArrayList<>();
-            b46.setDifficultyTarget(b44.getDifficultyTarget());
             b46.setMerkleRoot(Sha256Hash.ZERO_HASH);
 
             b46.setPrevBlockHash(b44.getHash());
-            b46.setTime(b44.getTimeSeconds() + 1);
         }
         b46.solve();
         blocks.add(new BlockAndValidity(b46, false, true, b44.getHash(), chainHeadHeight + 15, "b46"));

--- a/core/src/test/java/org/bitcoinj/params/AbstractBitcoinNetParamsTest.java
+++ b/core/src/test/java/org/bitcoinj/params/AbstractBitcoinNetParamsTest.java
@@ -16,7 +16,9 @@
 
 package org.bitcoinj.params;
 
+import org.bitcoinj.core.Block;
 import org.bitcoinj.core.Coin;
+import org.bitcoinj.core.Utils;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -24,12 +26,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class AbstractBitcoinNetParamsTest {
-    private final AbstractBitcoinNetParams BITCOIN_PARAMS = new AbstractBitcoinNetParams() {
-        @Override
-        public String getPaymentProtocolId() {
-            return null;
-        }
-    };
+    private final AbstractBitcoinNetParams BITCOIN_PARAMS = new AbstractBitcoinNetParamsSubClass();
 
     @Test
     public void isDifficultyTransitionPoint() {
@@ -57,5 +54,17 @@ public class AbstractBitcoinNetParamsTest {
         assertEquals(Coin.FIFTY_COINS, BITCOIN_PARAMS.getBlockInflation(209999));
         assertEquals(Coin.FIFTY_COINS.div(2), BITCOIN_PARAMS.getBlockInflation(210000));
         assertEquals(Coin.FIFTY_COINS.div(2), BITCOIN_PARAMS.getBlockInflation(210001));
+    }
+
+    static class AbstractBitcoinNetParamsSubClass extends AbstractBitcoinNetParams {
+
+        AbstractBitcoinNetParamsSubClass() {
+            super(UnitTestParams.MAX_TARGET, Block.EASIEST_DIFFICULTY_TARGET);
+        }
+
+        @Override
+        public String getPaymentProtocolId() {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
* Remove deprecated constructor
* Move difficultyTarget and time to constructors (where possible)
* Remove copyBitcoinHeaderTo(Block) method that requires a mutable
  Block. Instead do the copying inside cloneAsHeader().
* Mark some mutator methods as @VisibleForTesting

NetworkParameters and subclasses:

* Move Genesis Block parameters to constructors
* Refactor some code into new createGenesisTransaction() method
* Prefer static final fields (constants) to magic numbers
* Move id initialization to top of constructors

This code simplifies the setting of `Block.time` and may help with Issue #2147. It is also a step towards making Block more immutable/unmodifiable.
