### PR TITLE
Remove unnecessary type info on Collections.emptyList() calls

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/HDPath.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDPath.java
@@ -95,7 +95,7 @@ public class HDPath extends AbstractList<ChildNumber> {
      * Returns an empty path for a public key.
      */
     public static HDPath M() {
-        return HDPath.M(Collections.<ChildNumber>emptyList());
+        return HDPath.M(Collections.emptyList());
     }
 
     /**
@@ -129,7 +129,7 @@ public class HDPath extends AbstractList<ChildNumber> {
      * Returns an empty path for a private key.
      */
     public static HDPath m() {
-        return HDPath.m(Collections.<ChildNumber>emptyList());
+        return HDPath.m(Collections.emptyList());
     }
 
     /**

--- a/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -840,7 +840,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
 
     @Test
     public void testMaxOfMostFreq() {
-        assertEquals(0, PeerGroup.maxOfMostFreq(Collections.<Integer>emptyList()));
+        assertEquals(0, PeerGroup.maxOfMostFreq(Collections.emptyList()));
         assertEquals(0, PeerGroup.maxOfMostFreq(Arrays.asList(0, 0, 1)));
         assertEquals(3, PeerGroup.maxOfMostFreq(Arrays.asList(1, 3, 1, 2, 2, 3, 3)));
         assertEquals(0, PeerGroup.maxOfMostFreq(Arrays.asList(1, 1, 2, 2)));

--- a/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
@@ -29,14 +29,14 @@ import java.util.List;
 public class HDPathTest {
     @Test
     public void testPrimaryConstructor() {
-        HDPath path = new HDPath(true, Collections.<ChildNumber>emptyList());
+        HDPath path = new HDPath(true, Collections.emptyList());
         Assert.assertTrue("Has private key returns false incorrectly", path.hasPrivateKey);
         Assert.assertEquals("Path not empty", path.size(), 0);
     }
 
     @Test
     public void testExtendVarargs() {
-        HDPath basePath = new HDPath(true, Collections.<ChildNumber>emptyList());
+        HDPath basePath = new HDPath(true, Collections.emptyList());
         // Make sure we can do a depth of 5 as per BIP44, etc.
         // m / 44' / coinType' / accountIndex' / change / addressIndex
         HDPath path1 = basePath.extend(ChildNumber.ZERO_HARDENED);

--- a/core/src/test/java/org/bitcoinj/store/SPVBlockStoreTest.java
+++ b/core/src/test/java/org/bitcoinj/store/SPVBlockStoreTest.java
@@ -146,7 +146,7 @@ public class SPVBlockStoreTest {
         for (int i = 0; i < ITERATIONS; i++) {
             // Using i as the nonce so that the block hashes are different.
             Block block = new Block(UNITTEST, 0, Sha256Hash.ZERO_HASH, Sha256Hash.ZERO_HASH, 0, 0, i,
-                    Collections.<Transaction> emptyList());
+                    Collections.emptyList());
             StoredBlock b = new StoredBlock(block, BigInteger.ZERO, i);
             store.put(b);
             store.setChainHead(b);


### PR DESCRIPTION
I believe this was made unnecessary by Java 8+