### PR TITLE
UtilsTest: resetMocking() after MockClock test

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/UtilsTest.java
+++ b/core/src/test/java/org/bitcoinj/core/UtilsTest.java
@@ -237,5 +237,6 @@ public class UtilsTest {
     public void testRollMockClock() {
         Utils.setMockClock(25200);
         assertEquals(new Date("Thu Jan 01 07:00:08 GMT 1970"), Utils.rollMockClock(8));
+        Utils.resetMocking();
     }
 }


### PR DESCRIPTION
This should fix #2049. (We'll have to check what happens GitLab CI to know for sure)

Notice that the current time in the failures is: `1970-01-01T09:00:08Z` this definitely points at the test that this PR fixes.
Not just 1970, but notice the 8 seconds past the hour!

Update: Gitlab tests are passing on my fork: https://gitlab.com/ConsensusJ/bitcoinj/-/pipelines/367361062
