### PR TITLE
NetParams: Move genesis block construction to lazy getter

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -256,7 +256,7 @@ public class Block extends Message {
         length = cursor - offset;
     }
 
-    static Block createGenesis(NetworkParameters n) {
+    public static Block createGenesis(NetworkParameters n) {
         Block genesisBlock = new Block(n, BLOCK_VERSION_GENESIS);
         Transaction t = createGenesisTransaction(n, genesisTxInputScriptBytes, FIFTY_COINS, genesisTxScriptPubKeyBytes);
         genesisBlock.addTransaction(t);

--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -60,7 +60,6 @@ public abstract class NetworkParameters {
 
     // TODO: Seed nodes should be here as well.
 
-    protected final Block genesisBlock;
     protected BigInteger maxTarget;
     protected int port;
     protected long packetMagic;  // Indicates message origin network and is used to seek to the next message when stream state is unknown.
@@ -99,7 +98,6 @@ public abstract class NetworkParameters {
     protected volatile transient MessageSerializer defaultSerializer = null;
 
     protected NetworkParameters() {
-        genesisBlock = Block.createGenesis(this);
     }
 
     public static final int TARGET_TIMESPAN = 14 * 24 * 60 * 60;  // 2 weeks per difficulty cycle, on average.
@@ -233,9 +231,7 @@ public abstract class NetworkParameters {
      * and a message in the coinbase transaction. It says, <i>"The Times 03/Jan/2009 Chancellor on brink of second
      * bailout for banks"</i>.</p>
      */
-    public Block getGenesisBlock() {
-        return genesisBlock;
-    }
+    public abstract Block getGenesisBlock();
 
     /** Default TCP port on which to connect to nodes. */
     public int getPort() {

--- a/core/src/main/java/org/bitcoinj/params/AbstractBitcoinNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/AbstractBitcoinNetParams.java
@@ -54,6 +54,9 @@ public abstract class AbstractBitcoinNetParams extends NetworkParameters {
 
     private static final Logger log = LoggerFactory.getLogger(AbstractBitcoinNetParams.class);
 
+    /** lazy-initialized by the first call to {@link NetworkParameters#getGenesisBlock()} */
+    protected Block genesisBlock;
+
     public AbstractBitcoinNetParams() {
         super();
         interval = INTERVAL;

--- a/core/src/main/java/org/bitcoinj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/MainNetParams.java
@@ -37,7 +37,7 @@ public class MainNetParams extends AbstractBitcoinNetParams {
     public static final int MAINNET_MAJORITY_ENFORCE_BLOCK_UPGRADE = 750;
     private static final long GENESIS_TIME = 1231006505;
     private static final long GENESIS_NONCE = 2083236893;
-    public static final Sha256Hash GENESIS_HASH = Sha256Hash.wrap("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+    private static final Sha256Hash GENESIS_HASH = Sha256Hash.wrap("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
 
     public MainNetParams() {
         super();
@@ -45,11 +45,6 @@ public class MainNetParams extends AbstractBitcoinNetParams {
 
         targetTimespan = TARGET_TIMESPAN;
         maxTarget = Utils.decodeCompactBits(Block.STANDARD_MAX_DIFFICULTY_TARGET);
-
-        genesisBlock.setDifficultyTarget(Block.STANDARD_MAX_DIFFICULTY_TARGET);
-        genesisBlock.setTime(GENESIS_TIME);
-        genesisBlock.setNonce(GENESIS_NONCE);
-        checkState(genesisBlock.getHash().equals(GENESIS_HASH), "Invalid genesis hash");
 
         port = 8333;
         packetMagic = 0xf9beb4d9L;
@@ -147,6 +142,20 @@ public class MainNetParams extends AbstractBitcoinNetParams {
             instance = new MainNetParams();
         }
         return instance;
+    }
+
+    @Override
+    public Block getGenesisBlock() {
+        synchronized (GENESIS_HASH) {
+            if (genesisBlock == null) {
+                genesisBlock = Block.createGenesis(this);
+                genesisBlock.setDifficultyTarget(Block.STANDARD_MAX_DIFFICULTY_TARGET);
+                genesisBlock.setTime(GENESIS_TIME);
+                genesisBlock.setNonce(GENESIS_NONCE);
+                checkState(genesisBlock.getHash().equals(GENESIS_HASH), "Invalid genesis hash");
+            }
+        }
+        return genesisBlock;
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/params/RegTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/RegTestParams.java
@@ -29,7 +29,7 @@ import static com.google.common.base.Preconditions.checkState;
 public class RegTestParams extends AbstractBitcoinNetParams {
     private static final long GENESIS_TIME = 1296688602;
     private static final long GENESIS_NONCE = 2;
-    public static final Sha256Hash GENESIS_HASH = Sha256Hash.wrap("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206");
+    private static final Sha256Hash GENESIS_HASH = Sha256Hash.wrap("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206");
 
     public RegTestParams() {
         super();
@@ -42,11 +42,6 @@ public class RegTestParams extends AbstractBitcoinNetParams {
         // changes.
         interval = Integer.MAX_VALUE;
         subsidyDecreaseBlockCount = 150;
-
-        genesisBlock.setDifficultyTarget(Block.EASIEST_DIFFICULTY_TARGET);
-        genesisBlock.setTime(GENESIS_TIME);
-        genesisBlock.setNonce(GENESIS_NONCE);
-        checkState(genesisBlock.getHash().equals(GENESIS_HASH), "Invalid genesis hash");
 
         port = 18444;
         packetMagic = 0xfabfb5daL;
@@ -79,6 +74,20 @@ public class RegTestParams extends AbstractBitcoinNetParams {
             instance = new RegTestParams();
         }
         return instance;
+    }
+
+    @Override
+    public Block getGenesisBlock() {
+        synchronized (GENESIS_HASH) {
+            if (genesisBlock == null) {
+                genesisBlock = Block.createGenesis(this);
+                genesisBlock.setDifficultyTarget(Block.EASIEST_DIFFICULTY_TARGET);
+                genesisBlock.setTime(GENESIS_TIME);
+                genesisBlock.setNonce(GENESIS_NONCE);
+                checkState(genesisBlock.getHash().equals(GENESIS_HASH), "Invalid genesis hash");
+            }
+        }
+        return genesisBlock;
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
@@ -44,7 +44,7 @@ public class TestNet3Params extends AbstractBitcoinNetParams {
     public static final int TESTNET_MAJORITY_ENFORCE_BLOCK_UPGRADE = 51;
     private static final long GENESIS_TIME = 1296688602;
     private static final long GENESIS_NONCE = 414098458;
-    public static final Sha256Hash GENESIS_HASH = Sha256Hash.wrap("000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943");
+    private static final Sha256Hash GENESIS_HASH = Sha256Hash.wrap("000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943");
 
     public TestNet3Params() {
         super();
@@ -52,11 +52,6 @@ public class TestNet3Params extends AbstractBitcoinNetParams {
 
         targetTimespan = TARGET_TIMESPAN;
         maxTarget = Utils.decodeCompactBits(Block.STANDARD_MAX_DIFFICULTY_TARGET);
-
-        genesisBlock.setDifficultyTarget(Block.STANDARD_MAX_DIFFICULTY_TARGET);
-        genesisBlock.setTime(GENESIS_TIME);
-        genesisBlock.setNonce(GENESIS_NONCE);
-        checkState(genesisBlock.getHash().equals(GENESIS_HASH), "Invalid genesis hash");
 
         port = 18333;
         packetMagic = 0x0b110907;
@@ -98,6 +93,20 @@ public class TestNet3Params extends AbstractBitcoinNetParams {
             instance = new TestNet3Params();
         }
         return instance;
+    }
+
+    @Override
+    public Block getGenesisBlock() {
+        synchronized (GENESIS_HASH) {
+            if (genesisBlock == null) {
+                genesisBlock = Block.createGenesis(this);
+                genesisBlock.setDifficultyTarget(Block.STANDARD_MAX_DIFFICULTY_TARGET);
+                genesisBlock.setTime(GENESIS_TIME);
+                genesisBlock.setNonce(GENESIS_NONCE);
+                checkState(genesisBlock.getHash().equals(GENESIS_HASH), "Invalid genesis hash");
+            }
+        }
+        return genesisBlock;
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
@@ -38,10 +38,6 @@ public class UnitTestParams extends AbstractBitcoinNetParams {
         interval = 10;
         subsidyDecreaseBlockCount = 100;
 
-        genesisBlock.setDifficultyTarget(Block.EASIEST_DIFFICULTY_TARGET);
-        genesisBlock.setTime(Utils.currentTimeSeconds());
-        genesisBlock.solve();
-        
         port = 18333;
         packetMagic = 0x0b110907;
         dumpedPrivateKeyHeader = 239;
@@ -68,6 +64,19 @@ public class UnitTestParams extends AbstractBitcoinNetParams {
             instance = new UnitTestParams();
         }
         return instance;
+    }
+
+    @Override
+    public Block getGenesisBlock() {
+        synchronized (this) {
+            if (genesisBlock == null) {
+                genesisBlock = Block.createGenesis(this);
+                genesisBlock.setDifficultyTarget(Block.EASIEST_DIFFICULTY_TARGET);
+                genesisBlock.setTime(Utils.currentTimeSeconds());
+                genesisBlock.solve();
+            }
+        }
+        return genesisBlock;
     }
 
     @Override

--- a/core/src/test/java/org/bitcoinj/params/AbstractBitcoinNetParamsTest.java
+++ b/core/src/test/java/org/bitcoinj/params/AbstractBitcoinNetParamsTest.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.params;
 
+import org.bitcoinj.core.Block;
 import org.bitcoinj.core.Coin;
 import org.junit.Test;
 
@@ -25,6 +26,11 @@ import static org.junit.Assert.assertTrue;
 
 public class AbstractBitcoinNetParamsTest {
     private final AbstractBitcoinNetParams BITCOIN_PARAMS = new AbstractBitcoinNetParams() {
+        @Override
+        public Block getGenesisBlock() {
+            return null;
+        }
+
         @Override
         public String getPaymentProtocolId() {
             return null;


### PR DESCRIPTION
This PR will need rebasing after other pending PRs are merged.

This refactoring breaks the cyclic dependency of NetParams constructors
on the constructors in `Block` and will allow us to migrate the code
now in the `getGenesisBlock()` methods into (atomic) factories/constructors
in `Block` allowing us to create block objects that are unmodifiable/immutable.

Currently depends on PR #2183 which was submitted separately.