### PR TITLE
WalletProtobufSerializer: add WalletFactory::DEFAULT

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -93,13 +93,14 @@ public class WalletProtobufSerializer {
 
     public interface WalletFactory {
         Wallet create(NetworkParameters params, KeyChainGroup keyChainGroup);
+        WalletFactory DEFAULT = Wallet::new;
     }
 
     private final WalletFactory factory;
     private KeyChainFactory keyChainFactory;
 
     public WalletProtobufSerializer() {
-        this((params, keyChainGroup) -> new Wallet(params, keyChainGroup));
+        this(WalletFactory.DEFAULT);
     }
 
     public WalletProtobufSerializer(WalletFactory factory) {


### PR DESCRIPTION
This makes the default implementation more obvious and easier to reference.

It will also will help us make the `walletFactory` member of `WalletAppKit` not nullable in a dependent PR. (see PR #2361)