### PR TITLE
DeterministicKeyChain: remove SuppressWarnings(PublicStaticCollectionField)

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -96,7 +96,6 @@ import static java.util.stream.Collectors.toList;
  * 
  * @author Andreas Schildbach
  */
-@SuppressWarnings("PublicStaticCollectionField")
 public class DeterministicKeyChain implements EncryptableKeyChain {
     private static final Logger log = LoggerFactory.getLogger(DeterministicKeyChain.class);
     protected final ReentrantLock lock = Threading.lock(DeterministicKeyChain.class);


### PR DESCRIPTION
The warning is no longer present so we don't need to suppress.