### PR TITLE
global replace SegWit by segwit

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/MessageSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/MessageSerializer.java
@@ -30,7 +30,7 @@ import java.nio.ByteBuffer;
 public abstract class MessageSerializer {
 
     /**
-     * Create a new serializer with a specific protocol version. Mainly used to disable SegWit when parsing transactions.
+     * Create a new serializer with a specific protocol version. Mainly used to disable segwit when parsing transactions.
      */
     public abstract MessageSerializer withProtocolVersion(int protocolVersion);
 

--- a/core/src/main/java/org/bitcoinj/net/FilterMerger.java
+++ b/core/src/main/java/org/bitcoinj/net/FilterMerger.java
@@ -81,7 +81,7 @@ public class FilterMerger {
                 // it will likely mean we never need to create a filter with different parameters.
                 lastBloomFilterElementCount = elements > lastBloomFilterElementCount ? elements + 100 : lastBloomFilterElementCount;
                 double fpRate = vBloomFilterFPRate;
-                // We now always use UPDATE_ALL because with SegWit there is hardly any wallet that can do without.
+                // We now always use UPDATE_ALL because with segwit there is hardly any wallet that can do without.
                 BloomFilter filter = new BloomFilter(lastBloomFilterElementCount, fpRate, bloomFilterTweak,
                         BloomFilter.BloomUpdate.UPDATE_ALL);
                 for (PeerFilterProvider p : providers)

--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -1533,14 +1533,14 @@ public class Script {
      *                         Accessing txContainingThis from another thread while this method runs results in undefined behavior.
      * @param scriptSigIndex The index in txContainingThis of the scriptSig (note: NOT the index of the scriptPubKey).
      * @param scriptPubKey The connected scriptPubKey containing the conditions needed to claim the value.
-     * @param witness Transaction witness belonging to the transaction input containing this script. Needed for SegWit.
-     * @param value Value of the output. Needed for SegWit scripts.
+     * @param witness Transaction witness belonging to the transaction input containing this script. Needed for segwit.
+     * @param value Value of the output. Needed for segwit scripts.
      * @param verifyFlags Each flag enables one validation rule.
      */
     public void correctlySpends(Transaction txContainingThis, int scriptSigIndex, @Nullable TransactionWitness witness, @Nullable Coin value,
             Script scriptPubKey, Set<VerifyFlag> verifyFlags) throws ScriptException {
         if (ScriptPattern.isP2WPKH(scriptPubKey)) {
-            // For SegWit, full validation isn't implemented. So we simply check the signature. P2SH_P2WPKH is handled
+            // For segwit, full validation isn't implemented. So we simply check the signature. P2SH_P2WPKH is handled
             // by the P2SH code for now.
             if (witness.getPushCount() < 2)
                 throw new ScriptException(ScriptError.SCRIPT_ERR_WITNESS_PROGRAM_WITNESS_EMPTY, witness.toString());

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -664,7 +664,7 @@ public class TransactionTest {
 
     @Test
     public void nonSegwitZeroInputZeroOutputTx() {
-        // Non SegWit tx with zero input and outputs
+        // Non segwit tx with zero input and outputs
         String txHex = "010000000000f1f2f3f4";
         Transaction tx = UNITTEST.getDefaultSerializer().makeTransaction(HEX.decode(txHex));
         assertEquals(txHex, tx.toHexString());
@@ -672,8 +672,8 @@ public class TransactionTest {
 
     @Test
     public void nonSegwitZeroInputOneOutputTx() {
-        // Non SegWit tx with zero input and one output that has an amount of `0100000000000000` that could confuse
-        // a naive segwit parser. This can only be read with SegWit disabled
+        // Non segwit tx with zero input and one output that has an amount of `0100000000000000` that could confuse
+        // a naive segwit parser. This can only be read with segwit disabled
         MessageSerializer serializer = UNITTEST.getDefaultSerializer();
         String txHex = "0100000000010100000000000000016af1f2f3f4";
         int protoVersionNoWitness = serializer.getProtocolVersion() | Transaction.SERIALIZE_TRANSACTION_NO_WITNESS;

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -202,7 +202,7 @@ public class WalletTool implements Callable<Integer> {
     private String pubKeyStr;
     @CommandLine.Option(names = "--privkey", description = "Specifies a WIF-, hex- or base58-encoded private key.")
     private String privKeyStr;
-    @CommandLine.Option(names = "--addr", description ="Specifies a Bitcoin address, either SegWit or legacy.")
+    @CommandLine.Option(names = "--addr", description ="Specifies a Bitcoin address, either segwit or legacy.")
     private String addrStr;
     @CommandLine.Option(names = "--peers", description = "Comma separated IP addresses/domain names for connections instead of peer discovery.")
     private String peersStr;


### PR DESCRIPTION
I propose to use consistent capitalization of the word segwit.

As noted in #2274, usage of "segwit" outnumbers "SegWit" by about 5-10x in the source code of Bitcoin Core, the BIPs and the bitcoin.org website. 