### PR TITLE
CoinSelection: make fields final (minor breaking)

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/CoinSelection.java
+++ b/core/src/main/java/org/bitcoinj/wallet/CoinSelection.java
@@ -30,8 +30,8 @@ import java.util.List;
  * to their varying policies.
  */
 public class CoinSelection {
-    public Coin valueGathered;
-    public Collection<TransactionOutput> gathered;
+    public final Coin valueGathered;
+    public final Collection<TransactionOutput> gathered;
 
     public CoinSelection(Coin valueGathered, Collection<TransactionOutput> gathered) {
         this.valueGathered = valueGathered;


### PR DESCRIPTION
This could be breaking if anyone is setting these fields directly, but they really shouldn't be doing that. Making these fields immutable is a good practice and also a first step towards other possible improvements to `CoinSelector` and `CoinSelection`