### PR TITLE
update protobuf-javalite to 3.18.0 and OkHttp to 3.14.9

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     api 'org.bouncycastle:bcprov-jdk15to18:1.69'
     api 'com.google.guava:guava:31.0.1-android'
     api 'com.google.protobuf:protobuf-javalite:3.18.0'
-    api 'com.squareup.okhttp3:okhttp:3.12.13'
+    api 'com.squareup.okhttp3:okhttp:3.14.9'
     implementation 'org.slf4j:slf4j-api:1.7.32'
     implementation 'net.jcip:jcip-annotations:1.0'
     compileOnly 'org.fusesource.leveldbjni:leveldbjni-all:1.8'


### PR DESCRIPTION
* update protobuf-javalite to 3.18.0 → probably a no-brainer
* update OkHttp to 3.14.9 → The 3.14 branch seems to be kind of long-term supported, although that is not officially announced. It's the last branch that doesn't come with the Kotlin deps. Note the the 3.12 branch is officially out of support at the end of 2021.