### PR TITLE
Wallet: remove deprecated constructor

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -318,18 +318,6 @@ public class Wallet extends BaseTaggableObject
     }
 
     /**
-     * Creates a new, empty wallet with a randomly chosen seed and no transactions. Make sure to provide for sufficient
-     * backup! Any keys will be derived from the seed. If you want to restore a wallet from disk instead, see
-     * {@link #loadFromFile}.
-     * @deprecated Use {@link #createDeterministic(Context, ScriptType)}
-     */
-    @Deprecated
-    @VisibleForTesting
-    protected Wallet(Context context) {
-        this(context, KeyChainGroup.builder(context.getParams()).fromRandom(Script.ScriptType.P2PKH).build());
-    }
-
-    /**
      * Creates a new, empty wallet with just a basic keychain and no transactions. No deterministic chains will be created
      * automatically. This is meant for when you just want to import a few keys and operate on them.
      * @param params network parameters
@@ -443,6 +431,13 @@ public class Wallet extends BaseTaggableObject
             throw new IllegalArgumentException(base58.substring(0, 4));
     }
 
+    /**
+     * Creates a new, empty wallet with a randomly chosen seed and no transactions. Make sure to provide for sufficient
+     * backup! Any keys will be derived from the seed. If you want to restore a wallet from disk instead, see
+     * {@link #loadFromFile}.
+     * @param params network parameters
+     * @param keyChainGroup keychain group to manage keychains
+     */
     public Wallet(NetworkParameters params, KeyChainGroup keyChainGroup) {
         this(Context.getOrCreate(params), keyChainGroup);
     }

--- a/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
@@ -25,6 +25,7 @@ import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.testing.FakeTxBuilder;
 import org.bitcoinj.utils.BriefLogFormatter;
+import org.bitcoinj.wallet.KeyChainGroup;
 import org.bitcoinj.wallet.Wallet;
 import org.bitcoinj.wallet.Wallet.BalanceType;
 
@@ -80,7 +81,8 @@ public class BlockChainTest {
         Context.propagate(new Context(TESTNET, 100, Coin.ZERO, false));
         testNetChain = new BlockChain(TESTNET, Wallet.createDeterministic(TESTNET, Script.ScriptType.P2PKH), new MemoryBlockStore(TESTNET));
         Context.propagate(new Context(UNITTEST, 100, Coin.ZERO, false));
-        wallet = new Wallet(Context.get()) {
+        NetworkParameters params = Context.get().getParams();
+        wallet = new Wallet(params, KeyChainGroup.builder(params).fromRandom(Script.ScriptType.P2PKH).build()) {
             @Override
             public void receiveFromBlock(Transaction tx, StoredBlock block, BlockChain.NewBlockType blockType,
                                          int relativityOffset) throws VerificationException {


### PR DESCRIPTION
Also: Update unit test that used that constructor, add JavaDoc to replacement constructor.