### PR TITLE
Block/NetParams constants for difficulty targets, GENESIS_TIME, GENESIS_NONCE

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -75,6 +75,9 @@ public class Block extends Message {
      */
     public static final int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE / 50;
 
+    /** Standard maximum value for difficultyTarget (nBits) (Bitcoin MainNet and TestNet) */
+    public static final long STANDARD_MAX_DIFFICULTY_TARGET = 0x1d00ffffL;
+
     /** A value for difficultyTarget (nBits) that allows (slightly less than) half of all possible hash solutions. Used in unit testing. */
     public static final long EASIEST_DIFFICULTY_TARGET = 0x207fFFFFL;
 

--- a/core/src/main/java/org/bitcoinj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/MainNetParams.java
@@ -19,6 +19,7 @@ package org.bitcoinj.params;
 
 import java.net.URI;
 
+import org.bitcoinj.core.Block;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.Utils;
@@ -34,6 +35,8 @@ public class MainNetParams extends AbstractBitcoinNetParams {
     public static final int MAINNET_MAJORITY_WINDOW = 1000;
     public static final int MAINNET_MAJORITY_REJECT_BLOCK_OUTDATED = 950;
     public static final int MAINNET_MAJORITY_ENFORCE_BLOCK_UPGRADE = 750;
+    private static final long GENESIS_TIME = 1231006505;
+    private static final long GENESIS_NONCE = 2083236893;
     public static final Sha256Hash GENESIS_HASH = Sha256Hash.wrap("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
 
     public MainNetParams() {
@@ -41,11 +44,11 @@ public class MainNetParams extends AbstractBitcoinNetParams {
         id = ID_MAINNET;
 
         targetTimespan = TARGET_TIMESPAN;
-        maxTarget = Utils.decodeCompactBits(0x1d00ffffL);
+        maxTarget = Utils.decodeCompactBits(Block.STANDARD_MAX_DIFFICULTY_TARGET);
 
-        genesisBlock.setDifficultyTarget(0x1d00ffffL);
-        genesisBlock.setTime(1231006505L);
-        genesisBlock.setNonce(2083236893);
+        genesisBlock.setDifficultyTarget(Block.STANDARD_MAX_DIFFICULTY_TARGET);
+        genesisBlock.setTime(GENESIS_TIME);
+        genesisBlock.setNonce(GENESIS_NONCE);
         checkState(genesisBlock.getHash().equals(GENESIS_HASH), "Invalid genesis hash");
 
         port = 8333;

--- a/core/src/main/java/org/bitcoinj/params/RegTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/RegTestParams.java
@@ -19,8 +19,7 @@ package org.bitcoinj.params;
 
 import org.bitcoinj.core.Block;
 import org.bitcoinj.core.Sha256Hash;
-
-import java.math.BigInteger;
+import org.bitcoinj.core.Utils;
 
 import static com.google.common.base.Preconditions.checkState;
 
@@ -28,7 +27,8 @@ import static com.google.common.base.Preconditions.checkState;
  * Network parameters for the regression test mode of bitcoind in which all blocks are trivially solvable.
  */
 public class RegTestParams extends AbstractBitcoinNetParams {
-    private static final BigInteger MAX_TARGET = new BigInteger("7fffff0000000000000000000000000000000000000000000000000000000000", 16); // equivalent to EASIEST_DIFFICULTY_TARGET
+    private static final long GENESIS_TIME = 1296688602;
+    private static final long GENESIS_NONCE = 2;
     public static final Sha256Hash GENESIS_HASH = Sha256Hash.wrap("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206");
 
     public RegTestParams() {
@@ -36,16 +36,16 @@ public class RegTestParams extends AbstractBitcoinNetParams {
         id = ID_REGTEST;
         
         targetTimespan = TARGET_TIMESPAN;
-        maxTarget = MAX_TARGET;
+        maxTarget = Utils.decodeCompactBits(Block.EASIEST_DIFFICULTY_TARGET);
         // Difficulty adjustments are disabled for regtest.
         // By setting the block interval for difficulty adjustments to Integer.MAX_VALUE we make sure difficulty never
         // changes.
         interval = Integer.MAX_VALUE;
         subsidyDecreaseBlockCount = 150;
 
-        genesisBlock.setDifficultyTarget(0x207fFFFFL);
-        genesisBlock.setTime(1296688602L);
-        genesisBlock.setNonce(2);
+        genesisBlock.setDifficultyTarget(Block.EASIEST_DIFFICULTY_TARGET);
+        genesisBlock.setTime(GENESIS_TIME);
+        genesisBlock.setNonce(GENESIS_NONCE);
         checkState(genesisBlock.getHash().equals(GENESIS_HASH), "Invalid genesis hash");
 
         port = 18444;

--- a/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
@@ -42,6 +42,8 @@ public class TestNet3Params extends AbstractBitcoinNetParams {
     public static final int TESTNET_MAJORITY_WINDOW = 100;
     public static final int TESTNET_MAJORITY_REJECT_BLOCK_OUTDATED = 75;
     public static final int TESTNET_MAJORITY_ENFORCE_BLOCK_UPGRADE = 51;
+    private static final long GENESIS_TIME = 1296688602;
+    private static final long GENESIS_NONCE = 414098458;
     public static final Sha256Hash GENESIS_HASH = Sha256Hash.wrap("000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943");
 
     public TestNet3Params() {
@@ -49,11 +51,11 @@ public class TestNet3Params extends AbstractBitcoinNetParams {
         id = ID_TESTNET;
 
         targetTimespan = TARGET_TIMESPAN;
-        maxTarget = Utils.decodeCompactBits(0x1d00ffffL);
+        maxTarget = Utils.decodeCompactBits(Block.STANDARD_MAX_DIFFICULTY_TARGET);
 
-        genesisBlock.setDifficultyTarget(0x1d00ffffL);
-        genesisBlock.setTime(1296688602L);
-        genesisBlock.setNonce(414098458);
+        genesisBlock.setDifficultyTarget(Block.STANDARD_MAX_DIFFICULTY_TARGET);
+        genesisBlock.setTime(GENESIS_TIME);
+        genesisBlock.setNonce(GENESIS_NONCE);
         checkState(genesisBlock.getHash().equals(GENESIS_HASH), "Invalid genesis hash");
 
         port = 18333;

--- a/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
@@ -20,8 +20,6 @@ package org.bitcoinj.params;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.core.Utils;
 
-import java.math.BigInteger;
-
 /**
  * Network parameters used by the bitcoinj unit tests (and potentially your own). This lets you solve a block using
  * {@link Block#solve()} by setting difficulty to the easiest possible.
@@ -36,7 +34,7 @@ public class UnitTestParams extends AbstractBitcoinNetParams {
         id = ID_UNITTESTNET;
 
         targetTimespan = 200000000;  // 6 years. Just a very big number.
-        maxTarget = new BigInteger("007fffff0000000000000000000000000000000000000000000000000000000000", 16);  // equivalent to EASIEST_DIFFICULTY_TARGET
+        maxTarget = Utils.decodeCompactBits(Block.EASIEST_DIFFICULTY_TARGET);
         interval = 10;
         subsidyDecreaseBlockCount = 100;
 


### PR DESCRIPTION
* Add Block.STANDARD_MAX_DIFFICULTY_TARGET and use in *Params
* Always define maxTarget in terms of a nBits constant and use `Utils.decodeCompactBits()`
* Define constants for GENESIS_TIME and GENESIS_NONCE

This is a draft PR, that should be rebased after PR #2179 and PR #2180 are merged.

#2179 and #2180 both change behavior slightly, so I think it is best we review them separately. Once they are merged, this PR should not change behavior only replace hardcoded value with symbolic constants.