### PR TITLE
BasicKeyChain, DeterministicKeyChain, WalletTool: only use protobuf API that is available also on protobuf-lite.

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/BasicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/BasicKeyChain.java
@@ -320,9 +320,9 @@ public class BasicKeyChain implements EncryptableKeyChain {
             // which the leaf keys chain to an encrypted parent and rederive their private keys on the fly. In that
             // case the caller in DeterministicKeyChain will take care of setting the type.
             EncryptedData data = item.getEncryptedData();
-            proto.getEncryptedDataBuilder()
+            proto.setEncryptedData(proto.getEncryptedData().toBuilder()
                     .setEncryptedPrivateKey(ByteString.copyFrom(data.encryptedBytes))
-                    .setInitialisationVector(ByteString.copyFrom(data.initialisationVector));
+                    .setInitialisationVector(ByteString.copyFrom(data.initialisationVector)));
             // We don't allow mixing of encryption types at the moment.
             checkState(item.getEncryptionType() == Protos.Wallet.EncryptionType.ENCRYPTED_SCRYPT_AES);
             proto.setType(Protos.Key.Type.ENCRYPTED_SCRYPT_AES);

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -760,7 +760,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
             DeterministicKey key = (DeterministicKey) entry.getKey();
             Protos.Key.Builder proto = entry.getValue();
             proto.setType(Protos.Key.Type.DETERMINISTIC_KEY);
-            final Protos.DeterministicKey.Builder detKey = proto.getDeterministicKeyBuilder();
+            final Protos.DeterministicKey.Builder detKey = proto.getDeterministicKey().toBuilder();
             detKey.setChainCode(ByteString.copyFrom(key.getChainCode()));
             for (ChildNumber num : key.getPath())
                 detKey.addPath(num.i());
@@ -777,6 +777,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
             if (entries.isEmpty() && isFollowing()) {
                 detKey.setIsFollowing(true);
             }
+            proto.setDeterministicKey(detKey);
             if (key.getParent() != null) {
                 // HD keys inherit the timestamp of their parent if they have one, so no need to serialize it.
                 proto.clearCreationTimestamp();
@@ -1325,9 +1326,9 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
         // the seed.
         if (seed.isEncrypted() && seed.getEncryptedSeedData() != null) {
             EncryptedData data = seed.getEncryptedSeedData();
-            proto.getEncryptedDeterministicSeedBuilder()
+            proto.setEncryptedDeterministicSeed(proto.getEncryptedDeterministicSeed().toBuilder()
                     .setEncryptedPrivateKey(ByteString.copyFrom(data.encryptedBytes))
-                    .setInitialisationVector(ByteString.copyFrom(data.initialisationVector));
+                    .setInitialisationVector(ByteString.copyFrom(data.initialisationVector)));
             // We don't allow mixing of encryption types at the moment.
             checkState(seed.getEncryptionType() == Protos.Wallet.EncryptionType.ENCRYPTED_SCRYPT_AES);
         } else {

--- a/tools/src/main/java/org/bitcoinj/tools/WalletTool.java
+++ b/tools/src/main/java/org/bitcoinj/tools/WalletTool.java
@@ -495,15 +495,19 @@ public class WalletTool implements Callable<Integer> {
         // less "raw" but we will just abort on any errors.
         try {
             Protos.Wallet.Builder builder = proto.toBuilder();
-            for (Protos.Transaction.Builder tx : builder.getTransactionBuilderList()) {
-                tx.setHash(bytesToHex(tx.getHash()));
-                for (int i = 0; i < tx.getBlockHashCount(); i++)
-                    tx.setBlockHash(i, bytesToHex(tx.getBlockHash(i)));
-                for (Protos.TransactionInput.Builder input : tx.getTransactionInputBuilderList())
-                    input.setTransactionOutPointHash(bytesToHex(input.getTransactionOutPointHash()));
-                for (Protos.TransactionOutput.Builder output : tx.getTransactionOutputBuilderList()) {
-                    if (output.hasSpentByTransactionHash())
-                        output.setSpentByTransactionHash(bytesToHex(output.getSpentByTransactionHash()));
+            for (Protos.Transaction tx : builder.getTransactionList()) {
+                Protos.Transaction.Builder txBuilder = tx.toBuilder();
+                txBuilder.setHash(bytesToHex(txBuilder.getHash()));
+                for (int i = 0; i < txBuilder.getBlockHashCount(); i++)
+                    txBuilder.setBlockHash(i, bytesToHex(txBuilder.getBlockHash(i)));
+                for (Protos.TransactionInput input : txBuilder.getTransactionInputList()) {
+                    Protos.TransactionInput.Builder inputBuilder = input.toBuilder();
+                    inputBuilder.setTransactionOutPointHash(bytesToHex(inputBuilder.getTransactionOutPointHash()));
+                }
+                for (Protos.TransactionOutput output : txBuilder.getTransactionOutputList()) {
+                    Protos.TransactionOutput.Builder outputBuilder = output.toBuilder();
+                    if (outputBuilder.hasSpentByTransactionHash())
+                        outputBuilder.setSpentByTransactionHash(bytesToHex(outputBuilder.getSpentByTransactionHash()));
                 }
                 // TODO: keys, ip addresses etc.
             }


### PR DESCRIPTION
This is meant to aid migration to protobuf-lite.