### PR TITLE
Wallet: deprecate public serializeKeyChainGroupToProtobuf()

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -1438,9 +1438,13 @@ public class Wallet extends BaseTaggableObject
 
     //region Serialization support
 
-    // TODO: Make this package private once the classes finish moving around.
-    /** Internal use only. */
+    @Deprecated
     public List<Protos.Key> serializeKeyChainGroupToProtobuf() {
+        return serializeKeyChainGroupToProtobufInternal();
+    }
+
+    /** Internal use only. */
+    List<Protos.Key> serializeKeyChainGroupToProtobufInternal() {
         keyChainGroupLock.lock();
         try {
             return keyChainGroup.serializeToProtobuf();

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -180,7 +180,7 @@ public class WalletProtobufSerializer {
             walletBuilder.addTransaction(txProto);
         }
 
-        walletBuilder.addAllKey(wallet.serializeKeyChainGroupToProtobuf());
+        walletBuilder.addAllKey(wallet.serializeKeyChainGroupToProtobufInternal());
 
         for (Script script : wallet.getWatchedScripts()) {
             Protos.Script protoScript =


### PR DESCRIPTION
package-private `serializeKeyChainGroupToProtobufInternal()` remains for internal use.