### PR TITLE
Use no-args Utils.setMockClock() where possible

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
@@ -158,7 +158,7 @@ public class BlockChainTest {
         // Add a bunch of blocks in a loop until we reach a difficulty transition point. The unit test params have an
         // artificially shortened period.
         Block prev = UNITTEST.getGenesisBlock();
-        Utils.setMockClock(Utils.currentTimeSeconds());
+        Utils.setMockClock();
         for (int height = 0; height < UNITTEST.getInterval() - 1; height++) {
             Block newBlock = prev.createNextBlock(coinbaseTo, 1, Utils.currentTimeSeconds(), height);
             assertTrue(chain.add(newBlock));

--- a/core/src/test/java/org/bitcoinj/utils/ExponentialBackoffTest.java
+++ b/core/src/test/java/org/bitcoinj/utils/ExponentialBackoffTest.java
@@ -31,7 +31,7 @@ public class ExponentialBackoffTest {
 
     @Before
     public void setUp() {
-        Utils.setMockClock(Utils.currentTimeSeconds());
+        Utils.setMockClock();
         params = new ExponentialBackoff.Params();
         backoff = new ExponentialBackoff(params);
     }

--- a/core/src/test/java/org/bitcoinj/wallet/BasicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/BasicKeyChainTest.java
@@ -63,8 +63,8 @@ public class BasicKeyChainTest {
 
     @Test
     public void importKeys() {
+        Utils.setMockClock();
         long now = Utils.currentTimeSeconds();
-        Utils.setMockClock(now);
         final ECKey key1 = new ECKey();
         Utils.rollMockClock(86400);
         final ECKey key2 = new ECKey();


### PR DESCRIPTION
Replace a few calls to:

```
Utils.setMockClock(Utils.setCurrentTimeSeconds())
```
with

```
Utils.setMockClock()
```

The behavior of the former is slightly different and possibly pathological (i.e. if mocking wasn't reset by the previous test, it won't actually be setting to the "current" time)  However, I believe that in all three cases in this PR, it is the  later behavior that is intended.

Note that this PR, in conjunction with PR #2185 seems to make it clear that none of our blockchain unit tests are using MockTime to set the time in the past.

