### PR TITLE
PrefixedChecksummedBytes: remove Cloneable

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Coin.java
+++ b/core/src/main/java/org/bitcoinj/core/Coin.java
@@ -19,7 +19,6 @@ package org.bitcoinj.core;
 import com.google.common.math.LongMath;
 import org.bitcoinj.utils.MonetaryFormat;
 
-import java.io.Serializable;
 import java.math.BigDecimal;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -27,7 +26,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 /**
  * Represents a monetary Bitcoin value. This class is immutable.
  */
-public final class Coin implements Monetary, Comparable<Coin>, Serializable {
+public final class Coin implements Monetary, Comparable<Coin> {
 
     /**
      * Number of decimals for one Bitcoin. This constant is useful for quick adapting to other coins because a lot of

--- a/core/src/main/java/org/bitcoinj/core/Monetary.java
+++ b/core/src/main/java/org/bitcoinj/core/Monetary.java
@@ -16,12 +16,10 @@
 
 package org.bitcoinj.core;
 
-import java.io.Serializable;
-
 /**
  * Classes implementing this interface represent a monetary value, such as a Bitcoin or fiat amount.
  */
-public interface Monetary extends Serializable {
+public interface Monetary {
 
     /**
      * Returns the absolute value of exponent of the value of a "smallest unit" in scientific notation. For Bitcoin, a

--- a/core/src/main/java/org/bitcoinj/core/PrefixedChecksummedBytes.java
+++ b/core/src/main/java/org/bitcoinj/core/PrefixedChecksummedBytes.java
@@ -17,11 +17,6 @@
 
 package org.bitcoinj.core;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.Serializable;
-import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -40,7 +35,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * keys exported using Bitcoin Core's dumpprivkey command.
  * </p>
  */
-public abstract class PrefixedChecksummedBytes implements Serializable, Cloneable {
+public abstract class PrefixedChecksummedBytes implements Cloneable {
     protected final transient NetworkParameters params;
     protected final byte[] bytes;
 
@@ -77,24 +72,5 @@ public abstract class PrefixedChecksummedBytes implements Serializable, Cloneabl
     @Override
     public PrefixedChecksummedBytes clone() throws CloneNotSupportedException {
         return (PrefixedChecksummedBytes) super.clone();
-    }
-
-    // Java serialization
-
-    private void writeObject(ObjectOutputStream out) throws IOException {
-        out.defaultWriteObject();
-        out.writeUTF(params.getId());
-    }
-
-    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
-        in.defaultReadObject();
-        try {
-            Field paramsField = PrefixedChecksummedBytes.class.getDeclaredField("params");
-            paramsField.setAccessible(true);
-            paramsField.set(this, checkNotNull(NetworkParameters.fromID(in.readUTF())));
-            paramsField.setAccessible(false);
-        } catch (NoSuchFieldException | IllegalAccessException x) {
-            throw new RuntimeException(x);
-        }
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/PrefixedChecksummedBytes.java
+++ b/core/src/main/java/org/bitcoinj/core/PrefixedChecksummedBytes.java
@@ -35,7 +35,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * keys exported using Bitcoin Core's dumpprivkey command.
  * </p>
  */
-public abstract class PrefixedChecksummedBytes implements Cloneable {
+public abstract class PrefixedChecksummedBytes {
     protected final transient NetworkParameters params;
     protected final byte[] bytes;
 
@@ -62,15 +62,5 @@ public abstract class PrefixedChecksummedBytes implements Cloneable {
         if (o == null || getClass() != o.getClass()) return false;
         PrefixedChecksummedBytes other = (PrefixedChecksummedBytes) o;
         return this.params.equals(other.params) && Arrays.equals(this.bytes, other.bytes);
-    }
-
-    /**
-     * This implementation narrows the return type to {@link PrefixedChecksummedBytes}
-     * and allows subclasses to throw {@link CloneNotSupportedException} even though it
-     * is never thrown by this implementation.
-     */
-    @Override
-    public PrefixedChecksummedBytes clone() throws CloneNotSupportedException {
-        return (PrefixedChecksummedBytes) super.clone();
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/Sha256Hash.java
+++ b/core/src/main/java/org/bitcoinj/core/Sha256Hash.java
@@ -23,7 +23,6 @@ import com.google.common.primitives.Ints;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.Serializable;
 import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -37,7 +36,7 @@ import static com.google.common.base.Preconditions.checkArgument;
  * <p>
  * Given that {@code Sha256Hash} instances can be created using {@link #wrapReversed(byte[])} or {@link #twiceOf(byte[])} or by wrapping raw bytes, there is no guarantee that if two {@code Sha256Hash} instances are found equal (via {@link #equals(Object)}) that their preimages would be the same (even in the absence of a hash collision.)
  */
-public class Sha256Hash implements Serializable, Comparable<Sha256Hash> {
+public class Sha256Hash implements Comparable<Sha256Hash> {
     public static final int LENGTH = 32; // bytes
     public static final Sha256Hash ZERO_HASH = wrap(new byte[LENGTH]);
 

--- a/core/src/main/java/org/bitcoinj/crypto/KeyCrypter.java
+++ b/core/src/main/java/org/bitcoinj/crypto/KeyCrypter.java
@@ -19,8 +19,6 @@ package org.bitcoinj.crypto;
 import org.bitcoinj.wallet.Protos.Wallet.EncryptionType;
 import org.bouncycastle.crypto.params.KeyParameter;
 
-import java.io.Serializable;
-
 /**
  * <p>A KeyCrypter can be used to encrypt and decrypt a message. The sequence of events to encrypt and then decrypt
  * a message are as follows:</p>
@@ -34,7 +32,7 @@ import java.io.Serializable;
  * <p>There can be different algorithms used for encryption/ decryption so the getUnderstoodEncryptionType is used
  * to determine whether any given KeyCrypter can understand the type of encrypted data you have.</p>
  */
-public interface KeyCrypter extends Serializable {
+public interface KeyCrypter {
 
     /**
      * Return the EncryptionType enum value which denotes the type of encryption/ decryption that this KeyCrypter

--- a/core/src/main/java/org/bitcoinj/protocols/payments/PaymentProtocol.java
+++ b/core/src/main/java/org/bitcoinj/protocols/payments/PaymentProtocol.java
@@ -30,7 +30,6 @@ import org.bitcoinj.crypto.X509Utils;
 import org.bitcoinj.script.ScriptBuilder;
 
 import javax.annotation.Nullable;
-import java.io.Serializable;
 import java.security.GeneralSecurityException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -426,7 +425,7 @@ public class PaymentProtocol {
     /**
      * Value object to hold amount/script pairs.
      */
-    public static class Output implements Serializable {
+    public static class Output {
         @Nullable public final Coin amount;
         public final byte[] scriptData;
 

--- a/core/src/main/java/org/bitcoinj/utils/ExchangeRate.java
+++ b/core/src/main/java/org/bitcoinj/utils/ExchangeRate.java
@@ -18,7 +18,6 @@ package org.bitcoinj.utils;
 
 import org.bitcoinj.core.Coin;
 
-import java.io.Serializable;
 import java.math.BigInteger;
 import java.util.Objects;
 
@@ -27,7 +26,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 /**
  * An exchange rate is expressed as a ratio of a {@link Coin} and a {@link Fiat} amount.
  */
-public class ExchangeRate implements Serializable {
+public class ExchangeRate {
 
     public final Coin coin;
     public final Fiat fiat;

--- a/core/src/main/java/org/bitcoinj/utils/Fiat.java
+++ b/core/src/main/java/org/bitcoinj/utils/Fiat.java
@@ -20,7 +20,6 @@ import com.google.common.math.LongMath;
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.core.Monetary;
 
-import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Objects;
 
@@ -32,7 +31,7 @@ import static com.google.common.base.Preconditions.checkArgument;
  * 
  * This class is immutable.
  */
-public final class Fiat implements Monetary, Comparable<Fiat>, Serializable {
+public final class Fiat implements Monetary, Comparable<Fiat> {
 
     /**
      * The absolute value of exponent of the value of a "smallest unit" in scientific notation. We picked 4 rather than

--- a/core/src/test/java/org/bitcoinj/core/DumpedPrivateKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/core/DumpedPrivateKeyTest.java
@@ -42,16 +42,6 @@ public class DumpedPrivateKeyTest {
     }
 
     @Test
-    public void cloning() throws Exception {
-        DumpedPrivateKey a = new DumpedPrivateKey(MAINNET, new ECKey().getPrivKeyBytes(), true);
-        // TODO: Consider overriding clone() in DumpedPrivateKey to narrow the type
-        DumpedPrivateKey b = (DumpedPrivateKey) a.clone();
-
-        assertEquals(a, b);
-        assertNotSame(a, b);
-    }
-
-    @Test
     public void roundtripBase58() {
         String base58 = "5HtUCLMFWNueqN9unpgX2DzjMg6SDNZyKRb8s3LJgpFg5ubuMrk"; // 32-bytes key
         DumpedPrivateKey dumpedPrivateKey = DumpedPrivateKey.fromBase58(null, base58);

--- a/core/src/test/java/org/bitcoinj/core/DumpedPrivateKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/core/DumpedPrivateKeyTest.java
@@ -20,10 +20,6 @@ import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.TestNet3Params;
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
@@ -43,17 +39,6 @@ public class DumpedPrivateKeyTest {
     @Test(expected = AddressFormatException.WrongNetwork.class)
     public void checkNetworkWrong() {
         DumpedPrivateKey.fromBase58(TESTNET, "5HtUCLMFWNueqN9unpgX2DzjMg6SDNZyKRb8s3LJgpFg5ubuMrk");
-    }
-
-    @Test
-    public void testJavaSerialization() throws Exception {
-
-        DumpedPrivateKey key = new DumpedPrivateKey(MAINNET, new ECKey().getPrivKeyBytes(), true);
-        ByteArrayOutputStream os = new ByteArrayOutputStream();
-        new ObjectOutputStream(os).writeObject(key);
-        DumpedPrivateKey keyCopy = (DumpedPrivateKey) new ObjectInputStream(new ByteArrayInputStream(os.toByteArray()))
-                .readObject();
-        assertEquals(key, keyCopy);
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
@@ -188,27 +188,9 @@ public class LegacyAddressTest {
     }
 
     @Test
-    public void cloning() throws Exception {
-        LegacyAddress a = LegacyAddress.fromPubKeyHash(TESTNET, HEX.decode("fda79a24e50ff70ff42f7d89585da5bd19d9e5cc"));
-        LegacyAddress b = a.clone();
-
-        assertEquals(a, b);
-        assertNotSame(a, b);
-    }
-
-    @Test
     public void roundtripBase58() {
         String base58 = "17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL";
         assertEquals(base58, LegacyAddress.fromBase58(null, base58).toBase58());
-    }
-
-    @Test
-    public void comparisonCloneEqualTo() throws Exception {
-        LegacyAddress a = LegacyAddress.fromBase58(MAINNET, "1Dorian4RoXcnBv9hnQ4Y2C1an6NJ4UrjX");
-        LegacyAddress b = a.clone();
-
-        int result = a.compareTo(b);
-        assertEquals(0, result);
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
@@ -29,11 +29,7 @@ import org.bitcoinj.script.ScriptPattern;
 import org.junit.Test;
 
 import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.InputStreamReader;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.List;
 
@@ -55,23 +51,6 @@ public class LegacyAddressTest {
                 .suppress(Warning.TRANSIENT_FIELDS)
                 .usingGetClass()
                 .verify();
-    }
-
-    @Test
-    public void testJavaSerialization() throws Exception {
-        LegacyAddress testAddress = LegacyAddress.fromBase58(TESTNET, "n4eA2nbYqErp7H6jebchxAN59DmNpksexv");
-        ByteArrayOutputStream os = new ByteArrayOutputStream();
-        new ObjectOutputStream(os).writeObject(testAddress);
-        LegacyAddress testAddressCopy = (LegacyAddress) new ObjectInputStream(new ByteArrayInputStream(os.toByteArray()))
-                .readObject();
-        assertEquals(testAddress, testAddressCopy);
-
-        LegacyAddress mainAddress = LegacyAddress.fromBase58(MAINNET, "17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL");
-        os = new ByteArrayOutputStream();
-        new ObjectOutputStream(os).writeObject(mainAddress);
-        LegacyAddress mainAddressCopy = (LegacyAddress) new ObjectInputStream(new ByteArrayInputStream(os.toByteArray()))
-                .readObject();
-        assertEquals(mainAddress, mainAddressCopy);
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/core/PrefixedChecksummedBytesTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PrefixedChecksummedBytesTest.java
@@ -71,29 +71,4 @@ public class PrefixedChecksummedBytesTest {
         PrefixedChecksummedBytes b = new PrefixedChecksummedBytesToTest(params, HEX.decode("4a22c3c4cbb31e4d03b15550636762bda0baf85a"));
         assertEquals("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL", b.toString());
     }
-
-    @Test
-    public void cloning() throws Exception {
-        expect(params.getAddressHeader()).andReturn(111);
-        replay(params);
-
-        PrefixedChecksummedBytes a = new PrefixedChecksummedBytesToTest(params, HEX.decode("fda79a24e50ff70ff42f7d89585da5bd19d9e5cc"));
-        PrefixedChecksummedBytes b = a.clone();
-
-        assertEquals(a, b);
-        assertNotSame(a, b);
-    }
-
-    @Test
-    public void comparisonCloneEqualTo() throws Exception {
-        expect(params.getAddressHeader()).andReturn(111);
-        expect(params.getId()).andReturn("org.bitcoin.test").times(2);
-        replay(params);
-
-        PrefixedChecksummedBytes a = new PrefixedChecksummedBytesToTest(params, HEX.decode("fda79a24e50ff70ff42f7d89585da5bd19d9e5cc"));
-        PrefixedChecksummedBytes b = a.clone();
-
-        assertNotSame(a, b);
-        assertEquals(a, b);
-    }
 }

--- a/core/src/test/java/org/bitcoinj/core/SegwitAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/SegwitAddressTest.java
@@ -27,13 +27,8 @@ import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptPattern;
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.util.Locale;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -225,19 +220,5 @@ public class SegwitAddressTest {
     @Test(expected = AddressFormatException.WrongNetwork.class)
     public void fromBech32_wrongNetwork() {
         SegwitAddress.fromBech32(TESTNET, "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj");
-    }
-
-    @Test
-    public void testJavaSerialization() throws Exception {
-        SegwitAddress address = SegwitAddress.fromBech32(null, "BC1SW50QGDZ25J");
-
-        ByteArrayOutputStream os = new ByteArrayOutputStream();
-        new ObjectOutputStream(os).writeObject(address);
-        PrefixedChecksummedBytes addressCopy = (PrefixedChecksummedBytes) new ObjectInputStream(
-                new ByteArrayInputStream(os.toByteArray())).readObject();
-
-        assertEquals(address, addressCopy);
-        assertEquals(address.params, addressCopy.params);
-        assertArrayEquals(address.bytes, addressCopy.bytes);
     }
 }

--- a/core/src/test/java/org/bitcoinj/crypto/BIP38PrivateKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/BIP38PrivateKeyTest.java
@@ -25,11 +25,6 @@ import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.TestNet3Params;
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 
@@ -155,25 +150,6 @@ public class BIP38PrivateKeyTest {
     public void fromBase58_invalidLength() {
         String base58 = Base58.encodeChecked(1, new byte[16]);
         BIP38PrivateKey.fromBase58(null, base58);
-    }
-
-    @Test
-    public void testJavaSerialization() throws Exception {
-        BIP38PrivateKey testKey = BIP38PrivateKey.fromBase58(TESTNET,
-                "6PfMmVHn153N3x83Yiy4Nf76dHUkXufe2Adr9Fw5bewrunGNeaw2QCpifb");
-        ByteArrayOutputStream os = new ByteArrayOutputStream();
-        new ObjectOutputStream(os).writeObject(testKey);
-        BIP38PrivateKey testKeyCopy = (BIP38PrivateKey) new ObjectInputStream(
-                new ByteArrayInputStream(os.toByteArray())).readObject();
-        assertEquals(testKey, testKeyCopy);
-
-        BIP38PrivateKey mainKey = BIP38PrivateKey.fromBase58(MAINNET,
-                "6PfMmVHn153N3x83Yiy4Nf76dHUkXufe2Adr9Fw5bewrunGNeaw2QCpifb");
-        os = new ByteArrayOutputStream();
-        new ObjectOutputStream(os).writeObject(mainKey);
-        BIP38PrivateKey mainKeyCopy = (BIP38PrivateKey) new ObjectInputStream(
-                new ByteArrayInputStream(os.toByteArray())).readObject();
-        assertEquals(mainKey, mainKeyCopy);
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/crypto/BIP38PrivateKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/BIP38PrivateKeyTest.java
@@ -153,16 +153,6 @@ public class BIP38PrivateKeyTest {
     }
 
     @Test
-    public void cloning() throws Exception {
-        BIP38PrivateKey a = BIP38PrivateKey.fromBase58(TESTNET, "6PfMmVHn153N3x83Yiy4Nf76dHUkXufe2Adr9Fw5bewrunGNeaw2QCpifb");
-        // TODO: Consider overriding clone() in BIP38PrivateKey to narrow the type
-        BIP38PrivateKey b = (BIP38PrivateKey) a.clone();
-
-        assertEquals(a, b);
-        assertNotSame(a, b);
-    }
-
-    @Test
     public void roundtripBase58() {
         String base58 = "6PfMmVHn153N3x83Yiy4Nf76dHUkXufe2Adr9Fw5bewrunGNeaw2QCpifb";
         assertEquals(base58, BIP38PrivateKey.fromBase58(MAINNET, base58).toBase58());

--- a/core/src/test/java/org/bitcoinj/utils/ExchangeRateTest.java
+++ b/core/src/test/java/org/bitcoinj/utils/ExchangeRateTest.java
@@ -19,11 +19,6 @@ package org.bitcoinj.utils;
 import org.bitcoinj.core.Coin;
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-
 import static org.junit.Assert.assertEquals;
 
 public class ExchangeRateTest {
@@ -68,15 +63,5 @@ public class ExchangeRateTest {
     @Test(expected = IllegalArgumentException.class)
     public void constructFiatCoin() {
         new ExchangeRate(Fiat.valueOf("EUR", -1));
-    }
-
-    @Test
-    public void testJavaSerialization() throws Exception {
-        ExchangeRate rate = new ExchangeRate(Fiat.parseFiat("EUR", "500"));
-        ByteArrayOutputStream os = new ByteArrayOutputStream();
-        new ObjectOutputStream(os).writeObject(rate);
-        ExchangeRate rateCopy = (ExchangeRate) new ObjectInputStream(
-                new ByteArrayInputStream(os.toByteArray())).readObject();
-        assertEquals(rate, rateCopy);
     }
 }


### PR DESCRIPTION
* Remove the `implements Cloneable` marker
* Remove the `@Override` of `clone()`
* Remove tests of `clone()` for the implementing classes

Not logically dependent upon PR #2458, but does modify some of the same lines. So I'll make this a DRAFT PR and we can rebase (or modify) after #2458 is merged (or rejected).