### PR TITLE
Github gradle.yml workflow: add JDK 18

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        java: ['11', '17']
+        java: ['11', '17', '18']
         distribution: ['temurin']
         gradle: ['7.4']
         include:


### PR DESCRIPTION
Add JDK 18 (Temurin) to the existing build matrix.

I believe this will fail a unit test because of a minor, breaking cryptography change in JDK 18.