### PR TITLE
DeterministicKey: deprecate serializeP*B58 methods with outputScriptType parameter

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -479,6 +479,7 @@ public class DeterministicKey extends ECKey {
         return serialize(params, pub, Script.ScriptType.P2PKH);
     }
 
+    // TODO: remove outputScriptType parameter and merge with the two-param serialize() method. When deprecated serializePubB58/serializePrivB58 methods are removed.
     private byte[] serialize(NetworkParameters params, boolean pub, Script.ScriptType outputScriptType) {
         ByteBuffer ser = ByteBuffer.allocate(78);
         if (outputScriptType == Script.ScriptType.P2PKH)
@@ -496,20 +497,52 @@ public class DeterministicKey extends ECKey {
         return ser.array();
     }
 
+    /**
+     * Serialize public key to Base58
+     * <p>
+     * outputScriptType should not be used in generating "xpub" format. (and "ypub", "zpub", etc. should not be used)
+     * @param params Network parameters indicating which network to serialize key for
+     * @param outputScriptType output script type
+     * @return the key serialized as a Base58 address
+     * @see <a href="https://bitcoin.stackexchange.com/questions/89261/why-does-importmulti-not-support-zpub-and-ypub/89281#89281">Why does importmulti not support zpub and ypub?</a>
+     * @deprecated Use a {@link #serializePubB58(NetworkParameters)} or a descriptor if you need output type information
+     */
+    @Deprecated
     public String serializePubB58(NetworkParameters params, Script.ScriptType outputScriptType) {
         return toBase58(serialize(params, true, outputScriptType));
     }
 
+    /**
+     * Serialize public key to Base58
+     * <p>
+     * outputScriptType should not be used in generating "xprv" format. (and "zprv", "vprv", etc. should not be used)
+     * @param params Network parameters indicating which network to serialize key for
+     * @param outputScriptType output script type
+     * @return the key serialized as a Base58 address
+     * @see <a href="https://bitcoin.stackexchange.com/questions/89261/why-does-importmulti-not-support-zpub-and-ypub/89281#89281">Why does importmulti not support zpub and ypub?</a>
+     * @deprecated Use a {@link #serializePrivB58(NetworkParameters)} or a descriptor if you need output type information
+     */
+    @Deprecated
     public String serializePrivB58(NetworkParameters params, Script.ScriptType outputScriptType) {
         return toBase58(serialize(params, false, outputScriptType));
     }
 
+    /**
+     * Serialize public key to Base58 (either "xpub" or "tpub")
+     * @param params Network parameters indicating which network to serialize key for
+     * @return the key serialized as a Base58 address
+     */
     public String serializePubB58(NetworkParameters params) {
-        return serializePubB58(params, Script.ScriptType.P2PKH);
+        return toBase58(serialize(params, true));
     }
 
+    /**
+     * Serialize private key to Base58 (either "xprv" or "tprv")
+     * @param params Network parameters indicating which network to serialize key for
+     * @return the key serialized as a Base58 address
+     */
     public String serializePrivB58(NetworkParameters params) {
-        return serializePrivB58(params, Script.ScriptType.P2PKH);
+        return toBase58(serialize(params, false));
     }
 
     static String toBase58(byte[] ser) {

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -526,9 +526,11 @@ public class DeterministicKeyChainTest {
         DeterministicKey key4 = segwitChain.getKey(KeyChain.KeyPurpose.CHANGE);
 
         DeterministicKey watchingKey = segwitChain.getWatchingKey();
-        final String pub58 = watchingKey.serializePubB58(MAINNET, segwitChain.getOutputScriptType());
-        assertEquals("zpub6nywkzAGfYS2siEfJtm9mo3hwDk8eUtL8EJ31XeWSd7C7x7esnfMMWmWiSs8od5jRt11arTjKLLbxCXuWNSXcxpi9PMSAphMt2ZE2gLnXGE", pub58);
-        watchingKey = DeterministicKey.deserializeB58(null, pub58, MAINNET);
+        final String xpub58 = watchingKey.serializePubB58(MAINNET);
+        assertEquals("xpub69KR9epSNBM5B7rReBBuMcrhbHTEmEuLJ1FbSjrjgcMS1kVCNULE7PTEg2wxoomtcbmQ5uGcQ1dWBdJn4ycW2VTWQhxb114PLaRwFYeHuui", xpub58);
+        final String zpub58 = watchingKey.serializePubB58(MAINNET, segwitChain.getOutputScriptType());
+        assertEquals("zpub6nywkzAGfYS2siEfJtm9mo3hwDk8eUtL8EJ31XeWSd7C7x7esnfMMWmWiSs8od5jRt11arTjKLLbxCXuWNSXcxpi9PMSAphMt2ZE2gLnXGE", zpub58);
+        watchingKey = DeterministicKey.deserializeB58(null, xpub58, MAINNET);
         watchingKey.setCreationTimeSeconds(100000);
         segwitChain = DeterministicKeyChain.builder().watch(watchingKey)
                 .outputScriptType(segwitChain.getOutputScriptType()).build();


### PR DESCRIPTION
The reasons are explained in the added JavaDoc

* Add deprecation and JavaDoc comments
* Remove usage of deprecated methods


Note: DeterministicKeyChain.toString() will no longer output the non-standard "ypub", etc formats.

Draft because dependent upon PR #2461