### PR TITLE
walletfx: Hook up the unused “Primary” and “Secondary” buttons

### DIFF
--- a/wallettemplate/src/main/java/wallettemplate/MainController.java
+++ b/wallettemplate/src/main/java/wallettemplate/MainController.java
@@ -33,6 +33,7 @@ import javafx.util.Duration;
 import wallettemplate.controls.ClickableBitcoinAddress;
 import wallettemplate.controls.NotificationBarPane;
 import org.bitcoinj.walletfx.utils.BitcoinUIModel;
+import org.bitcoinj.walletfx.utils.GuiUtils;
 import org.bitcoinj.walletfx.utils.easing.EasingMode;
 import org.bitcoinj.walletfx.utils.easing.ElasticInterpolator;
 
@@ -98,6 +99,14 @@ public class MainController {
     public void settingsClicked(ActionEvent event) {
         Main.OverlayUI<WalletSettingsController> screen = Main.instance.overlayUI("wallet_settings.fxml");
         screen.controller.initialize(null);
+    }
+
+    public void primaryClicked(ActionEvent event) {
+        GuiUtils.informationalAlert("Unused button #1", "You can hook this up in your app");
+    }
+
+    public void secondaryClicked(ActionEvent event) {
+        GuiUtils.informationalAlert("Unused button #2", "You can hook this up in your app");
     }
 
     public void restoreFromSeedAnimation() {

--- a/wallettemplate/src/main/resources/wallettemplate/main.fxml
+++ b/wallettemplate/src/main/resources/wallettemplate/main.fxml
@@ -36,8 +36,8 @@
     </HBox>
     <HBox fx:id="controlsBox" alignment="TOP_LEFT" fillHeight="true" layoutX="14.0" layoutY="347.0" minHeight="16.0" prefHeight="36.0" prefWidth="243.0" spacing="10.0" translateY="60.0" visible="true" AnchorPane.bottomAnchor="17.0">
       <children>
-        <Button defaultButton="true" mnemonicParsing="false" styleClass="fat-button" text="Primary" />
-        <Button cancelButton="true" mnemonicParsing="false" styleClass="fat-button" text="Secondary" />
+        <Button onAction="#primaryClicked" defaultButton="true" mnemonicParsing="false" styleClass="fat-button" text="Primary" />
+        <Button onAction="#secondaryClicked" cancelButton="true" mnemonicParsing="false" styleClass="fat-button" text="Secondary" />
       </children>
     </HBox>
     <ImageView fitHeight="243.0" fitWidth="243.0" opacity="0.28" pickOnBounds="true" preserveRatio="true" AnchorPane.bottomAnchor="-36.0" AnchorPane.rightAnchor="-34.0">


### PR DESCRIPTION
I did this for two reasons:

1. So users will know why the buttons are there and that they work
2. A convenient way to test the informational alert function.

Draft PR: Waiting for PR #2196 to be merged, then I'll rebase, and submit.