### PR TITLE
HDPath: add .list(), replace usage of Guava ImmutableList in core/test

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/HDPath.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDPath.java
@@ -225,6 +225,14 @@ public class HDPath extends AbstractList<ChildNumber> {
         return this.extend(HDPath.M(path2));
     }
 
+    /**
+     * Return a simple list of {@link ChildNumber}
+     * @return an unmodifiable list of {@code ChildNumber}
+     */
+    public List<ChildNumber> list() {
+        return unmodifiableList;
+    }
+
     @Override
     public ChildNumber get(int index) {
         return unmodifiableList.get(index);

--- a/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -18,7 +18,7 @@
 package org.bitcoinj.core;
 
 import com.google.common.base.Stopwatch;
-import com.google.common.collect.*;
+import com.google.common.collect.Lists;
 import org.bitcoinj.core.listeners.*;
 import org.bitcoinj.net.discovery.*;
 import org.bitcoinj.script.Script;
@@ -604,7 +604,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         assertTrue(outbound(p1) instanceof GetDataMessage);
         final Sha256Hash dephash = tx.getInput(0).getOutpoint().getHash();
         final InventoryItem inv = new InventoryItem(InventoryItem.Type.TRANSACTION, dephash);
-        inbound(p1, new NotFoundMessage(UNITTEST, ImmutableList.of(inv)));
+        inbound(p1, new NotFoundMessage(UNITTEST, Collections.singletonList(inv)));
         assertNull(outbound(p1));
         assertNull(outbound(p2));
         peerGroup.waitForJobQueue();

--- a/core/src/test/java/org/bitcoinj/core/TransactionOutputTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionOutputTest.java
@@ -16,7 +16,6 @@
 
 package org.bitcoinj.core;
 
-import com.google.common.collect.ImmutableList;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
@@ -27,6 +26,9 @@ import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -53,7 +55,7 @@ public class TransactionOutputTest extends TestWithWallet {
 
         // Create multi-sig transaction
         Transaction multiSigTransaction = new Transaction(UNITTEST);
-        ImmutableList<ECKey> keys = ImmutableList.of(myKey, otherKey);
+        List<ECKey> keys = Arrays.asList(myKey, otherKey);
 
         Script scriptPubKey = ScriptBuilder.createMultiSigOutputScript(2, keys);
         multiSigTransaction.addOutput(Coin.COIN, scriptPubKey);

--- a/core/src/test/java/org/bitcoinj/crypto/HDKeyDerivationTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/HDKeyDerivationTest.java
@@ -28,8 +28,6 @@ import org.bitcoinj.crypto.HDKeyDerivation.PublicDeriveMode;
 import org.bouncycastle.crypto.params.KeyParameter;
 import org.junit.Test;
 
-import com.google.common.collect.ImmutableList;
-
 /**
  * @author Andreas Schildbach
  */

--- a/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
@@ -16,10 +16,10 @@
 
 package org.bitcoinj.crypto;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -56,23 +56,23 @@ public class HDPathTest {
     public void testFormatPath() {
         Object[] tv = {
                 "M/44H/0H/0H/1/1",
-                ImmutableList.of(new ChildNumber(44, true), new ChildNumber(0, true), new ChildNumber(0, true),
+                HDPath.M(new ChildNumber(44, true), new ChildNumber(0, true), new ChildNumber(0, true),
                         new ChildNumber(1, false), new ChildNumber(1, false)),
 
                 "M/7H/3/3/1H",
-                ImmutableList.of(new ChildNumber(7, true), new ChildNumber(3, false), new ChildNumber(3, false),
+                HDPath.M(new ChildNumber(7, true), new ChildNumber(3, false), new ChildNumber(3, false),
                         new ChildNumber(1, true)),
 
                 "M/1H/2H/3H",
-                ImmutableList.of(new ChildNumber(1, true), new ChildNumber(2, true), new ChildNumber(3, true)),
+                HDPath.M(new ChildNumber(1, true), new ChildNumber(2, true), new ChildNumber(3, true)),
 
                 "M/1/2/3",
-                ImmutableList.of(new ChildNumber(1, false), new ChildNumber(2, false), new ChildNumber(3, false))
+                HDPath.M(new ChildNumber(1, false), new ChildNumber(2, false), new ChildNumber(3, false))
         };
 
         for (int i = 0; i < tv.length; i += 2) {
             String expectedStrPath = (String) tv[i];
-            HDPath path = HDPath.M((List<ChildNumber>) tv[i + 1]);
+            HDPath path = (HDPath) tv[i + 1];
 
             String generatedStrPath = path.toString();
 
@@ -84,26 +84,26 @@ public class HDPathTest {
     public void testParsePath() {
         Object[] tv = {
                 "M / 44H / 0H / 0H / 1 / 1",
-                ImmutableList.of(new ChildNumber(44, true), new ChildNumber(0, true), new ChildNumber(0, true),
+                HDPath.M(new ChildNumber(44, true), new ChildNumber(0, true), new ChildNumber(0, true),
                         new ChildNumber(1, false), new ChildNumber(1, false)),
                 false,
 
                 "M/7H/3/3/1H/",
-                ImmutableList.of(new ChildNumber(7, true), new ChildNumber(3, false), new ChildNumber(3, false),
+                HDPath.M(new ChildNumber(7, true), new ChildNumber(3, false), new ChildNumber(3, false),
                         new ChildNumber(1, true)),
                 false,
 
                 "m/7H/3/3/1H/",
-                ImmutableList.of(new ChildNumber(7, true), new ChildNumber(3, false), new ChildNumber(3, false),
+                HDPath.m(new ChildNumber(7, true), new ChildNumber(3, false), new ChildNumber(3, false),
                         new ChildNumber(1, true)),
                 true,
 
                 "1 H / 2 H / 3 H /",
-                ImmutableList.of(new ChildNumber(1, true), new ChildNumber(2, true), new ChildNumber(3, true)),
+                Arrays.asList(new ChildNumber(1, true), new ChildNumber(2, true), new ChildNumber(3, true)),
                 false,
 
                 "1 / 2 / 3 /",
-                ImmutableList.of(new ChildNumber(1, false), new ChildNumber(2, false), new ChildNumber(3, false)),
+                Arrays.asList(new ChildNumber(1, false), new ChildNumber(2, false), new ChildNumber(3, false)),
                 false
         };
 

--- a/core/src/test/java/org/bitcoinj/script/ScriptChunkSizeTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptChunkSizeTest.java
@@ -16,7 +16,6 @@
 
 package org.bitcoinj.script;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,6 +23,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Random;
 
 import static org.bitcoinj.script.ScriptOpCodes.*;
@@ -62,13 +63,13 @@ public class ScriptChunkSizeTest {
         for (int i = 0; i < Script.MAX_SCRIPT_ELEMENT_SIZE + 1; i++)
             pushData4.add(new ScriptChunk(OP_PUSHDATA4, randomBytes(i)));
 
-        return ImmutableList.<ScriptChunk>builder()
-                .addAll(opcodes)
-                .addAll(smallData)
-                .addAll(pushData1)
-                .addAll(pushData2)
-                .addAll(pushData4)
-                .build();
+        List<ScriptChunk> temp = new ArrayList<>();
+        temp.addAll(opcodes);
+        temp.addAll(smallData);
+        temp.addAll(pushData1);
+        temp.addAll(pushData2);
+        temp.addAll(pushData4);
+        return Collections.unmodifiableList(temp);
     }
 
     private static byte[] randomBytes(int size) {

--- a/core/src/test/java/org/bitcoinj/script/ScriptTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptTest.java
@@ -26,7 +26,6 @@ import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.script.Script.VerifyFlag;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.hamcrest.core.IsNot;
@@ -146,7 +145,7 @@ public class ScriptTest {
         TransactionSignature party2TransactionSignature = new TransactionSignature(party2Signature, SigHash.ALL, false);
 
         // Create p2sh multisig input script
-        Script inputScript = ScriptBuilder.createP2SHMultiSigInputScript(ImmutableList.of(party1TransactionSignature, party2TransactionSignature), multisigScript);
+        Script inputScript = ScriptBuilder.createP2SHMultiSigInputScript(Arrays.asList(party1TransactionSignature, party2TransactionSignature), multisigScript);
 
         // Assert that the input script contains 4 chunks
         assertTrue(inputScript.getChunks().size() == 4);
@@ -157,7 +156,7 @@ public class ScriptTest {
         Assert.assertArrayEquals(scriptChunk.data, multisigScript.getProgram());
 
         // Create regular multisig input script
-        inputScript = ScriptBuilder.createMultiSigInputScript(ImmutableList.of(party1TransactionSignature, party2TransactionSignature));
+        inputScript = ScriptBuilder.createMultiSigInputScript(Arrays.asList(party1TransactionSignature, party2TransactionSignature));
 
         // Assert that the input script only contains 3 chunks
         assertTrue(inputScript.getChunks().size() == 3);

--- a/core/src/test/java/org/bitcoinj/testing/KeyChainTransactionSigner.java
+++ b/core/src/test/java/org/bitcoinj/testing/KeyChainTransactionSigner.java
@@ -19,9 +19,9 @@ package org.bitcoinj.testing;
 import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.crypto.ChildNumber;
 import org.bitcoinj.crypto.DeterministicKey;
+import org.bitcoinj.crypto.HDPath;
 import org.bitcoinj.signers.CustomTransactionSigner;
 import org.bitcoinj.wallet.DeterministicKeyChain;
-import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 
@@ -44,7 +44,7 @@ public class KeyChainTransactionSigner extends CustomTransactionSigner {
 
     @Override
     protected SignatureAndKey getSignature(Sha256Hash sighash, List<ChildNumber> derivationPath) {
-        List<ChildNumber> keyPath = ImmutableList.copyOf(derivationPath);
+        HDPath keyPath = HDPath.M(derivationPath);
         DeterministicKey key = keyChain.getKeyByPath(keyPath, true);
         return new SignatureAndKey(key.sign(sighash), key.dropPrivateBytes().dropParent());
     }

--- a/core/src/test/java/org/bitcoinj/uri/BitcoinURITest.java
+++ b/core/src/test/java/org/bitcoinj/uri/BitcoinURITest.java
@@ -20,7 +20,6 @@ import org.bitcoinj.core.Address;
 import org.bitcoinj.core.LegacyAddress;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.TestNet3Params;
-import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 
 import static org.bitcoinj.core.Coin.*;
@@ -29,6 +28,8 @@ import org.bitcoinj.core.SegwitAddress;
 
 import static org.junit.Assert.*;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Locale;
 
 public class BitcoinURITest {
@@ -404,7 +405,7 @@ public class BitcoinURITest {
         // Non-backwards compatible form ...
         BitcoinURI uri = new BitcoinURI(TESTNET, "bitcoin:?r=https%3A%2F%2Fbitcoincore.org%2F%7Egavin%2Ff.php%3Fh%3Db0f02e7cea67f168e25ec9b9f9d584f9");
         assertEquals("https://bitcoincore.org/~gavin/f.php?h=b0f02e7cea67f168e25ec9b9f9d584f9", uri.getPaymentRequestUrl());
-        assertEquals(ImmutableList.of("https://bitcoincore.org/~gavin/f.php?h=b0f02e7cea67f168e25ec9b9f9d584f9"),
+        assertEquals(Collections.singletonList("https://bitcoincore.org/~gavin/f.php?h=b0f02e7cea67f168e25ec9b9f9d584f9"),
                 uri.getPaymentRequestUrls());
         assertNull(uri.getAddress());
     }
@@ -413,7 +414,7 @@ public class BitcoinURITest {
     public void testMultiplePaymentProtocolReq() throws Exception {
         BitcoinURI uri = new BitcoinURI(MAINNET,
                 "bitcoin:?r=https%3A%2F%2Fbitcoincore.org%2F%7Egavin&r1=bt:112233445566");
-        assertEquals(ImmutableList.of("bt:112233445566", "https://bitcoincore.org/~gavin"), uri.getPaymentRequestUrls());
+        assertEquals(Arrays.asList("bt:112233445566", "https://bitcoincore.org/~gavin"), uri.getPaymentRequestUrls());
         assertEquals("https://bitcoincore.org/~gavin", uri.getPaymentRequestUrl());
     }
 
@@ -421,7 +422,7 @@ public class BitcoinURITest {
     public void testNoPaymentProtocolReq() throws Exception {
         BitcoinURI uri = new BitcoinURI(MAINNET, "bitcoin:" + MAINNET_GOOD_ADDRESS);
         assertNull(uri.getPaymentRequestUrl());
-        assertEquals(ImmutableList.of(), uri.getPaymentRequestUrls());
+        assertEquals(Collections.emptyList(), uri.getPaymentRequestUrls());
         assertNotNull(uri.getAddress());
     }
 
@@ -430,7 +431,7 @@ public class BitcoinURITest {
         BitcoinURI uri = new BitcoinURI(TESTNET,
                 "bitcoin:?r=https://merchant.com/pay.php?h%3D2a8628fc2fbe");
         assertEquals("https://merchant.com/pay.php?h=2a8628fc2fbe", uri.getPaymentRequestUrl());
-        assertEquals(ImmutableList.of("https://merchant.com/pay.php?h=2a8628fc2fbe"), uri.getPaymentRequestUrls());
+        assertEquals(Collections.singletonList("https://merchant.com/pay.php?h=2a8628fc2fbe"), uri.getPaymentRequestUrls());
         assertNull(uri.getAddress());
     }
 }

--- a/core/src/test/java/org/bitcoinj/wallet/BasicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/BasicKeyChainTest.java
@@ -23,7 +23,6 @@ import org.bitcoinj.crypto.KeyCrypter;
 import org.bitcoinj.crypto.KeyCrypterException;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
 import org.bitcoinj.utils.Threading;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.bitcoinj.wallet.BasicKeyChain;
@@ -34,6 +33,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -173,13 +174,13 @@ public class BasicKeyChainTest {
     @Test(expected = KeyCrypterException.class)
     public void cannotImportEncryptedKey() {
         final ECKey key1 = new ECKey();
-        chain.importKeys(ImmutableList.of(key1));
+        chain.importKeys(Collections.singletonList(key1));
         chain = chain.toEncrypted("foobar");
         ECKey encryptedKey = chain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         assertTrue(encryptedKey.isEncrypted());
 
         BasicKeyChain chain2 = new BasicKeyChain();
-        chain2.importKeys(ImmutableList.of(encryptedKey));
+        chain2.importKeys(Collections.singletonList(encryptedKey));
     }
 
     @Test(expected = KeyCrypterException.class)
@@ -197,7 +198,7 @@ public class BasicKeyChainTest {
         final ECKey key1 = new ECKey();
         Utils.rollMockClock(5000);
         final ECKey key2 = new ECKey();
-        chain.importKeys(ImmutableList.of(key1, key2));
+        chain.importKeys(Arrays.asList(key1, key2));
         List<Protos.Key> keys = chain.serializeToProtobuf();
         assertEquals(2, keys.size());
         assertArrayEquals(key1.getPubKey(), keys.get(0).getPublicKey().toByteArray());

--- a/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
@@ -17,7 +17,6 @@
 
 package org.bitcoinj.wallet;
 
-import com.google.common.collect.*;
 import org.bitcoinj.core.*;
 import org.bitcoinj.crypto.*;
 import org.bitcoinj.params.*;
@@ -39,7 +38,7 @@ public class DefaultRiskAnalysisTest {
     private Wallet wallet;
     private final int TIMESTAMP = 1384190189;
     private static final ECKey key1 = new ECKey();
-    private final ImmutableList<Transaction> NO_DEPS = ImmutableList.of();
+    private final List<Transaction> NO_DEPS = Collections.emptyList();
 
     @Before
     public void setup() {
@@ -112,7 +111,7 @@ public class DefaultRiskAnalysisTest {
         tx2.addInput(output);
         tx2.addOutput(COIN, new ECKey());
 
-        DefaultRiskAnalysis analysis = DefaultRiskAnalysis.FACTORY.create(wallet, tx2, ImmutableList.of(tx1));
+        DefaultRiskAnalysis analysis = DefaultRiskAnalysis.FACTORY.create(wallet, tx2, Collections.singletonList(tx1));
         assertEquals(RiskAnalysis.Result.NON_FINAL, analysis.analyze());
         assertEquals(tx1, analysis.getNonFinal());
     }
@@ -206,7 +205,7 @@ public class DefaultRiskAnalysisTest {
         tx.addOutput(Coin.CENT, ScriptBuilder.createP2PKOutputScript(key1));
         tx.addOutput(Coin.CENT, ScriptBuilder.createP2PKOutputScript(key1));
         // 1-of-2 multisig output.
-        ImmutableList<ECKey> keys = ImmutableList.of(key1, new ECKey());
+        List<ECKey> keys = Arrays.asList(key1, new ECKey());
         tx.addOutput(Coin.CENT, ScriptBuilder.createMultiSigOutputScript(1, keys));
         // 2-of-2 multisig output.
         tx.addOutput(Coin.CENT, ScriptBuilder.createMultiSigOutputScript(2, keys));

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -32,7 +32,6 @@ import org.bitcoinj.utils.BriefLogFormatter;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.listeners.AbstractKeyChainEventListener;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.junit.Before;
@@ -49,6 +48,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -61,7 +61,7 @@ public class DeterministicKeyChainTest {
     private final byte[] ENTROPY = Sha256Hash.hash("don't use a string seed like this in real life".getBytes());
     private static final NetworkParameters UNITTEST = UnitTestParams.get();
     private static final NetworkParameters MAINNET = MainNetParams.get();
-    private static final List<ChildNumber> BIP44_COIN_1_ACCOUNT_ZERO_PATH = ImmutableList.of(new ChildNumber(44, true),
+    private static final HDPath BIP44_COIN_1_ACCOUNT_ZERO_PATH = HDPath.M(new ChildNumber(44, true),
             new ChildNumber(1, true), ChildNumber.ZERO_HARDENED);
 
     @Before
@@ -117,7 +117,7 @@ public class DeterministicKeyChainTest {
     @Test
     public void deriveAccountOne() {
         final long secs = 1389353062L;
-        final List<ChildNumber> accountOne = ImmutableList.of(ChildNumber.ONE);
+        final HDPath accountOne = HDPath.M(ChildNumber.ONE);
         DeterministicKeyChain chain1 = DeterministicKeyChain.builder().accountPath(accountOne)
                 .entropy(ENTROPY, secs).build();
         ECKey key1 = chain1.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
@@ -139,7 +139,7 @@ public class DeterministicKeyChainTest {
     @Test
     public void serializeAccountOne() throws Exception {
         final long secs = 1389353062L;
-        final List<ChildNumber> accountOne = ImmutableList.of(ChildNumber.ONE);
+        final HDPath accountOne = HDPath.M(ChildNumber.ONE);
         DeterministicKeyChain chain1 = DeterministicKeyChain.builder().accountPath(accountOne)
                 .entropy(ENTROPY, secs).build();
         ECKey key1 = chain1.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
@@ -473,7 +473,7 @@ public class DeterministicKeyChainTest {
     @Test
     public void watchingChainAccountOne() throws UnreadableWalletException {
         Utils.setMockClock();
-        final List<ChildNumber> accountOne = ImmutableList.of(ChildNumber.ONE);
+        final HDPath accountOne = HDPath.M(ChildNumber.ONE);
         DeterministicKeyChain chain1 = DeterministicKeyChain.builder().accountPath(accountOne)
                 .seed(chain.getSeed()).build();
         DeterministicKey key1 = chain1.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
@@ -596,7 +596,7 @@ public class DeterministicKeyChainTest {
     public void spendingChainAccountTwo() throws UnreadableWalletException {
         Utils.setMockClock();
         final long secs = 1389353062L;
-        final List<ChildNumber> accountTwo = ImmutableList.of(new ChildNumber(2, true));
+        final HDPath accountTwo = HDPath.M(new ChildNumber(2, true));
         chain = DeterministicKeyChain.builder().accountPath(accountTwo).entropy(ENTROPY, secs).build();
         DeterministicKey firstReceiveKey = chain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         DeterministicKey secondReceiveKey = chain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);

--- a/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
@@ -32,13 +32,13 @@ import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.KeyChain.KeyPurpose;
 import org.bitcoinj.wallet.listeners.KeyChainEventListener;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Test;
 import org.bouncycastle.crypto.params.KeyParameter;
 
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -162,7 +162,7 @@ public class KeyChainGroupTest {
         ECKey key1 = new ECKey();
         int numKeys = group.numKeys();
         assertFalse(group.removeImportedKey(key1));
-        assertEquals(1, group.importKeys(ImmutableList.of(key1)));
+        assertEquals(1, group.importKeys(Collections.singletonList(key1)));
         assertEquals(numKeys + 1, group.numKeys());   // Lookahead is triggered by requesting a key, so none yet.
         group.removeImportedKey(key1);
         assertEquals(numKeys, group.numKeys());
@@ -294,10 +294,10 @@ public class KeyChainGroupTest {
                 fail();
             } catch (KeyCrypterException e) {
             }
-            group.importKeysAndEncrypt(ImmutableList.of(c), AES_KEY);
+            group.importKeysAndEncrypt(Collections.singletonList(c), AES_KEY);
             ECKey ec = group.findKeyFromPubKey(c.getPubKey());
             try {
-                group.importKeysAndEncrypt(ImmutableList.of(ec), AES_KEY);
+                group.importKeysAndEncrypt(Collections.singletonList(ec), AES_KEY);
                 fail();
             } catch (IllegalArgumentException e) {
             }

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -59,7 +59,6 @@ import org.bitcoinj.wallet.listeners.WalletCoinsReceivedEventListener;
 import org.bitcoinj.wallet.listeners.WalletCoinsSentEventListener;
 import org.easymock.EasyMock;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import org.bitcoinj.wallet.KeyChain.KeyPurpose;
@@ -2049,7 +2048,7 @@ public class WalletTest extends TestWithWallet {
         encryptedWallet.encrypt(PASSWORD1);
 
         final ECKey key = new ECKey();
-        encryptedWallet.importKeysAndEncrypt(ImmutableList.of(key), PASSWORD1);
+        encryptedWallet.importKeysAndEncrypt(Collections.singletonList(key), PASSWORD1);
         assertEquals(1, encryptedWallet.getImportedKeys().size());
         assertEquals(key.getPubKeyPoint(), encryptedWallet.getImportedKeys().get(0).getPubKeyPoint());
         sendMoneyToWallet(encryptedWallet, AbstractBlockChain.NewBlockType.BEST_CHAIN, Coin.COIN, LegacyAddress.fromKey(UNITTEST, key));
@@ -3271,13 +3270,13 @@ public class WalletTest extends TestWithWallet {
             @Override
             public boolean signInputs(ProposedTransaction propTx, KeyBag keyBag) {
                 assertEquals(propTx.partialTx.getInputs().size(), propTx.keyPaths.size());
-                List<ChildNumber> externalZeroLeaf = ImmutableList.<ChildNumber>builder()
-                        .addAll(DeterministicKeyChain.ACCOUNT_ZERO_PATH)
-                        .addAll(DeterministicKeyChain.EXTERNAL_SUBPATH).add(ChildNumber.ZERO).build();
+                HDPath externalZeroLeaf = DeterministicKeyChain.ACCOUNT_ZERO_PATH
+                        .extend(DeterministicKeyChain.EXTERNAL_SUBPATH)
+                        .extend(ChildNumber.ZERO);
                 for (TransactionInput input : propTx.partialTx.getInputs()) {
-                    List<ChildNumber> keypath = propTx.keyPaths.get(input.getConnectedOutput().getScriptPubKey());
+                    HDPath keypath = HDPath.M(propTx.keyPaths.get(input.getConnectedOutput().getScriptPubKey()));
                     assertNotNull(keypath);
-                    assertEquals(externalZeroLeaf, keypath);
+                    assertEquals(externalZeroLeaf.list(), keypath.list());
                 }
                 return true;
             }


### PR DESCRIPTION
Add a `list()` "getter" to HDPath for interoperability and comparison with
standard List<ChildNumber>

Replace remaining usage of Guava ImmutableList in core/test