### PR TITLE
wallet-tool: add graalvm `nativeCompile` support to `build.gradle`

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -1,0 +1,35 @@
+name: GraalVM Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        java: [ 'java17' ]
+        graalvm: [ '22.1.0' ]
+        gradle: ['7.4.2']
+      fail-fast: false
+    name: ${{ matrix.os }} JDK ${{ matrix.graalvm }}.${{ matrix.java }}
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v1
+      - name: Set up GraalVM
+        uses: DeLaGuardo/setup-graalvm@4.0
+        with:
+          graalvm: ${{ matrix.graalvm }}
+          java: ${{ matrix.java }}
+      - name: Install native-image plugin
+        run: gu install native-image
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v1
+        with:
+          gradle-version: ${{ matrix.gradle }}
+          arguments: nativeCompile --info --stacktrace
+      - name: Upload wallet-tool as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: wallet-tool-${{ matrix.os }}
+          path: wallettool/build/native/nativeCompile/wallet-tool

--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -5,12 +5,16 @@ plugins {
     id 'application'
     id 'eclipse'
     id 'org.asciidoctor.jvm.convert' version '3.3.2' apply false
+    id 'org.graalvm.buildtools.native' version '0.9.11' apply false
 }
 
 def annotationProcessorMinVersion = GradleVersion.version("4.6")
 boolean hasAnnotationProcessor = (GradleVersion.current().compareTo(annotationProcessorMinVersion) >= 0)
 def junit5MinVersion = GradleVersion.version("4.6")
 boolean hasJunit5 = (GradleVersion.current().compareTo(junit5MinVersion) >= 0)
+
+def toolchainsMinVersion = GradleVersion.version("6.8")     // Toolchains with selection by vendor
+boolean hasToolchains = (GradleVersion.current().compareTo(toolchainsMinVersion) >= 0)
 
 dependencies {
     implementation project(':bitcoinj-core')
@@ -69,5 +73,24 @@ asciidoctor {
     logDocuments = true
     outputOptions {
         backends = ['manpage', 'html5']
+    }
+}
+
+if (hasToolchains) {
+
+    apply plugin: 'org.graalvm.buildtools.native'
+
+    graalvmNative {
+        binaries {
+            main {
+                imageName = applicationName
+                configurationFileDirectories.from(file('src/main/graal'))
+                buildArgs.add('--allow-incomplete-classpath')
+                javaLauncher = javaToolchains.launcherFor {
+                    languageVersion = JavaLanguageVersion.of(17)
+                    vendor = JvmVendorSpec.matching("GraalVM Community")
+                }
+            }
+        }
     }
 }

--- a/wallettool/src/main/graal/reflect-config.json
+++ b/wallettool/src/main/graal/reflect-config.json
@@ -1,0 +1,365 @@
+[
+{
+  "name":"[B"
+},
+{
+  "name":"[Ljava.lang.String;"
+},
+{
+  "name":"[Lsun.security.pkcs.SignerInfo;"
+},
+{
+  "name":"com.google.common.primitives.UnsignedBytes$LexicographicalComparatorHolder$UnsafeComparator"
+},
+{
+  "name":"com.sun.crypto.provider.HmacCore$HmacSHA512",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"java.lang.Object",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
+  "name":"java.lang.String"
+},
+{
+  "name":"java.nio.Buffer",
+  "fields":[{"name":"address"}]
+},
+{
+  "name":"java.nio.file.Path"
+},
+{
+  "name":"java.nio.file.Paths",
+  "queriedMethods":[{"name":"get","parameterTypes":["java.lang.String","java.lang.String[]"] }]
+},
+{
+  "name":"java.security.AlgorithmParametersSpi"
+},
+{
+  "name":"java.security.MessageDigestSpi"
+},
+{
+  "name":"java.security.SecureRandomParameters"
+},
+{
+  "name":"java.security.interfaces.DSAPrivateKey"
+},
+{
+  "name":"java.security.interfaces.DSAPublicKey"
+},
+{
+  "name":"java.security.interfaces.RSAPrivateKey"
+},
+{
+  "name":"java.security.interfaces.RSAPublicKey"
+},
+{
+  "name":"java.security.spec.DSAParameterSpec"
+},
+{
+  "name":"java.sql.Connection"
+},
+{
+  "name":"java.sql.Driver"
+},
+{
+  "name":"java.sql.DriverManager",
+  "queriedMethods":[
+    {"name":"getConnection","parameterTypes":["java.lang.String"] }, 
+    {"name":"getDriver","parameterTypes":["java.lang.String"] }
+  ]
+},
+{
+  "name":"java.sql.Time",
+  "queriedMethods":[{"name":"<init>","parameterTypes":["long"] }]
+},
+{
+  "name":"java.sql.Timestamp",
+  "queriedMethods":[{"name":"valueOf","parameterTypes":["java.lang.String"] }]
+},
+{
+  "name":"java.time.Duration",
+  "queriedMethods":[{"name":"parse","parameterTypes":["java.lang.CharSequence"] }]
+},
+{
+  "name":"java.time.Instant",
+  "queriedMethods":[{"name":"parse","parameterTypes":["java.lang.CharSequence"] }]
+},
+{
+  "name":"java.time.LocalDate",
+  "queriedMethods":[{"name":"parse","parameterTypes":["java.lang.CharSequence"] }]
+},
+{
+  "name":"java.time.LocalDateTime",
+  "queriedMethods":[{"name":"parse","parameterTypes":["java.lang.CharSequence"] }]
+},
+{
+  "name":"java.time.LocalTime",
+  "queriedMethods":[{"name":"parse","parameterTypes":["java.lang.CharSequence"] }]
+},
+{
+  "name":"java.time.MonthDay",
+  "queriedMethods":[{"name":"parse","parameterTypes":["java.lang.CharSequence"] }]
+},
+{
+  "name":"java.time.OffsetDateTime",
+  "queriedMethods":[{"name":"parse","parameterTypes":["java.lang.CharSequence"] }]
+},
+{
+  "name":"java.time.OffsetTime",
+  "queriedMethods":[{"name":"parse","parameterTypes":["java.lang.CharSequence"] }]
+},
+{
+  "name":"java.time.Period",
+  "queriedMethods":[{"name":"parse","parameterTypes":["java.lang.CharSequence"] }]
+},
+{
+  "name":"java.time.Year",
+  "queriedMethods":[{"name":"parse","parameterTypes":["java.lang.CharSequence"] }]
+},
+{
+  "name":"java.time.YearMonth",
+  "queriedMethods":[{"name":"parse","parameterTypes":["java.lang.CharSequence"] }]
+},
+{
+  "name":"java.time.ZoneId",
+  "queriedMethods":[{"name":"of","parameterTypes":["java.lang.String"] }]
+},
+{
+  "name":"java.time.ZoneOffset",
+  "queriedMethods":[{"name":"of","parameterTypes":["java.lang.String"] }]
+},
+{
+  "name":"java.time.ZonedDateTime",
+  "queriedMethods":[{"name":"parse","parameterTypes":["java.lang.CharSequence"] }]
+},
+{
+  "name":"java.util.Date"
+},
+{
+  "name":"javax.security.auth.x500.X500Principal",
+  "fields":[{"name":"thisX500Name"}],
+  "methods":[{"name":"<init>","parameterTypes":["sun.security.x509.X500Name"] }]
+},
+{
+  "name":"org.bitcoinj.wallet.Protos$DeterministicKey",
+  "fields":[
+    {"name":"bitField0_"}, 
+    {"name":"chainCode_"}, 
+    {"name":"isFollowing_"}, 
+    {"name":"issuedSubkeys_"}, 
+    {"name":"lookaheadSize_"}, 
+    {"name":"path_"}, 
+    {"name":"sigsRequiredToSpend_"}
+  ]
+},
+{
+  "name":"org.bitcoinj.wallet.Protos$Extension",
+  "fields":[
+    {"name":"bitField0_"}, 
+    {"name":"data_"}, 
+    {"name":"id_"}, 
+    {"name":"mandatory_"}
+  ]
+},
+{
+  "name":"org.bitcoinj.wallet.Protos$Key",
+  "fields":[
+    {"name":"accountPath_"}, 
+    {"name":"bitField0_"}, 
+    {"name":"creationTimestamp_"}, 
+    {"name":"deterministicKey_"}, 
+    {"name":"deterministicSeed_"}, 
+    {"name":"encryptedData_"}, 
+    {"name":"encryptedDeterministicSeed_"}, 
+    {"name":"label_"}, 
+    {"name":"outputScriptType_"}, 
+    {"name":"publicKey_"}, 
+    {"name":"secretBytes_"}, 
+    {"name":"type_"}
+  ]
+},
+{
+  "name":"org.bitcoinj.wallet.Protos$Script",
+  "fields":[
+    {"name":"bitField0_"}, 
+    {"name":"creationTimestamp_"}, 
+    {"name":"program_"}
+  ]
+},
+{
+  "name":"org.bitcoinj.wallet.Protos$Tag",
+  "fields":[
+    {"name":"bitField0_"}, 
+    {"name":"data_"}, 
+    {"name":"tag_"}
+  ]
+},
+{
+  "name":"org.bitcoinj.wallet.Protos$Transaction",
+  "fields":[
+    {"name":"bitField0_"}, 
+    {"name":"blockHash_"}, 
+    {"name":"blockRelativityOffsets_"}, 
+    {"name":"confidence_"}, 
+    {"name":"exchangeRate_"}, 
+    {"name":"hash_"}, 
+    {"name":"lockTime_"}, 
+    {"name":"memo_"}, 
+    {"name":"pool_"}, 
+    {"name":"purpose_"}, 
+    {"name":"transactionInput_"}, 
+    {"name":"transactionOutput_"}, 
+    {"name":"updatedAt_"}, 
+    {"name":"version_"}
+  ]
+},
+{
+  "name":"org.bitcoinj.wallet.Protos$Wallet",
+  "fields":[
+    {"name":"bitField0_"}, 
+    {"name":"description_"}, 
+    {"name":"encryptionParameters_"}, 
+    {"name":"encryptionType_"}, 
+    {"name":"extension_"}, 
+    {"name":"keyRotationTime_"}, 
+    {"name":"key_"}, 
+    {"name":"lastSeenBlockHash_"}, 
+    {"name":"lastSeenBlockHeight_"}, 
+    {"name":"lastSeenBlockTimeSecs_"}, 
+    {"name":"networkIdentifier_"}, 
+    {"name":"tags_"}, 
+    {"name":"transaction_"}, 
+    {"name":"version_"}, 
+    {"name":"watchedScript_"}
+  ]
+},
+{
+  "name":"org.bitcoinj.wallettool.WalletTool",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
+  "name":"sun.misc.Unsafe",
+  "allDeclaredFields":true,
+  "queriedMethods":[
+    {"name":"arrayBaseOffset","parameterTypes":["java.lang.Class"] }, 
+    {"name":"arrayIndexScale","parameterTypes":["java.lang.Class"] }, 
+    {"name":"copyMemory","parameterTypes":["long","long","long"] }, 
+    {"name":"copyMemory","parameterTypes":["java.lang.Object","long","java.lang.Object","long","long"] }, 
+    {"name":"getBoolean","parameterTypes":["java.lang.Object","long"] }, 
+    {"name":"getByte","parameterTypes":["long"] }, 
+    {"name":"getByte","parameterTypes":["java.lang.Object","long"] }, 
+    {"name":"getDouble","parameterTypes":["java.lang.Object","long"] }, 
+    {"name":"getFloat","parameterTypes":["java.lang.Object","long"] }, 
+    {"name":"getInt","parameterTypes":["long"] }, 
+    {"name":"getInt","parameterTypes":["java.lang.Object","long"] }, 
+    {"name":"getLong","parameterTypes":["long"] }, 
+    {"name":"getLong","parameterTypes":["java.lang.Object","long"] }, 
+    {"name":"getObject","parameterTypes":["java.lang.Object","long"] }, 
+    {"name":"objectFieldOffset","parameterTypes":["java.lang.reflect.Field"] }, 
+    {"name":"putBoolean","parameterTypes":["java.lang.Object","long","boolean"] }, 
+    {"name":"putByte","parameterTypes":["long","byte"] }, 
+    {"name":"putByte","parameterTypes":["java.lang.Object","long","byte"] }, 
+    {"name":"putDouble","parameterTypes":["java.lang.Object","long","double"] }, 
+    {"name":"putFloat","parameterTypes":["java.lang.Object","long","float"] }, 
+    {"name":"putInt","parameterTypes":["long","int"] }, 
+    {"name":"putInt","parameterTypes":["java.lang.Object","long","int"] }, 
+    {"name":"putLong","parameterTypes":["long","long"] }, 
+    {"name":"putLong","parameterTypes":["java.lang.Object","long","long"] }, 
+    {"name":"putObject","parameterTypes":["java.lang.Object","long","java.lang.Object"] }
+  ]
+},
+{
+  "name":"sun.security.provider.DSA$SHA1withDSA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.DSA$SHA256withDSA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.DSAKeyFactory",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.DSAParameters",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.NativePRNG",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.SHA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.SHA2$SHA256",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.SHA5$SHA512",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.provider.X509Factory",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.rsa.RSAKeyFactory$Legacy",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.rsa.RSASignature$SHA256withRSA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"sun.security.util.ObjectIdentifier"
+},
+{
+  "name":"sun.security.x509.AuthorityInfoAccessExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.AuthorityKeyIdentifierExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.BasicConstraintsExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.CRLDistributionPointsExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.CertificateExtensions"
+},
+{
+  "name":"sun.security.x509.CertificatePoliciesExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.ExtendedKeyUsageExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.KeyUsageExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.NetscapeCertTypeExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.SubjectAlternativeNameExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.SubjectKeyIdentifierExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+}
+]

--- a/wallettool/src/main/graal/resource-config.json
+++ b/wallettool/src/main/graal/resource-config.json
@@ -1,0 +1,7 @@
+{
+  "resources": {
+    "includes": [
+      {"pattern": ".*/english.txt$"}
+    ]
+  }
+}


### PR DESCRIPTION
At this checkpoint the tool builds and can run well enough to display help.

To build:
```
gradle clean bitcoinj-wallettool:nativeCompile
``` 

To run:
```
./wallettool/build/native/nativeCompile/wallet-tool --help
```

TODO:
- [x] Add config/hints to get all "actions" in the tool working properly
- [x] Add GraalVM build to Github Actions
