### PR TITLE
Wallet: add createDeterministic() overload with KeyChainGroupStructure parameter

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -302,19 +302,48 @@ public class Wallet extends BaseTaggableObject
      * {@link #loadFromFile}.
      * @param params network parameters
      * @param outputScriptType type of addresses (aka output scripts) to generate for receiving
+     * @return A new empty wallet
      */
     public static Wallet createDeterministic(NetworkParameters params, Script.ScriptType outputScriptType) {
-        return createDeterministic(Context.getOrCreate(params), outputScriptType);
+        return createDeterministic(Context.getOrCreate(params), outputScriptType, KeyChainGroupStructure.BIP32);
     }
 
     /**
      * Creates a new, empty wallet with a randomly chosen seed and no transactions. Make sure to provide for sufficient
      * backup! Any keys will be derived from the seed. If you want to restore a wallet from disk instead, see
      * {@link #loadFromFile}.
+     * @param params network parameters
      * @param outputScriptType type of addresses (aka output scripts) to generate for receiving
+     * @param keyChainGroupStructure structure (e.g. BIP43)
+     * @return A new empty wallet
+     */
+    public static Wallet createDeterministic(NetworkParameters params, Script.ScriptType outputScriptType, KeyChainGroupStructure keyChainGroupStructure) {
+        return createDeterministic(Context.getOrCreate(params), outputScriptType, keyChainGroupStructure);
+    }
+
+    /**
+     * Creates a new, empty wallet with a randomly chosen seed and no transactions. Make sure to provide for sufficient
+     * backup! Any keys will be derived from the seed. If you want to restore a wallet from disk instead, see
+     * {@link #loadFromFile}.
+     * @param context bitcoinj context
+     * @param outputScriptType type of addresses (aka output scripts) to generate for receiving
+     * @return A new empty wallet
      */
     public static Wallet createDeterministic(Context context, Script.ScriptType outputScriptType) {
-        return new Wallet(context, KeyChainGroup.builder(context.getParams()).fromRandom(outputScriptType).build());
+        return createDeterministic(context, outputScriptType, KeyChainGroupStructure.BIP32);
+    }
+
+    /**
+     * Creates a new, empty wallet with a randomly chosen seed and no transactions. Make sure to provide for sufficient
+     * backup! Any keys will be derived from the seed. If you want to restore a wallet from disk instead, see
+     * {@link #loadFromFile}.
+     * @param context bitcoinj context
+     * @param outputScriptType type of addresses (aka output scripts) to generate for receiving
+     * @param keyChainGroupStructure structure (e.g. BIP43)
+     * @return A new empty wallet
+     */
+    public static Wallet createDeterministic(Context context, Script.ScriptType outputScriptType, KeyChainGroupStructure keyChainGroupStructure) {
+        return new Wallet(context, KeyChainGroup.builder(context.getParams(), keyChainGroupStructure).fromRandom(outputScriptType).build());
     }
 
     /**

--- a/core/src/test/java/org/bitcoinj/testing/TestWithWallet.java
+++ b/core/src/test/java/org/bitcoinj/testing/TestWithWallet.java
@@ -33,6 +33,7 @@ import org.bitcoinj.script.Script;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.utils.BriefLogFormatter;
+import org.bitcoinj.wallet.KeyChainGroupStructure;
 import org.bitcoinj.wallet.Wallet;
 import org.junit.BeforeClass;
 
@@ -69,7 +70,7 @@ public class TestWithWallet {
     public void setUp() throws Exception {
         BriefLogFormatter.init();
         Context.propagate(new Context(UNITTEST, 100, Coin.ZERO, false));
-        wallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        wallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH, KeyChainGroupStructure.BIP32);
         myKey = wallet.freshReceiveKey();
         myAddress = wallet.freshReceiveAddress(Script.ScriptType.P2PKH);
         blockStore = new MemoryBlockStore(UNITTEST);


### PR DESCRIPTION
Add `Wallet.createDeterministic()` overload with KeyChainGroupStructure parameter and update `setUp()` in `TestWithWallet` to make sure it is used in some tests. (And to remind us that we need to work on parameterizing tests with structure and scriptType parameters)