### PR TITLE
Deprecate KeyChainGroupStructure.DEFAULT

### DIFF
--- a/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
+++ b/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
@@ -133,7 +133,7 @@ public class WalletAppKit extends AbstractIdleService {
         this.context = context;
         this.params = checkNotNull(context.getParams());
         this.preferredOutputScriptType = checkNotNull(preferredOutputScriptType);
-        this.structure = structure != null ? structure : KeyChainGroupStructure.DEFAULT;
+        this.structure = structure != null ? structure : KeyChainGroupStructure.BIP32;
         this.directory = checkNotNull(directory);
         this.filePrefix = checkNotNull(filePrefix);
     }

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
@@ -255,7 +255,7 @@ public class KeyChainGroup implements KeyBag {
     }
 
     public static KeyChainGroup.Builder builder(NetworkParameters params) {
-        return new Builder(params, KeyChainGroupStructure.DEFAULT);
+        return new Builder(params, KeyChainGroupStructure.BIP32);
     }
 
     public static KeyChainGroup.Builder builder(NetworkParameters params, KeyChainGroupStructure structure) {

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroupStructure.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroupStructure.java
@@ -25,7 +25,7 @@ import org.bitcoinj.utils.Network;
 /**
  *  Defines a structure for hierarchical deterministic wallets.
  *  <p>
- *  Use {@link KeyChainGroupStructure#DEFAULT} for BIP-32 wallets and {@link KeyChainGroupStructure#BIP43} for
+ *  Use {@link KeyChainGroupStructure#BIP32} for BIP-32 wallets and {@link KeyChainGroupStructure#BIP43} for
  *  BIP-43-family wallets.
  *  <p>
  *  <b>bitcoinj</b> BIP-32 wallets use {@link DeterministicKeyChain#ACCOUNT_ZERO_PATH} for {@link Script.ScriptType#P2PKH}
@@ -90,7 +90,9 @@ public interface KeyChainGroupStructure {
 
     /**
      * Default {@link KeyChainGroupStructure} implementation. Alias for {@link KeyChainGroupStructure#BIP32}
+     * @deprecated Use {@link #BIP32} for BIP-32
      */
+    @Deprecated
     KeyChainGroupStructure DEFAULT = BIP32;
 
     /**

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -334,7 +334,7 @@ public class Wallet extends BaseTaggableObject
      */
     public static Wallet fromSeed(NetworkParameters params, DeterministicSeed seed,
             Script.ScriptType outputScriptType) {
-        return fromSeed(params, seed, outputScriptType, KeyChainGroupStructure.DEFAULT);
+        return fromSeed(params, seed, outputScriptType, KeyChainGroupStructure.BIP32);
     }
 
     /**
@@ -718,7 +718,7 @@ public class Wallet extends BaseTaggableObject
      */
     public void upgradeToDeterministic(Script.ScriptType outputScriptType, @Nullable KeyParameter aesKey)
             throws DeterministicUpgradeRequiresPassword {
-        upgradeToDeterministic(outputScriptType, KeyChainGroupStructure.DEFAULT, aesKey);
+        upgradeToDeterministic(outputScriptType, KeyChainGroupStructure.BIP32, aesKey);
     }
 
     /**
@@ -5301,7 +5301,7 @@ public class Wallet extends BaseTaggableObject
      */
     public ListenableCompletableFuture<List<Transaction>> doMaintenance(@Nullable KeyParameter aesKey, boolean signAndSend)
             throws DeterministicUpgradeRequiresPassword {
-        return doMaintenance(KeyChainGroupStructure.DEFAULT, aesKey, signAndSend);
+        return doMaintenance(KeyChainGroupStructure.BIP32, aesKey, signAndSend);
     }
 
     /**

--- a/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
@@ -552,7 +552,7 @@ public class KeyChainGroupTest {
         group = KeyChainGroup.builder(MAINNET).fromRandom(Script.ScriptType.P2PKH).lookaheadSize(LOOKAHEAD_SIZE).build();
 
         List<Protos.Key> protobufs = group.serializeToProtobuf();
-        group.upgradeToDeterministic(Script.ScriptType.P2PKH, KeyChainGroupStructure.DEFAULT, 0, null);
+        group.upgradeToDeterministic(Script.ScriptType.P2PKH, KeyChainGroupStructure.BIP32, 0, null);
         assertFalse(group.isEncrypted());
         assertFalse(group.isDeterministicUpgradeRequired(Script.ScriptType.P2PKH, 0));
         assertTrue(group.isDeterministicUpgradeRequired(Script.ScriptType.P2WPKH, 0));
@@ -561,7 +561,7 @@ public class KeyChainGroupTest {
         assertNotNull(seed1);
 
         group = KeyChainGroup.fromProtobufUnencrypted(MAINNET, protobufs);
-        group.upgradeToDeterministic(Script.ScriptType.P2PKH, KeyChainGroupStructure.DEFAULT, 0, null);  // Should give same result as last time.
+        group.upgradeToDeterministic(Script.ScriptType.P2PKH, KeyChainGroupStructure.BIP32, 0, null);  // Should give same result as last time.
         assertFalse(group.isEncrypted());
         assertFalse(group.isDeterministicUpgradeRequired(Script.ScriptType.P2PKH, 0));
         assertTrue(group.isDeterministicUpgradeRequired(Script.ScriptType.P2WPKH, 0));

--- a/integration-test/src/test/java/org/bitcoinj/wallet/WalletAccountPathTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/wallet/WalletAccountPathTest.java
@@ -37,7 +37,7 @@ import static org.bitcoinj.script.Script.ScriptType.P2WPKH;
 import static org.bitcoinj.utils.Network.MAIN;
 import static org.bitcoinj.utils.Network.TEST;
 import static org.bitcoinj.wallet.KeyChainGroupStructure.BIP43;
-import static org.bitcoinj.wallet.KeyChainGroupStructure.DEFAULT;
+import static org.bitcoinj.wallet.KeyChainGroupStructure.BIP32;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -68,10 +68,10 @@ public class WalletAccountPathTest {
     private static Stream<Arguments> walletStructureParams() {
         return Stream.of(
             // Note: For BIP32 wallets the Network does not affect the path
-            Arguments.of(DEFAULT, "M/0H", P2PKH,  MAIN),
-            Arguments.of(DEFAULT, "M/0H", P2PKH,  TEST),
-            Arguments.of(DEFAULT, "M/1H", P2WPKH, MAIN),
-            Arguments.of(DEFAULT, "M/1H", P2WPKH, TEST),
+            Arguments.of(BIP32, "M/0H", P2PKH,  MAIN),
+            Arguments.of(BIP32, "M/0H", P2PKH,  TEST),
+            Arguments.of(BIP32, "M/1H", P2WPKH, MAIN),
+            Arguments.of(BIP32, "M/1H", P2WPKH, TEST),
             Arguments.of(BIP43, "M/44H/0H/0H", P2PKH, MAIN),
             Arguments.of(BIP43, "M/44H/1H/0H", P2PKH, TEST),
             Arguments.of(BIP43, "M/84H/0H/0H", P2WPKH, MAIN),


### PR DESCRIPTION
Deprecated DEFAULT and use BIP32 internally where DEFAULT had been used before. 

This makes the code more clear. I think it makes sense to be explicit when specifying a KeyChainGroupStructure and not have a DEFAULT symbol (which sort of implies the default might change.)

Various constructors, static constructors and builders having a default is OK, but it should say `BIP32` in the code. Perhaps in the future we might choose to deprecate some of them, but I don't think we should do that in this release.