### PR TITLE
WalletApplication: improve encapsulation

### DIFF
--- a/wallettemplate/src/main/java/wallettemplate/MainController.java
+++ b/wallettemplate/src/main/java/wallettemplate/MainController.java
@@ -43,8 +43,6 @@ import org.bitcoinj.walletfx.utils.BitcoinUIModel;
 import org.bitcoinj.walletfx.utils.easing.EasingMode;
 import org.bitcoinj.walletfx.utils.easing.ElasticInterpolator;
 
-import static org.bitcoinj.walletfx.application.WalletApplication.bitcoin;
-
 /**
  * Gets created auto-magically by FXMLLoader via reflection. The widget fields are set to the GUI controls they're named
  * after. This class handles all the updates and event handling for the main UI.
@@ -60,15 +58,17 @@ public class MainController extends MainWindowController {
     private NotificationBarPane.Item syncItem;
     private static final MonetaryFormat MONETARY_FORMAT = MonetaryFormat.BTC.noCode();
 
+    private WalletApplication app;
     private NotificationBarPane notificationBar;
 
     // Called by FXMLLoader.
     public void initialize() {
         instance = this;
+        app = WalletApplication.instance();
         // Special case of initOverlay that passes null as the 2nd parameter because ClickableBitcoinAddress is loaded by FXML
         // TODO: Extract QRCode Pane to separate reusable class that is a more standard OverlayController instance
         addressControl.initOverlay(this, null);
-        addressControl.setAppName(WalletApplication.instance.applicationName);
+        addressControl.setAppName(app.applicationName());
         addressControl.setOpacity(0.0);
     }
 
@@ -85,12 +85,12 @@ public class MainController extends MainWindowController {
         // Add CSS that we need. cssResourceName will be loaded from the same package as this class.
         scene.getStylesheets().add(getClass().getResource(cssResourceName).toString());
         uiStack.getChildren().add(notificationBar);
-        scene.getAccelerators().put(KeyCombination.valueOf("Shortcut+F"), () -> bitcoin.peerGroup().getDownloadPeer().close());
+        scene.getAccelerators().put(KeyCombination.valueOf("Shortcut+F"), () -> app.walletAppKit().peerGroup().getDownloadPeer().close());
     }
 
     @Override
     public void onBitcoinSetup() {
-        model.setWallet(bitcoin.wallet());
+        model.setWallet(app.walletAppKit().wallet());
         addressControl.addressProperty().bind(model.addressProperty());
         balance.textProperty().bind(createBalanceStringBinding(model.balanceProperty()));
         // Don't let the user click send money when the wallet is empty.

--- a/wallettemplate/src/main/java/wallettemplate/WalletSetPasswordController.java
+++ b/wallettemplate/src/main/java/wallettemplate/WalletSetPasswordController.java
@@ -46,6 +46,7 @@ public class WalletSetPasswordController implements OverlayController<WalletSetP
     public Button closeButton;
     public Label explanationLabel;
 
+    private WalletApplication app;
     private OverlayableStackPaneController rootController;
     private OverlayableStackPaneController.OverlayUI<? extends OverlayController<WalletSetPasswordController>> overlayUI;
     // These params were determined empirically on a top-range (as of 2014) MacBook Pro with native scrypt support,
@@ -64,6 +65,7 @@ public class WalletSetPasswordController implements OverlayController<WalletSetP
     }
 
     public void initialize() {
+        app = WalletApplication.instance();
         progressMeter.setOpacity(0);
     }
 
@@ -118,7 +120,7 @@ public class WalletSetPasswordController implements OverlayController<WalletSetP
                 WalletPasswordController.setTargetTime(Duration.ofMillis(timeTakenMsec));
                 // The actual encryption part doesn't take very long as most private keys are derived on demand.
                 log.info("Key derived, now encrypting");
-                WalletApplication.bitcoin.wallet().encrypt(scrypt, aesKey);
+                app.walletAppKit().wallet().encrypt(scrypt, aesKey);
                 log.info("Encryption done");
                 informationalAlert("Wallet encrypted",
                         "You can remove the password at any time from the settings screen.");


### PR DESCRIPTION
* Make all public fields private and wrap with accessors
* Make `WalletAppKit` (was confusingly named `bitcoin`) field a member not a static
* Rename `bitcoin` to `walletAppKit`