### PR TITLE
Upgrade to JavaFX 17.0.0.1

### DIFF
--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 }
 
 javafx {
-    version = '15'
+    version = '17.0.0.1'
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 


### PR DESCRIPTION
JavaFX 17 is an LTS release and works with JDK 11 or later.