### PR TITLE
WalletAccountPathTest: use Wallet.fromSeed() to simplify private createWallet()

### DIFF
--- a/integration-test/src/test/java/org/bitcoinj/wallet/WalletAccountPathTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/wallet/WalletAccountPathTest.java
@@ -83,11 +83,8 @@ public class WalletAccountPathTest {
     private static Wallet createWallet(File walletFile, NetworkParameters params, KeyChainGroupStructure structure, Script.ScriptType outputScriptType) throws IOException, UnreadableWalletException {
         Context.propagate(new Context(params));
         DeterministicSeed seed = new DeterministicSeed(testWalletMnemonic, null, "", Instant.now().getEpochSecond());
-        KeyChainGroup keyChainGroup = KeyChainGroup.builder(params, structure)
-                .fromSeed(seed, outputScriptType)
-                .build();
-        Wallet memoryWallet = new Wallet(params, keyChainGroup);
-        memoryWallet.saveToFile(walletFile);
+        Wallet wallet = Wallet.fromSeed(params, seed, outputScriptType, structure);
+        wallet.saveToFile(walletFile);
         return Wallet.loadFromFile(walletFile);
     }
 }


### PR DESCRIPTION
I discover that the private method `createWallet()` duplicated code from `Wallet.fromSeed()`. This PR fixes that.