### PR TITLE
Threading: Replace CountdownLatch with CompletableFuture

### DIFF
--- a/core/src/main/java/org/bitcoinj/utils/Threading.java
+++ b/core/src/main/java/org/bitcoinj/utils/Threading.java
@@ -59,13 +59,15 @@ public class Threading {
      * Put a dummy task into the queue and wait for it to be run. Because it's single threaded, this means all
      * tasks submitted before this point are now completed. Usually you won't want to use this method - it's a
      * convenience primarily used in unit testing. If you want to wait for an event to be called the right thing
-     * to do is usually to create a {@link com.google.common.util.concurrent.SettableFuture} and then call set
-     * on it. You can then either block on that future, compose it, add listeners to it and so on.
+     * to do is usually to create a {@link CompletableFuture} and then call {@link CompletableFuture#complete(Object)}
+     * on it. For example:
+     * <pre>{@code
+     * CompletableFuture f = CompletableFuture.supplyAsync(() -> event, USER_THREAD)
+     * }</pre>
+     * You can then either block on that future, compose it, add listeners to it and so on.
      */
     public static void waitForUserCode() {
-        final CountDownLatch latch = new CountDownLatch(1);
-        USER_THREAD.execute(() -> latch.countDown());
-        Uninterruptibles.awaitUninterruptibly(latch);
+        CompletableFuture.runAsync(() -> {}, USER_THREAD).join();
     }
 
     /**


### PR DESCRIPTION
1. Simplify `waitForUserCode()` with `CompletableFuture.runAsync`
2. Replace reference to `SettableFuture` in the comment with `CompletableFuture` (including example code)
