### PR TITLE
DeterministicKey: remove deprecated serializePublic/serializePrivate

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -17,6 +17,7 @@
 
 package org.bitcoinj.crypto;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import org.bitcoinj.core.Address;
 import org.bitcoinj.core.Base58;
@@ -472,15 +473,10 @@ public class DeterministicKey extends ECKey {
         checkState(key != null, "Private key bytes not available");
         return key;
     }
-
-    @Deprecated
-    public byte[] serializePublic(NetworkParameters params) {
-        return serialize(params, true, Script.ScriptType.P2PKH);
-    }
-
-    @Deprecated
-    public byte[] serializePrivate(NetworkParameters params) {
-        return serialize(params, false, Script.ScriptType.P2PKH);
+    
+    @VisibleForTesting
+    byte[] serialize(NetworkParameters params, boolean pub) {
+        return serialize(params, pub, Script.ScriptType.P2PKH);
     }
 
     private byte[] serialize(NetworkParameters params, boolean pub, Script.ScriptType outputScriptType) {

--- a/core/src/test/java/org/bitcoinj/crypto/ChildKeyDerivationTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ChildKeyDerivationTest.java
@@ -247,8 +247,8 @@ public class ChildKeyDerivationTest {
         {
             final String pub58 = key1.serializePubB58(params);
             final String priv58 = key1.serializePrivB58(params);
-            final byte[] pub = key1.serializePublic(params);
-            final byte[] priv = key1.serializePrivate(params);
+            final byte[] pub = key1.serialize(params, true);
+            final byte[] priv = key1.serialize(params, false);
             assertEquals("xpub661MyMwAqRbcF7mq7Aejj5xZNzFfgi3ABamE9FedDHVmViSzSxYTgAQGcATDo2J821q7Y9EAagjg5EP3L7uBZk11PxZU3hikL59dexfLkz3", pub58);
             assertEquals("xprv9s21ZrQH143K2dhN197jMx1ppxRBHFKJpMqdLsF1ewxncv7quRED8N5nksxphju3W7naj1arF56L5PUEWfuSk8h73Sb2uh7bSwyXNrjzhAZ", priv58);
             assertArrayEquals(new byte[]{4, -120, -78, 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 57, -68, 93, -104, -97, 31, -105, -18, 109, 112, 104, 45, -77, -77, 18, 85, -29, -120, 86, -113, 26, 48, -18, -79, -110, -6, -27, 87, 86, 24, 124, 99, 3, 96, -33, -14, 67, -19, -47, 16, 76, -49, -11, -30, -123, 7, 56, 101, 91, 74, 125, -127, 61, 42, -103, 90, -93, 66, -36, 2, -126, -107, 30, 24, -111}, pub);
@@ -265,8 +265,8 @@ public class ChildKeyDerivationTest {
         {
             final String pub58 = key2.serializePubB58(params);
             final String priv58 = key2.serializePrivB58(params);
-            final byte[] pub = key2.serializePublic(params);
-            final byte[] priv = key2.serializePrivate(params);
+            final byte[] pub = key2.serialize(params, true);
+            final byte[] priv = key2.serialize(params, false);
             assertEquals(DeterministicKey.deserializeB58(key1, priv58, params), key2);
             assertEquals(DeterministicKey.deserializeB58(key1, pub58, params).getPubKeyPoint(), key2.getPubKeyPoint());
             assertEquals(DeterministicKey.deserialize(params, priv, key1), key2);
@@ -281,9 +281,9 @@ public class ChildKeyDerivationTest {
         DeterministicKey key3 = HDKeyDerivation.deriveChildKey(key2, ChildNumber.ZERO_HARDENED);
         DeterministicKey key4 = HDKeyDerivation.deriveChildKey(key3, ChildNumber.ZERO_HARDENED);
         assertEquals(key4.getPath().size(), 3);
-        assertEquals(DeterministicKey.deserialize(UNITTEST, key4.serializePrivate(UNITTEST), key3).getPath().size(), 3);
-        assertEquals(DeterministicKey.deserialize(UNITTEST, key4.serializePrivate(UNITTEST), null).getPath().size(), 1);
-        assertEquals(DeterministicKey.deserialize(UNITTEST, key4.serializePrivate(UNITTEST)).getPath().size(), 1);
+        assertEquals(DeterministicKey.deserialize(UNITTEST, key4.serialize(UNITTEST, false), key3).getPath().size(), 3);
+        assertEquals(DeterministicKey.deserialize(UNITTEST, key4.serialize(UNITTEST, false), null).getPath().size(), 1);
+        assertEquals(DeterministicKey.deserialize(UNITTEST, key4.serialize(UNITTEST, false)).getPath().size(), 1);
     }
 
     /** Reserializing a deserialized key should yield the original input */


### PR DESCRIPTION
Add a package-visible serialize() method annotated with @VisibleForTesting to
support existing tests.