### PR TITLE
README.md: update Android runtime requirement to Android 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The bitcoinj library is a Java implementation of the Bitcoin protocol, which all
 
 ### Technologies
 
-* Java 8+ (needs Java 8 API or Android 6.0 API, compiles to Java 8 bytecode) and Gradle 4.4+ for the `core` module
+* Java 8+ (needs Java 8 API or Android 7.0 API, compiles to Java 8 bytecode) and Gradle 4.4+ for the `core` module
 * Java 8+ and Gradle 4.4+ for `tools` and `examples`
 * Java 11+ and Gradle 4.10+ for the JavaFX-based `wallettemplate`
 * [Gradle](https://gradle.org/) - for building the project


### PR DESCRIPTION
The Java runtime requirement is left unchanged at Java 8.

This would allow us to use more of the Java 8 API in core. Note we can always only use the subset of the two requirements, as we use one binary for both platforms.