### PR TITLE
PaymentSessionTest: Remove a throws IOException where it can’t happen

### DIFF
--- a/core/src/test/java/org/bitcoinj/protocols/payments/PaymentSessionTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/payments/PaymentSessionTest.java
@@ -37,7 +37,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
@@ -119,7 +118,7 @@ public class PaymentSessionTest {
     }
 
     @Test
-    public void testExpiredPaymentRequest() throws PaymentProtocolException, IOException {
+    public void testExpiredPaymentRequest() throws PaymentProtocolException {
         MockPaymentSession paymentSession = new MockPaymentSession(newExpiredPaymentRequest());
         assertTrue(paymentSession.isExpired());
         // Send the payment and verify that an exception is thrown.


### PR DESCRIPTION
* Remove a throws IOException where it can’t happen.

This is a resubmit of the portion of PR #2346 that was not merged.

See my comment https://github.com/bitcoinj/bitcoinj/pull/2346#issuecomment-1083429123 on the closed PR.

In the case of this specific test, the minimal/specific `throws` clause makes it more clear that the test expects a `PaymentProtocolException.Expired` exception, but the code under test can theoretically throw the more general `PaymentProtocolException` exception which is uncaught by the test.

I can go either way on this, but I wanted @schildbach to consider my argument and take a second look at this one change in isolation.