### PR TITLE
JavaDoc: fix all empty <p> tag warnings in core

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/listeners/TransactionConfidenceEventListener.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/TransactionConfidenceEventListener.java
@@ -20,30 +20,34 @@ import org.bitcoinj.core.Transaction;
 import org.bitcoinj.wallet.Wallet;
 
 /**
- * <p>Implementors are called when confidence of a transaction changes.</p>
+ * Implementors are called when confidence of a transaction changes.
  */
 public interface TransactionConfidenceEventListener {
     /**
-     * <p>Called when a transaction changes its confidence level. You can also attach event listeners to
+     * Called when a transaction changes its confidence level. You can also attach event listeners to
      * the individual transactions, if you don't care about all of them. Usually you would save the wallet to disk after
-     * receiving this callback unless you already set up autosaving.</p>
-     *
-     * <p>You should pay attention to this callback in case a transaction becomes <i>dead</i>, that is, a transaction
-     * you believed to be active (send or receive) becomes overridden by the network. This can happen if</p>
+     * receiving this callback unless you already set up autosaving.
+     * <p>
+     * You should pay attention to this callback in case a transaction becomes <i>dead</i>, that is, a transaction
+     * you believed to be active (send or receive) becomes overridden by the network. This can happen if:
      *
      * <ol>
      *     <li>You are sharing keys between wallets and accidentally create/broadcast a double spend.</li>
      *     <li>Somebody is attacking the network and reversing transactions, ie, the user is a victim of fraud.</li>
      *     <li>A bug: for example you create a transaction, broadcast it but fail to commit it. The {@link Wallet}
      *     will then re-use the same outputs when creating the next spend.</li>
-     * </ol><p>
+     * </ol>
      *
-     * <p>To find if the transaction is dead, you can use {@code tx.getConfidence().getConfidenceType() == TransactionConfidence.ConfidenceType.DEAD}.
-     * If it is, you should notify the user in some way so they know the thing they bought may not arrive/the thing they sold should not be dispatched.</p>
-     *
-     * <p>Note that this callback will be invoked for every transaction in the wallet, for every new block that is
+     * To find if the transaction is dead, you can use:
+     * <pre>
+     * {@code
+     * tx.getConfidence().getConfidenceType() == TransactionConfidence.ConfidenceType.DEAD}
+     * </pre>
+     * If it is, you should notify the user in some way so they know the thing they bought may not arrive/the thing they sold should not be dispatched.
+     * <p>
+     * Note that this callback will be invoked for every transaction in the wallet, for every new block that is
      * received (because the depth has changed). <b>If you want to update a UI view from the contents of the wallet
-     * it is more efficient to use onWalletChanged instead.</b></p>
+     * it is more efficient to use onWalletChanged instead.</b>
      */
     void onTransactionConfidenceChanged(Wallet wallet, Transaction tx);
 }

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -2723,12 +2723,10 @@ public class Wallet extends BaseTaggableObject
     /**
      * Updates the wallet with the given transaction: puts it into the pending pool, sets the spent flags and runs
      * the onCoinsSent/onCoinsReceived event listener. Used in two situations:
-     * <p>
      * <ol>
      *     <li>When we have just successfully transmitted the tx we created to the network.</li>
      *     <li>When we receive a pending transaction that didn't appear in the chain yet, and we did not create it.</li>
      * </ol>
-     * <p>
      * Triggers an auto save (if enabled.)
      * <p>
      * Unlike {@link Wallet#maybeCommitTx} {@code commitTx} throws an exception if the transaction

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -64,16 +64,16 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * a data interchange format developed by Google with an efficient binary representation, a type safe specification
  * language and compilers that generate code to work with those data structures for many languages. Protocol buffers
  * can have their format evolved over time: conceptually they represent data using (tag, length, value) tuples. The
- * format is defined by the {@code wallet.proto} file in the bitcoinj source distribution.<p>
- *
+ * format is defined by the {@code wallet.proto} file in the bitcoinj source distribution.
+ * <p>
  * This class is used through its static methods. The most common operations are writeWallet and readWallet, which do
  * the obvious operations on Output/InputStreams. You can use a {@link ByteArrayInputStream} and equivalent
  * {@link ByteArrayOutputStream} if you'd like byte arrays instead. The protocol buffer can also be manipulated
- * in its object form if you'd like to modify the flattened data structure before serialization to binary.<p>
- *
+ * in its object form if you'd like to modify the flattened data structure before serialization to binary.
+ * <p>
  * You can extend the wallet format with additional fields specific to your application if you want, but make sure
  * to either put the extra data in the provided extension areas, or select tag numbers that are unlikely to be used
- * by anyone else.<p>
+ * by anyone else.
  *
  * @author Miron Cuperman
  * @author Andreas Schildbach


### PR DESCRIPTION
After this PR is merged all the remaining JavaDoc warnings in `bitcoinj-core` are either:

* `warning: no comment`
* `warning: no @param for`
* `warning: no @return`