### PR TITLE
Network.java: remove PROD (alias for MAIN)

### DIFF
--- a/core/src/main/java/org/bitcoinj/utils/Network.java
+++ b/core/src/main/java/org/bitcoinj/utils/Network.java
@@ -23,7 +23,6 @@ import org.bitcoinj.core.NetworkParameters;
  */
 public enum Network {
     MAIN(NetworkParameters.ID_MAINNET),
-    PROD(NetworkParameters.ID_MAINNET), // alias for MAIN
     TEST(NetworkParameters.ID_TESTNET),
     SIGNET(NetworkParameters.ID_SIGNET),
     REGTEST(NetworkParameters.ID_REGTEST);

--- a/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
@@ -78,7 +78,6 @@ public class BuildCheckpoints implements Callable<Integer> {
 
         switch (net) {
             case MAIN:
-            case PROD:
                 suffix = "";
                 break;
             case TEST:

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -373,7 +373,6 @@ public class WalletTool implements Callable<Integer> {
         String fileName;
         switch (net) {
             case MAIN:
-            case PROD:
                 fileName = "mainnet.chain";
                 break;
             case TEST:


### PR DESCRIPTION
This will affect the command-line UI of some tools, but since the
`Network` enum hasn't been released yet, we can remove it without deprecating 
first.