### PR TITLE
Wallet.loadFromFile: Add support for WalletAppKit

### DIFF
--- a/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
+++ b/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
@@ -405,17 +405,8 @@ public class WalletAppKit extends AbstractIdleService {
     }
 
     private Wallet loadWallet(boolean shouldReplayWallet) throws Exception {
-        Wallet wallet;
-        try (FileInputStream walletStream = new FileInputStream(vWalletFile)) {
-            List<WalletExtension> extensions = provideWalletExtensions();
-            WalletExtension[] extArray = extensions.toArray(new WalletExtension[extensions.size()]);
-            Protos.Wallet proto = WalletProtobufSerializer.parseToProto(walletStream);
-            final WalletProtobufSerializer serializer = new WalletProtobufSerializer(walletFactory);
-            wallet = serializer.readWallet(params, extArray, proto);
-            if (shouldReplayWallet)
-                wallet.reset();
-        }
-        return wallet;
+        WalletExtension[] extensions = provideWalletExtensions().toArray(new WalletExtension[0]);
+        return Wallet.loadFromFile(vWalletFile, walletFactory, shouldReplayWallet, false, extensions );
     }
 
     protected Wallet createWallet() {

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -1672,7 +1672,7 @@ public class Wallet extends BaseTaggableObject
      * @throws UnreadableWalletException if there was a problem loading or parsing the file
      */
     public static Wallet loadFromFile(File file, @Nullable WalletExtension... walletExtensions) throws UnreadableWalletException {
-        return loadFromFile(file, false, false, walletExtensions);
+        return loadFromFile(file, WalletProtobufSerializer.WalletFactory.DEFAULT, false, false, walletExtensions);
     }
 
     /**
@@ -1680,15 +1680,16 @@ public class Wallet extends BaseTaggableObject
      * deserialized by calling @{@link WalletExtension#deserializeWalletExtension(Wallet, byte[])}}
      *
      * @param file the wallet file to read
+     * @param factory wallet factory
      * @param forceReset force a reset of the wallet
      * @param ignoreMandatoryExtensions if true, mandatory extensions will be ignored instead of causing load errors (not recommended)
      * @param walletExtensions extensions possibly added to the wallet.
      * @return The Wallet
      * @throws UnreadableWalletException if there was a problem loading or parsing the file
      */
-    public static Wallet loadFromFile(File file, boolean forceReset, boolean ignoreMandatoryExtensions, @Nullable WalletExtension... walletExtensions) throws UnreadableWalletException {
+    public static Wallet loadFromFile(File file, WalletProtobufSerializer.WalletFactory factory, boolean forceReset, boolean ignoreMandatoryExtensions, @Nullable WalletExtension... walletExtensions) throws UnreadableWalletException {
         try (FileInputStream stream = new FileInputStream(file)) {
-            return loadFromFileStream(stream, forceReset, ignoreMandatoryExtensions, walletExtensions);
+            return loadFromFileStream(stream, factory, forceReset, ignoreMandatoryExtensions, walletExtensions);
         } catch (IOException e) {
             throw new UnreadableWalletException("Could not open file", e);
         }
@@ -1785,20 +1786,21 @@ public class Wallet extends BaseTaggableObject
      * @throws UnreadableWalletException if there was a problem reading or parsing the stream
      */
     public static Wallet loadFromFileStream(InputStream stream, @Nullable WalletExtension... walletExtensions) throws UnreadableWalletException {
-        return loadFromFileStream(stream, false, false, walletExtensions);
+        return loadFromFileStream(stream, WalletProtobufSerializer.WalletFactory.DEFAULT, false, false, walletExtensions);
     }
 
     /**
      * Returns a wallet deserialized from the given input stream and wallet extensions.
      * @param stream An open InputStream containing a ProtoBuf Wallet
+     * @param factory wallet factory
      * @param forceReset if true, configure wallet to replay transactions from the blockchain
      * @param ignoreMandatoryExtensions if true, mandatory extensions will be ignored instead of causing load errors (not recommended)
      * @param walletExtensions extensions possibly added to the wallet.
      * @return The Wallet
      * @throws UnreadableWalletException if there was a problem reading or parsing the stream
      */
-    public static Wallet loadFromFileStream(InputStream stream, boolean forceReset, boolean ignoreMandatoryExtensions, @Nullable WalletExtension... walletExtensions) throws UnreadableWalletException {
-        WalletProtobufSerializer loader = new WalletProtobufSerializer();
+    public static Wallet loadFromFileStream(InputStream stream,  WalletProtobufSerializer.WalletFactory factory, boolean forceReset, boolean ignoreMandatoryExtensions, @Nullable WalletExtension... walletExtensions) throws UnreadableWalletException {
+        WalletProtobufSerializer loader = new WalletProtobufSerializer(factory);
         if (ignoreMandatoryExtensions) {
             loader.setRequireMandatoryExtensions(false);
         }

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -421,7 +421,7 @@ public class WalletTool implements Callable<Integer> {
                 || (action == ActionEnum.SYNC
                 && force);
         try {
-            wallet = Wallet.loadFromFile(walletFile, forceReset, ignoreMandatoryExtensions);
+            wallet = Wallet.loadFromFile(walletFile, WalletProtobufSerializer.WalletFactory.DEFAULT, forceReset, ignoreMandatoryExtensions);
         } catch (UnreadableWalletException e) {
             System.err.println("Failed to load wallet '" + walletFile + "': " + e.getMessage());
             e.printStackTrace();


### PR DESCRIPTION
* Add WalletFactory parameter to support WalletAppKit
* Simplify WalletAppKit by using the Wallet.loadFromFile
* Update WalletTool to pass WalletFactory.DEFAULT