### PR TITLE
Fix JavaDoc warnings in core/org.bitcoin.*

### DIFF
--- a/core/src/main/java/org/bitcoin/NativeSecp256k1.java
+++ b/core/src/main/java/org/bitcoin/NativeSecp256k1.java
@@ -51,6 +51,8 @@ public class NativeSecp256k1 {
      * @param data The data which was signed, must be exactly 32 bytes
      * @param signature The signature
      * @param pub The public key which did the signing
+     * @return true if correct signature
+     * @throws AssertFailException never thrown?
      */
     public static boolean verify(byte[] data, byte[] signature, byte[] pub) throws AssertFailException {
         Preconditions.checkArgument(data.length == 32 && signature.length <= 520 && pub.length <= 520);
@@ -80,6 +82,7 @@ public class NativeSecp256k1 {
      * @param data Message hash, 32 bytes
      * @param sec Secret key, 32 bytes
      * @return sig byte array of signature
+     * @throws AssertFailException on bad signature length
      */
     public static byte[] sign(byte[] data, byte[] sec) throws AssertFailException {
         Preconditions.checkArgument(data.length == 32 && sec.length <= 32);
@@ -116,6 +119,7 @@ public class NativeSecp256k1 {
      * libsecp256k1 Seckey Verify - returns 1 if valid, 0 if invalid
      *
      * @param seckey ECDSA Secret key, 32 bytes
+     * @return true if valid, false if invalid
      */
     public static boolean secKeyVerify(byte[] seckey) {
         Preconditions.checkArgument(seckey.length == 32);
@@ -142,6 +146,7 @@ public class NativeSecp256k1 {
      *
      * @param seckey ECDSA Secret key, 32 bytes
      * @return pubkey ECDSA Public key, 33 or 65 bytes
+     * @throws AssertFailException if bad pubkey length
      */
     // TODO add a 'compressed' arg
     public static byte[] computePubkey(byte[] seckey) throws AssertFailException {
@@ -187,6 +192,11 @@ public class NativeSecp256k1 {
         }
     }
 
+    /**
+     * Clone context
+     *
+     * @return context reference
+     */
     public static long cloneContext() {
         r.lock();
         try {
@@ -201,6 +211,8 @@ public class NativeSecp256k1 {
      *
      * @param tweak some bytes to tweak with
      * @param privkey 32-byte seckey
+     * @return The tweaked private key
+     * @throws AssertFailException assertion failure
      */
     public static byte[] privKeyTweakMul(byte[] privkey, byte[] tweak) throws AssertFailException {
         Preconditions.checkArgument(privkey.length == 32);
@@ -240,6 +252,8 @@ public class NativeSecp256k1 {
      *
      * @param tweak some bytes to tweak with
      * @param privkey 32-byte seckey
+     * @return The tweaked private key
+     * @throws AssertFailException assertion failure
      */
     public static byte[] privKeyTweakAdd(byte[] privkey, byte[] tweak) throws AssertFailException {
         Preconditions.checkArgument(privkey.length == 32);
@@ -279,6 +293,8 @@ public class NativeSecp256k1 {
      *
      * @param tweak some bytes to tweak with
      * @param pubkey 32-byte seckey
+     * @return The tweaked private key
+     * @throws AssertFailException assertion failure
      */
     public static byte[] pubKeyTweakAdd(byte[] pubkey, byte[] tweak) throws AssertFailException {
         Preconditions.checkArgument(pubkey.length == 33 || pubkey.length == 65);
@@ -318,6 +334,8 @@ public class NativeSecp256k1 {
      *
      * @param tweak some bytes to tweak with
      * @param pubkey 32-byte seckey
+     * @return The tweaked private key
+     * @throws AssertFailException assertion failure
      */
     public static byte[] pubKeyTweakMul(byte[] pubkey, byte[] tweak) throws AssertFailException {
         Preconditions.checkArgument(pubkey.length == 33 || pubkey.length == 65);
@@ -355,8 +373,10 @@ public class NativeSecp256k1 {
     /**
      * libsecp256k1 create ECDH secret - constant time ECDH calculation
      *
-     * @param seckey byte array of secret key used in exponentiaion
-     * @param pubkey byte array of public key used in exponentiaion
+     * @param seckey byte array of secret key used in exponentiation
+     * @param pubkey byte array of public key used in exponentiation
+     * @return the secret
+     * @throws AssertFailException assertion failure
      */
     public static byte[] createECDHSecret(byte[] seckey, byte[] pubkey) throws AssertFailException {
         Preconditions.checkArgument(seckey.length <= 32 && pubkey.length <= 65);
@@ -392,8 +412,10 @@ public class NativeSecp256k1 {
      * libsecp256k1 randomize - updates the context randomization
      *
      * @param seed 32-byte random seed
+     * @return true if successful, false otherwise
+     * @throws AssertFailException never thrown?
      */
-    public static synchronized boolean randomize(byte[] seed) throws AssertFailException {
+    public static synchronized boolean randomize(byte[] seed) throws AssertFailException  {
         Preconditions.checkArgument(seed.length == 32 || seed == null);
 
         ByteBuffer byteBuff = nativeECDSABuffer.get();
@@ -413,6 +435,12 @@ public class NativeSecp256k1 {
         }
     }
 
+    /**
+     * @param data data to sign
+     * @param sec secret key
+     * @return Signature or byte[0]
+     * @throws AssertFailException assertion failure
+     */
     public static byte[] schnorrSign(byte[] data, byte[] sec) throws AssertFailException {
         Preconditions.checkArgument(data.length == 32 && sec.length <= 32);
 

--- a/core/src/main/java/org/bitcoin/NativeSecp256k1Util.java
+++ b/core/src/main/java/org/bitcoin/NativeSecp256k1Util.java
@@ -19,15 +19,34 @@ package org.bitcoin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Assertion utilities for {@link NativeSecp256k1}
+ */
 public class NativeSecp256k1Util {
 
     private static final Logger log = LoggerFactory.getLogger(NativeSecp256k1Util.class);
 
+    /**
+     * Compare two integers and throw {@link AssertFailException} if not equal
+     *
+     * @param val first int
+     * @param val2 second int
+     * @param message failure error message
+     * @throws AssertFailException when ints are not equal
+     */
     public static void assertEquals(int val, int val2, String message) throws AssertFailException {
         if (val != val2)
             throw new AssertFailException("FAIL: " + message);
     }
 
+    /**
+     * Compare two booleans and throw {@link AssertFailException} if not equal
+     *
+     * @param val first boolean
+     * @param val2 second boolean
+     * @param message failure error message
+     * @throws AssertFailException when booleans are not equal
+     */
     public static void assertEquals(boolean val, boolean val2, String message) throws AssertFailException {
         if (val != val2)
             throw new AssertFailException("FAIL: " + message);
@@ -35,6 +54,14 @@ public class NativeSecp256k1Util {
             log.debug("PASS: " + message);
     }
 
+    /**
+     * Compare two Strings and throw {@link AssertFailException} if not equal
+     *
+     * @param val first String
+     * @param val2 second String
+     * @param message failure error message
+     * @throws AssertFailException when Strings are not equal
+     */
     public static void assertEquals(String val, String val2, String message) throws AssertFailException {
         if (!val.equals(val2))
             throw new AssertFailException("FAIL: " + message);
@@ -42,7 +69,13 @@ public class NativeSecp256k1Util {
             log.debug("PASS: " + message);
     }
 
+    /**
+     * Assertion failure exception
+     */
     public static class AssertFailException extends Exception {
+        /**
+         * @param message The failure message
+         */
         public AssertFailException(String message) {
             super(message);
         }

--- a/core/src/main/java/org/bitcoin/Secp256k1Context.java
+++ b/core/src/main/java/org/bitcoin/Secp256k1Context.java
@@ -45,10 +45,16 @@ public class Secp256k1Context {
         context = contextRef;
     }
 
+    /**
+     * @return true if enabled
+     */
     public static boolean isEnabled() {
         return enabled;
     }
 
+    /**
+     * @return context reference
+     */
     public static long getContext() {
         if (!enabled)
             return -1; // sanity check


### PR DESCRIPTION
This commit fixes all the JavaDoc warning messages from the Gradle build in the `org.bitcoin` package in the `core` module.

I'm not up for fixing them all in one sitting, but I'm hoping to fix them one bite at a time.
