### PR TITLE
Convert (remaining non-Peer-related) to CompletableFuture

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -20,7 +20,6 @@ package org.bitcoinj.wallet;
 import com.google.common.annotations.*;
 import com.google.common.collect.*;
 import com.google.common.math.IntMath;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.*;
 import net.jcip.annotations.*;
 import org.bitcoinj.core.listeners.*;

--- a/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
@@ -19,7 +19,6 @@ package org.bitcoinj.core;
 
 import com.google.common.base.*;
 import com.google.common.collect.*;
-import com.google.common.util.concurrent.SettableFuture;
 import org.bitcoinj.core.listeners.*;
 import org.bitcoinj.net.*;
 import org.bitcoinj.params.*;
@@ -30,6 +29,7 @@ import org.slf4j.*;
 import java.io.*;
 import java.net.*;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.*;
 
 /**
@@ -86,7 +86,7 @@ public class BitcoindComparisonTool {
         final Set<Sha256Hash> blocksRequested = Collections.synchronizedSet(new HashSet<Sha256Hash>());
         final Set<Sha256Hash> blocksPendingSend = Collections.synchronizedSet(new HashSet<Sha256Hash>());
         final AtomicInteger unexpectedInvs = new AtomicInteger(0);
-        final SettableFuture<Void> connectedFuture = SettableFuture.create();
+        final CompletableFuture<Void> connectedFuture = new CompletableFuture<>();
         bitcoind.addConnectedEventListener(Threading.SAME_THREAD, (peer, peerCount) -> {
             if (!peer.getPeerVersionMessage().subVer.contains("Satoshi")) {
                 System.out.println();
@@ -103,7 +103,7 @@ public class BitcoindComparisonTool {
             // Make sure bitcoind has no blocks
             bitcoind.setDownloadParameters(0, false);
             bitcoind.startBlockChainDownload();
-            connectedFuture.set(null);
+            connectedFuture.complete(null);
         });
 
         bitcoind.addDisconnectedEventListener(Threading.SAME_THREAD, (peer, peerCount) -> {

--- a/core/src/test/java/org/bitcoinj/testing/InboundMessageQueuer.java
+++ b/core/src/test/java/org/bitcoinj/testing/InboundMessageQueuer.java
@@ -17,7 +17,6 @@
 package org.bitcoinj.testing;
 
 import org.bitcoinj.core.*;
-import com.google.common.util.concurrent.SettableFuture;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -25,13 +24,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * An extension of {@link PeerSocketHandler} that keeps inbound messages in a queue for later processing
  */
 public abstract class InboundMessageQueuer extends PeerSocketHandler {
     public final BlockingQueue<Message> inboundMessages = new ArrayBlockingQueue<>(1000);
-    public final Map<Long, SettableFuture<Void>> mapPingFutures = new HashMap<>();
+    public final Map<Long, CompletableFuture<Void>> mapPingFutures = new HashMap<>();
 
     public Peer peer;
     public BloomFilter lastReceivedFilter;
@@ -51,9 +51,9 @@ public abstract class InboundMessageQueuer extends PeerSocketHandler {
     @Override
     protected void processMessage(Message m) throws Exception {
         if (m instanceof Ping) {
-            SettableFuture<Void> future = mapPingFutures.get(((Ping) m).getNonce());
+            CompletableFuture<Void> future = mapPingFutures.get(((Ping) m).getNonce());
             if (future != null) {
-                future.set(null);
+                future.complete(null);
                 return;
             }
         }

--- a/core/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
+++ b/core/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
@@ -30,8 +30,6 @@ import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.KeyChainGroup;
 import org.bitcoinj.wallet.Wallet;
 
-import com.google.common.util.concurrent.SettableFuture;
-
 import javax.annotation.Nullable;
 import javax.net.SocketFactory;
 import java.io.IOException;
@@ -39,6 +37,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -198,7 +197,7 @@ public class TestWithNetworkConnections {
 
     private void outboundPingAndWait(final InboundMessageQueuer p, long nonce) throws Exception {
         // Send a ping and wait for it to get to the other side
-        SettableFuture<Void> pingReceivedFuture = SettableFuture.create();
+        CompletableFuture<Void> pingReceivedFuture = new CompletableFuture<>();
         p.mapPingFutures.put(nonce, pingReceivedFuture);
         p.peer.sendMessage(new Ping(nonce));
         pingReceivedFuture.get();
@@ -207,10 +206,10 @@ public class TestWithNetworkConnections {
 
     private void inboundPongAndWait(final InboundMessageQueuer p, final long nonce) throws Exception {
         // Receive a ping (that the Peer doesn't see) and wait for it to get through the socket
-        final SettableFuture<Void> pongReceivedFuture = SettableFuture.create();
+        final CompletableFuture<Void> pongReceivedFuture = new CompletableFuture<>();
         PreMessageReceivedEventListener listener = (p1, m) -> {
             if (m instanceof Pong && ((Pong) m).getNonce() == nonce) {
-                pongReceivedFuture.set(null);
+                pongReceivedFuture.complete(null);
                 return null;
             }
             return m;

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -61,7 +61,6 @@ import org.easymock.EasyMock;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.ListenableFuture;
 
 import org.bitcoinj.wallet.KeyChain.KeyPurpose;
 import org.bitcoinj.wallet.Protos.Wallet.EncryptionType;
@@ -417,8 +416,8 @@ public class WalletTest extends TestWithWallet {
     }
 
     private void receiveATransactionAmount(Wallet wallet, Address toAddress, Coin amount) {
-        final ListenableFuture<Coin> availFuture = wallet.getBalanceFuture(amount, Wallet.BalanceType.AVAILABLE);
-        final ListenableFuture<Coin> estimatedFuture = wallet.getBalanceFuture(amount, Wallet.BalanceType.ESTIMATED);
+        final CompletableFuture<Coin> availFuture = wallet.getBalanceFuture(amount, Wallet.BalanceType.AVAILABLE);
+        final CompletableFuture<Coin> estimatedFuture = wallet.getBalanceFuture(amount, Wallet.BalanceType.ESTIMATED);
         assertFalse(availFuture.isDone());
         assertFalse(estimatedFuture.isDone());
         // Send some pending coins to the wallet.

--- a/examples/src/main/java/org/bitcoinj/examples/SendRequest.java
+++ b/examples/src/main/java/org/bitcoinj/examples/SendRequest.java
@@ -16,11 +16,6 @@
 
 package org.bitcoinj.examples;
 
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
-
 import org.bitcoinj.core.*;
 import org.bitcoinj.kits.WalletAppKit;
 import org.bitcoinj.params.TestNet3Params;
@@ -28,6 +23,7 @@ import org.bitcoinj.wallet.Wallet;
 import org.bitcoinj.wallet.Wallet.BalanceType;
 
 import java.io.File;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * The following example shows you how to create a SendRequest to send coins from a wallet to a given address.
@@ -68,21 +64,15 @@ public class SendRequest {
             System.out.println("Send money to: " + kit.wallet().currentReceiveAddress().toString());
 
             // Bitcoinj allows you to define a BalanceFuture to execute a callback once your wallet has a certain balance.
-            // Here we wait until the we have enough balance and display a notice.
-            // Bitcoinj is using the ListenableFutures of the Guava library. Have a look here for more information: https://github.com/google/guava/wiki/ListenableFutureExplained
-            ListenableFuture<Coin> balanceFuture = kit.wallet().getBalanceFuture(value, BalanceType.AVAILABLE);
-            FutureCallback<Coin> callback = new FutureCallback<Coin>() {
-                @Override
-                public void onSuccess(Coin balance) {
+            // Here we wait until we have enough balance and display a notice.
+            CompletableFuture<Coin> balanceFuture = kit.wallet().getBalanceFuture(value, BalanceType.AVAILABLE);
+            balanceFuture.whenComplete((balance, throwable) -> {
+                if (balance != null) {
                     System.out.println("coins arrived and the wallet now has enough balance");
-                }
-
-                @Override
-                public void onFailure(Throwable t) {
+                } else {
                     System.out.println("something went wrong");
                 }
-            };
-            Futures.addCallback(balanceFuture, callback, MoreExecutors.directExecutor());
+            });
         }
 
         // shutting down 


### PR DESCRIPTION
This converts all/most of the remaining non Peer-related code in `core` to use `CompletableFuture`.