### PR TITLE
wallet-tool: add picocli-codegen annotationProcessor dependency

### DIFF
--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'java'
     id 'application'
     id 'eclipse'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2' apply false
 }
 
 def annotationProcessorMinVersion = GradleVersion.version("4.6")
@@ -31,3 +32,24 @@ compileJava {
 
 mainClassName = "org.bitcoinj.wallettool.WalletTool"
 applicationName = "wallet-tool"
+
+task generateManpageAsciiDoc(type: JavaExec) {
+    dependsOn(classes)
+    group = "Documentation"
+    description = "Generate AsciiDoc manpage"
+    classpath(sourceSets.main.compileClasspath, configurations.annotationProcessor, sourceSets.main.runtimeClasspath)
+    main 'picocli.codegen.docgen.manpage.ManPageGenerator'
+    args mainClassName, "--outdir=${project.buildDir}/generated-picocli-docs", "-v" //, "--template-dir=src/docs/mantemplates"
+}
+
+apply plugin: 'org.asciidoctor.jvm.convert'
+asciidoctor {
+    dependsOn(generateManpageAsciiDoc)
+    sourceDir = file("${project.buildDir}/generated-picocli-docs")
+    outputDir = file("${project.buildDir}/docs")
+    logDocuments = true
+    outputOptions {
+        backends = ['manpage', 'html5']
+    }
+}
+

--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -37,7 +37,11 @@ task generateManpageAsciiDoc(type: JavaExec) {
     dependsOn(classes)
     group = "Documentation"
     description = "Generate AsciiDoc manpage"
-    classpath(sourceSets.main.compileClasspath, configurations.annotationProcessor, sourceSets.main.runtimeClasspath)
+    if (hasAnnotationProcessor) {
+        classpath(sourceSets.main.compileClasspath, configurations.annotationProcessor, sourceSets.main.runtimeClasspath)
+    } else {
+        classpath(sourceSets.main.compileClasspath, sourceSets.main.runtimeClasspath)
+    }
     main 'picocli.codegen.docgen.manpage.ManPageGenerator'
     args mainClassName, "--outdir=${project.buildDir}/generated-picocli-docs", "-v" //, "--template-dir=src/docs/mantemplates"
 }

--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -1,14 +1,23 @@
+import org.gradle.util.GradleVersion
+
 plugins {
     id 'java'
     id 'application'
     id 'eclipse'
 }
 
+def annotationProcessorMinVersion = GradleVersion.version("4.6")
+boolean hasAnnotationProcessor = (GradleVersion.current().compareTo(annotationProcessorMinVersion) > 0)
+
 dependencies {
     implementation project(':bitcoinj-core')
     implementation 'info.picocli:picocli:4.6.3'
     implementation 'org.slf4j:slf4j-jdk14:1.7.36'
-    annotationProcessor 'info.picocli:picocli-codegen:4.6.3'
+    if (hasAnnotationProcessor) {
+        annotationProcessor 'info.picocli:picocli-codegen:4.6.3'
+    } else {
+        compileOnly 'info.picocli:picocli-codegen:4.6.3'
+    }
 }
 
 sourceCompatibility = 11

--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     implementation project(':bitcoinj-core')
     implementation 'info.picocli:picocli:4.6.3'
     implementation 'org.slf4j:slf4j-jdk14:1.7.36'
+    annotationProcessor 'info.picocli:picocli-codegen:4.6.3'
 }
 
 sourceCompatibility = 11


### PR DESCRIPTION
This does not seem to be necessary for non-GraalVM builds, but does not hurt (and I suspect it improves startup speed) and is necessary for the GraalVM `nativeCompile` build which is coming in a separate PR.
