### PR TITLE
X509Utils: swallow CertificateParsingException in getDisplayNameFromCertificate() if certificate has no SubjectAltName extension

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/X509Utils.java
+++ b/core/src/main/java/org/bitcoinj/crypto/X509Utils.java
@@ -66,12 +66,16 @@ public class X509Utils {
             else if (type.equals(RFC4519Style.c))
                 country = val;
         }
-        final Collection<List<?>> subjectAlternativeNames = certificate.getSubjectAlternativeNames();
         String altName = null;
-        if (subjectAlternativeNames != null)
-            for (final List<?> subjectAlternativeName : subjectAlternativeNames)
-                if ((Integer) subjectAlternativeName.get(0) == 1) // rfc822name
-                    altName = (String) subjectAlternativeName.get(1);
+        try {
+            final Collection<List<?>> subjectAlternativeNames = certificate.getSubjectAlternativeNames();
+            if (subjectAlternativeNames != null)
+                for (final List<?> subjectAlternativeName : subjectAlternativeNames)
+                    if ((Integer) subjectAlternativeName.get(0) == 1) // rfc822name
+                        altName = (String) subjectAlternativeName.get(1);
+        } catch (CertificateParsingException e) {
+            // swallow
+        }
 
         if (org != null) {
             return withLocation ? Joiner.on(", ").skipNulls().join(org, location, country) : org;


### PR DESCRIPTION
This fix should make the method compatible with JDK 18.