### PR TITLE
HDPath: deprecate list constructor

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/HDPath.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDPath.java
@@ -53,7 +53,7 @@ public class HDPath extends AbstractList<ChildNumber> {
     protected final List<ChildNumber> unmodifiableList;
 
     /**
-     * Constructs a path for a public or private key.
+     * Constructs a path for a public or private key. Should probably be a private constructor.
      *
      * @param hasPrivateKey Whether it is a path to a private key or not
      * @param list List of children in the path
@@ -67,7 +67,9 @@ public class HDPath extends AbstractList<ChildNumber> {
      * Constructs a path for a public key.
      *
      * @param list List of children in the path
+     * @deprecated Use {@link HDPath#M(List)} or {@link HDPath#m(List)} instead
      */
+    @Deprecated
     public HDPath(List<ChildNumber> list) {
         this(false, list);
     }


### PR DESCRIPTION
This constructor is/was used in HDUtils methods that were deprecated/removed (removed in PR #2392)
The .M(list) and .m(list) factory methods should be used instead.

Also add a mild warning to the (boolean, List) constructor.