### PR TITLE
Add testOnJdk8 task (if Gradle > 6.7)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,7 +30,7 @@ jobs:
         uses: gradle/gradle-build-action@v1
         with:
           gradle-version: ${{ matrix.gradle }}
-          arguments: build --stacktrace
+          arguments: -PtestJdk8=true build --stacktrace
       - name: Upload Test Results and Reports
         uses: actions/upload-artifact@v2
         if: always()

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -53,13 +53,40 @@ protobuf {
     generatedFilesBaseDir = new File(projectDir, '/src') // workaround for '$projectDir/src'
 }
 
-test {
+tasks.withType(Test) {
     exclude 'org/bitcoinj/core/PeerTest*'
     exclude 'org/bitcoinj/core/TransactionBroadcastTest*'
     exclude 'org/bitcoinj/net/discovery/DnsDiscoveryTest*'
     testLogging {
         events "failed"
         exceptionFormat "full"
+    }
+}
+
+// Test with default Java toolchain
+test {
+    doFirst {
+        logger.lifecycle("Testing with default toolchain")
+    }
+}
+
+def gradleVersionToolchains = GradleVersion.version("6.7")
+
+if (GradleVersion.current().compareTo(gradleVersionToolchains) > 0) {
+    // If the Gradle Java Toolchains feature is available, run tests on older JDKs
+    System.err.println "Adding 'testOnJdk8' task, because ${GradleVersion.current()}"
+
+    task('testOnJdk8', type: Test) {
+        doFirst {
+            logger.lifecycle("Testing with JDK ${javaLauncher.get().metadata.javaRuntimeVersion}")
+        }
+        javaLauncher = javaToolchains.launcherFor {
+            languageVersion = JavaLanguageVersion.of(8)
+        }
+    }
+    // Activate if `testJdk8` is `true` in `gradle.properties` or `-PtestJdk8=true` is on command-line
+    if (Boolean.valueOf(findProperty('testJdk8'))) {
+        check.dependsOn testOnJdk8
     }
 }
 


### PR DESCRIPTION
* Task `testOnJdk8` is not run by default
* If `testJdk8` Gradle property is set, run `testOnJdk8` as part of `check`
* Set `testJdk8` in `gradle.yml` Github Actions workflow
