### PR TITLE
BIP32Test: Use HDPath

### DIFF
--- a/core/src/test/java/org/bitcoinj/crypto/BIP32Test.java
+++ b/core/src/test/java/org/bitcoinj/crypto/BIP32Test.java
@@ -47,31 +47,31 @@ public class BIP32Test {
                     Arrays.asList(
                             new HDWTestVector.DerivedTestCase(
                                     "Test1 m/0H",
-                                    new ChildNumber[]{new ChildNumber(0, true)},
+                                    HDPath.m(new ChildNumber(0, true)),
                                     "xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7",
                                     "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw"
                             ),
                             new HDWTestVector.DerivedTestCase(
                                     "Test1 m/0H/1",
-                                    new ChildNumber[]{new ChildNumber(0, true), new ChildNumber(1, false)},
+                                    HDPath.m(new ChildNumber(0, true), new ChildNumber(1, false)),
                                     "xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLnvSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs",
                                     "xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ"
                             ),
                             new HDWTestVector.DerivedTestCase(
                                     "Test1 m/0H/1/2H",
-                                    new ChildNumber[]{new ChildNumber(0, true), new ChildNumber(1, false), new ChildNumber(2, true)},
+                                    HDPath.m(new ChildNumber(0, true), new ChildNumber(1, false), new ChildNumber(2, true)),
                                     "xprv9z4pot5VBttmtdRTWfWQmoH1taj2axGVzFqSb8C9xaxKymcFzXBDptWmT7FwuEzG3ryjH4ktypQSAewRiNMjANTtpgP4mLTj34bhnZX7UiM",
                                     "xpub6D4BDPcP2GT577Vvch3R8wDkScZWzQzMMUm3PWbmWvVJrZwQY4VUNgqFJPMM3No2dFDFGTsxxpG5uJh7n7epu4trkrX7x7DogT5Uv6fcLW5"
                             ),
                             new HDWTestVector.DerivedTestCase(
                                     "Test1 m/0H/1/2H/2",
-                                    new ChildNumber[]{new ChildNumber(0, true), new ChildNumber(1, false), new ChildNumber(2, true), new ChildNumber(2, false)},
+                                    HDPath.m(new ChildNumber(0, true), new ChildNumber(1, false), new ChildNumber(2, true), new ChildNumber(2, false)),
                                     "xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334",
                                     "xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV"
                             ),
                             new HDWTestVector.DerivedTestCase(
                                     "Test1 m/0H/1/2H/2/1000000000",
-                                    new ChildNumber[]{new ChildNumber(0, true), new ChildNumber(1, false), new ChildNumber(2, true), new ChildNumber(2, false), new ChildNumber(1000000000, false)},
+                                    HDPath.m(new ChildNumber(0, true), new ChildNumber(1, false), new ChildNumber(2, true), new ChildNumber(2, false), new ChildNumber(1000000000, false)),
                                     "xprvA41z7zogVVwxVSgdKUHDy1SKmdb533PjDz7J6N6mV6uS3ze1ai8FHa8kmHScGpWmj4WggLyQjgPie1rFSruoUihUZREPSL39UNdE3BBDu76",
                                     "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy"
                             )
@@ -84,31 +84,31 @@ public class BIP32Test {
                     Arrays.asList(
                             new HDWTestVector.DerivedTestCase(
                                     "Test2 m/0",
-                                    new ChildNumber[]{new ChildNumber(0, false)},
+                                    HDPath.m(new ChildNumber(0, false)),
                                     "xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt",
                                     "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH"
                             ),
                             new HDWTestVector.DerivedTestCase(
                                     "Test2 m/0/2147483647H",
-                                    new ChildNumber[]{new ChildNumber(0, false), new ChildNumber(2147483647, true)},
+                                    HDPath.m(new ChildNumber(0, false), new ChildNumber(2147483647, true)),
                                     "xprv9wSp6B7kry3Vj9m1zSnLvN3xH8RdsPP1Mh7fAaR7aRLcQMKTR2vidYEeEg2mUCTAwCd6vnxVrcjfy2kRgVsFawNzmjuHc2YmYRmagcEPdU9",
                                     "xpub6ASAVgeehLbnwdqV6UKMHVzgqAG8Gr6riv3Fxxpj8ksbH9ebxaEyBLZ85ySDhKiLDBrQSARLq1uNRts8RuJiHjaDMBU4Zn9h8LZNnBC5y4a"
                             ),
                             new HDWTestVector.DerivedTestCase(
                                     "Test2 m/0/2147483647H/1",
-                                    new ChildNumber[]{new ChildNumber(0, false), new ChildNumber(2147483647, true), new ChildNumber(1, false)},
+                                    HDPath.m(new ChildNumber(0, false), new ChildNumber(2147483647, true), new ChildNumber(1, false)),
                                     "xprv9zFnWC6h2cLgpmSA46vutJzBcfJ8yaJGg8cX1e5StJh45BBciYTRXSd25UEPVuesF9yog62tGAQtHjXajPPdbRCHuWS6T8XA2ECKADdw4Ef",
                                     "xpub6DF8uhdarytz3FWdA8TvFSvvAh8dP3283MY7p2V4SeE2wyWmG5mg5EwVvmdMVCQcoNJxGoWaU9DCWh89LojfZ537wTfunKau47EL2dhHKon"
                             ),
                             new HDWTestVector.DerivedTestCase(
                                     "Test2 m/0/2147483647H/1/2147483646H",
-                                    new ChildNumber[]{new ChildNumber(0, false), new ChildNumber(2147483647, true), new ChildNumber(1, false), new ChildNumber(2147483646, true)},
+                                    HDPath.m(new ChildNumber(0, false), new ChildNumber(2147483647, true), new ChildNumber(1, false), new ChildNumber(2147483646, true)),
                                     "xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc",
                                     "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL"
                             ),
                             new HDWTestVector.DerivedTestCase(
                                     "Test2 m/0/2147483647H/1/2147483646H/2",
-                                    new ChildNumber[]{new ChildNumber(0, false), new ChildNumber(2147483647, true), new ChildNumber(1, false), new ChildNumber(2147483646, true), new ChildNumber(2, false)},
+                                    HDPath.m(new ChildNumber(0, false), new ChildNumber(2147483647, true), new ChildNumber(1, false), new ChildNumber(2147483646, true), new ChildNumber(2, false)),
                                     "xprvA2nrNbFZABcdryreWet9Ea4LvTJcGsqrMzxHx98MMrotbir7yrKCEXw7nadnHM8Dq38EGfSh6dqA9QWTyefMLEcBYJUuekgW4BYPJcr9E7j",
                                     "xpub6FnCn6nSzZAw5Tw7cgR9bi15UV96gLZhjDstkXXxvCLsUXBGXPdSnLFbdpq8p9HmGsApME5hQTZ3emM2rnY5agb9rXpVGyy3bdW6EEgAtqt"
                             )
@@ -121,7 +121,7 @@ public class BIP32Test {
                     Arrays.asList(
                             new HDWTestVector.DerivedTestCase(
                                     "Test3 m/0H",
-                                    new ChildNumber[]{new ChildNumber(0, true)},
+                                    HDPath.m(new ChildNumber(0, true)),
                                     "xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L",
                                     "xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y"
                             )
@@ -134,13 +134,13 @@ public class BIP32Test {
                     Arrays.asList(
                             new HDWTestVector.DerivedTestCase(
                                     "Test4 m/0H",
-                                    new ChildNumber[]{new ChildNumber(0, true)},
+                                    HDPath.m(new ChildNumber(0, true)),
                                     "xprv9vB7xEWwNp9kh1wQRfCCQMnZUEG21LpbR9NPCNN1dwhiZkjjeGRnaALmPXCX7SgjFTiCTT6bXes17boXtjq3xLpcDjzEuGLQBM5ohqkao9G",
                                     "xpub69AUMk3qDBi3uW1sXgjCmVjJ2G6WQoYSnNHyzkmdCHEhSZ4tBok37xfFEqHd2AddP56Tqp4o56AePAgCjYdvpW2PU2jbUPFKsav5ut6Ch1m"
                             ),
                             new HDWTestVector.DerivedTestCase(
                                     "Test4 m/0H/1H",
-                                    new ChildNumber[]{new ChildNumber(0, true), new ChildNumber(1, true)},
+                                    HDPath.m(new ChildNumber(0, true), new ChildNumber(1, true)),
                                     "xprv9xJocDuwtYCMNAo3Zw76WENQeAS6WGXQ55RCy7tDJ8oALr4FWkuVoHJeHVAcAqiZLE7Je3vZJHxspZdFHfnBEjHqU5hG1Jaj32dVoS6XLT1",
                                     "xpub6BJA1jSqiukeaesWfxe6sNK9CCGaujFFSJLomWHprUL9DePQ4JDkM5d88n49sMGJxrhpjazuXYWdMf17C9T5XnxkopaeS7jGk1GyyVziaMt"
                             )
@@ -178,9 +178,9 @@ public class BIP32Test {
         for (int i = 0; i < tv.derived.size(); i++) {
             HDWTestVector.DerivedTestCase tc = tv.derived.get(i);
             log.info("{}", tc.name);
-            assertEquals(tc.name, String.format(Locale.US, "Test%d %s", testCase + 1, tc.getPathDescription()));
-            int depth = tc.path.length - 1;
-            DeterministicKey ehkey = dh.deriveChild(Arrays.asList(tc.path).subList(0, depth), false, true, tc.path[depth]);
+            assertEquals(tc.name, String.format(Locale.US, "Test%d %s", testCase + 1, tc.path));
+            int depth = tc.path.size() - 1;
+            DeterministicKey ehkey = dh.deriveChild(tc.path.subList(0, depth), false, true, tc.path.get(depth));
             assertEquals(testEncode(tc.priv), testEncode(ehkey.serializePrivB58(MAINNET)));
             assertEquals(testEncode(tc.pub), testEncode(ehkey.serializePubB58(MAINNET)));
         }
@@ -205,19 +205,15 @@ public class BIP32Test {
 
         static class DerivedTestCase {
             final String name;
-            final ChildNumber[] path;
+            final HDPath path;
             final String pub;
             final String priv;
 
-            DerivedTestCase(String name, ChildNumber[] path, String priv, String pub) {
+            DerivedTestCase(String name, HDPath path, String priv, String pub) {
                 this.name = name;
                 this.path = path;
                 this.pub = pub;
                 this.priv = priv;
-            }
-
-            String getPathDescription() {
-                return "m/" + InternalUtils.joiner("/").join(Arrays.asList(path));
             }
         }
     }


### PR DESCRIPTION
Use HDPath to simplify the tests and also be more consistent in using HDPath.