### PR TITLE
Move FakeTxBuilder from `src/test` to `src/main`

### DIFF
--- a/core/src/main/java/org/bitcoinj/testing/FakeTxBuilder.java
+++ b/core/src/main/java/org/bitcoinj/testing/FakeTxBuilder.java
@@ -17,6 +17,7 @@
 
 package org.bitcoinj.testing;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.bitcoinj.core.Address;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.core.Coin;
@@ -48,6 +49,12 @@ import static com.google.common.base.Preconditions.checkState;
 import static org.bitcoinj.core.Coin.COIN;
 import static org.bitcoinj.core.Coin.valueOf;
 
+/**
+ * Methods for building fake transactions for unit tests. Since these methods are currently used both in the `bitcoinj-core`
+ * unit tests and in the `integration-test` subproject, they are (for now) included in the `bitcoinj-core` JAR. They should
+ * not be considered part of the API.
+ */
+@VisibleForTesting
 public class FakeTxBuilder {
     /** Create a fake transaction, without change. */
     public static Transaction createFakeTx(final NetworkParameters params) {


### PR DESCRIPTION
This will allow it to be used in both core tests and integration-test or in tests for any other module.

I'm also imagining some of this functionality might get merged into the "immutable" transactions capability we plan on adding.