### PR TITLE
Upgrade to bcprov-jdk18on

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,7 +10,7 @@ version = '0.18-SNAPSHOT'
 
 dependencies {
     api project(':bitcoinj-base')
-    api 'org.bouncycastle:bcprov-jdk15to18:1.80'
+    api 'org.bouncycastle:bcprov-jdk18on:1.80'
     api 'com.google.guava:guava:33.4.4-android'
     api 'com.google.protobuf:protobuf-javalite:4.30.2'
 

--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -36,7 +36,7 @@ application {
 }
 
 jlink {
-    options = ['--add-modules', 'org.slf4j.jul']
+    options = ['--add-modules', 'org.slf4j.jul', '--ignore-signing-information']
 }
 
 test {


### PR DESCRIPTION
See PR #2375 (and PR #2373 and PR #2374 for the issues around 1.71 not being on Maven Central yet)