### PR TITLE
if tests throw a checked exception, only declare a simple `throws Exception`

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/CheckpointManagerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/CheckpointManagerTest.java
@@ -33,28 +33,28 @@ public class CheckpointManagerTest {
     NetworkParameters params;
 
     @Test(expected = NullPointerException.class)
-    public void shouldThrowNullPointerExceptionWhenCheckpointsNotFound() throws IOException {
+    public void shouldThrowNullPointerExceptionWhenCheckpointsNotFound() throws Exception {
         expect(params.getId()).andReturn("org/bitcoinj/core/checkpointmanagertest/notFound");
         replay(params);
         new CheckpointManager(params, null);
     }
 
     @Test(expected = IOException.class)
-    public void shouldThrowNullPointerExceptionWhenCheckpointsInUnknownFormat() throws IOException {
+    public void shouldThrowNullPointerExceptionWhenCheckpointsInUnknownFormat() throws Exception {
         expect(params.getId()).andReturn("org/bitcoinj/core/checkpointmanagertest/unsupportedFormat");
         replay(params);
         new CheckpointManager(params, null);
     }
 
     @Test(expected = IllegalStateException.class)
-    public void shouldThrowIllegalStateExceptionWithNoCheckpoints() throws IOException {
+    public void shouldThrowIllegalStateExceptionWithNoCheckpoints() throws Exception {
         expect(params.getId()).andReturn("org/bitcoinj/core/checkpointmanagertest/noCheckpoints");
         replay(params);
         new CheckpointManager(params, null);
     }
 
     @Test
-    public void canReadTextualStream() throws IOException {
+    public void canReadTextualStream() throws Exception {
         expect(params.getId()).andReturn("org/bitcoinj/core/checkpointmanagertest/validTextualFormat");
         expect(params.getSerializer(false)).andReturn(
                 new BitcoinSerializer(params, NetworkParameters.ProtocolVersion.CURRENT.getBitcoinProtocolVersion(), false));

--- a/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -29,7 +29,6 @@ import org.junit.*;
 import org.junit.runner.*;
 import org.junit.runners.*;
 
-import java.io.*;
 import java.net.*;
 import java.util.*;
 import java.util.concurrent.*;
@@ -131,7 +130,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
     }
 
     @Test
-    public void peerDiscoveryPolling() throws InterruptedException {
+    public void peerDiscoveryPolling() throws Exception {
         // Check that if peer discovery fails, we keep trying until we have some nodes to talk with.
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicBoolean result = new AtomicBoolean();
@@ -713,7 +712,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
     }
 
     @Test
-    public void preferLocalPeer() throws IOException {
+    public void preferLocalPeer() throws Exception {
         // Because we are using the same port (8333 or 18333) that is used by Bitcoin Core
         // We have to consider 2 cases:
         // 1. Test are executed on the same machine that is running a full node

--- a/core/src/test/java/org/bitcoinj/core/TransactionWitnessTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionWitnessTest.java
@@ -39,7 +39,7 @@ public class TransactionWitnessTest {
     }
 
     @Test
-    public void testRedeemP2WSH() throws SignatureDecodeException {
+    public void testRedeemP2WSH() throws Exception {
         ECKey.ECDSASignature ecdsaSignature1 = TransactionSignature.decodeFromDER(Hex.decode("3045022100c3d84f7bf41c7eda3b23bbbccebde842a451c1a0aca39df706a3ff2fe78b1e0a02206e2e3c23559798b02302ad6fa5ddbbe87af5cc7d3b9f86b88588253770ab9f79"));
         TransactionSignature signature1 = new TransactionSignature(ecdsaSignature1, Transaction.SigHash.ALL, false);
         ECKey.ECDSASignature ecdsaSignature2 = TransactionSignature.decodeFromDER(Hex.decode("3045022100fcfe4a58f2878047ef7c5889fc52a3816ad2dd218807daa3c3eafd4841ffac4d022073454df7e212742f0fee20416b418a2c1340a33eebed5583d19a61088b112832"));

--- a/core/src/test/java/org/bitcoinj/net/discovery/DnsDiscoveryTest.java
+++ b/core/src/test/java/org/bitcoinj/net/discovery/DnsDiscoveryTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 public class DnsDiscoveryTest {
 
     @Test
-    public void testBuildDiscoveries() throws PeerDiscoveryException {
+    public void testBuildDiscoveries() throws Exception {
         String[] seeds = new String[] { "seed.bitcoin.sipa.be", "dnsseed.bluematt.me" };
         DnsDiscovery dnsDiscovery = new DnsDiscovery(seeds, MainNetParams.get());
         assertTrue(dnsDiscovery.seeds.size() == 2);
@@ -39,13 +39,13 @@ public class DnsDiscoveryTest {
     }
 
     @Test(expected = PeerDiscoveryException.class)
-    public void testGetPeersThrowsPeerDiscoveryExceptionWithServicesGreaterThanZero() throws PeerDiscoveryException {
+    public void testGetPeersThrowsPeerDiscoveryExceptionWithServicesGreaterThanZero() throws Exception {
         DnsDiscovery.DnsSeedDiscovery dnsSeedDiscovery = new DnsDiscovery.DnsSeedDiscovery(MainNetParams.get(), "");
         dnsSeedDiscovery.getPeers(1, 100, TimeUnit.MILLISECONDS);
     }
 
     @Test
-    public void testGetPeersReturnsNotEmptyListOfSocketAddresses() throws PeerDiscoveryException {
+    public void testGetPeersReturnsNotEmptyListOfSocketAddresses() throws Exception {
         DnsDiscovery.DnsSeedDiscovery dnsSeedDiscovery = new DnsDiscovery.DnsSeedDiscovery(MainNetParams.get(),
                 "localhost");
         List<InetSocketAddress> inetSocketAddresses = dnsSeedDiscovery.getPeers(0, 100, TimeUnit.MILLISECONDS);
@@ -53,7 +53,7 @@ public class DnsDiscoveryTest {
     }
 
     @Test(expected = PeerDiscoveryException.class)
-    public void testGetPeersThrowsPeerDiscoveryExceptionForUnknownHost() throws PeerDiscoveryException {
+    public void testGetPeersThrowsPeerDiscoveryExceptionForUnknownHost() throws Exception {
         DnsDiscovery.DnsSeedDiscovery dnsSeedDiscovery = new DnsDiscovery.DnsSeedDiscovery(MainNetParams.get(),
                 "unknown host");
         dnsSeedDiscovery.getPeers(0, 100, TimeUnit.MILLISECONDS);

--- a/core/src/test/java/org/bitcoinj/protocols/payments/PaymentSessionTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/payments/PaymentSessionTest.java
@@ -118,7 +118,7 @@ public class PaymentSessionTest {
     }
 
     @Test
-    public void testExpiredPaymentRequest() throws PaymentProtocolException {
+    public void testExpiredPaymentRequest() throws Exception {
         MockPaymentSession paymentSession = new MockPaymentSession(newExpiredPaymentRequest());
         assertTrue(paymentSession.isExpired());
         // Send the payment and verify that an exception is thrown.
@@ -155,7 +155,7 @@ public class PaymentSessionTest {
     }
 
     @Test(expected = PaymentProtocolException.InvalidNetwork.class)
-    public void testWrongNetwork() throws Throwable {
+    public void testWrongNetwork() throws Exception {
         // Create a PaymentRequest and make sure the correct values are parsed by the PaymentSession.
         MockPaymentSession paymentSession = new MockPaymentSession(newSimplePaymentRequest("main"));
         assertEquals(MAINNET, paymentSession.getNetworkParameters());
@@ -172,7 +172,7 @@ public class PaymentSessionTest {
             fail("Incorrect exception type");
         } catch (ExecutionException e) {
             // We're expecting PaymentProtocolException.InvalidNetwork as the cause
-            throw e.getCause();
+            throw (Exception) e.getCause();
         }
     }
 

--- a/core/src/test/java/org/bitcoinj/store/SPVBlockStoreTest.java
+++ b/core/src/test/java/org/bitcoinj/store/SPVBlockStoreTest.java
@@ -136,7 +136,7 @@ public class SPVBlockStoreTest {
     }
 
     @Test
-    public void performanceTest() throws BlockStoreException {
+    public void performanceTest() throws Exception {
         // On slow machines, this test could fail. Then either add @Ignore or adapt the threshold and please report to
         // us.
         final int ITERATIONS = 100000;

--- a/core/src/test/java/org/bitcoinj/uri/BitcoinURITest.java
+++ b/core/src/test/java/org/bitcoinj/uri/BitcoinURITest.java
@@ -95,7 +95,7 @@ public class BitcoinURITest {
     }
 
     @Test
-    public void testGood_legacy() throws BitcoinURIParseException {
+    public void testGood_legacy() throws Exception {
         testObject = new BitcoinURI(MAINNET, BITCOIN_SCHEME + ":" + MAINNET_GOOD_ADDRESS);
         assertEquals(MAINNET_GOOD_ADDRESS, testObject.getAddress().toString());
         assertNull("Unexpected amount", testObject.getAmount());
@@ -104,7 +104,7 @@ public class BitcoinURITest {
     }
 
     @Test
-    public void testGood_uppercaseScheme() throws BitcoinURIParseException {
+    public void testGood_uppercaseScheme() throws Exception {
         testObject = new BitcoinURI(MAINNET, BITCOIN_SCHEME.toUpperCase(Locale.US) + ":" + MAINNET_GOOD_ADDRESS);
         assertEquals(MAINNET_GOOD_ADDRESS, testObject.getAddress().toString());
         assertNull("Unexpected amount", testObject.getAmount());
@@ -113,7 +113,7 @@ public class BitcoinURITest {
     }
 
     @Test
-    public void testGood_segwit() throws BitcoinURIParseException {
+    public void testGood_segwit() throws Exception {
         testObject = new BitcoinURI(MAINNET, BITCOIN_SCHEME + ":" + MAINNET_GOOD_SEGWIT_ADDRESS);
         assertEquals(MAINNET_GOOD_SEGWIT_ADDRESS, testObject.getAddress().toString());
         assertNull("Unexpected amount", testObject.getAmount());
@@ -193,7 +193,7 @@ public class BitcoinURITest {
      *             If something goes wrong
      */
     @Test
-    public void testGood_Amount() throws BitcoinURIParseException {
+    public void testGood_Amount() throws Exception {
         // Test the decimal parsing
         testObject = new BitcoinURI(MAINNET, BITCOIN_SCHEME + ":" + MAINNET_GOOD_ADDRESS
                 + "?amount=6543210.12345678");
@@ -217,7 +217,7 @@ public class BitcoinURITest {
      *             If something goes wrong
      */
     @Test
-    public void testGood_Label() throws BitcoinURIParseException {
+    public void testGood_Label() throws Exception {
         testObject = new BitcoinURI(MAINNET, BITCOIN_SCHEME + ":" + MAINNET_GOOD_ADDRESS
                 + "?label=Hello%20World");
         assertEquals("Hello World", testObject.getLabel());
@@ -230,7 +230,7 @@ public class BitcoinURITest {
      *             If something goes wrong
      */
     @Test
-    public void testGood_LabelWithAmpersandAndPlus() throws BitcoinURIParseException {
+    public void testGood_LabelWithAmpersandAndPlus() throws Exception {
         String testString = "Hello Earth & Mars + Venus";
         String encodedLabel = BitcoinURI.encodeURLString(testString);
         testObject = new BitcoinURI(MAINNET, BITCOIN_SCHEME + ":" + MAINNET_GOOD_ADDRESS + "?label="
@@ -245,7 +245,7 @@ public class BitcoinURITest {
      *             If something goes wrong
      */
     @Test
-    public void testGood_LabelWithRussian() throws BitcoinURIParseException {
+    public void testGood_LabelWithRussian() throws Exception {
         // Moscow in Russian in Cyrillic
         String moscowString = "\u041c\u043e\u0441\u043a\u0432\u0430";
         String encodedLabel = BitcoinURI.encodeURLString(moscowString); 
@@ -256,12 +256,9 @@ public class BitcoinURITest {
 
     /**
      * Handles a simple message
-     * 
-     * @throws BitcoinURIParseException
-     *             If something goes wrong
      */
     @Test
-    public void testGood_Message() throws BitcoinURIParseException {
+    public void testGood_Message() throws Exception {
         testObject = new BitcoinURI(MAINNET, BITCOIN_SCHEME + ":" + MAINNET_GOOD_ADDRESS
                 + "?message=Hello%20World");
         assertEquals("Hello World", testObject.getMessage());
@@ -269,12 +266,9 @@ public class BitcoinURITest {
 
     /**
      * Handles various well-formed combinations
-     * 
-     * @throws BitcoinURIParseException
-     *             If something goes wrong
      */
     @Test
-    public void testGood_Combinations() throws BitcoinURIParseException {
+    public void testGood_Combinations() throws Exception {
         testObject = new BitcoinURI(MAINNET, BITCOIN_SCHEME + ":" + MAINNET_GOOD_ADDRESS
                 + "?amount=6543210&label=Hello%20World&message=Be%20well");
         assertEquals(
@@ -307,13 +301,13 @@ public class BitcoinURITest {
     }
 
     @Test
-    public void testEmpty_Label() throws BitcoinURIParseException {
+    public void testEmpty_Label() throws Exception {
         assertNull(new BitcoinURI(MAINNET, BITCOIN_SCHEME + ":" + MAINNET_GOOD_ADDRESS
                 + "?label=").getLabel());
     }
 
     @Test
-    public void testEmpty_Message() throws BitcoinURIParseException {
+    public void testEmpty_Message() throws Exception {
         assertNull(new BitcoinURI(MAINNET, BITCOIN_SCHEME + ":" + MAINNET_GOOD_ADDRESS
                 + "?message=").getMessage());
     }
@@ -333,19 +327,16 @@ public class BitcoinURITest {
     }
 
     @Test
-    public void testGood_ManyEquals() throws BitcoinURIParseException {
+    public void testGood_ManyEquals() throws Exception {
         assertEquals("aardvark=zebra", new BitcoinURI(MAINNET, BITCOIN_SCHEME + ":"
                 + MAINNET_GOOD_ADDRESS + "?label=aardvark=zebra").getLabel());
     }
     
     /**
      * Handles unknown fields (required and not required)
-     * 
-     * @throws BitcoinURIParseException
-     *             If something goes wrong
      */
     @Test
-    public void testUnknown() throws BitcoinURIParseException {
+    public void testUnknown() throws Exception {
         // Unknown not required field
         testObject = new BitcoinURI(MAINNET, BITCOIN_SCHEME + ":" + MAINNET_GOOD_ADDRESS
                 + "?aardvark=true");
@@ -373,7 +364,7 @@ public class BitcoinURITest {
     }
 
     @Test
-    public void brokenURIs() throws BitcoinURIParseException {
+    public void brokenURIs() throws Exception {
         // Check we can parse the incorrectly formatted URIs produced by blockchain.info and its iPhone app.
         String str = "bitcoin://1KzTSfqjF2iKCduwz59nv2uqh1W2JsTxZH?amount=0.01000000";
         BitcoinURI uri = new BitcoinURI(str);
@@ -382,19 +373,19 @@ public class BitcoinURITest {
     }
 
     @Test(expected = BitcoinURIParseException.class)
-    public void testBad_AmountTooPrecise() throws BitcoinURIParseException {
+    public void testBad_AmountTooPrecise() throws Exception {
         new BitcoinURI(MAINNET, BITCOIN_SCHEME + ":" + MAINNET_GOOD_ADDRESS
                 + "?amount=0.123456789");
     }
 
     @Test(expected = BitcoinURIParseException.class)
-    public void testBad_NegativeAmount() throws BitcoinURIParseException {
+    public void testBad_NegativeAmount() throws Exception {
         new BitcoinURI(MAINNET, BITCOIN_SCHEME + ":" + MAINNET_GOOD_ADDRESS
                 + "?amount=-1");
     }
 
     @Test(expected = BitcoinURIParseException.class)
-    public void testBad_TooLargeAmount() throws BitcoinURIParseException {
+    public void testBad_TooLargeAmount() throws Exception {
         new BitcoinURI(MAINNET, BITCOIN_SCHEME + ":" + MAINNET_GOOD_ADDRESS
                 + "?amount=100000000");
     }

--- a/core/src/test/java/org/bitcoinj/utils/BtcFormatTest.java
+++ b/core/src/test/java/org/bitcoinj/utils/BtcFormatTest.java
@@ -287,7 +287,7 @@ public class BtcFormatTest {
 
     @Ignore("non-determinism between OpenJDK versions")
     @Test
-    public void parseTest() throws java.text.ParseException {
+    public void parseTest() throws Exception {
         BtcFormat us = BtcFormat.getSymbolInstance(Locale.US);
         BtcFormat usCoded = BtcFormat.getCodeInstance(Locale.US);
         // Coins
@@ -497,7 +497,7 @@ public class BtcFormatTest {
     }
 
     @Test
-    public void parseMetricTest() throws ParseException {
+    public void parseMetricTest() throws Exception {
         BtcFormat cp = BtcFormat.getCodeInstance(Locale.US);
         BtcFormat sp = BtcFormat.getSymbolInstance(Locale.US);
         // coin

--- a/core/src/test/java/org/bitcoinj/utils/VersionTallyTest.java
+++ b/core/src/test/java/org/bitcoinj/utils/VersionTallyTest.java
@@ -23,7 +23,6 @@ import org.bitcoinj.core.StoredBlock;
 import org.bitcoinj.core.Utils;
 import org.bitcoinj.params.UnitTestParams;
 import org.bitcoinj.store.BlockStore;
-import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.testing.FakeTxBuilder;
 import org.junit.BeforeClass;
@@ -101,7 +100,7 @@ public class VersionTallyTest {
     }
 
     @Test
-    public void testInitialize() throws BlockStoreException {
+    public void testInitialize() throws Exception {
         final BlockStore blockStore = new MemoryBlockStore(UNITTEST);
         final BlockChain chain = new BlockChain(UNITTEST, blockStore);
 

--- a/core/src/test/java/org/bitcoinj/wallet/BasicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/BasicKeyChainTest.java
@@ -191,7 +191,7 @@ public class BasicKeyChainTest {
     }
 
     @Test
-    public void serializationUnencrypted() throws UnreadableWalletException {
+    public void serializationUnencrypted() throws Exception {
         Utils.setMockClock();
         Date now = Utils.now();
         final ECKey key1 = new ECKey();
@@ -215,7 +215,7 @@ public class BasicKeyChainTest {
     }
 
     @Test
-    public void serializationEncrypted() throws UnreadableWalletException {
+    public void serializationEncrypted() throws Exception {
         ECKey key1 = new ECKey();
         chain.importKeys(key1);
         chain = chain.toEncrypted("foo bar");
@@ -231,7 +231,7 @@ public class BasicKeyChainTest {
     }
 
     @Test
-    public void watching() throws UnreadableWalletException {
+    public void watching() throws Exception {
         ECKey key1 = new ECKey();
         ECKey pub = ECKey.fromPublicOnly(key1);
         chain.importKeys(pub);

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -222,7 +222,7 @@ public class DeterministicKeyChainTest {
     }
 
     @Test
-    public void serializeUnencrypted() throws UnreadableWalletException {
+    public void serializeUnencrypted() throws Exception {
         chain.maybeLookAhead();
         DeterministicKey key1 = chain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         DeterministicKey key2 = chain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
@@ -260,7 +260,7 @@ public class DeterministicKeyChainTest {
     }
 
     @Test
-    public void serializeSegwitUnencrypted() throws UnreadableWalletException {
+    public void serializeSegwitUnencrypted() throws Exception {
         segwitChain.maybeLookAhead();
         DeterministicKey key1 = segwitChain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         DeterministicKey key2 = segwitChain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
@@ -297,7 +297,7 @@ public class DeterministicKeyChainTest {
     }
 
     @Test
-    public void serializeUnencryptedBIP44() throws UnreadableWalletException {
+    public void serializeUnencryptedBIP44() throws Exception {
         bip44chain.maybeLookAhead();
         DeterministicKey key1 = bip44chain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         DeterministicKey key2 = bip44chain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
@@ -361,7 +361,7 @@ public class DeterministicKeyChainTest {
     }
 
     @Test
-    public void encryption() throws UnreadableWalletException {
+    public void encryption() throws Exception {
         DeterministicKey key1 = chain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         DeterministicKeyChain encChain = chain.toEncrypted("open secret");
         DeterministicKey encKey1 = encChain.findKeyFromPubKey(key1.getPubKey());
@@ -395,7 +395,7 @@ public class DeterministicKeyChainTest {
     }
 
     @Test
-    public void watchingChain() throws UnreadableWalletException {
+    public void watchingChain() throws Exception {
         Utils.setMockClock();
         DeterministicKey key1 = chain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         DeterministicKey key2 = chain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
@@ -434,7 +434,7 @@ public class DeterministicKeyChainTest {
     }
 
     @Test
-    public void watchingChainArbitraryPath() throws UnreadableWalletException {
+    public void watchingChainArbitraryPath() throws Exception {
         Utils.setMockClock();
         DeterministicKey key1 = bip44chain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         DeterministicKey key2 = bip44chain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
@@ -471,7 +471,7 @@ public class DeterministicKeyChainTest {
     }
 
     @Test
-    public void watchingChainAccountOne() throws UnreadableWalletException {
+    public void watchingChainAccountOne() throws Exception {
         Utils.setMockClock();
         final List<ChildNumber> accountOne = ImmutableList.of(ChildNumber.ONE);
         DeterministicKeyChain chain1 = DeterministicKeyChain.builder().accountPath(accountOne)
@@ -514,7 +514,7 @@ public class DeterministicKeyChainTest {
     }
 
     @Test
-    public void watchingSegwitChain() throws UnreadableWalletException {
+    public void watchingSegwitChain() throws Exception {
         Utils.setMockClock();
         DeterministicKey key1 = segwitChain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         DeterministicKey key2 = segwitChain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
@@ -554,7 +554,7 @@ public class DeterministicKeyChainTest {
     }
 
     @Test
-    public void spendingChain() throws UnreadableWalletException {
+    public void spendingChain() throws Exception {
         Utils.setMockClock();
         DeterministicKey key1 = chain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         DeterministicKey key2 = chain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
@@ -593,7 +593,7 @@ public class DeterministicKeyChainTest {
     }
 
     @Test
-    public void spendingChainAccountTwo() throws UnreadableWalletException {
+    public void spendingChainAccountTwo() throws Exception {
         Utils.setMockClock();
         final long secs = 1389353062L;
         final List<ChildNumber> accountTwo = ImmutableList.of(new ChildNumber(2, true));
@@ -621,7 +621,7 @@ public class DeterministicKeyChainTest {
     }
 
     @Test
-    public void masterKeyAccount() throws UnreadableWalletException {
+    public void masterKeyAccount() throws Exception {
         Utils.setMockClock();
         long secs = 1389353062L;
         DeterministicKey firstReceiveKey = bip44chain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
@@ -674,7 +674,7 @@ public class DeterministicKeyChainTest {
      */
     private void verifySpendableKeyChain(DeterministicKey firstReceiveKey, DeterministicKey secondReceiveKey,
                                          DeterministicKey firstChangeKey, DeterministicKey secondChangeKey,
-                                         DeterministicKeyChain keyChain, String serializationFile) throws UnreadableWalletException {
+                                         DeterministicKeyChain keyChain, String serializationFile) throws Exception {
 
         //verify that the keys are the same as the keyChain
         assertEquals(firstReceiveKey.getPubKeyPoint(), keyChain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS).getPubKeyPoint());

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -159,7 +159,7 @@ public class WalletTest extends TestWithWallet {
     }
 
     @Test
-    public void checkSeed() throws MnemonicException {
+    public void checkSeed() throws Exception {
         wallet.getKeyChainSeed().check();
     }
 
@@ -2044,7 +2044,7 @@ public class WalletTest extends TestWithWallet {
     }
 
     @Test
-    public void importAndEncrypt() throws InsufficientMoneyException {
+    public void importAndEncrypt() throws Exception {
         Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
         encryptedWallet.encrypt(PASSWORD1);
 
@@ -2158,7 +2158,7 @@ public class WalletTest extends TestWithWallet {
     }
 
     @Test(expected = Wallet.DustySendRequested.class)
-    public void sendDustTest() throws InsufficientMoneyException {
+    public void sendDustTest() throws Exception {
         // Tests sending dust, should throw DustySendRequested.
         Transaction tx = new Transaction(UNITTEST);
         Coin dustThreshold = new TransactionOutput(UNITTEST, null, Coin.COIN, OTHER_ADDRESS).getMinNonDustValue();
@@ -2657,7 +2657,7 @@ public class WalletTest extends TestWithWallet {
     }
 
     @Test
-    public void lowerThanDefaultFee() throws InsufficientMoneyException {
+    public void lowerThanDefaultFee() throws Exception {
         int feeFactor = 200;
         Coin fee = Transaction.DEFAULT_TX_FEE.divide(feeFactor);
         receiveATransactionAmount(wallet, myAddress, Coin.COIN);
@@ -2678,7 +2678,7 @@ public class WalletTest extends TestWithWallet {
     }
 
     @Test
-    public void higherThanDefaultFee() throws InsufficientMoneyException {
+    public void higherThanDefaultFee() throws Exception {
         int feeFactor = 10;
         Coin fee = Transaction.DEFAULT_TX_FEE.multiply(feeFactor);
         receiveATransactionAmount(wallet, myAddress, Coin.COIN);
@@ -3316,14 +3316,14 @@ public class WalletTest extends TestWithWallet {
     }
 
     @Test(expected = java.lang.IllegalStateException.class)
-    public void sendCoinsNoBroadcasterTest() throws InsufficientMoneyException {
+    public void sendCoinsNoBroadcasterTest() throws Exception {
         ECKey key = ECKey.fromPrivate(BigInteger.TEN);
         SendRequest req = SendRequest.to(OTHER_ADDRESS.getParameters(), key, SATOSHI.multiply(12));
         wallet.sendCoins(req);
     }
 
     @Test
-    public void sendCoinsWithBroadcasterTest() throws InsufficientMoneyException {
+    public void sendCoinsWithBroadcasterTest() throws Exception {
         ECKey key = ECKey.fromPrivate(BigInteger.TEN);
         receiveATransactionAmount(wallet, myAddress, Coin.COIN);
         MockTransactionBroadcaster broadcaster = new MockTransactionBroadcaster(wallet);


### PR DESCRIPTION
For tests that don't throw a checked exception, the `throws` clause is
removed entirely.

There is no need to declare a proper API, as test frameworks are the
only consumer. Rather, keep the tests simple.