### PR TITLE
AbstractBlockChain: migrate to CompletableFuture

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
@@ -18,8 +18,6 @@
 package org.bitcoinj.core;
 
 import com.google.common.base.*;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 import org.bitcoinj.core.listeners.*;
 import org.bitcoinj.script.ScriptException;
 import org.bitcoinj.store.*;
@@ -1041,21 +1039,19 @@ public abstract class AbstractBlockChain {
      * @param height desired height
      * @return future that will complete when height is reached
      */
-    public ListenableFuture<StoredBlock> getHeightFuture(final int height) {
-        final SettableFuture<StoredBlock> result = SettableFuture.create();
+    public ListenableCompletableFuture<StoredBlock> getHeightFuture(final int height) {
+        final ListenableCompletableFuture<StoredBlock> result = new ListenableCompletableFuture<>();
         addNewBestBlockListener(Threading.SAME_THREAD, new NewBestBlockListener() {
             @Override
             public void notifyNewBestBlock(StoredBlock block) throws VerificationException {
                 if (block.getHeight() >= height) {
                     removeNewBestBlockListener(this);
-                    result.set(block);
+                    result.complete(block);
                 }
             }
         });
         return result;
     }
-
-
 
     /**
      * The false positive rate is the average over all blockchain transactions of:

--- a/core/src/main/java/org/bitcoinj/utils/ListenableCompletableFuture.java
+++ b/core/src/main/java/org/bitcoinj/utils/ListenableCompletableFuture.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.utils;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A {@link CompletableFuture} that is also a {@link com.google.common.util.concurrent.ListenableFuture} for migration
+ * from Guava {@code ListenableFuture} to {@link CompletableFuture}.
+ */
+public class ListenableCompletableFuture<V> extends CompletableFuture<V> implements ListenableCompletionStage<V> {
+}

--- a/core/src/main/java/org/bitcoinj/utils/ListenableCompletionStage.java
+++ b/core/src/main/java/org/bitcoinj/utils/ListenableCompletionStage.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.utils;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+
+/**
+ * A {@link CompletionStage} with a {@link ListenableFuture}-compatible interface to smooth migration
+ * from Guava {@code ListenableFuture} to {@link java.util.concurrent.CompletableFuture}/{@code CompletionStage}.
+ * <p>
+ * Note that this is much easier to implement than trying to extend {@link com.google.common.util.concurrent.AbstractFuture}
+ * to implement {@code CompletionStage}.
+ */
+public interface ListenableCompletionStage<V> extends CompletionStage<V>, ListenableFuture<V> {
+    @Override
+    default void addListener(Runnable listener, Executor executor) {
+        this.thenRunAsync(listener, executor);
+    }
+}

--- a/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
@@ -28,7 +28,6 @@ import org.bitcoinj.utils.BriefLogFormatter;
 import org.bitcoinj.wallet.Wallet;
 import org.bitcoinj.wallet.Wallet.BalanceType;
 
-import com.google.common.util.concurrent.ListenableFuture;
 import org.junit.rules.ExpectedException;
 import org.junit.Before;
 import org.junit.Rule;
@@ -38,6 +37,7 @@ import java.math.BigInteger;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
 
 import static org.bitcoinj.core.Coin.*;
 import static org.bitcoinj.testing.FakeTxBuilder.createFakeBlock;
@@ -102,7 +102,7 @@ public class BlockChainTest {
     @Test
     public void testBasicChaining() throws Exception {
         // Check that we can plug a few blocks together and the futures work.
-        ListenableFuture<StoredBlock> future = testNetChain.getHeightFuture(2);
+        CompletableFuture<StoredBlock> future = testNetChain.getHeightFuture(2);
         // Block 1 from the testnet.
         Block b1 = getBlock1();
         assertTrue(testNetChain.add(b1));


### PR DESCRIPTION
This pull request introduces two new utility classes:

* `ListenableCompletionStage` an interface with a single default method that implements Guava `ListenableFuture` using JDK8's `CompletionStage` 
* `ListenableCompletableFuture` a subclass of `CompletableFuture` that implements `ListenableCompletableFuture` (and therefore `ListenableFuture`)

`AbstractBlockchain::getHeightFuture` is updated to return `ListenableCompletableFuture`.

`BlockChainTest` is updated to use `CompletableFuture`  (although it would continue to work without the change)