### PR TITLE
org.bitcoinj.jni package: Deprecate all classes

### DIFF
--- a/core/src/main/java/org/bitcoinj/jni/NativeBlockChainListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeBlockChainListener.java
@@ -31,7 +31,9 @@ import java.util.List;
  * An event listener that relays events to a native C++ object. A pointer to that object is stored in
  * this class using JNI on the native side, thus several instances of this can point to different actual
  * native implementations.
+ * @deprecated See https://github.com/bitcoinj/bitcoinj/issues/2465
  */
+@Deprecated
 public class NativeBlockChainListener implements NewBestBlockListener, ReorganizeListener, TransactionReceivedInBlockListener {
     public long ptr;
 

--- a/core/src/main/java/org/bitcoinj/jni/NativeFutureCallback.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeFutureCallback.java
@@ -22,7 +22,9 @@ import com.google.common.util.concurrent.FutureCallback;
  * An event listener that relays events to a native C++ object. A pointer to that object is stored in
  * this class using JNI on the native side, thus several instances of this can point to different actual
  * native implementations.
+ * @deprecated See https://github.com/bitcoinj/bitcoinj/issues/2465
  */
+@Deprecated
 public class NativeFutureCallback implements FutureCallback {
     public long ptr;
 

--- a/core/src/main/java/org/bitcoinj/jni/NativeKeyChainEventListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeKeyChainEventListener.java
@@ -25,7 +25,9 @@ import java.util.List;
  * An event listener that relays events to a native C++ object. A pointer to that object is stored in
  * this class using JNI on the native side, thus several instances of this can point to different actual
  * native implementations.
+ * @deprecated See https://github.com/bitcoinj/bitcoinj/issues/2465
  */
+@Deprecated
 public class NativeKeyChainEventListener implements KeyChainEventListener {
     public long ptr;
 

--- a/core/src/main/java/org/bitcoinj/jni/NativeScriptsChangeEventListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeScriptsChangeEventListener.java
@@ -26,7 +26,9 @@ import java.util.List;
  * An event listener that relays events to a native C++ object. A pointer to that object is stored in
  * this class using JNI on the native side, thus several instances of this can point to different actual
  * native implementations.
+ * @deprecated See https://github.com/bitcoinj/bitcoinj/issues/2465
  */
+@Deprecated
 public class NativeScriptsChangeEventListener implements ScriptsChangeEventListener {
     public long ptr;
 

--- a/core/src/main/java/org/bitcoinj/jni/NativeTransactionConfidenceEventListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeTransactionConfidenceEventListener.java
@@ -24,7 +24,9 @@ import org.bitcoinj.wallet.Wallet;
  * An event listener that relays events to a native C++ object. A pointer to that object is stored in
  * this class using JNI on the native side, thus several instances of this can point to different actual
  * native implementations.
+ * @deprecated See https://github.com/bitcoinj/bitcoinj/issues/2465
  */
+@Deprecated
 public class NativeTransactionConfidenceEventListener implements TransactionConfidenceEventListener {
     public long ptr;
 

--- a/core/src/main/java/org/bitcoinj/jni/NativeTransactionConfidenceListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeTransactionConfidenceListener.java
@@ -22,7 +22,9 @@ import org.bitcoinj.core.TransactionConfidence;
  * An event listener that relays events to a native C++ object. A pointer to that object is stored in
  * this class using JNI on the native side, thus several instances of this can point to different actual
  * native implementations.
+ * @deprecated See https://github.com/bitcoinj/bitcoinj/issues/2465
  */
+@Deprecated
 public class NativeTransactionConfidenceListener implements TransactionConfidence.Listener {
     public long ptr;
 

--- a/core/src/main/java/org/bitcoinj/jni/NativeWalletChangeEventListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeWalletChangeEventListener.java
@@ -23,7 +23,9 @@ import org.bitcoinj.wallet.listeners.WalletChangeEventListener;
  * An event listener that relays events to a native C++ object. A pointer to that object is stored in
  * this class using JNI on the native side, thus several instances of this can point to different actual
  * native implementations.
+ * @deprecated See https://github.com/bitcoinj/bitcoinj/issues/2465
  */
+@Deprecated
 public class NativeWalletChangeEventListener implements WalletChangeEventListener {
     public long ptr;
 

--- a/core/src/main/java/org/bitcoinj/jni/NativeWalletCoinsReceivedEventListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeWalletCoinsReceivedEventListener.java
@@ -25,7 +25,9 @@ import org.bitcoinj.wallet.listeners.WalletCoinsReceivedEventListener;
  * An event listener that relays events to a native C++ object. A pointer to that object is stored in
  * this class using JNI on the native side, thus several instances of this can point to different actual
  * native implementations.
+ * @deprecated See https://github.com/bitcoinj/bitcoinj/issues/2465
  */
+@Deprecated
 public class NativeWalletCoinsReceivedEventListener implements WalletCoinsReceivedEventListener {
     public long ptr;
 

--- a/core/src/main/java/org/bitcoinj/jni/NativeWalletCoinsSentEventListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeWalletCoinsSentEventListener.java
@@ -25,7 +25,9 @@ import org.bitcoinj.wallet.listeners.WalletCoinsSentEventListener;
  * An event listener that relays events to a native C++ object. A pointer to that object is stored in
  * this class using JNI on the native side, thus several instances of this can point to different actual
  * native implementations.
+ * @deprecated See https://github.com/bitcoinj/bitcoinj/issues/2465
  */
+@Deprecated
 public class NativeWalletCoinsSentEventListener implements WalletCoinsSentEventListener {
     public long ptr;
 

--- a/core/src/main/java/org/bitcoinj/jni/NativeWalletReorganizeEventListener.java
+++ b/core/src/main/java/org/bitcoinj/jni/NativeWalletReorganizeEventListener.java
@@ -23,7 +23,9 @@ import org.bitcoinj.wallet.listeners.WalletReorganizeEventListener;
  * An event listener that relays events to a native C++ object. A pointer to that object is stored in
  * this class using JNI on the native side, thus several instances of this can point to different actual
  * native implementations.
+ * @deprecated See https://github.com/bitcoinj/bitcoinj/issues/2465
  */
+@Deprecated
 public class NativeWalletReorganizeEventListener implements WalletReorganizeEventListener {
     public long ptr;
 


### PR DESCRIPTION
Deprecate all classes in the `org.bitcoinj.jni` package for removal. See Issue #2465