### PR TITLE
Peer: Convert getDataFutures to concurrent Queue

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -41,6 +41,7 @@ import javax.annotation.Nullable;
 import java.net.SocketAddress;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -141,7 +142,7 @@ public class Peer extends PeerSocketHandler {
         }
     }
     // TODO: The types/locking should be rationalised a bit.
-    private final CopyOnWriteArrayList<GetDataRequest> getDataFutures;
+    private final Queue<GetDataRequest> getDataFutures;
     @GuardedBy("getAddrFutures") private final LinkedList<CompletableFuture<AddressMessage>> getAddrFutures;
 
     // Outstanding pings against this peer and how long the last one took to complete.
@@ -214,7 +215,7 @@ public class Peer extends PeerSocketHandler {
         this.blockChain = chain;  // Allowed to be null.
         this.requiredServices = requiredServices;
         this.vDownloadData = chain != null;
-        this.getDataFutures = new CopyOnWriteArrayList<>();
+        this.getDataFutures = new ConcurrentLinkedQueue<>();
         this.getAddrFutures = new LinkedList<>();
         this.fastCatchupTimeSecs = params.getGenesisBlock().getTimeSeconds();
         this.pendingPings = new CopyOnWriteArrayList<>();


### PR DESCRIPTION
* Convert the declared type of `getDataFutures` to `Queue` - we do not need random access, so `Queue` is better interface to use for this data structure.
* Convert the implementing class to `ConcurrentLinkedQueue` this provides  the concurrency we need and is theoretically/likely more efficient than `CopyOnWriteArrayList`.

 (This is a small improvement that precedes  some additional improvements)