### PR TITLE
WalletAppKit: replace null with BIP32 in constructor

### DIFF
--- a/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
+++ b/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
@@ -114,7 +114,7 @@ public class WalletAppKit extends AbstractIdleService {
      * Creates a new WalletAppKit, with a newly created {@link Context}. Files will be stored in the given directory.
      */
     public WalletAppKit(NetworkParameters params, File directory, String filePrefix) {
-        this(new Context(params), Script.ScriptType.P2PKH, null, directory, filePrefix);
+        this(new Context(params), Script.ScriptType.P2PKH, KeyChainGroupStructure.BIP32, directory, filePrefix);
     }
 
     /**


### PR DESCRIPTION
This makes the code for this constructor more explicit/readable and prepares the way for making the parameter in the "full" constructor non-nullable (in a minor breaking change) in the future.