### PR TITLE
wallettemplate: JavaFX Gradle Plugin to 0.0.12

### DIFF
--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'eclipse'
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.10'
+    id 'org.openjfx.javafxplugin' version '0.0.12'
 }
 
 dependencies {


### PR DESCRIPTION
Among other things, this version provides support for macOS on the M1 processor.