### PR TITLE
build.gradle: produce Java 8 bytecode for the core module

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The bitcoinj library is a Java implementation of the Bitcoin protocol, which all
 
 ### Technologies
 
-* Java 7+ and Gradle 4.4+ for the `core` module
+* Java 8+ (Java 7 API, Java 8 bytecode) and Gradle 4.4+ for the `core` module
 * Java 8+ and Gradle 4.4+ for `tools` and `examples`
 * Java 11+ and Gradle 4.10+ for the JavaFX-based `wallettemplate`
 * [Gradle](https://gradle.org/) - for building the project

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 }
 
 sourceCompatibility = 1.7
+targetCompatibility = 1.8
 compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
 javadoc.options.encoding = 'UTF-8'


### PR DESCRIPTION
It will still only use the Java 7 API.