### PR TITLE
All modules: add detailed deprecation warnings

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -34,6 +34,7 @@ javadoc.options.encoding = 'UTF-8'
 
 compileJava {
     options.compilerArgs.addAll(['--release', '8'])
+    options.compilerArgs << '-Xlint:deprecation'
 }
 
 protobuf {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -16,4 +16,5 @@ javadoc.options.encoding = 'UTF-8'
 
 compileJava {
     options.compilerArgs.addAll(['--release', '11'])
+    options.compilerArgs << '-Xlint:deprecation'
 }

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -17,6 +17,10 @@ compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
 javadoc.options.encoding = 'UTF-8'
 
+compileJava {
+    options.compilerArgs << '-Xlint:deprecation'
+}
+
 test {
     useJUnitPlatform()
 }

--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -16,6 +16,7 @@ javadoc.options.encoding = 'UTF-8'
 
 compileJava {
     options.compilerArgs.addAll(['--release', '11'])
+    options.compilerArgs << '-Xlint:deprecation'
 }
 
 task build_checkpoints(type: JavaExec) {

--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -24,6 +24,7 @@ javadoc.options.encoding = 'UTF-8'
 
 compileJava {
     options.compilerArgs.addAll(['--release', '11'])
+    options.compilerArgs << '-Xlint:deprecation'
 }
 
 mainClassName = 'wallettemplate.Main'

--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -35,6 +35,7 @@ javadoc.options.encoding = 'UTF-8'
 
 compileJava {
     options.compilerArgs.addAll(['--release', '11'])
+    options.compilerArgs << '-Xlint:deprecation'
 }
 
 mainClassName = "org.bitcoinj.wallettool.WalletTool"


### PR DESCRIPTION
The only module with deprecation warnings is `core` and it has two:

1. `AbstractPeerDataEventListener` which is fixed in PR #2213.
2. `getObject() in ASN1TaggedObject` which we should try to fix. I took a quick look, but I'm not knowledgable enough on ASN1 to know how to fix it.

Given that we only have 1 deprecation warning (after PR #2213 is merged) we should display it to remind us to fix it and make it more obvious if another deprecation occurs.