### PR TITLE
Github Actions: JDK 16 -> JDK 17 LTS

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        java: [ '8', '11', '16']
+        java: [ '8', '11', '17']
         distribution: ['temurin']
         gradle: ['7.2']
       fail-fast: false


### PR DESCRIPTION
Temurin 17 is available. I'm not sure if it's available yet via the `setup-java` action, but Github Actions will tell us... 