### PR TITLE
KeyChainGroupStructure: add BIP32 constant, DEFAULT = BIP32

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroupStructure.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroupStructure.java
@@ -68,10 +68,10 @@ public interface KeyChainGroupStructure {
 
 
     /**
-     * Default {@link KeyChainGroupStructure} implementation. Based on BIP32 "Wallet structure".
-     * For this structure network is ignored
+     * Original <b>bitcoinj</b> {@link KeyChainGroupStructure} implementation. Based on BIP32 "Wallet structure".
+     * For this structure {@code network} is ignored
      */
-    KeyChainGroupStructure DEFAULT = (outputScriptType, network) -> {
+    KeyChainGroupStructure BIP32 = (outputScriptType, network) -> {
         // network is ignored
         if (outputScriptType == null || outputScriptType == Script.ScriptType.P2PKH)
             return DeterministicKeyChain.ACCOUNT_ZERO_PATH;
@@ -87,6 +87,11 @@ public interface KeyChainGroupStructure {
      */
     KeyChainGroupStructure BIP43 = (outputScriptType, network) ->
             purpose(outputScriptType).extend(coinType(network), account(0));
+
+    /**
+     * Default {@link KeyChainGroupStructure} implementation. Alias for {@link KeyChainGroupStructure#BIP32}
+     */
+    KeyChainGroupStructure DEFAULT = BIP32;
 
     /**
      * Return the (root) path containing "purpose" for the specified scriptType


### PR DESCRIPTION
KeyChainGroupStructure:

* rename `DEFAULT` to `BIP32`
* add `DEFAULT = BIP32`

This will allow code to be more clear as to what it intends to use, and potentially allows us to deprecated `DEFAULT` in the future.