### PR TITLE
Simplify KeyChain serialization with Streams

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -758,18 +758,25 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
     //
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+    /**
+     * Serialize to a list of keys
+     * @return A list of keys (treat as unmodifiable list, will change in future release)
+     */
     @Override
     public List<Protos.Key> serializeToProtobuf() {
-        List<Protos.Key> result = new ArrayList<>();
         lock.lock();
         try {
-            result.addAll(serializeMyselfToProtobuf());
+            // TODO: return unmodifiable list
+            return serializeMyselfToProtobuf();
         } finally {
             lock.unlock();
         }
-        return result;
     }
 
+    /**
+     * Serialize to a list of keys. Does not use {@code lock}, expects caller to provide locking.
+     * @return A list of keys (treat as unmodifiable list, will change in future release)
+     */
     protected List<Protos.Key> serializeMyselfToProtobuf() {
         // Most of the serialization work is delegated to the basic key chain, which will serialize the bulk of the
         // data (handling encryption along the way), and letting us patch it up with the extra data we care about.
@@ -814,6 +821,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
             }
             entries.add(proto.build());
         }
+        // TODO: return unmodifiable list
         return entries;
     }
 

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChain.java
@@ -51,7 +51,10 @@ public interface KeyChain {
     /** Obtains a key intended for the given purpose. The chain may create a new key, derive one, or re-use an old one. */
     ECKey getKey(KeyPurpose purpose);
 
-    /** Returns a list of keys serialized to the bitcoinj protobuf format. */
+    /**
+     * Return a list of keys serialized to the bitcoinj protobuf format.
+     * @return list of keys (treat as unmodifiable list)
+     */
     List<Protos.Key> serializeToProtobuf();
 
     /** Adds a listener for events that are run when keys are added, on the user thread. */


### PR DESCRIPTION
In 5 related KeyChain classes:

* Convert serialization to use Streams
* Add JavaDoc
* Warn that returned lists/maps will become unmodifiable in the future