### PR TITLE
WalletTool: Move to its own `wallettool` submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The bitcoinj library is a Java implementation of the Bitcoin protocol, which all
 ### Technologies
 
 * Java 8+ (needs Java 8 API or Android 7.0 API, compiles to Java 8 bytecode) and Gradle 4.4+ for the `core` module
-* Java 11+ and Gradle 4.4+ for `tools` and `examples`
+* Java 11+ and Gradle 4.4+ for `tools`, `wallettool` and `examples`
 * Java 11+ and Gradle 4.10+ for the JavaFX-based `wallettemplate`
 * [Gradle](https://gradle.org/) - for building the project
 * [Google Protocol Buffers](https://github.com/google/protobuf) - for use with serialization and hardware communications
@@ -41,16 +41,16 @@ Alternatively, just import the project using your IDE. [IntelliJ](http://www.jet
 
 ### Building and Using the Wallet Tool
 
-The **bitcoinj** `tools` subproject includes a command-line Wallet Tool (`wallet-tool`) that can be used to create and manage **bitcoinj**-based wallets (both the HD keychain and SPV blockchain state.) Using `wallet-tool` on Bitcoin's test net is a great way to learn about Bitcoin and **bitcoinj**.
+The **bitcoinj** `wallettool` subproject includes a command-line Wallet Tool (`wallet-tool`) that can be used to create and manage **bitcoinj**-based wallets (both the HD keychain and SPV blockchain state.) Using `wallet-tool` on Bitcoin's test net is a great way to learn about Bitcoin and **bitcoinj**.
 
 To build an executable shell script that runs the command-line Wallet Tool, use:
 ```
-gradle bitcoinj-tools:installDist
+gradle bitcoinj-wallettool:installDist
 ```
 
 You can now run the `wallet-tool` without parameters to get help on its operation:
 ```
-./tools/build/install/wallet-tool/bin/wallet-tool
+./wallettool/build/install/wallet-tool/bin/wallet-tool
 ```
 
 To create a test net wallet file in `~/bitcoinj/bitcoinj-test.wallet`, you would use:
@@ -58,20 +58,20 @@ To create a test net wallet file in `~/bitcoinj/bitcoinj-test.wallet`, you would
 mkdir ~/bitcoinj
 ```
 ```
-./tools/build/install/wallet-tool/bin/wallet-tool --net=TEST --wallet=$HOME/bitcoinj/bitcoinj-test.wallet create
+./wallettool/build/install/wallet-tool/bin/wallet-tool --net=TEST --wallet=$HOME/bitcoinj/bitcoinj-test.wallet create
 ```
 
 To sync the newly created wallet in `~/bitcoinj/bitcoinj-test.wallet` with the test net, you would use:
 ```
-./tools/build/install/wallet-tool/bin/wallet-tool --net=TEST --wallet=$HOME/bitcoinj/bitcoinj-test.wallet sync
+./wallettool/build/install/wallet-tool/bin/wallet-tool --net=TEST --wallet=$HOME/bitcoinj/bitcoinj-test.wallet sync
 ```
 
 To dump the state of the wallet in `~/bitcoinj/bitcoinj-test.wallet` with the test net, you would use:
 ```
-./tools/build/install/wallet-tool/bin/wallet-tool --net=TEST --wallet=$HOME/bitcoinj/bitcoinj-test.wallet dump
+./wallettool/build/install/wallet-tool/bin/wallet-tool --net=TEST --wallet=$HOME/bitcoinj/bitcoinj-test.wallet dump
 ```
 
-Note: These instructions are for macOS/Linux, for Windows use the `tools/build/install/wallet-tool/bin/wallet-tool.bat` batch file with the equivalent Windows command-line commands and options.
+Note: These instructions are for macOS/Linux, for Windows use the `wallettool/build/install/wallet-tool/bin/wallet-tool.bat` batch file with the equivalent Windows command-line commands and options.
 
 ### Example applications
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,6 +22,9 @@ project(':core').name = 'bitcoinj-core'
 include 'tools'
 project(':tools').name = 'bitcoinj-tools'
 
+include 'wallettool'
+project(':wallettool').name = 'bitcoinj-wallettool'
+
 include 'examples'
 project(':examples').name = 'bitcoinj-examples'
 

--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'application'
     id 'eclipse'
 }
 
@@ -18,10 +19,5 @@ compileJava {
     options.compilerArgs.addAll(['--release', '11'])
 }
 
-task build_checkpoints(type: JavaExec) {
-    description = 'Create checkpoint files to use with CheckpointManager.'
-    main = 'org.bitcoinj.tools.BuildCheckpoints'
-    if (project.hasProperty('appArgs') && appArgs.length() > 0)
-        args = Arrays.asList(appArgs.split("\\s+"))
-    classpath = sourceSets.main.runtimeClasspath
-}
+mainClassName = "org.bitcoinj.wallettool.WalletTool"
+applicationName = "wallet-tool"

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.tools;
+package org.bitcoinj.wallettool;
 
 import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.TransactionOutput;


### PR DESCRIPTION
* Create a new module `bitcoinj-wallettool` in a new `wallettool` directory and move `WalletTool.java` into that submodule.
* Update the README build instructions for WalletTool to reflect the new directory.
* Remove the application plugin and it's configuration from `build.gradle` in the `tools` project.