### PR TITLE
wallettool: Add some basic JUnit tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -40,3 +40,5 @@ jobs:
           path: |
             core/build/reports/tests/test/
             core/build/test-results/test/
+            wallettool/build/reports/tests/test/
+            wallettool/build/test-results/test/

--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -9,6 +9,8 @@ plugins {
 
 def annotationProcessorMinVersion = GradleVersion.version("4.6")
 boolean hasAnnotationProcessor = (GradleVersion.current().compareTo(annotationProcessorMinVersion) >= 0)
+def junit5MinVersion = GradleVersion.version("4.6")
+boolean hasJunit5 = (GradleVersion.current().compareTo(junit5MinVersion) >= 0)
 
 dependencies {
     implementation project(':bitcoinj-core')
@@ -19,6 +21,11 @@ dependencies {
     } else {
         compileOnly 'info.picocli:picocli-codegen:4.6.3'
     }
+
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.8.2"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.8.2"
+
+    testImplementation 'org.slf4j:slf4j-jdk14:1.7.36'
 }
 
 sourceCompatibility = 11
@@ -32,6 +39,13 @@ compileJava {
 
 mainClassName = "org.bitcoinj.wallettool.WalletTool"
 applicationName = "wallet-tool"
+
+// wallettool is using JUnit 5 for testing, if it's not available no tests will be run
+if (hasJunit5) {
+    test {
+        useJUnitPlatform()
+    }
+}
 
 task generateManpageAsciiDoc(type: JavaExec) {
     dependsOn(classes)

--- a/wallettool/src/test/java/org/bitcoinj/wallettool/WalletToolTest.java
+++ b/wallettool/src/test/java/org/bitcoinj/wallettool/WalletToolTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.wallettool;
+
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Basic functional/integration tests of {@code wallet-tool}
+ */
+public class WalletToolTest {
+
+    @Test
+    void canConstruct() {
+        WalletTool walletTool = new WalletTool();
+
+        assertNotNull(walletTool);
+    }
+
+    @Test
+    void noArgsFails() {
+        int exitCode = execute();
+
+        assertEquals(2, exitCode);
+    }
+
+    @Test
+    void emptyStringArgFails() {
+        int exitCode = execute("");
+
+        assertEquals(1, exitCode);
+    }
+
+    @Test
+    void helpSucceeds() {
+        int exitCode = execute("--help");
+
+        assertEquals(0, exitCode);
+    }
+
+    /**
+     * Run the wallet-tool via {@link CommandLine#execute(String...)}
+     * @param args command-line arguments
+     * @return exit code
+     */
+    int execute(String... args) {
+        return new CommandLine(new WalletTool()).execute(args);
+    }
+}


### PR DESCRIPTION
To un-ignore the `dump()` test we either need to create a test wallet before testing or we need to check in a test wallet to test resources...