### PR TITLE
walletfx: Refactor overlay, reduce usage of `instance` static globals

### DIFF
--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/overlay/OverlayController.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/overlay/OverlayController.java
@@ -20,7 +20,8 @@ package org.bitcoinj.walletfx.overlay;
  */
 public interface OverlayController<T> {
     /**
+     * @param rootController The root controller (containing the StackPane)
      * @param ui The overlay UI (node, controller pair)
      */
-    void setOverlayUI(OverlayableStackPaneController.OverlayUI<? extends OverlayController<T>> ui);
+    void initOverlay(OverlayableStackPaneController rootController, OverlayableStackPaneController.OverlayUI<? extends OverlayController<T>> ui);
 }

--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/overlay/OverlayableStackPaneController.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/overlay/OverlayableStackPaneController.java
@@ -55,7 +55,7 @@ public abstract class OverlayableStackPaneController {
     public <T extends OverlayController<T>> OverlayUI<T> overlayUI(Node node, T controller) {
         checkGuiThread();
         OverlayUI<T> pair = new OverlayUI<>(node, controller);
-        controller.setOverlayUI(pair);
+        controller.initOverlay(this, pair);
         pair.show();
         return pair;
     }
@@ -65,12 +65,12 @@ public abstract class OverlayableStackPaneController {
         try {
             checkGuiThread();
             // Load the UI from disk.
-            URL location = GuiUtils.getResource(name);
+            URL location = GuiUtils.getResource(this.getClass(), name);
             FXMLLoader loader = new FXMLLoader(location);
-            Pane ui = loader.load();
+            Pane overlayNode = loader.load();
             T controller = loader.getController();
-            OverlayUI<T> pair = new OverlayUI<>(ui, controller);
-            controller.setOverlayUI(pair);
+            OverlayUI<T> pair = new OverlayUI<>(overlayNode, controller);
+            controller.initOverlay(this, pair);
             pair.show();
             return pair;
         } catch (IOException e) {

--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/utils/GuiUtils.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/utils/GuiUtils.java
@@ -27,7 +27,6 @@ import javafx.scene.layout.Pane;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.util.Duration;
-import wallettemplate.MainController;
 
 import java.io.IOException;
 import java.net.URL;
@@ -172,11 +171,11 @@ public class GuiUtils {
      * A useful helper for development purposes. Used as a switch for loading files from local disk, allowing live
      * editing whilst the app runs without rebuilds.
      */
-    public static URL getResource(String name) {
+    public static URL getResource(Class<?> clazz, String name) {
         if (false)
             return unchecked(() -> new URL("file:///your/path/here/src/main/wallettemplate/" + name));
         else
-            return MainController.class.getResource(name);
+            return clazz.getResource(name);
     }
 
     public static void checkGuiThread() {

--- a/wallettemplate/src/main/java/wallettemplate/Main.java
+++ b/wallettemplate/src/main/java/wallettemplate/Main.java
@@ -49,10 +49,10 @@ public class Main extends Application {
     private static final String WALLET_FILE_NAME = APP_NAME.replaceAll("[^a-zA-Z0-9.-]", "_") + "-"
             + params.getPaymentProtocolId();
 
-    public static WalletAppKit bitcoin;
-    public static Main instance;
+    static WalletAppKit bitcoin;
+    static Main instance;
 
-    public MainController controller;
+    private MainController controller;
 
     @Override
     public void start(Stage mainWindow) throws Exception {

--- a/wallettemplate/src/main/java/wallettemplate/MainController.java
+++ b/wallettemplate/src/main/java/wallettemplate/MainController.java
@@ -49,7 +49,7 @@ import static wallettemplate.Main.bitcoin;
  * after. This class handles all the updates and event handling for the main UI.
  */
 public class MainController extends OverlayableStackPaneController {
-    public static MainController instance;
+    static MainController instance;
     public HBox controlsBox;
     public Label balance;
     public Button sendMoneyOutBtn;
@@ -64,6 +64,10 @@ public class MainController extends OverlayableStackPaneController {
     // Called by FXMLLoader.
     public void initialize() {
         instance = this;
+        // Special case of initOverlay that passes null as the 2nd parameter because ClickableBitcoinAddress is loaded by FXML
+        // TODO: Extract QRCode Pane to separate reusable class that is a more standard OverlayController instance
+        addressControl.initOverlay(this, null);
+        addressControl.setAppName(Main.APP_NAME);
         addressControl.setOpacity(0.0);
     }
 

--- a/wallettemplate/src/main/java/wallettemplate/SendMoneyController.java
+++ b/wallettemplate/src/main/java/wallettemplate/SendMoneyController.java
@@ -49,13 +49,15 @@ public class SendMoneyController implements OverlayController<SendMoneyControlle
     public TextField amountEdit;
     public Label btcLabel;
 
+    private OverlayableStackPaneController rootController;
     private OverlayableStackPaneController.OverlayUI<? extends OverlayController<SendMoneyController>> overlayUI;
 
     private Wallet.SendResult sendResult;
     private KeyParameter aesKey;
 
     @Override
-    public void setOverlayUI(OverlayableStackPaneController.OverlayUI<? extends OverlayController<SendMoneyController>> ui) {
+    public void initOverlay(OverlayableStackPaneController overlayableStackPaneController, OverlayableStackPaneController.OverlayUI<? extends OverlayController<SendMoneyController>> ui) {
+        rootController = overlayableStackPaneController;
         overlayUI = ui;
     }
 
@@ -121,14 +123,14 @@ public class SendMoneyController implements OverlayController<SendMoneyControlle
     }
 
     private void askForPasswordAndRetry() {
-        OverlayableStackPaneController.OverlayUI<WalletPasswordController> pwd = MainController.instance.overlayUI("wallet_password.fxml");
+        OverlayableStackPaneController.OverlayUI<WalletPasswordController> pwd = rootController.overlayUI("wallet_password.fxml");
         final String addressStr = address.getText();
         final String amountStr = amountEdit.getText();
         pwd.controller.aesKeyProperty().addListener((observable, old, cur) -> {
             // We only get here if the user found the right password. If they don't or they cancel, we end up back on
             // the main UI screen. By now the send money screen is history so we must recreate it.
             checkGuiThread();
-            OverlayableStackPaneController.OverlayUI<SendMoneyController> screen = MainController.instance.overlayUI("send_money.fxml");
+            OverlayableStackPaneController.OverlayUI<SendMoneyController> screen = rootController.overlayUI("send_money.fxml");
             screen.controller.aesKey = cur;
             screen.controller.address.setText(addressStr);
             screen.controller.amountEdit.setText(amountStr);

--- a/wallettemplate/src/main/java/wallettemplate/WalletPasswordController.java
+++ b/wallettemplate/src/main/java/wallettemplate/WalletPasswordController.java
@@ -56,12 +56,14 @@ public class WalletPasswordController implements OverlayController<WalletPasswor
     @FXML GridPane widgetGrid;
     @FXML Label explanationLabel;
 
+    private OverlayableStackPaneController rootController;
     private OverlayableStackPaneController.OverlayUI<? extends OverlayController<WalletPasswordController>> overlayUI;
 
     private SimpleObjectProperty<KeyParameter> aesKey = new SimpleObjectProperty<>();
 
     @Override
-    public void setOverlayUI(OverlayableStackPaneController.OverlayUI<? extends OverlayController<WalletPasswordController>> ui) {
+    public void initOverlay(OverlayableStackPaneController overlayableStackPaneController, OverlayableStackPaneController.OverlayUI<? extends OverlayController<WalletPasswordController>> ui) {
+        rootController = overlayableStackPaneController;
         overlayUI = ui;
     }
 

--- a/wallettemplate/src/main/java/wallettemplate/WalletSetPasswordController.java
+++ b/wallettemplate/src/main/java/wallettemplate/WalletSetPasswordController.java
@@ -45,6 +45,7 @@ public class WalletSetPasswordController implements OverlayController<WalletSetP
     public Button closeButton;
     public Label explanationLabel;
 
+    private OverlayableStackPaneController rootController;
     private OverlayableStackPaneController.OverlayUI<? extends OverlayController<WalletSetPasswordController>> overlayUI;
     // These params were determined empirically on a top-range (as of 2014) MacBook Pro with native scrypt support,
     // using the scryptenc command line tool from the original scrypt distribution, given a memory limit of 40mb.
@@ -56,7 +57,8 @@ public class WalletSetPasswordController implements OverlayController<WalletSetP
             .build();
 
     @Override
-    public void setOverlayUI(OverlayableStackPaneController.OverlayUI<? extends OverlayController<WalletSetPasswordController>> ui) {
+    public void initOverlay(OverlayableStackPaneController overlayableStackPaneController, OverlayableStackPaneController.OverlayUI<? extends OverlayController<WalletSetPasswordController>> ui) {
+        rootController = overlayableStackPaneController;
         overlayUI = ui;
     }
 

--- a/wallettemplate/src/main/java/wallettemplate/WalletSettingsController.java
+++ b/wallettemplate/src/main/java/wallettemplate/WalletSettingsController.java
@@ -57,12 +57,14 @@ public class WalletSettingsController implements OverlayController<WalletSetting
     @FXML TextArea wordsArea;
     @FXML Button restoreButton;
 
+    private OverlayableStackPaneController rootController;
     private OverlayableStackPaneController.OverlayUI<? extends OverlayController<WalletSettingsController>> overlayUI;
 
     private KeyParameter aesKey;
 
     @Override
-    public void setOverlayUI(OverlayableStackPaneController.OverlayUI<? extends OverlayController<WalletSettingsController>> ui) {
+    public void initOverlay(OverlayableStackPaneController overlayableStackPaneController, OverlayableStackPaneController.OverlayUI<? extends OverlayController<WalletSettingsController>> ui) {
+        rootController = overlayableStackPaneController;
         overlayUI = ui;
     }
 
@@ -139,12 +141,12 @@ public class WalletSettingsController implements OverlayController<WalletSetting
     }
 
     private void askForPasswordAndRetry() {
-        OverlayableStackPaneController.OverlayUI<WalletPasswordController> pwd = MainController.instance.overlayUI("wallet_password.fxml");
+        OverlayableStackPaneController.OverlayUI<WalletPasswordController> pwd = rootController.overlayUI("wallet_password.fxml");
         pwd.controller.aesKeyProperty().addListener((observable, old, cur) -> {
             // We only get here if the user found the right password. If they don't or they cancel, we end up back on
             // the main UI screen.
             checkGuiThread();
-            OverlayableStackPaneController.OverlayUI<WalletSettingsController> screen = MainController.instance.overlayUI("wallet_settings.fxml");
+            OverlayableStackPaneController.OverlayUI<WalletSettingsController> screen = rootController.overlayUI("wallet_settings.fxml");
             screen.controller.initialize(cur);
         });
     }
@@ -191,7 +193,7 @@ public class WalletSettingsController implements OverlayController<WalletSetting
 
     public void passwordButtonClicked(ActionEvent event) {
         if (aesKey == null) {
-            MainController.instance.overlayUI("wallet_set_password.fxml");
+            rootController.overlayUI("wallet_set_password.fxml");
         } else {
             Main.bitcoin.wallet().decrypt(aesKey);
             informationalAlert("Wallet decrypted", "A password will no longer be required to send money or edit settings.");

--- a/wallettemplate/src/main/java/wallettemplate/controls/ClickableBitcoinAddress.java
+++ b/wallettemplate/src/main/java/wallettemplate/controls/ClickableBitcoinAddress.java
@@ -44,13 +44,11 @@ import org.bitcoinj.uri.BitcoinURI;
 
 import org.bitcoinj.walletfx.overlay.OverlayController;
 import org.bitcoinj.walletfx.overlay.OverlayableStackPaneController;
-import wallettemplate.Main;
 import org.bitcoinj.walletfx.utils.GuiUtils;
 import org.bitcoinj.walletfx.utils.QRCodeImages;
 
 import de.jensd.fx.fontawesome.AwesomeDude;
 import de.jensd.fx.fontawesome.AwesomeIcon;
-import wallettemplate.MainController;
 
 import static javafx.beans.binding.Bindings.convert;
 
@@ -68,9 +66,23 @@ public class ClickableBitcoinAddress extends AnchorPane implements OverlayContro
     protected SimpleObjectProperty<Address> address = new SimpleObjectProperty<>();
     private final StringExpression addressStr;
 
+    private OverlayableStackPaneController rootController;
+
+    private String appName = "app-name";
+
     @Override
-    public void setOverlayUI(OverlayableStackPaneController.OverlayUI<? extends OverlayController<ClickableBitcoinAddress>> ui) {
+    public void initOverlay(OverlayableStackPaneController overlayableStackPaneController, OverlayableStackPaneController.OverlayUI<? extends OverlayController<ClickableBitcoinAddress>> ui) {
+        rootController = overlayableStackPaneController;
     }
+
+    /**
+     * @param theAppName The application name to use in Bitcoin URIs
+     */
+    public void setAppName(String theAppName) {
+        appName = theAppName;
+    }
+
+
 
     public ClickableBitcoinAddress() {
         try {
@@ -95,7 +107,7 @@ public class ClickableBitcoinAddress extends AnchorPane implements OverlayContro
     }
 
     public String uri() {
-        return BitcoinURI.convertToBitcoinURI(address.get(), null, Main.APP_NAME, null);
+        return BitcoinURI.convertToBitcoinURI(address.get(), null, appName, null);
     }
 
     public Address getAddress() {
@@ -150,7 +162,7 @@ public class ClickableBitcoinAddress extends AnchorPane implements OverlayContro
         // non-centered on the screen. Finally fade/blur it in.
         Pane pane = new Pane(view);
         pane.setMaxSize(qrImage.getWidth(), qrImage.getHeight());
-        final OverlayableStackPaneController.OverlayUI<ClickableBitcoinAddress> overlay = MainController.instance.overlayUI(pane, this);
+        final OverlayableStackPaneController.OverlayUI<ClickableBitcoinAddress> overlay = rootController.overlayUI(pane, this);
         view.setOnMouseClicked(event1 -> overlay.done());
     }
 


### PR DESCRIPTION
* OverlayController: rename init method, add rootController to params
* OverlayableStackPaneController: update to use updated initOverlay() method, also pass this.getClass() into GuiUtils.getResource()
* GuiUtils.getResource(): replace reference to MainController.class with clazz parameter
* Main: Reduce visibility to “package” of 3 static globals
* MainController: Reduce visibility of `instance` static to “package”, initialize addressControl by calling 2 initialization methods
* 4 other controllers: Update for OverlayController changes
* ClickableBitcoinAddress: OverlayController changes, eliminate use of Main.APP_NAME

Rationale:

* Decrease coupling
* Eliminate cross-package use of `Main` and `MainController` static globals
* Prepare for further refactoring — moving `wallettemplate.controls` package to `org.bitcoinj.walletfx.controls`