### PR TITLE
WalletTool: remove `throws Exception` from main

### DIFF
--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -340,7 +340,7 @@ public class WalletTool implements Callable<Integer> {
         SPV
     }
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
         int exitCode = new CommandLine(new WalletTool()).execute(args);
         System.exit(exitCode);
     }


### PR DESCRIPTION
`main()` currently throws no checked exceptions. This is a good thing and
means all checked exceptions are caught and (hopefully properly) handled by
outputting error messages and return a non-zero exit code.
