### PR TITLE
BasicKeyChainTest: fix spontaneous failure of bloom() because of false positive

### DIFF
--- a/core/src/test/java/org/bitcoinj/wallet/BasicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/BasicKeyChainTest.java
@@ -252,13 +252,22 @@ public class BasicKeyChainTest {
         chain.importKeys(key1, key2);
         assertEquals(2, chain.numKeys());
         assertEquals(4, chain.numBloomFilterEntries());
-        BloomFilter filter = chain.getFilter(4, 0.001, 100);
+        final double FALSE_POSITIVE_RATE = 0.001;
+        BloomFilter filter = chain.getFilter(4, FALSE_POSITIVE_RATE, 100);
         assertTrue(filter.contains(key1.getPubKey()));
         assertTrue(filter.contains(key1.getPubKeyHash()));
         assertTrue(filter.contains(key2.getPubKey()));
         assertTrue(filter.contains(key2.getPubKeyHash()));
-        ECKey key3 = new ECKey();
-        assertFalse(filter.contains(key3.getPubKey()));
+        final int COUNT = 10000;
+        int falsePositives = 0;
+        for (int i = 0; i < COUNT; i++) {
+            ECKey key = new ECKey();
+            if (filter.contains(key.getPubKey()))
+                falsePositives++;
+        }
+        double actualRate = (double) falsePositives / COUNT;
+        assertTrue("roughly expected: " + FALSE_POSITIVE_RATE + ", actual: " + actualRate,
+                actualRate < FALSE_POSITIVE_RATE * 8);
     }
 
     @Test


### PR DESCRIPTION
This should hopefully fix #1804, or at least make it very rare.