### PR TITLE
Fix JavaDoc comment on EASIEST_DIFFICULTY_TARGET

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -75,7 +75,7 @@ public class Block extends Message {
      */
     public static final int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE / 50;
 
-    /** A value for difficultyTarget (nBits) that allows half of all possible hash solutions. Used in unit testing. */
+    /** A value for difficultyTarget (nBits) that allows (slightly less than) half of all possible hash solutions. Used in unit testing. */
     public static final long EASIEST_DIFFICULTY_TARGET = 0x207fFFFFL;
 
     /** Value to use if the block height is unknown */


### PR DESCRIPTION
It said “half of all possible hash solutions” which
led me to believe that decodeCompactBits() would
extend 1’s all the way out to the least significant
bit.

(This is a nitpick, but the error caused me to spend an hour researching how difficulty targets work.)