### PR TITLE
PaymentSessionTest.MockPaymentSession: Don’t return a null Future

### DIFF
--- a/core/src/test/java/org/bitcoinj/protocols/payments/PaymentSessionTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/payments/PaymentSessionTest.java
@@ -230,7 +230,8 @@ public class PaymentSessionTest {
         @Override
         protected ListenableCompletableFuture<PaymentProtocol.Ack> sendPayment(final URL url, final Protos.Payment payment) {
             paymentLog.add(new PaymentLogItem(url, payment));
-            return null;
+            // Return a completed future that has a `null` value. This will satisfy the current tests.
+            return ListenableCompletableFuture.completedFuture(null);
         }
 
         public class PaymentLogItem {


### PR DESCRIPTION
* Use `ListenableCompletableFuture(null)` instead.

If I had been more observant, this would have been included in PR #2344.

