### PR TITLE
Wrap OkHttp -- make it an `implementation` not `api` dependency

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     api 'org.bouncycastle:bcprov-jdk15to18:1.68'
     api 'com.google.guava:guava:30.0-android'
     api 'com.google.protobuf:protobuf-java:3.13.0'
-    api 'com.squareup.okhttp3:okhttp:3.12.12'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.12'
     implementation 'org.slf4j:slf4j-api:1.7.32'
     implementation 'net.jcip:jcip-annotations:1.0'
     compileOnly 'org.fusesource.leveldbjni:leveldbjni-all:1.8'

--- a/core/src/main/java/org/bitcoinj/net/discovery/MultiplexingDiscovery.java
+++ b/core/src/main/java/org/bitcoinj/net/discovery/MultiplexingDiscovery.java
@@ -31,8 +31,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.*;
 
-import okhttp3.OkHttpClient;
-
 import static com.google.common.base.Preconditions.checkArgument;
 
 /**
@@ -72,7 +70,7 @@ public class MultiplexingDiscovery implements PeerDiscovery {
         List<PeerDiscovery> discoveries = new ArrayList<>();
         HttpDiscovery.Details[] httpSeeds = params.getHttpSeeds();
         if (httpSeeds != null) {
-            OkHttpClient httpClient = new OkHttpClient();
+            HttpDiscovery.HttpDiscoveryClient httpClient = HttpDiscovery.newDefaultClient();
             for (HttpDiscovery.Details httpSeed : httpSeeds)
                 discoveries.add(new HttpDiscovery(params, httpSeed, httpClient));
         }


### PR DESCRIPTION
1. Make usage of OkHttpClient internal to HttpDiscovery.java
2. Deprecate one constructor in HttpDiscovery 
3. Use wrapper in MultiplexingDiscovery
4. Change build.gradle dependency for OkHttp to `api`