### PR TITLE
Script: take into account the various witness length fields in getNumberOfBytesRequiredToSpend()

### DIFF
--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -606,7 +606,12 @@ public class Script {
             // scriptSig is empty
             // witness: <sig> <pubKey>
             int compressedPubKeySize = 33;
-            return SIG_SIZE + (pubKey != null ? pubKey.getPubKey().length : compressedPubKeySize);
+            int publicKeyLength = pubKey != null ? pubKey.getPubKey().length : compressedPubKeySize;
+            return VarInt.sizeOf(2) // number of witness pushes
+                    + VarInt.sizeOf(SIG_SIZE) // size of signature push
+                    + SIG_SIZE // signature push
+                    + VarInt.sizeOf(publicKeyLength) // size of pubKey push
+                    + publicKeyLength; // pubKey push
         } else {
             throw new IllegalStateException("Unsupported script type");
         }

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -2696,7 +2696,13 @@ public class WalletTest extends TestWithWallet {
         SendRequest request = SendRequest.to(OTHER_SEGWIT_ADDRESS, CENT);
         request.feePerKb = Transaction.DEFAULT_TX_FEE;
         mySegwitWallet.completeTx(request);
-        assertEquals(Coin.valueOf(14000), request.tx.getFee());
+
+        // Fee test, absolute and per virtual kilobyte
+        Coin fee = request.tx.getFee();
+        int vsize = request.tx.getVsize();
+        Coin feePerVkb = fee.multiply(1000).divide(vsize);
+        assertEquals(Coin.valueOf(14100), fee);
+        assertEquals(Transaction.DEFAULT_TX_FEE, feePerVkb);
     }
 
     @Test


### PR DESCRIPTION
This will (hopefully entirely) fix the slight fee underspending for spends from P2WPKH.

Fixes #2235.