### PR TITLE
Upgrade Github actions to use Gradle 7.3.2 by default

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,7 +10,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         java: ['8', '11', '17']
         distribution: ['temurin']
-        gradle: ['7.2']
+        gradle: ['7.3.2']
         include:
           # Special case to test something close to Debian config with the oldest supported (standard) Gradle on Ubuntu
           - os: ubuntu-latest


### PR DESCRIPTION
Notable changes:

* Gradle 7.3 is the first Gradle release to officially
  support JDK 17
* Gradle 7.3.2 includes log4j mitigations to protect against
  build dependencies pulling in the bad log4j.