### PR TITLE
WalletTool: remove unnecessary `null` setting

### DIFF
--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -469,7 +469,7 @@ public class WalletTool implements Callable<Integer> {
                     }
                     CoinSelector coinSelector = null;
                     if (selectAddrStr != null) {
-                        Address selectAddr = null;
+                        Address selectAddr;
                         try {
                             selectAddr = Address.fromString(params, selectAddrStr);
                         } catch (AddressFormatException x) {
@@ -1247,7 +1247,7 @@ public class WalletTool implements Callable<Integer> {
             System.err.println("One of --pubkey or --addr must be specified.");
             return;
         }
-        ECKey key = null;
+        ECKey key;
         if (pubKeyStr != null) {
             key = wallet.findKeyFromPubKey(HEX.decode(pubKeyStr));
         } else {


### PR DESCRIPTION
Remove unnecessary setting of variables to `null` (IDE warning)

