### PR TITLE
walletfx: refactor initialization of `estimatedKeyDerivationTime`

### DIFF
--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/application/WalletApplication.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/application/WalletApplication.java
@@ -18,7 +18,6 @@ package org.bitcoinj.walletfx.application;
 
 import com.google.common.util.concurrent.Service;
 import javafx.application.Platform;
-import javafx.scene.Scene;
 import javafx.scene.input.KeyCombination;
 import javafx.stage.Stage;
 import org.bitcoinj.core.NetworkParameters;
@@ -130,7 +129,7 @@ public abstract class WalletApplication implements AppDelegate {
 
         primaryStage.show();
 
-        WalletSetPasswordController.estimateKeyDerivationTimeMsec();
+        WalletSetPasswordController.initEstimatedKeyDerivationTime();
 
         walletAppKit.addListener(new Service.Listener() {
             @Override


### PR DESCRIPTION
These changes should not change behavior of the application

* make `estimatedKeyDerivationTime` private
* Rename `WalletSetPasswordController.estimateKeyDerivationTimeMsec()` to `WalletSetPasswordController.initEstimatedKeyDerivationTime()`
* `WalletSetPasswordController.initEstimatedKeyDerivationTime()` returns `void` (result was previously unused)
* Separate the calculation into a synchronous `estimateKeyDerivationTime()` with no side effects, and `initEstimatedKeyDerivationTime()` which provides the asynchrony via `supplyAsync` and uses `thenAccept` to update the `estimatedKeyDerivationTime ` field.
* In `initEstimatedKeyDerivationTime()` actually implement the comment:  "If we haven't recorded it before"

Rationale:

* Better encapsulation
* Use `CompletableFuture` in an easier-to-read, more idiomatic way
* Separate computation of the value from setting the global static
* Remove confusing (and unnecessary) use of `Platform::runLater`

Will need to rebase after #2212 is merged.
