### PR TITLE
Script: add opcode name to disabled opcode exception message

### DIFF
--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -796,7 +796,7 @@ public class Script {
                     opcode == OP_INVERT || opcode == OP_AND || opcode == OP_OR || opcode == OP_XOR ||
                     opcode == OP_2MUL || opcode == OP_2DIV || opcode == OP_MUL || opcode == OP_DIV ||
                     opcode == OP_MOD || opcode == OP_LSHIFT || opcode == OP_RSHIFT)
-                throw new ScriptException(ScriptError.SCRIPT_ERR_DISABLED_OPCODE, "Script included a disabled Script Op.");
+                throw new ScriptException(ScriptError.SCRIPT_ERR_DISABLED_OPCODE, "Script included disabled Script Op " + ScriptOpCodes.getOpCodeName(opcode));
 
             if (shouldExecute && OP_0 <= opcode && opcode <= OP_PUSHDATA4) {
                 // Check minimal push


### PR DESCRIPTION
This PR adds the name of the specific disabled opcode that led to the `ScriptException` to the exception message. The current message can be a bit vague, especially for beginners who are unfamiliar with which opcodes are disabled, and since the specific opcode which caused the exception is available at the point of the exception being thrown, the opcode name can easily be included in the exception message. 

I was working on a university assignment to create a simple bitcoin script and I ended up using `OP_XOR` while not realizing it was disabled. After I ran it, I got the current exception message without the opcode name which did not help narrow it down to which opcode was causing problems and although I figured out it was `OP_XOR` by looking at https://en.bitcoin.it/wiki/Script I think it makes sense to just include the opcode name in the exception message.

Example of exception messages:
 - Before: `Script included a disabled Script Op.`
 - After: `Script included disabled Script Op XOR`