### PR TITLE
core: switch from BouncyCastle bcprov-jdk15to18 to bcprov-jdk15on

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,7 +10,7 @@ plugins {
 version = '0.17-SNAPSHOT'
 
 dependencies {
-    api 'org.bouncycastle:bcprov-jdk15to18:1.70'
+    api 'org.bouncycastle:bcprov-jdk15on:1.70'
     api 'com.google.guava:guava:31.0.1-android'
     api 'com.google.protobuf:protobuf-javalite:3.19.4'
     api 'com.squareup.okhttp3:okhttp:3.14.9'


### PR DESCRIPTION
This will pave the way for switching to the `bcprov-jdk18on` JARs once
they make it to Maven Central. The build and tests seem to work,
but @schildbach can you try it on Android to make sure that your
Android build tooling doesn’t have any issues with multi-release jars?