### PR TITLE
PeerAddress::equals, PeerAddress::hashCode - don’t use `time`

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerAddress.java
@@ -331,12 +331,12 @@ public class PeerAddress extends ChildMessage {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         PeerAddress other = (PeerAddress) o;
-        return other.addr.equals(addr) && other.port == port && other.time == time && other.services.equals(services);
+        return other.addr.equals(addr) && other.port == port && other.services.equals(services);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(addr, port, time, services);
+        return Objects.hash(addr, port, services);
     }
     
     public InetSocketAddress toSocketAddress() {


### PR DESCRIPTION
I'm not sure if this will break anything that depends on the old behavior. It doesn't seem to break the unit tests. It might fix Issue #2161 (and possibly Issue #1842)

A better (or perhaps) additional solution might be able to create a `PeerAddress` type that contains just the identifying fields of an actual "peer address" and create a separate `PeerAddressMessage` that is a subclass of `ChildMessage`.