### PR TITLE
WalletProtobufSerializer: declare WalletFactory a @FunctionalInterface

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -91,6 +91,7 @@ public class WalletProtobufSerializer {
     private boolean requireAllExtensionsKnown = false;
     private int walletWriteBufferSize = CodedOutputStream.DEFAULT_BUFFER_SIZE;
 
+    @FunctionalInterface
     public interface WalletFactory {
         Wallet create(NetworkParameters params, KeyChainGroup keyChainGroup);
         WalletFactory DEFAULT = Wallet::new;


### PR DESCRIPTION
I would actually locate those cases on our entire codebase, but there doesn't seem to be a refactoring for that in IntelliJ (though it seems to know about and verify the annotation).