### PR TITLE
VarInt: make `value` member private

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/VarInt.java
+++ b/core/src/main/java/org/bitcoinj/core/VarInt.java
@@ -23,9 +23,7 @@ import com.google.common.primitives.Ints;
  * A variable-length encoded unsigned integer using Satoshi's encoding (a.k.a. "CompactSize").
  */
 public class VarInt {
-    /** @deprecated use {{@link #intValue()} or {{@link #longValue()}}} */
-    @Deprecated
-    public final long value;
+    private final long value;
     private final int originallyEncodedSize;
 
     /**


### PR DESCRIPTION
(it was marked as @Deprecated so nobody should be using it)