### PR TITLE
move Script.ScriptType to a top level type in `o.b.base`

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/ScriptType.java
+++ b/core/src/main/java/org/bitcoinj/base/ScriptType.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.base;
+
+/**
+ * Enumeration of Bitcoin script types.
+ */
+public enum ScriptType {
+    P2PKH(1), // pay to pubkey hash (aka pay to address)
+    P2PK(2), // pay to pubkey
+    P2SH(3), // pay to script hash
+    P2WPKH(4), // pay to witness pubkey hash
+    P2WSH(5), // pay to witness script hash
+    P2TR(6); // pay to taproot
+
+    public final int id;
+
+    ScriptType(int id) {
+        this.id = id;
+    }
+}

--- a/core/src/main/java/org/bitcoinj/core/Address.java
+++ b/core/src/main/java/org/bitcoinj/core/Address.java
@@ -16,8 +16,7 @@
 
 package org.bitcoinj.core;
 
-import org.bitcoinj.script.Script;
-import org.bitcoinj.script.Script.ScriptType;
+import org.bitcoinj.base.ScriptType;
 
 import javax.annotation.Nullable;
 import java.util.Comparator;
@@ -82,9 +81,9 @@ public abstract class Address extends PrefixedChecksummedBytes implements Compar
      * @return constructed address
      */
     public static Address fromKey(final NetworkParameters params, final ECKey key, final ScriptType outputScriptType) {
-        if (outputScriptType == Script.ScriptType.P2PKH)
+        if (outputScriptType == ScriptType.P2PKH)
             return LegacyAddress.fromKey(params, key);
-        else if (outputScriptType == Script.ScriptType.P2WPKH)
+        else if (outputScriptType == ScriptType.P2WPKH)
             return SegwitAddress.fromKey(params, key);
         else
             throw new IllegalArgumentException(outputScriptType.toString());

--- a/core/src/main/java/org/bitcoinj/core/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/core/ECKey.java
@@ -24,13 +24,13 @@ import com.google.common.primitives.UnsignedBytes;
 import org.bitcoin.NativeSecp256k1;
 import org.bitcoin.NativeSecp256k1Util;
 import org.bitcoin.Secp256k1Context;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.crypto.EncryptableItem;
 import org.bitcoinj.crypto.EncryptedData;
 import org.bitcoinj.crypto.KeyCrypter;
 import org.bitcoinj.crypto.KeyCrypterException;
 import org.bitcoinj.crypto.LazyECPoint;
 import org.bitcoinj.crypto.LinuxSecureRandom;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.wallet.Protos;
 import org.bitcoinj.wallet.Wallet;
 import org.bouncycastle.asn1.ASN1InputStream;
@@ -1202,7 +1202,7 @@ public class ECKey implements EncryptableItem {
     }
 
     public void formatKeyWithAddress(boolean includePrivateKeys, @Nullable KeyParameter aesKey, StringBuilder builder,
-            NetworkParameters params, Script.ScriptType outputScriptType, @Nullable String comment) {
+                                     NetworkParameters params, ScriptType outputScriptType, @Nullable String comment) {
         builder.append("  addr:");
         if (outputScriptType != null) {
             builder.append(Address.fromKey(params, this, outputScriptType));

--- a/core/src/main/java/org/bitcoinj/core/LegacyAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/LegacyAddress.java
@@ -20,7 +20,7 @@ package org.bitcoinj.core;
 
 import com.google.common.primitives.UnsignedBytes;
 import org.bitcoinj.params.Networks;
-import org.bitcoinj.script.Script.ScriptType;
+import org.bitcoinj.base.ScriptType;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;

--- a/core/src/main/java/org/bitcoinj/core/SegwitAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/SegwitAddress.java
@@ -17,8 +17,8 @@
 package org.bitcoinj.core;
 
 import com.google.common.primitives.UnsignedBytes;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.params.Networks;
-import org.bitcoinj.script.Script;
 
 import javax.annotation.Nullable;
 import java.io.ByteArrayOutputStream;
@@ -131,24 +131,24 @@ public class SegwitAddress extends Address {
 
     /**
      * Get the type of output script that will be used for sending to the address. This is either
-     * {@link Script.ScriptType#P2WPKH} or {@link Script.ScriptType#P2WSH}.
+     * {@link ScriptType#P2WPKH} or {@link ScriptType#P2WSH}.
      * 
      * @return type of output script
      */
     @Override
-    public Script.ScriptType getOutputScriptType() {
+    public ScriptType getOutputScriptType() {
         int version = getWitnessVersion();
         if (version == 0) {
             int programLength = getWitnessProgram().length;
             if (programLength == WITNESS_PROGRAM_LENGTH_PKH)
-                return Script.ScriptType.P2WPKH;
+                return ScriptType.P2WPKH;
             if (programLength == WITNESS_PROGRAM_LENGTH_SH)
-                return Script.ScriptType.P2WSH;
+                return ScriptType.P2WSH;
             throw new IllegalStateException(); // cannot happen
         } else if (version == 1) {
             int programLength = getWitnessProgram().length;
             if (programLength == WITNESS_PROGRAM_LENGTH_TR)
-                return Script.ScriptType.P2TR;
+                return ScriptType.P2TR;
             throw new IllegalStateException(); // cannot happen
         }
         throw new IllegalStateException("cannot handle: " + version);

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -24,7 +24,7 @@ import org.bitcoinj.base.Coin;
 import org.bitcoinj.core.TransactionConfidence.ConfidenceType;
 import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.script.Script;
-import org.bitcoinj.script.Script.ScriptType;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptError;
 import org.bitcoinj.script.ScriptException;

--- a/core/src/main/java/org/bitcoinj/core/TransactionBag.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionBag.java
@@ -17,6 +17,7 @@
 
 package org.bitcoinj.core;
 
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.wallet.Wallet;
 import org.bitcoinj.wallet.WalletTransaction;
@@ -31,10 +32,10 @@ public interface TransactionBag {
     /**
      * Look for a public key which hashes to the given hash and (optionally) is used for a specific script type.
      * @param pubKeyHash hash of the public key to look for
-     * @param scriptType only look for given usage (currently {@link Script.ScriptType#P2PKH} or {@link Script.ScriptType#P2WPKH}) or {@code null} if we don't care
+     * @param scriptType only look for given usage (currently {@link ScriptType#P2PKH} or {@link ScriptType#P2WPKH}) or {@code null} if we don't care
      * @return true if hash was found
      */
-    boolean isPubKeyHashMine(byte[] pubKeyHash, @Nullable Script.ScriptType scriptType);
+    boolean isPubKeyHashMine(byte[] pubKeyHash, @Nullable ScriptType scriptType);
 
     /** Returns true if this wallet is watching transactions for outputs with the script. */
     boolean isWatchedScript(Script script);

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -17,6 +17,7 @@
 
 package org.bitcoinj.core;
 
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptError;
 import org.bitcoinj.script.ScriptException;
@@ -149,10 +150,10 @@ public class TransactionOutPoint extends ChildMessage {
         Script connectedScript = connectedOutput.getScriptPubKey();
         if (ScriptPattern.isP2PKH(connectedScript)) {
             byte[] addressBytes = ScriptPattern.extractHashFromP2PKH(connectedScript);
-            return keyBag.findKeyFromPubKeyHash(addressBytes, Script.ScriptType.P2PKH);
+            return keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2PKH);
         } else if (ScriptPattern.isP2WPKH(connectedScript)) {
             byte[] addressBytes = ScriptPattern.extractHashFromP2WH(connectedScript);
-            return keyBag.findKeyFromPubKeyHash(addressBytes, Script.ScriptType.P2WPKH);
+            return keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2WPKH);
         } else if (ScriptPattern.isP2PK(connectedScript)) {
             byte[] pubkeyBytes = ScriptPattern.extractKeyFromP2PK(connectedScript);
             return keyBag.findKeyFromPubKey(pubkeyBytes);
@@ -175,10 +176,10 @@ public class TransactionOutPoint extends ChildMessage {
         Script connectedScript = connectedOutput.getScriptPubKey();
         if (ScriptPattern.isP2PKH(connectedScript)) {
             byte[] addressBytes = ScriptPattern.extractHashFromP2PKH(connectedScript);
-            return RedeemData.of(keyBag.findKeyFromPubKeyHash(addressBytes, Script.ScriptType.P2PKH), connectedScript);
+            return RedeemData.of(keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2PKH), connectedScript);
         } else if (ScriptPattern.isP2WPKH(connectedScript)) {
             byte[] addressBytes = ScriptPattern.extractHashFromP2WH(connectedScript);
-            return RedeemData.of(keyBag.findKeyFromPubKeyHash(addressBytes, Script.ScriptType.P2WPKH), connectedScript);
+            return RedeemData.of(keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2WPKH), connectedScript);
         } else if (ScriptPattern.isP2PK(connectedScript)) {
             byte[] pubkeyBytes = ScriptPattern.extractKeyFromP2PK(connectedScript);
             return RedeemData.of(keyBag.findKeyFromPubKey(pubkeyBytes), connectedScript);

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -18,6 +18,7 @@
 package org.bitcoinj.core;
 
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptException;
@@ -321,10 +322,10 @@ public class TransactionOutput extends ChildMessage {
                 return transactionBag.isPayToScriptHashMine(ScriptPattern.extractHashFromP2SH(script));
             else if (ScriptPattern.isP2PKH(script))
                 return transactionBag.isPubKeyHashMine(ScriptPattern.extractHashFromP2PKH(script),
-                        Script.ScriptType.P2PKH);
+                        ScriptType.P2PKH);
             else if (ScriptPattern.isP2WPKH(script))
                 return transactionBag.isPubKeyHashMine(ScriptPattern.extractHashFromP2WH(script),
-                        Script.ScriptType.P2WPKH);
+                        ScriptType.P2WPKH);
             else
                 return false;
         } catch (ScriptException e) {

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -19,13 +19,13 @@ package org.bitcoinj.crypto;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.Address;
 import org.bitcoinj.core.Base58;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.Utils;
-import org.bitcoinj.script.Script;
 import org.bouncycastle.crypto.params.KeyParameter;
 import org.bouncycastle.math.ec.ECPoint;
 
@@ -476,15 +476,15 @@ public class DeterministicKey extends ECKey {
 
     @VisibleForTesting
     byte[] serialize(NetworkParameters params, boolean pub) {
-        return serialize(params, pub, Script.ScriptType.P2PKH);
+        return serialize(params, pub, ScriptType.P2PKH);
     }
 
     // TODO: remove outputScriptType parameter and merge with the two-param serialize() method. When deprecated serializePubB58/serializePrivB58 methods are removed.
-    private byte[] serialize(NetworkParameters params, boolean pub, Script.ScriptType outputScriptType) {
+    private byte[] serialize(NetworkParameters params, boolean pub, ScriptType outputScriptType) {
         ByteBuffer ser = ByteBuffer.allocate(78);
-        if (outputScriptType == Script.ScriptType.P2PKH)
+        if (outputScriptType == ScriptType.P2PKH)
             ser.putInt(pub ? params.getBip32HeaderP2PKHpub() : params.getBip32HeaderP2PKHpriv());
-        else if (outputScriptType == Script.ScriptType.P2WPKH)
+        else if (outputScriptType == ScriptType.P2WPKH)
             ser.putInt(pub ? params.getBip32HeaderP2WPKHpub() : params.getBip32HeaderP2WPKHpriv());
         else
             throw new IllegalStateException(outputScriptType.toString());
@@ -508,7 +508,7 @@ public class DeterministicKey extends ECKey {
      * @deprecated Use a {@link #serializePubB58(NetworkParameters)} or a descriptor if you need output type information
      */
     @Deprecated
-    public String serializePubB58(NetworkParameters params, Script.ScriptType outputScriptType) {
+    public String serializePubB58(NetworkParameters params, ScriptType outputScriptType) {
         return toBase58(serialize(params, true, outputScriptType));
     }
 
@@ -523,7 +523,7 @@ public class DeterministicKey extends ECKey {
      * @deprecated Use a {@link #serializePrivB58(NetworkParameters)} or a descriptor if you need output type information
      */
     @Deprecated
-    public String serializePrivB58(NetworkParameters params, Script.ScriptType outputScriptType) {
+    public String serializePrivB58(NetworkParameters params, ScriptType outputScriptType) {
         return toBase58(serialize(params, false, outputScriptType));
     }
 
@@ -675,7 +675,7 @@ public class DeterministicKey extends ECKey {
 
     @Override
     public void formatKeyWithAddress(boolean includePrivateKeys, @Nullable KeyParameter aesKey, StringBuilder builder,
-            NetworkParameters params, Script.ScriptType outputScriptType, @Nullable String comment) {
+                                     NetworkParameters params, ScriptType outputScriptType, @Nullable String comment) {
         builder.append("  addr:").append(Address.fromKey(params, this, outputScriptType).toString());
         builder.append("  hash160:").append(Utils.HEX.encode(getPubKeyHash()));
         builder.append("  (").append(getPathAsString());

--- a/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
+++ b/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
@@ -19,6 +19,7 @@ package org.bitcoinj.kits;
 
 import com.google.common.io.Closeables;
 import com.google.common.util.concurrent.AbstractIdleService;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.BlockChain;
 import org.bitcoinj.core.CheckpointManager;
 import org.bitcoinj.core.Context;
@@ -30,7 +31,6 @@ import org.bitcoinj.core.listeners.DownloadProgressTracker;
 import org.bitcoinj.crypto.DeterministicKey;
 import org.bitcoinj.net.discovery.DnsDiscovery;
 import org.bitcoinj.net.discovery.PeerDiscovery;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.store.SPVBlockStore;
@@ -85,7 +85,7 @@ public class WalletAppKit extends AbstractIdleService {
     protected static final Logger log = LoggerFactory.getLogger(WalletAppKit.class);
 
     protected final NetworkParameters params;
-    protected final Script.ScriptType preferredOutputScriptType;
+    protected final ScriptType preferredOutputScriptType;
     protected final KeyChainGroupStructure structure;
     protected final String filePrefix;
     protected volatile BlockChain vChain;
@@ -114,13 +114,13 @@ public class WalletAppKit extends AbstractIdleService {
      * Creates a new WalletAppKit, with a newly created {@link Context}. Files will be stored in the given directory.
      */
     public WalletAppKit(NetworkParameters params, File directory, String filePrefix) {
-        this(new Context(params), Script.ScriptType.P2PKH, KeyChainGroupStructure.BIP32, directory, filePrefix);
+        this(new Context(params), ScriptType.P2PKH, KeyChainGroupStructure.BIP32, directory, filePrefix);
     }
 
     /**
      * Creates a new WalletAppKit, with a newly created {@link Context}. Files will be stored in the given directory.
      */
-    public WalletAppKit(NetworkParameters params, Script.ScriptType preferredOutputScriptType,
+    public WalletAppKit(NetworkParameters params, ScriptType preferredOutputScriptType,
             @Nullable KeyChainGroupStructure structure, File directory, String filePrefix) {
         this(new Context(params), preferredOutputScriptType, structure, directory, filePrefix);
     }
@@ -128,7 +128,7 @@ public class WalletAppKit extends AbstractIdleService {
     /**
      * Creates a new WalletAppKit, with the given {@link Context}. Files will be stored in the given directory.
      */
-    public WalletAppKit(Context context, Script.ScriptType preferredOutputScriptType,
+    public WalletAppKit(Context context, ScriptType preferredOutputScriptType,
             @Nullable KeyChainGroupStructure structure, File directory, String filePrefix) {
         this.context = context;
         this.params = checkNotNull(context.getParams());

--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -19,6 +19,7 @@
 
 package org.bitcoinj.script;
 
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.Address;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.core.ECKey;
@@ -183,22 +184,6 @@ import static org.bitcoinj.script.ScriptOpCodes.OP_XOR;
  * static methods for building scripts.</p>
  */
 public class Script {
-
-    /** Enumeration to encapsulate the type of this script. */
-    public enum ScriptType {
-        P2PKH(1), // pay to pubkey hash (aka pay to address)
-        P2PK(2), // pay to pubkey
-        P2SH(3), // pay to script hash
-        P2WPKH(4), // pay to witness pubkey hash
-        P2WSH(5), // pay to witness script hash
-        P2TR(6); // pay to taproot
-
-        public final int id;
-
-        ScriptType(int id) {
-            this.id = id;
-        }
-    }
 
     /** Flags to pass to {@link Script#correctlySpends(Transaction, int, TransactionWitness, Coin, Script, Set)}.
      * Note currently only P2SH, DERSIG and NULLDUMMY are actually supported.
@@ -1802,7 +1787,7 @@ public class Script {
     }
 
     /**
-     * Get the {@link Script.ScriptType}.
+     * Get the {@link ScriptType}.
      * @return The script type, or null if the script is of unknown type
      */
     public @Nullable ScriptType getScriptType() {

--- a/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
@@ -26,7 +26,7 @@ import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.Utils;
 import org.bitcoinj.crypto.TransactionSignature;
-import org.bitcoinj.script.Script.ScriptType;
+import org.bitcoinj.base.ScriptType;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;

--- a/core/src/main/java/org/bitcoinj/signers/MissingSigResolutionSigner.java
+++ b/core/src/main/java/org/bitcoinj/signers/MissingSigResolutionSigner.java
@@ -17,6 +17,7 @@
 
 package org.bitcoinj.signers;
 
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.TransactionInput;
 import org.bitcoinj.core.TransactionWitness;
@@ -98,7 +99,7 @@ public class MissingSigResolutionSigner implements TransactionSigner {
                         throw new ECKey.MissingPrivateKeyException();
                     } else if (missingSigsMode == Wallet.MissingSigsMode.USE_DUMMY_SIG) {
                         ECKey key = keyBag.findKeyFromPubKeyHash(
-                                ScriptPattern.extractHashFromP2WH(scriptPubKey), Script.ScriptType.P2WPKH);
+                                ScriptPattern.extractHashFromP2WH(scriptPubKey), ScriptType.P2WPKH);
                         txIn.setWitness(TransactionWitness.redeemP2WPKH(TransactionSignature.dummy(), key));
                     }
                 }

--- a/core/src/main/java/org/bitcoinj/store/DatabaseFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/DatabaseFullPrunedBlockStore.java
@@ -35,7 +35,7 @@ import org.bitcoinj.core.UTXOProviderException;
 import org.bitcoinj.core.Utils;
 import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.script.Script;
-import org.bitcoinj.script.Script.ScriptType;
+import org.bitcoinj.base.ScriptType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/src/main/java/org/bitcoinj/wallet/DecryptingKeyBag.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DecryptingKeyBag.java
@@ -16,8 +16,8 @@
 
 package org.bitcoinj.wallet;
 
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.ECKey;
-import org.bitcoinj.script.Script;
 import org.bouncycastle.crypto.params.KeyParameter;
 
 import javax.annotation.Nullable;
@@ -63,7 +63,7 @@ public class DecryptingKeyBag implements KeyBag {
 
     @Nullable
     @Override
-    public ECKey findKeyFromPubKeyHash(byte[] pubKeyHash, @Nullable Script.ScriptType scriptType) {
+    public ECKey findKeyFromPubKeyHash(byte[] pubKeyHash, @Nullable ScriptType scriptType) {
         return maybeDecrypt(target.findKeyFromPubKeyHash(pubKeyHash, scriptType));
     }
 

--- a/core/src/main/java/org/bitcoinj/wallet/DefaultKeyChainFactory.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DefaultKeyChainFactory.java
@@ -17,10 +17,10 @@
 
 package org.bitcoinj.wallet;
 
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.crypto.ChildNumber;
 import org.bitcoinj.crypto.DeterministicKey;
 import org.bitcoinj.crypto.KeyCrypter;
-import org.bitcoinj.script.Script;
 
 import java.util.List;
 
@@ -30,7 +30,7 @@ import java.util.List;
 public class DefaultKeyChainFactory implements KeyChainFactory {
     @Override
     public DeterministicKeyChain makeKeyChain(DeterministicSeed seed, KeyCrypter crypter, boolean isMarried,
-            Script.ScriptType outputScriptType, List<ChildNumber> accountPath) {
+                                              ScriptType outputScriptType, List<ChildNumber> accountPath) {
         DeterministicKeyChain chain;
         if (isMarried)
             chain = new MarriedKeyChain(seed, crypter, outputScriptType, accountPath);
@@ -41,7 +41,7 @@ public class DefaultKeyChainFactory implements KeyChainFactory {
 
     @Override
     public DeterministicKeyChain makeWatchingKeyChain(DeterministicKey accountKey, boolean isFollowingKey,
-            boolean isMarried, Script.ScriptType outputScriptType) throws UnreadableWalletException {
+            boolean isMarried, ScriptType outputScriptType) throws UnreadableWalletException {
         DeterministicKeyChain chain;
         if (isMarried)
             chain = new MarriedKeyChain(accountKey, outputScriptType);
@@ -54,7 +54,7 @@ public class DefaultKeyChainFactory implements KeyChainFactory {
 
     @Override
     public DeterministicKeyChain makeSpendingKeyChain(DeterministicKey accountKey, boolean isMarried,
-            Script.ScriptType outputScriptType) throws UnreadableWalletException {
+            ScriptType outputScriptType) throws UnreadableWalletException {
         DeterministicKeyChain chain;
         if (isMarried)
             chain = new MarriedKeyChain(accountKey, outputScriptType);

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -19,6 +19,7 @@ package org.bitcoinj.wallet;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Stopwatch;
 import com.google.protobuf.ByteString;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.BloomFilter;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.NetworkParameters;
@@ -124,7 +125,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
     private DeterministicHierarchy hierarchy;
     @Nullable private DeterministicKey rootKey;
     @Nullable private final DeterministicSeed seed;
-    private final Script.ScriptType outputScriptType;
+    private final ScriptType outputScriptType;
     private final HDPath accountPath;
 
     // Paths through the key tree. External keys are ones that are communicated to other parties. Internal keys are
@@ -190,7 +191,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
         protected long creationTimeSecs = 0;
         protected byte[] entropy;
         protected DeterministicSeed seed;
-        protected Script.ScriptType outputScriptType = Script.ScriptType.P2PKH;
+        protected ScriptType outputScriptType = ScriptType.P2PKH;
         protected DeterministicKey watchingKey = null;
         protected boolean isFollowing = false;
         protected DeterministicKey spendingKey = null;
@@ -279,7 +280,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
             return self();
         }
 
-        public T outputScriptType(Script.ScriptType outputScriptType) {
+        public T outputScriptType(ScriptType outputScriptType) {
             this.outputScriptType = outputScriptType;
             return self();
         }
@@ -348,7 +349,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
      * </p>
      */
     public DeterministicKeyChain(DeterministicKey key, boolean isFollowing, boolean isWatching,
-            Script.ScriptType outputScriptType) {
+            ScriptType outputScriptType) {
         if (isWatching)
             checkArgument(key.isPubKeyOnly(), "Private subtrees not currently supported for watching keys: if you got this key from DKC.getWatchingKey() then use .dropPrivate().dropParent() on it first.");
         else
@@ -378,10 +379,10 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
      * </p>
      */
     protected DeterministicKeyChain(DeterministicSeed seed, @Nullable KeyCrypter crypter,
-            Script.ScriptType outputScriptType, List<ChildNumber> accountPath) {
-        checkArgument(outputScriptType == null || outputScriptType == Script.ScriptType.P2PKH
-                || outputScriptType == Script.ScriptType.P2WPKH, "Only P2PKH or P2WPKH allowed.");
-        this.outputScriptType = outputScriptType != null ? outputScriptType : Script.ScriptType.P2PKH;
+                                    ScriptType outputScriptType, List<ChildNumber> accountPath) {
+        checkArgument(outputScriptType == null || outputScriptType == ScriptType.P2PKH
+                || outputScriptType == ScriptType.P2WPKH, "Only P2PKH or P2WPKH allowed.");
+        this.outputScriptType = outputScriptType != null ? outputScriptType : ScriptType.P2PKH;
         this.accountPath = HDPath.M(accountPath);
         this.seed = seed;
         basicKeyChain = new BasicKeyChain(crypter);
@@ -404,7 +405,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
      * For use in encryption when {@link #toEncrypted(KeyCrypter, KeyParameter)} is called, so that
      * subclasses can override that method and create an instance of the right class.
      *
-     * See also {@link #makeKeyChainFromSeed(DeterministicSeed, List, Script.ScriptType)}
+     * See also {@link #makeKeyChainFromSeed(DeterministicSeed, List, ScriptType)}
      */
     protected DeterministicKeyChain(KeyCrypter crypter, KeyParameter aesKey, DeterministicKeyChain chain) {
         // Can't encrypt a watching chain.
@@ -449,7 +450,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
         return accountPath;
     }
 
-    public Script.ScriptType getOutputScriptType() {
+    public ScriptType getOutputScriptType() {
         return outputScriptType;
     }
 
@@ -842,7 +843,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
         int sigsRequiredToSpend = 1;
 
         HDPath accountPath = HDPath.M();
-        Script.ScriptType outputScriptType = Script.ScriptType.P2PKH;
+        ScriptType outputScriptType = ScriptType.P2PKH;
         for (Protos.Key key : keys) {
             final Protos.Key.Type t = key.getType();
             if (t == Protos.Key.Type.DETERMINISTIC_MNEMONIC) {
@@ -887,7 +888,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
                 // Deserialize the path through the tree.
                 final HDPath path = HDPath.deserialize(key.getDeterministicKey().getPathList());
                 if (key.hasOutputScriptType())
-                    outputScriptType = Script.ScriptType.valueOf(key.getOutputScriptType().name());
+                    outputScriptType = ScriptType.valueOf(key.getOutputScriptType().name());
                 // Possibly create the chain, if we didn't already do so yet.
                 boolean isWatchingAccountKey = false;
                 boolean isFollowingKey = false;
@@ -1068,7 +1069,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
      * This is used in encryption/decryption.
      */
     protected DeterministicKeyChain makeKeyChainFromSeed(DeterministicSeed seed, List<ChildNumber> accountPath,
-            Script.ScriptType outputScriptType) {
+            ScriptType outputScriptType) {
         return new DeterministicKeyChain(seed, null, outputScriptType, accountPath);
     }
 

--- a/core/src/main/java/org/bitcoinj/wallet/KeyBag.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyBag.java
@@ -16,8 +16,8 @@
 
 package org.bitcoinj.wallet;
 
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.ECKey;
-import org.bitcoinj.script.Script;
 
 import javax.annotation.Nullable;
 
@@ -33,12 +33,12 @@ public interface KeyBag {
      * @param pubKeyHash
      *            hash of the keypair to look for
      * @param scriptType
-     *            only look for given usage (currently {@link Script.ScriptType#P2PKH} or
-     *            {@link Script.ScriptType#P2WPKH}) or {@code null} if we don't care
+     *            only look for given usage (currently {@link ScriptType#P2PKH} or
+     *            {@link ScriptType#P2WPKH}) or {@code null} if we don't care
      * @return found key or null if no such key was found.
      */
     @Nullable
-    ECKey findKeyFromPubKeyHash(byte[] pubKeyHash, @Nullable Script.ScriptType scriptType);
+    ECKey findKeyFromPubKeyHash(byte[] pubKeyHash, @Nullable ScriptType scriptType);
 
     /**
      * Locates a keypair from the keychain given the raw public key bytes.

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainFactory.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainFactory.java
@@ -17,10 +17,10 @@
 
 package org.bitcoinj.wallet;
 
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.crypto.ChildNumber;
 import org.bitcoinj.crypto.DeterministicKey;
 import org.bitcoinj.crypto.KeyCrypter;
-import org.bitcoinj.script.Script;
 
 import java.util.List;
 
@@ -38,7 +38,7 @@ public interface KeyChainFactory {
      * @param accountPath account path to generate receiving addresses on
      */
     DeterministicKeyChain makeKeyChain(DeterministicSeed seed, KeyCrypter crypter, boolean isMarried,
-            Script.ScriptType outputScriptType, List<ChildNumber> accountPath);
+                                       ScriptType outputScriptType, List<ChildNumber> accountPath);
 
     /**
      * Make a watching keychain.
@@ -51,7 +51,7 @@ public interface KeyChainFactory {
      * @param outputScriptType type of addresses (aka output scripts) to generate for watching
      */
     DeterministicKeyChain makeWatchingKeyChain(DeterministicKey accountKey, boolean isFollowingKey, boolean isMarried,
-            Script.ScriptType outputScriptType) throws UnreadableWalletException;
+            ScriptType outputScriptType) throws UnreadableWalletException;
 
     /**
      * Make a spending keychain.
@@ -63,5 +63,5 @@ public interface KeyChainFactory {
      * @param outputScriptType type of addresses (aka output scripts) to generate for spending
      */
     DeterministicKeyChain makeSpendingKeyChain(DeterministicKey accountKey, boolean isMarried,
-            Script.ScriptType outputScriptType) throws UnreadableWalletException;
+            ScriptType outputScriptType) throws UnreadableWalletException;
 }

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
@@ -30,7 +30,7 @@ import org.bitcoinj.crypto.KeyCrypter;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
 import org.bitcoinj.crypto.LinuxSecureRandom;
 import org.bitcoinj.script.Script;
-import org.bitcoinj.script.Script.ScriptType;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptPattern;
 import org.bitcoinj.utils.ListenerRegistration;
@@ -112,7 +112,7 @@ public class KeyChainGroup implements KeyBag {
          * activated.</p>
          * @param outputScriptType type of addresses (aka output scripts) to generate for receiving
          */
-        public Builder fromRandom(Script.ScriptType outputScriptType) {
+        public Builder fromRandom(ScriptType outputScriptType) {
             DeterministicSeed seed = new DeterministicSeed(new SecureRandom(),
                     DeterministicSeed.DEFAULT_SEED_ENTROPY_BITS, "");
             fromSeed(seed, outputScriptType);
@@ -129,20 +129,20 @@ public class KeyChainGroup implements KeyBag {
          * @param seed deterministic seed to derive all keys from
          * @param outputScriptType type of addresses (aka output scripts) to generate for receiving
          */
-        public Builder fromSeed(DeterministicSeed seed, Script.ScriptType outputScriptType) {
-            if (outputScriptType == Script.ScriptType.P2PKH) {
+        public Builder fromSeed(DeterministicSeed seed, ScriptType outputScriptType) {
+            if (outputScriptType == ScriptType.P2PKH) {
                 DeterministicKeyChain chain = DeterministicKeyChain.builder().seed(seed)
-                        .outputScriptType(Script.ScriptType.P2PKH)
-                        .accountPath(structure.accountPathFor(Script.ScriptType.P2PKH, params)).build();
+                        .outputScriptType(ScriptType.P2PKH)
+                        .accountPath(structure.accountPathFor(ScriptType.P2PKH, params)).build();
                 this.chains.clear();
                 this.chains.add(chain);
-            } else if (outputScriptType == Script.ScriptType.P2WPKH) {
+            } else if (outputScriptType == ScriptType.P2WPKH) {
                 DeterministicKeyChain fallbackChain = DeterministicKeyChain.builder().seed(seed)
-                        .outputScriptType(Script.ScriptType.P2PKH)
-                        .accountPath(structure.accountPathFor(Script.ScriptType.P2PKH, params)).build();
+                        .outputScriptType(ScriptType.P2PKH)
+                        .accountPath(structure.accountPathFor(ScriptType.P2PKH, params)).build();
                 DeterministicKeyChain defaultChain = DeterministicKeyChain.builder().seed(seed)
-                        .outputScriptType(Script.ScriptType.P2WPKH)
-                        .accountPath(structure.accountPathFor(Script.ScriptType.P2WPKH, params)).build();
+                        .outputScriptType(ScriptType.P2WPKH)
+                        .accountPath(structure.accountPathFor(ScriptType.P2WPKH, params)).build();
                 this.chains.clear();
                 this.chains.add(fallbackChain);
                 this.chains.add(defaultChain);
@@ -162,20 +162,20 @@ public class KeyChainGroup implements KeyBag {
          * @param accountKey deterministic account key to derive all keys from
          * @param outputScriptType type of addresses (aka output scripts) to generate for receiving
          */
-        public Builder fromKey(DeterministicKey accountKey, Script.ScriptType outputScriptType) {
-            if (outputScriptType == Script.ScriptType.P2PKH) {
+        public Builder fromKey(DeterministicKey accountKey, ScriptType outputScriptType) {
+            if (outputScriptType == ScriptType.P2PKH) {
                 DeterministicKeyChain chain = DeterministicKeyChain.builder().spend(accountKey)
-                        .outputScriptType(Script.ScriptType.P2PKH)
-                        .accountPath(structure.accountPathFor(Script.ScriptType.P2PKH, params)).build();
+                        .outputScriptType(ScriptType.P2PKH)
+                        .accountPath(structure.accountPathFor(ScriptType.P2PKH, params)).build();
                 this.chains.clear();
                 this.chains.add(chain);
-            } else if (outputScriptType == Script.ScriptType.P2WPKH) {
+            } else if (outputScriptType == ScriptType.P2WPKH) {
                 DeterministicKeyChain fallbackChain = DeterministicKeyChain.builder().spend(accountKey)
-                        .outputScriptType(Script.ScriptType.P2PKH)
-                        .accountPath(structure.accountPathFor(Script.ScriptType.P2PKH, params)).build();
+                        .outputScriptType(ScriptType.P2PKH)
+                        .accountPath(structure.accountPathFor(ScriptType.P2PKH, params)).build();
                 DeterministicKeyChain defaultChain = DeterministicKeyChain.builder().spend(accountKey)
-                        .outputScriptType(Script.ScriptType.P2WPKH)
-                        .accountPath(structure.accountPathFor(Script.ScriptType.P2WPKH, params)).build();
+                        .outputScriptType(ScriptType.P2WPKH)
+                        .accountPath(structure.accountPathFor(ScriptType.P2WPKH, params)).build();
                 this.chains.clear();
                 this.chains.add(fallbackChain);
                 this.chains.add(defaultChain);
@@ -374,7 +374,7 @@ public class KeyChainGroup implements KeyBag {
      */
     public Address currentAddress(KeyChain.KeyPurpose purpose) {
         DeterministicKeyChain chain = getActiveKeyChain();
-        Script.ScriptType outputScriptType = chain.getOutputScriptType();
+        ScriptType outputScriptType = chain.getOutputScriptType();
         if (chain.isMarried()) {
             Address current = currentAddresses.get(purpose);
             if (current == null) {
@@ -382,7 +382,7 @@ public class KeyChainGroup implements KeyBag {
                 currentAddresses.put(purpose, current);
             }
             return current;
-        } else if (outputScriptType == Script.ScriptType.P2PKH || outputScriptType == Script.ScriptType.P2WPKH) {
+        } else if (outputScriptType == ScriptType.P2PKH || outputScriptType == ScriptType.P2WPKH) {
             return Address.fromKey(params, currentKey(purpose), outputScriptType);
         } else {
             throw new IllegalStateException(chain.getOutputScriptType().toString());
@@ -428,12 +428,12 @@ public class KeyChainGroup implements KeyBag {
 
     /**
      * <p>Returns a fresh address for a given {@link KeyChain.KeyPurpose} and of a given
-     * {@link Script.ScriptType}.</p>
+     * {@link ScriptType}.</p>
      * <p>This method is meant for when you really need a fallback address. Normally, you should be
      * using {@link #freshAddress(KeyChain.KeyPurpose)} or
      * {@link #currentAddress(KeyChain.KeyPurpose)}.</p>
      */
-    public Address freshAddress(KeyChain.KeyPurpose purpose, Script.ScriptType outputScriptType, long keyRotationTimeSecs) {
+    public Address freshAddress(KeyChain.KeyPurpose purpose, ScriptType outputScriptType, long keyRotationTimeSecs) {
         DeterministicKeyChain chain = getActiveKeyChain(outputScriptType, keyRotationTimeSecs);
         return Address.fromKey(params, chain.getKey(purpose), outputScriptType);
     }
@@ -443,7 +443,7 @@ public class KeyChainGroup implements KeyBag {
      */
     public Address freshAddress(KeyChain.KeyPurpose purpose) {
         DeterministicKeyChain chain = getActiveKeyChain();
-        Script.ScriptType outputScriptType = chain.getOutputScriptType();
+        ScriptType outputScriptType = chain.getOutputScriptType();
         if (chain.isMarried()) {
             Script outputScript = chain.freshOutputScript(purpose);
             checkState(ScriptPattern.isP2SH(outputScript)); // Only handle P2SH for now
@@ -452,7 +452,7 @@ public class KeyChainGroup implements KeyBag {
             maybeLookaheadScripts();
             currentAddresses.put(purpose, freshAddress);
             return freshAddress;
-        } else if (outputScriptType == Script.ScriptType.P2PKH || outputScriptType == Script.ScriptType.P2WPKH) {
+        } else if (outputScriptType == ScriptType.P2PKH || outputScriptType == ScriptType.P2WPKH) {
             return Address.fromKey(params, freshKey(purpose), outputScriptType);
         } else {
             throw new IllegalStateException(chain.getOutputScriptType().toString());
@@ -476,7 +476,7 @@ public class KeyChainGroup implements KeyBag {
      * Returns the key chain that's used for generation of fresh/current keys of the given type. If it's not the default
      * type and no active chain for this type exists, {@code null} is returned. No upgrade or downgrade is tried.
      */
-    public final DeterministicKeyChain getActiveKeyChain(Script.ScriptType outputScriptType, long keyRotationTimeSecs) {
+    public final DeterministicKeyChain getActiveKeyChain(ScriptType outputScriptType, long keyRotationTimeSecs) {
         checkState(supportsDeterministicChains(), "doesn't support deterministic chains");
         List<DeterministicKeyChain> chainsReversed = new ArrayList<>(chains);
         Collections.reverse(chainsReversed);
@@ -601,7 +601,7 @@ public class KeyChainGroup implements KeyBag {
 
     @Nullable
     @Override
-    public ECKey findKeyFromPubKeyHash(byte[] pubKeyHash, @Nullable Script.ScriptType scriptType) {
+    public ECKey findKeyFromPubKeyHash(byte[] pubKeyHash, @Nullable ScriptType scriptType) {
         ECKey result;
         // BasicKeyChain can mix output script types.
         if ((result = basic.findKeyFromPubHash(pubKeyHash)) != null)
@@ -990,8 +990,8 @@ public class KeyChainGroup implements KeyBag {
      * @throws DeterministicUpgradeRequiresPassword if the key chain group is encrypted
      *         and you should provide the users encryption key.
      */
-    public void upgradeToDeterministic(Script.ScriptType preferredScriptType, KeyChainGroupStructure structure,
-            long keyRotationTimeSecs, @Nullable KeyParameter aesKey)
+    public void upgradeToDeterministic(ScriptType preferredScriptType, KeyChainGroupStructure structure,
+                                       long keyRotationTimeSecs, @Nullable KeyParameter aesKey)
             throws DeterministicUpgradeRequiresPassword {
         checkState(supportsDeterministicChains(), "doesn't support deterministic chains");
         checkNotNull(structure);
@@ -1000,9 +1000,9 @@ public class KeyChainGroup implements KeyBag {
             return; // Nothing to do.
 
         // P2PKH --> P2WPKH upgrade
-        if (preferredScriptType == Script.ScriptType.P2WPKH
-                && getActiveKeyChain(Script.ScriptType.P2WPKH, keyRotationTimeSecs) == null) {
-            DeterministicSeed seed = getActiveKeyChain(Script.ScriptType.P2PKH, keyRotationTimeSecs).getSeed();
+        if (preferredScriptType == ScriptType.P2WPKH
+                && getActiveKeyChain(ScriptType.P2WPKH, keyRotationTimeSecs) == null) {
+            DeterministicSeed seed = getActiveKeyChain(ScriptType.P2PKH, keyRotationTimeSecs).getSeed();
             boolean seedWasEncrypted = seed.isEncrypted();
             if (seedWasEncrypted) {
                 if (aesKey == null)
@@ -1011,8 +1011,8 @@ public class KeyChainGroup implements KeyBag {
             }
             log.info("Upgrading from P2PKH to P2WPKH deterministic keychain. Using seed: {}", seed);
             DeterministicKeyChain chain = DeterministicKeyChain.builder().seed(seed)
-                    .outputScriptType(Script.ScriptType.P2WPKH)
-                    .accountPath(structure.accountPathFor(Script.ScriptType.P2WPKH, Network.MAIN)).build();
+                    .outputScriptType(ScriptType.P2WPKH)
+                    .accountPath(structure.accountPathFor(ScriptType.P2WPKH, Network.MAIN)).build();
             if (seedWasEncrypted)
                 chain = chain.toEncrypted(checkNotNull(keyCrypter), aesKey);
             addAndActivateHDChain(chain);
@@ -1023,7 +1023,7 @@ public class KeyChainGroup implements KeyBag {
      * Returns true if a call to {@link #upgradeToDeterministic(ScriptType, KeyChainGroupStructure, long, KeyParameter)} is required
      * in order to have an active deterministic keychain of the desired script type.
      */
-    public boolean isDeterministicUpgradeRequired(Script.ScriptType preferredScriptType, long keyRotationTimeSecs) {
+    public boolean isDeterministicUpgradeRequired(ScriptType preferredScriptType, long keyRotationTimeSecs) {
         if (!supportsDeterministicChains())
             return false;
         if (getActiveKeyChain(preferredScriptType, keyRotationTimeSecs) == null)

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroupStructure.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroupStructure.java
@@ -16,10 +16,10 @@
 
 package org.bitcoinj.wallet;
 
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.crypto.ChildNumber;
 import org.bitcoinj.crypto.HDPath;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.utils.Network;
 
 /**
@@ -28,8 +28,8 @@ import org.bitcoinj.utils.Network;
  *  Use {@link KeyChainGroupStructure#BIP32} for BIP-32 wallets and {@link KeyChainGroupStructure#BIP43} for
  *  BIP-43-family wallets.
  *  <p>
- *  <b>bitcoinj</b> BIP-32 wallets use {@link DeterministicKeyChain#ACCOUNT_ZERO_PATH} for {@link Script.ScriptType#P2PKH}
- *  and {@link DeterministicKeyChain#ACCOUNT_ONE_PATH} for {@link Script.ScriptType#P2WPKH}
+ *  <b>bitcoinj</b> BIP-32 wallets use {@link DeterministicKeyChain#ACCOUNT_ZERO_PATH} for {@link ScriptType#P2PKH}
+ *  and {@link DeterministicKeyChain#ACCOUNT_ONE_PATH} for {@link ScriptType#P2WPKH}
  *  <p>
  *  BIP-43-family wallets structured via {@link KeyChainGroupStructure} will always use account number zero. Currently,
  *  only BIP-44 (P2PKH) and BIP-84 (P2WPKH) are supported.
@@ -41,10 +41,10 @@ public interface KeyChainGroupStructure {
      *  Default to MainNet, BIP-32 Keychains use the same path for MainNet and TestNet
      * @param outputScriptType the script/address type
      * @return account path
-     * @deprecated Use {@link #accountPathFor(Script.ScriptType, Network)} or {@link #accountPathFor(Script.ScriptType, NetworkParameters)}
+     * @deprecated Use {@link #accountPathFor(ScriptType, Network)} or {@link #accountPathFor(ScriptType, NetworkParameters)}
      */
     @Deprecated
-    default HDPath accountPathFor(Script.ScriptType outputScriptType) {
+    default HDPath accountPathFor(ScriptType outputScriptType) {
         return accountPathFor(outputScriptType, Network.MAIN);
     }
 
@@ -54,7 +54,7 @@ public interface KeyChainGroupStructure {
      * @param network network/coin type
      * @return The HD Path: purpose / coinType / accountIndex
      */
-    HDPath accountPathFor(Script.ScriptType outputScriptType, Network network);
+    HDPath accountPathFor(ScriptType outputScriptType, Network network);
 
     /**
      * Map desired output script type and network to an account path
@@ -62,7 +62,7 @@ public interface KeyChainGroupStructure {
      * @param networkParameters network/coin type
      * @return The HD Path: purpose / coinType / accountIndex
      */
-    default HDPath accountPathFor(Script.ScriptType outputScriptType, NetworkParameters networkParameters) {
+    default HDPath accountPathFor(ScriptType outputScriptType, NetworkParameters networkParameters) {
         return accountPathFor(outputScriptType, Network.of(networkParameters));
     }
 
@@ -73,9 +73,9 @@ public interface KeyChainGroupStructure {
      */
     KeyChainGroupStructure BIP32 = (outputScriptType, network) -> {
         // network is ignored
-        if (outputScriptType == null || outputScriptType == Script.ScriptType.P2PKH)
+        if (outputScriptType == null || outputScriptType == ScriptType.P2PKH)
             return DeterministicKeyChain.ACCOUNT_ZERO_PATH;
-        else if (outputScriptType == Script.ScriptType.P2WPKH)
+        else if (outputScriptType == ScriptType.P2WPKH)
             return DeterministicKeyChain.ACCOUNT_ONE_PATH;
         else
             throw new IllegalArgumentException(outputScriptType.toString());
@@ -100,10 +100,10 @@ public interface KeyChainGroupStructure {
      * @param scriptType script/address type
      * @return An HDPath with a BIP44 "purpose" entry
      */
-    static HDPath purpose(Script.ScriptType scriptType) {
-        if (scriptType == null || scriptType == Script.ScriptType.P2PKH) {
+    static HDPath purpose(ScriptType scriptType) {
+        if (scriptType == null || scriptType == ScriptType.P2PKH) {
             return HDPath.BIP44_PARENT;
-        } else if (scriptType == Script.ScriptType.P2WPKH) {
+        } else if (scriptType == ScriptType.P2WPKH) {
             return HDPath.BIP84_PARENT;
         } else {
             throw new IllegalArgumentException(scriptType.toString());

--- a/core/src/main/java/org/bitcoinj/wallet/KeyTimeCoinSelector.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyTimeCoinSelector.java
@@ -18,6 +18,7 @@
 package org.bitcoinj.wallet;
 
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionConfidence;
@@ -68,9 +69,9 @@ public class KeyTimeCoinSelector implements CoinSelector {
                 if (ScriptPattern.isP2PK(scriptPubKey)) {
                     controllingKey = wallet.findKeyFromPubKey(ScriptPattern.extractKeyFromP2PK(scriptPubKey));
                 } else if (ScriptPattern.isP2PKH(scriptPubKey)) {
-                    controllingKey = wallet.findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2PKH(scriptPubKey), Script.ScriptType.P2PKH);
+                    controllingKey = wallet.findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2PKH(scriptPubKey), ScriptType.P2PKH);
                 } else if (ScriptPattern.isP2WPKH(scriptPubKey)) {
-                    controllingKey = wallet.findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2WH(scriptPubKey), Script.ScriptType.P2WPKH);
+                    controllingKey = wallet.findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2WH(scriptPubKey), ScriptType.P2WPKH);
                 } else {
                     log.info("Skipping tx output {} because it's not of simple form.", output);
                     continue;

--- a/core/src/main/java/org/bitcoinj/wallet/MarriedKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/MarriedKeyChain.java
@@ -18,6 +18,7 @@ package org.bitcoinj.wallet;
 
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.BloomFilter;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.NetworkParameters;
@@ -125,7 +126,7 @@ public class MarriedKeyChain extends DeterministicKeyChain {
      * This constructor is not stable across releases! If you need a stable API, use {@link #builder()} to use a
      * {@link Builder}.
      */
-    protected MarriedKeyChain(DeterministicKey accountKey, Script.ScriptType outputScriptType) {
+    protected MarriedKeyChain(DeterministicKey accountKey, ScriptType outputScriptType) {
         super(accountKey, false, true, outputScriptType);
     }
 
@@ -133,7 +134,7 @@ public class MarriedKeyChain extends DeterministicKeyChain {
      * This constructor is not stable across releases! If you need a stable API, use {@link #builder()} to use a
      * {@link Builder}.
      */
-    protected MarriedKeyChain(DeterministicSeed seed, KeyCrypter crypter, Script.ScriptType outputScriptType, List<ChildNumber> accountPath) {
+    protected MarriedKeyChain(DeterministicSeed seed, KeyCrypter crypter, ScriptType outputScriptType, List<ChildNumber> accountPath) {
         super(seed, crypter, outputScriptType, accountPath);
     }
 

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -69,7 +69,7 @@ import org.bitcoinj.crypto.KeyCrypter;
 import org.bitcoinj.crypto.KeyCrypterException;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
 import org.bitcoinj.script.Script;
-import org.bitcoinj.script.Script.ScriptType;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptChunk;
 import org.bitcoinj.script.ScriptException;
@@ -305,7 +305,7 @@ public class Wallet extends BaseTaggableObject
      * @param outputScriptType type of addresses (aka output scripts) to generate for receiving
      * @return A new empty wallet
      */
-    public static Wallet createDeterministic(NetworkParameters params, Script.ScriptType outputScriptType) {
+    public static Wallet createDeterministic(NetworkParameters params, ScriptType outputScriptType) {
         return createDeterministic(Context.getOrCreate(params), outputScriptType, KeyChainGroupStructure.BIP32);
     }
 
@@ -318,7 +318,7 @@ public class Wallet extends BaseTaggableObject
      * @param keyChainGroupStructure structure (e.g. BIP32 or BIP43)
      * @return A new empty wallet
      */
-    public static Wallet createDeterministic(NetworkParameters params, Script.ScriptType outputScriptType, KeyChainGroupStructure keyChainGroupStructure) {
+    public static Wallet createDeterministic(NetworkParameters params, ScriptType outputScriptType, KeyChainGroupStructure keyChainGroupStructure) {
         return createDeterministic(Context.getOrCreate(params), outputScriptType, keyChainGroupStructure);
     }
 
@@ -330,7 +330,7 @@ public class Wallet extends BaseTaggableObject
      * @param outputScriptType type of addresses (aka output scripts) to generate for receiving
      * @return A new empty wallet
      */
-    public static Wallet createDeterministic(Context context, Script.ScriptType outputScriptType) {
+    public static Wallet createDeterministic(Context context, ScriptType outputScriptType) {
         return createDeterministic(context, outputScriptType, KeyChainGroupStructure.BIP32);
     }
 
@@ -343,7 +343,7 @@ public class Wallet extends BaseTaggableObject
      * @param keyChainGroupStructure structure (e.g. BIP32 or BIP43)
      * @return A new empty wallet
      */
-    public static Wallet createDeterministic(Context context, Script.ScriptType outputScriptType, KeyChainGroupStructure keyChainGroupStructure) {
+    public static Wallet createDeterministic(Context context, ScriptType outputScriptType, KeyChainGroupStructure keyChainGroupStructure) {
         return new Wallet(context, KeyChainGroup.builder(context.getParams(), keyChainGroupStructure).fromRandom(outputScriptType).build());
     }
 
@@ -363,7 +363,7 @@ public class Wallet extends BaseTaggableObject
      * @return a wallet from a deterministic seed with a default account path
      */
     public static Wallet fromSeed(NetworkParameters params, DeterministicSeed seed,
-            Script.ScriptType outputScriptType) {
+            ScriptType outputScriptType) {
         return fromSeed(params, seed, outputScriptType, KeyChainGroupStructure.BIP32);
     }
 
@@ -374,7 +374,7 @@ public class Wallet extends BaseTaggableObject
      * @param structure structure for your wallet
      * @return a wallet from a deterministic seed with a default account path
      */
-    public static Wallet fromSeed(NetworkParameters params, DeterministicSeed seed, Script.ScriptType outputScriptType,
+    public static Wallet fromSeed(NetworkParameters params, DeterministicSeed seed, ScriptType outputScriptType,
             KeyChainGroupStructure structure) {
         return new Wallet(params, KeyChainGroup.builder(params, structure).fromSeed(seed, outputScriptType).build());
     }
@@ -386,7 +386,7 @@ public class Wallet extends BaseTaggableObject
      * @param accountPath account path to generate receiving addresses on
      * @return an instance of a wallet from a deterministic seed.
      */
-    public static Wallet fromSeed(NetworkParameters params, DeterministicSeed seed, Script.ScriptType outputScriptType,
+    public static Wallet fromSeed(NetworkParameters params, DeterministicSeed seed, ScriptType outputScriptType,
             List<ChildNumber> accountPath) {
         DeterministicKeyChain chain = DeterministicKeyChain.builder().seed(seed).outputScriptType(outputScriptType)
                 .accountPath(accountPath).build();
@@ -398,7 +398,7 @@ public class Wallet extends BaseTaggableObject
      * to be an account key as returned by {@link DeterministicKeyChain#getWatchingKey()}.
      */
     public static Wallet fromWatchingKey(NetworkParameters params, DeterministicKey watchKey,
-            Script.ScriptType outputScriptType) {
+            ScriptType outputScriptType) {
         DeterministicKeyChain chain = DeterministicKeyChain.builder().watch(watchKey).outputScriptType(outputScriptType)
                 .build();
         return new Wallet(params, KeyChainGroup.builder(params).addChain(chain).build());
@@ -420,7 +420,7 @@ public class Wallet extends BaseTaggableObject
      * to be an account key as returned by {@link DeterministicKeyChain#getWatchingKey()}. This wallet can also spend.
      */
     public static Wallet fromSpendingKey(NetworkParameters params, DeterministicKey spendKey,
-            Script.ScriptType outputScriptType) {
+            ScriptType outputScriptType) {
         DeterministicKeyChain chain = DeterministicKeyChain.builder().spend(spendKey).outputScriptType(outputScriptType)
                 .build();
         return new Wallet(params, KeyChainGroup.builder(params).addChain(chain).build());
@@ -442,7 +442,7 @@ public class Wallet extends BaseTaggableObject
      * to be an account key as returned by {@link DeterministicKeyChain#getWatchingKey()}.
      */
     public static Wallet fromMasterKey(NetworkParameters params, DeterministicKey masterKey,
-            Script.ScriptType outputScriptType, ChildNumber accountNumber) {
+                                       ScriptType outputScriptType, ChildNumber accountNumber) {
         DeterministicKey accountKey = HDKeyDerivation.deriveChildKey(masterKey, accountNumber);
         accountKey = accountKey.dropParent();
         accountKey.setCreationTimeSeconds(masterKey.getCreationTimeSeconds());
@@ -451,12 +451,12 @@ public class Wallet extends BaseTaggableObject
         return new Wallet(params, KeyChainGroup.builder(params).addChain(chain).build());
     }
 
-    private static Script.ScriptType outputScriptTypeFromB58(NetworkParameters params, String base58) {
+    private static ScriptType outputScriptTypeFromB58(NetworkParameters params, String base58) {
         int header = ByteBuffer.wrap(Base58.decodeChecked(base58)).getInt();
         if (header == params.getBip32HeaderP2PKHpub() || header == params.getBip32HeaderP2PKHpriv())
-            return Script.ScriptType.P2PKH;
+            return ScriptType.P2PKH;
         else if (header == params.getBip32HeaderP2WPKHpub() || header == params.getBip32HeaderP2WPKHpriv())
-            return Script.ScriptType.P2WPKH;
+            return ScriptType.P2WPKH;
         else
             throw new IllegalArgumentException(base58.substring(0, 4));
     }
@@ -684,12 +684,12 @@ public class Wallet extends BaseTaggableObject
     }
 
     /**
-     * <p>Returns a fresh receive address for a given {@link Script.ScriptType}.</p>
+     * <p>Returns a fresh receive address for a given {@link ScriptType}.</p>
      * <p>This method is meant for when you really need a fallback address. Normally, you should be
      * using {@link #freshAddress(KeyChain.KeyPurpose)} or
      * {@link #currentAddress(KeyChain.KeyPurpose)}.</p>
      */
-    public Address freshReceiveAddress(Script.ScriptType scriptType) {
+    public Address freshReceiveAddress(ScriptType scriptType) {
         Address address;
         keyChainGroupLock.lock();
         try {
@@ -729,7 +729,7 @@ public class Wallet extends BaseTaggableObject
             List<Address> addresses = new ArrayList<>();
             long keyRotationTimeSecs = vKeyRotationTimestamp;
             for (final DeterministicKeyChain chain : keyChainGroup.getActiveKeyChains(keyRotationTimeSecs)) {
-                Script.ScriptType outputScriptType = chain.getOutputScriptType();
+                ScriptType outputScriptType = chain.getOutputScriptType();
                 for (ECKey key : chain.getIssuedReceiveKeys())
                     addresses.add(Address.fromKey(getParams(), key, outputScriptType));
             }
@@ -746,7 +746,7 @@ public class Wallet extends BaseTaggableObject
      * to do this will result in an exception being thrown. For non-encrypted wallets, the upgrade will be done for
      * you automatically the first time a new key is requested (this happens when spending due to the change address).
      */
-    public void upgradeToDeterministic(Script.ScriptType outputScriptType, @Nullable KeyParameter aesKey)
+    public void upgradeToDeterministic(ScriptType outputScriptType, @Nullable KeyParameter aesKey)
             throws DeterministicUpgradeRequiresPassword {
         upgradeToDeterministic(outputScriptType, KeyChainGroupStructure.BIP32, aesKey);
     }
@@ -758,8 +758,8 @@ public class Wallet extends BaseTaggableObject
      * to do this will result in an exception being thrown. For non-encrypted wallets, the upgrade will be done for
      * you automatically the first time a new key is requested (this happens when spending due to the change address).
      */
-    public void upgradeToDeterministic(Script.ScriptType outputScriptType, KeyChainGroupStructure structure,
-            @Nullable KeyParameter aesKey) throws DeterministicUpgradeRequiresPassword {
+    public void upgradeToDeterministic(ScriptType outputScriptType, KeyChainGroupStructure structure,
+                                       @Nullable KeyParameter aesKey) throws DeterministicUpgradeRequiresPassword {
         keyChainGroupLock.lock();
         try {
             long keyRotationTimeSecs = vKeyRotationTimestamp;
@@ -774,7 +774,7 @@ public class Wallet extends BaseTaggableObject
      * {@link #upgradeToDeterministic(ScriptType, KeyParameter)} before attempting to do anything
      * that would require a new address or key.
      */
-    public boolean isDeterministicUpgradeRequired(Script.ScriptType outputScriptType) {
+    public boolean isDeterministicUpgradeRequired(ScriptType outputScriptType) {
         keyChainGroupLock.lock();
         try {
             long keyRotationTimeSecs = vKeyRotationTimestamp;
@@ -1129,7 +1129,7 @@ public class Wallet extends BaseTaggableObject
      */
     @Override
     @Nullable
-    public ECKey findKeyFromPubKeyHash(byte[] pubKeyHash, @Nullable Script.ScriptType scriptType) {
+    public ECKey findKeyFromPubKeyHash(byte[] pubKeyHash, @Nullable ScriptType scriptType) {
         keyChainGroupLock.lock();
         try {
             return keyChainGroup.findKeyFromPubKeyHash(pubKeyHash, scriptType);
@@ -1164,7 +1164,7 @@ public class Wallet extends BaseTaggableObject
     }
 
     @Override
-    public boolean isPubKeyHashMine(byte[] pubKeyHash, @Nullable Script.ScriptType scriptType) {
+    public boolean isPubKeyHashMine(byte[] pubKeyHash, @Nullable ScriptType scriptType) {
         return findKeyFromPubKeyHash(pubKeyHash, scriptType) != null;
     }
 
@@ -4438,11 +4438,11 @@ public class Wallet extends BaseTaggableObject
             return data != null && canSignFor(data.redeemScript);
         } else if (ScriptPattern.isP2PKH(script)) {
             ECKey key = findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2PKH(script),
-                    Script.ScriptType.P2PKH);
+                    ScriptType.P2PKH);
             return key != null && (key.isEncrypted() || key.hasPrivKey());
         } else if (ScriptPattern.isP2WPKH(script)) {
             ECKey key = findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2WH(script),
-                    Script.ScriptType.P2WPKH);
+                    ScriptType.P2WPKH);
             return key != null && (key.isEncrypted() || key.hasPrivKey()) && key.isCompressed();
         } else if (ScriptPattern.isSentToMultisig(script)) {
             for (ECKey pubkey : script.getPubKeys()) {
@@ -5168,11 +5168,11 @@ public class Wallet extends BaseTaggableObject
                 ECKey key = null;
                 Script redeemScript = null;
                 if (ScriptPattern.isP2PKH(script)) {
-                    key = findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2PKH(script), Script.ScriptType.P2PKH);
+                    key = findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2PKH(script), ScriptType.P2PKH);
                     checkNotNull(key, "Coin selection includes unspendable outputs");
                     vsize += script.getNumberOfBytesRequiredToSpend(key, redeemScript);
                 } else if (ScriptPattern.isP2WPKH(script)) {
-                    key = findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2WH(script), Script.ScriptType.P2WPKH);
+                    key = findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2WH(script), ScriptType.P2WPKH);
                     checkNotNull(key, "Coin selection includes unspendable outputs");
                     vsize += IntMath.divide(script.getNumberOfBytesRequiredToSpend(key, redeemScript), 4,
                             RoundingMode.CEILING); // round up
@@ -5393,7 +5393,7 @@ public class Wallet extends BaseTaggableObject
 
         // We might have to create a new HD hierarchy if the previous ones are now rotating.
         boolean allChainsRotating = true;
-        Script.ScriptType preferredScriptType = Script.ScriptType.P2PKH;
+        ScriptType preferredScriptType = ScriptType.P2PKH;
         if (keyChainGroup.supportsDeterministicChains()) {
             for (DeterministicKeyChain chain : keyChainGroup.getDeterministicKeyChains()) {
                 if (chain.getEarliestKeyCreationTime() >= keyRotationTimestamp)

--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -19,6 +19,7 @@ package org.bitcoinj.core;
 
 import com.google.common.collect.Lists;
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.UnitTestParams;
 import org.bitcoinj.script.Script;
@@ -324,7 +325,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         rollingBlock = rollingBlock.createNextBlock(null);
 
         // Create 1 BTC spend to a key in this wallet (to ourselves).
-        Wallet wallet = Wallet.createDeterministic(PARAMS, Script.ScriptType.P2PKH);
+        Wallet wallet = Wallet.createDeterministic(PARAMS, ScriptType.P2PKH);
         assertEquals("Available balance is incorrect", Coin.ZERO, wallet.getBalance(Wallet.BalanceType.AVAILABLE));
         assertEquals("Estimated balance is incorrect", Coin.ZERO, wallet.getBalance(Wallet.BalanceType.ESTIMATED));
 

--- a/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
@@ -18,10 +18,10 @@
 package org.bitcoinj.core;
 
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.params.UnitTestParams;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.testing.FakeTxBuilder;
@@ -86,10 +86,10 @@ public class BlockChainTest {
         BriefLogFormatter.initVerbose();
         Utils.setMockClock(); // Use mock clock
         Context.propagate(new Context(TESTNET, 100, Coin.ZERO, false));
-        testNetChain = new BlockChain(TESTNET, Wallet.createDeterministic(TESTNET, Script.ScriptType.P2PKH), new MemoryBlockStore(TESTNET));
+        testNetChain = new BlockChain(TESTNET, Wallet.createDeterministic(TESTNET, ScriptType.P2PKH), new MemoryBlockStore(TESTNET));
         Context.propagate(new Context(UNITTEST, 100, Coin.ZERO, false));
         NetworkParameters params = Context.get().getParams();
-        wallet = new Wallet(params, KeyChainGroup.builder(params).fromRandom(Script.ScriptType.P2PKH).build()) {
+        wallet = new Wallet(params, KeyChainGroup.builder(params).fromRandom(ScriptType.P2PKH).build()) {
             @Override
             public void receiveFromBlock(Transaction tx, StoredBlock block, BlockChain.NewBlockType blockType,
                                          int relativityOffset) throws VerificationException {
@@ -325,7 +325,7 @@ public class BlockChainTest {
         // Check that a coinbase transaction is only available to spend after NetworkParameters.getSpendableCoinbaseDepth() blocks.
 
         // Create a second wallet to receive the coinbase spend.
-        Wallet wallet2 = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        Wallet wallet2 = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         ECKey receiveKey = wallet2.freshReceiveKey();
         int height = 1;
         chain.addWallet(wallet2);

--- a/core/src/test/java/org/bitcoinj/core/BlockTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockTest.java
@@ -19,11 +19,11 @@ package org.bitcoinj.core;
 
 import com.google.common.io.ByteStreams;
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.AbstractBlockChain.NewBlockType;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.params.UnitTestParams;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptOpCodes;
 import org.bitcoinj.wallet.Wallet;
 import org.bitcoinj.wallet.Wallet.BalanceType;
@@ -225,7 +225,7 @@ public class BlockTest {
         ECKey miningKey = DumpedPrivateKey.fromBase58(MAINNET, MINING_PRIVATE_KEY).getKey();
         assertNotNull(miningKey);
         Context context = new Context(MAINNET);
-        Wallet wallet = Wallet.createDeterministic(context, Script.ScriptType.P2PKH);
+        Wallet wallet = Wallet.createDeterministic(context, ScriptType.P2PKH);
         wallet.importKey(miningKey);
 
         // Initial balance should be zero by construction.

--- a/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
@@ -18,9 +18,9 @@
 package org.bitcoinj.core;
 
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.TransactionConfidence.ConfidenceType;
 import org.bitcoinj.params.UnitTestParams;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.testing.FakeTxBuilder;
 import org.bitcoinj.utils.BriefLogFormatter;
@@ -66,7 +66,7 @@ public class ChainSplitTest {
         Utils.setMockClock(); // Use mock clock
         Context.propagate(new Context(UNITTEST, 100, Coin.ZERO, false));
         MemoryBlockStore blockStore = new MemoryBlockStore(UNITTEST);
-        wallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        wallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         ECKey key1 = wallet.freshReceiveKey();
         ECKey key2 = wallet.freshReceiveKey();
         chain = new BlockChain(UNITTEST, wallet, blockStore);

--- a/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
@@ -23,7 +23,7 @@ import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.Networks;
 import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.script.Script;
-import org.bitcoinj.script.Script.ScriptType;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptPattern;
 import org.junit.Test;

--- a/core/src/test/java/org/bitcoinj/core/ParseByteCacheTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ParseByteCacheTest.java
@@ -17,9 +17,9 @@
 
 package org.bitcoinj.core;
 
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.UnitTestParams;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.wallet.Wallet;
@@ -90,7 +90,7 @@ public class ParseByteCacheTest {
     public void setUp() throws Exception {
         Utils.setMockClock(); // Use mock clock
         Context context = new Context(UNITTEST);
-        Wallet wallet = Wallet.createDeterministic(context, Script.ScriptType.P2PKH);
+        Wallet wallet = Wallet.createDeterministic(context, ScriptType.P2PKH);
         wallet.freshReceiveKey();
 
         resetBlockStore();

--- a/core/src/test/java/org/bitcoinj/core/SegwitAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/SegwitAddressTest.java
@@ -22,7 +22,7 @@ import nl.jqno.equalsverifier.Warning;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.script.Script;
-import org.bitcoinj.script.Script.ScriptType;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptPattern;
 import org.junit.Test;

--- a/core/src/test/java/org/bitcoinj/core/TransactionInputTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionInputTest.java
@@ -18,8 +18,8 @@ package org.bitcoinj.core;
 
 import com.google.common.collect.Lists;
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.params.UnitTestParams;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.testing.FakeTxBuilder;
 import org.bitcoinj.wallet.SendRequest;
@@ -36,7 +36,7 @@ public class TransactionInputTest {
 
     @Test
     public void testStandardWalletDisconnect() throws Exception {
-        Wallet w = Wallet.createDeterministic(new Context(UNITTEST), Script.ScriptType.P2PKH);
+        Wallet w = Wallet.createDeterministic(new Context(UNITTEST), ScriptType.P2PKH);
         Address a = w.currentReceiveAddress();
         Transaction tx1 = FakeTxBuilder.createFakeTxWithoutChangeAddress(UNITTEST, Coin.COIN, a);
         w.receivePending(tx1, null);
@@ -59,7 +59,7 @@ public class TransactionInputTest {
 
     @Test
     public void testUTXOWalletDisconnect() throws Exception {
-        Wallet w = Wallet.createDeterministic(new Context(UNITTEST), Script.ScriptType.P2PKH);
+        Wallet w = Wallet.createDeterministic(new Context(UNITTEST), ScriptType.P2PKH);
         Address a = w.currentReceiveAddress();
         final UTXO utxo = new UTXO(Sha256Hash.of(new byte[] { 1, 2, 3 }), 1, Coin.COIN, 0, false,
                 ScriptBuilder.createOutputScript(a));

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -18,6 +18,7 @@
 package org.bitcoinj.core;
 
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.TransactionConfidence.ConfidenceType;
 import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.params.TestNet3Params;
@@ -192,13 +193,13 @@ public class TransactionTest {
 
     @Test
     public void addSignedInput_P2PKH() {
-        final Address toAddr = Address.fromKey(TESTNET, new ECKey(), Script.ScriptType.P2PKH);
+        final Address toAddr = Address.fromKey(TESTNET, new ECKey(), ScriptType.P2PKH);
         final Sha256Hash utxo_id = Sha256Hash.wrap("81b4c832d70cb56ff957589752eb4125a4cab78a25a8fc52d6a09e5bd4404d48");
         final Coin inAmount = Coin.ofSat(91234);
         final Coin outAmount = Coin.ofSat(91234);
 
         ECKey fromKey = new ECKey();
-        Address fromAddress = Address.fromKey(TESTNET, fromKey, Script.ScriptType.P2PKH);
+        Address fromAddress = Address.fromKey(TESTNET, fromKey, ScriptType.P2PKH);
         Transaction tx = new Transaction(TESTNET);
         TransactionOutPoint outPoint = new TransactionOutPoint(TESTNET, 0, utxo_id);
         TransactionOutput output = new TransactionOutput(TESTNET, null, inAmount, fromAddress);
@@ -215,13 +216,13 @@ public class TransactionTest {
 
     @Test
     public void addSignedInput_P2WPKH() {
-        final Address toAddr = Address.fromKey(TESTNET, new ECKey(), Script.ScriptType.P2WPKH);
+        final Address toAddr = Address.fromKey(TESTNET, new ECKey(), ScriptType.P2WPKH);
         final Sha256Hash utxo_id = Sha256Hash.wrap("81b4c832d70cb56ff957589752eb4125a4cab78a25a8fc52d6a09e5bd4404d48");
         final Coin inAmount = Coin.ofSat(91234);
         final Coin outAmount = Coin.ofSat(91234);
 
         ECKey fromKey = new ECKey();
-        Address fromAddress = Address.fromKey(TESTNET, fromKey, Script.ScriptType.P2WPKH);
+        Address fromAddress = Address.fromKey(TESTNET, fromKey, ScriptType.P2WPKH);
         Transaction tx = new Transaction(TESTNET);
         TransactionOutPoint outPoint = new TransactionOutPoint(TESTNET, 0, utxo_id);
         tx.addOutput(outAmount, toAddr);

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -19,6 +19,7 @@ package org.bitcoinj.store;
 
 import com.google.common.io.ByteStreams;
 import com.google.protobuf.ByteString;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.Address;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.core.BlockChain;
@@ -39,7 +40,6 @@ import org.bitcoinj.core.Utils;
 import org.bitcoinj.crypto.DeterministicKey;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.UnitTestParams;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.testing.FakeTxBuilder;
 import org.bitcoinj.testing.FooWalletExtension;
@@ -107,7 +107,7 @@ public class WalletProtobufSerializerTest {
         myKey = new ECKey();
         myKey.setCreationTimeSeconds(123456789L);
         myAddress = LegacyAddress.fromKey(UNITTEST, myKey);
-        myWallet = new Wallet(UNITTEST, KeyChainGroup.builder(UNITTEST).fromRandom(Script.ScriptType.P2PKH).build());
+        myWallet = new Wallet(UNITTEST, KeyChainGroup.builder(UNITTEST).fromRandom(ScriptType.P2PKH).build());
         myWallet.importKey(myKey);
         mScriptCreationTime = new Date().getTime() / 1000 - 1234;
         myWallet.addWatchedAddress(LegacyAddress.fromKey(UNITTEST, myWatchedKey), mScriptCreationTime);
@@ -203,7 +203,7 @@ public class WalletProtobufSerializerTest {
         for (int i = 0 ; i < 20 ; i++) {
             myKey = new ECKey();
             myAddress = LegacyAddress.fromKey(UNITTEST, myKey);
-            myWallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+            myWallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
             myWallet.importKey(myKey);
             Wallet wallet1 = roundTrip(myWallet);
             ECKey foundKey = wallet1.findKeyFromPubKeyHash(myKey.getPubKeyHash(), null);
@@ -217,7 +217,7 @@ public class WalletProtobufSerializerTest {
         // Test the lastBlockSeenHash field works.
 
         // LastBlockSeenHash should be empty if never set.
-        Wallet wallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        Wallet wallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         Protos.Wallet walletProto = new WalletProtobufSerializer().walletToProto(wallet);
         ByteString lastSeenBlockHash = walletProto.getLastSeenBlockHash();
         assertTrue(lastSeenBlockHash.isEmpty());
@@ -243,7 +243,7 @@ public class WalletProtobufSerializerTest {
 
     @Test
     public void testSequenceNumber() throws Exception {
-        Wallet wallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        Wallet wallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         Transaction tx1 = createFakeTx(UNITTEST, Coin.COIN, wallet.currentReceiveAddress());
         tx1.getInput(0).setSequenceNumber(TransactionInput.NO_SEQUENCE);
         wallet.receivePending(tx1, null);
@@ -363,7 +363,7 @@ public class WalletProtobufSerializerTest {
     @Test
     public void testRoundTripMarriedWallet() throws Exception {
         // create 2-of-2 married wallet
-        myWallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        myWallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         final DeterministicKeyChain partnerChain = DeterministicKeyChain.builder().random(new SecureRandom()).build();
         DeterministicKey partnerKey = DeterministicKey.deserializeB58(null, partnerChain.getWatchingKey().serializePubB58(UNITTEST), UNITTEST);
         MarriedKeyChain chain = MarriedKeyChain.builder()
@@ -434,7 +434,7 @@ public class WalletProtobufSerializerTest {
         assertTrue(wallet.getExtensions().containsKey("com.whatever.required"));
 
         // Non-mandatory extensions are ignored if the wallet doesn't know how to read them.
-        Wallet wallet2 = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        Wallet wallet2 = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         wallet2.addExtension(new FooWalletExtension("com.whatever.optional", false));
         Protos.Wallet proto2 = new WalletProtobufSerializer().walletToProto(wallet2);
         Wallet wallet5 = new WalletProtobufSerializer().readWallet(UNITTEST, null, proto2);

--- a/core/src/test/java/org/bitcoinj/testing/TestWithWallet.java
+++ b/core/src/test/java/org/bitcoinj/testing/TestWithWallet.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.testing;
 
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.AbstractBlockChain;
 import org.bitcoinj.core.Address;
 import org.bitcoinj.core.Block;
@@ -29,7 +30,6 @@ import org.bitcoinj.core.Utils;
 import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.UnitTestParams;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.utils.BriefLogFormatter;
@@ -70,9 +70,9 @@ public class TestWithWallet {
     public void setUp() throws Exception {
         BriefLogFormatter.init();
         Context.propagate(new Context(UNITTEST, 100, Coin.ZERO, false));
-        wallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH, KeyChainGroupStructure.BIP32);
+        wallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH, KeyChainGroupStructure.BIP32);
         myKey = wallet.freshReceiveKey();
-        myAddress = wallet.freshReceiveAddress(Script.ScriptType.P2PKH);
+        myAddress = wallet.freshReceiveAddress(ScriptType.P2PKH);
         blockStore = new MemoryBlockStore(UNITTEST);
         chain = new BlockChain(UNITTEST, wallet, blockStore);
     }

--- a/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
@@ -18,6 +18,7 @@
 package org.bitcoinj.wallet;
 
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.Context;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.NetworkParameters;
@@ -57,7 +58,7 @@ public class DefaultRiskAnalysisTest {
 
     @Before
     public void setup() {
-        wallet = Wallet.createDeterministic(new Context(MAINNET), Script.ScriptType.P2PKH);
+        wallet = Wallet.createDeterministic(new Context(MAINNET), ScriptType.P2PKH);
         wallet.setLastBlockSeenHeight(1000);
         wallet.setLastBlockSeenTimeSecs(TIMESTAMP);
     }

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -18,6 +18,7 @@
 package org.bitcoinj.wallet;
 
 import com.google.common.collect.Lists;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.Address;
 import org.bitcoinj.core.BloomFilter;
 import org.bitcoinj.core.ECKey;
@@ -31,7 +32,6 @@ import org.bitcoinj.crypto.HDKeyDerivation;
 import org.bitcoinj.crypto.HDPath;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.UnitTestParams;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.utils.BriefLogFormatter;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.listeners.AbstractKeyChainEventListener;
@@ -75,15 +75,15 @@ public class DeterministicKeyChainTest {
         // serialized data properly.
         long secs = 1389353062L;
         chain = DeterministicKeyChain.builder().entropy(ENTROPY, secs)
-                .accountPath(DeterministicKeyChain.ACCOUNT_ZERO_PATH).outputScriptType(Script.ScriptType.P2PKH).build();
+                .accountPath(DeterministicKeyChain.ACCOUNT_ZERO_PATH).outputScriptType(ScriptType.P2PKH).build();
         chain.setLookaheadSize(10);
 
         segwitChain = DeterministicKeyChain.builder().entropy(ENTROPY, secs)
-                .accountPath(DeterministicKeyChain.ACCOUNT_ONE_PATH).outputScriptType(Script.ScriptType.P2WPKH).build();
+                .accountPath(DeterministicKeyChain.ACCOUNT_ONE_PATH).outputScriptType(ScriptType.P2WPKH).build();
         segwitChain.setLookaheadSize(10);
 
         bip44chain = DeterministicKeyChain.builder().entropy(ENTROPY, secs).accountPath(BIP44_COIN_1_ACCOUNT_ZERO_PATH)
-                .outputScriptType(Script.ScriptType.P2PKH).build();
+                .outputScriptType(ScriptType.P2PKH).build();
         bip44chain.setLookaheadSize(10);
     }
 
@@ -182,7 +182,7 @@ public class DeterministicKeyChainTest {
         // Check that we get the right events at the right time.
         final List<List<ECKey>> listenerKeys = new ArrayList<>();
         long secs = 1389353062L;
-        chain = DeterministicKeyChain.builder().entropy(ENTROPY, secs).outputScriptType(Script.ScriptType.P2PKH)
+        chain = DeterministicKeyChain.builder().entropy(ENTROPY, secs).outputScriptType(ScriptType.P2PKH)
                 .build();
         chain.addEventListener(new AbstractKeyChainEventListener() {
             @Override
@@ -554,7 +554,7 @@ public class DeterministicKeyChainTest {
         checkSerialization(serialization, "watching-wallet-p2wpkh-serialization.txt");
         final DeterministicKeyChain chain = DeterministicKeyChain.fromProtobuf(serialization, null).get(0);
         assertEquals(DeterministicKeyChain.ACCOUNT_ONE_PATH, chain.getAccountPath());
-        assertEquals(Script.ScriptType.P2WPKH, chain.getOutputScriptType());
+        assertEquals(ScriptType.P2WPKH, chain.getOutputScriptType());
         final DeterministicKey rekey4 = segwitChain.getKey(KeyChain.KeyPurpose.CHANGE);
         assertEquals(key4.getPubKeyPoint(), rekey4.getPubKeyPoint());
     }

--- a/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
@@ -28,8 +28,7 @@ import org.bitcoinj.crypto.KeyCrypterException;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
 import org.bitcoinj.crypto.MnemonicCode;
 import org.bitcoinj.params.MainNetParams;
-import org.bitcoinj.script.Script;
-import org.bitcoinj.script.Script.ScriptType;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.utils.BriefLogFormatter;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.KeyChain.KeyPurpose;
@@ -68,7 +67,7 @@ public class KeyChainGroupTest {
     public void setup() {
         BriefLogFormatter.init();
         Utils.setMockClock();
-        group = KeyChainGroup.builder(MAINNET).lookaheadSize(LOOKAHEAD_SIZE).fromRandom(Script.ScriptType.P2PKH)
+        group = KeyChainGroup.builder(MAINNET).lookaheadSize(LOOKAHEAD_SIZE).fromRandom(ScriptType.P2PKH)
                 .build();
         group.getActiveKeyChain();  // Force create a chain.
 
@@ -77,21 +76,21 @@ public class KeyChainGroupTest {
 
     @Test
     public void createDeterministic_P2PKH() {
-        KeyChainGroup kcg = KeyChainGroup.builder(MAINNET).fromRandom(Script.ScriptType.P2PKH).build();
+        KeyChainGroup kcg = KeyChainGroup.builder(MAINNET).fromRandom(ScriptType.P2PKH).build();
         // check default
         Address address = kcg.currentAddress(KeyPurpose.RECEIVE_FUNDS);
-        assertEquals(Script.ScriptType.P2PKH, address.getOutputScriptType());
+        assertEquals(ScriptType.P2PKH, address.getOutputScriptType());
     }
 
     @Test
     public void createDeterministic_P2WPKH() {
-        KeyChainGroup kcg = KeyChainGroup.builder(MAINNET).fromRandom(Script.ScriptType.P2WPKH).build();
+        KeyChainGroup kcg = KeyChainGroup.builder(MAINNET).fromRandom(ScriptType.P2WPKH).build();
         // check default
         Address address = kcg.currentAddress(KeyPurpose.RECEIVE_FUNDS);
-        assertEquals(Script.ScriptType.P2WPKH, address.getOutputScriptType());
+        assertEquals(ScriptType.P2WPKH, address.getOutputScriptType());
         // check fallback (this will go away at some point)
-        address = kcg.freshAddress(KeyPurpose.RECEIVE_FUNDS, Script.ScriptType.P2PKH, 0);
-        assertEquals(Script.ScriptType.P2PKH, address.getOutputScriptType());
+        address = kcg.freshAddress(KeyPurpose.RECEIVE_FUNDS, ScriptType.P2PKH, 0);
+        assertEquals(ScriptType.P2PKH, address.getOutputScriptType());
     }
 
     private KeyChainGroup createMarriedKeyChainGroup() {
@@ -329,7 +328,7 @@ public class KeyChainGroupTest {
 
     @Test
     public void encryptionWhilstEmpty() {
-        group = KeyChainGroup.builder(MAINNET).lookaheadSize(5).fromRandom(Script.ScriptType.P2PKH).build();
+        group = KeyChainGroup.builder(MAINNET).lookaheadSize(5).fromRandom(ScriptType.P2PKH).build();
         group.encrypt(KEY_CRYPTER, AES_KEY);
         assertTrue(group.freshKey(KeyChain.KeyPurpose.RECEIVE_FUNDS).isEncrypted());
         final ECKey key = group.currentKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
@@ -473,7 +472,7 @@ public class KeyChainGroupTest {
     @Test
     public void serializeWatching() throws Exception {
         group = KeyChainGroup.builder(MAINNET).lookaheadSize(LOOKAHEAD_SIZE).addChain(DeterministicKeyChain.builder()
-                .watch(watchingAccountKey).outputScriptType(Script.ScriptType.P2PKH).build()).build();
+                .watch(watchingAccountKey).outputScriptType(ScriptType.P2PKH).build()).build();
         group.freshKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         group.freshKey(KeyChain.KeyPurpose.CHANGE);
         group.getBloomFilterElementCount();  // Force lookahead.
@@ -510,7 +509,7 @@ public class KeyChainGroupTest {
         ECKey key1 = group.freshKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         final DeterministicSeed seed = checkNotNull(group.getActiveKeyChain().getSeed());
         KeyChainGroup group2 = KeyChainGroup.builder(MAINNET).lookaheadSize(5)
-                .addChain(DeterministicKeyChain.builder().seed(seed).outputScriptType(Script.ScriptType.P2PKH).build())
+                .addChain(DeterministicKeyChain.builder().seed(seed).outputScriptType(ScriptType.P2PKH).build())
                 .build();
         ECKey key2 = group2.freshKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         assertEquals(key1, key2);
@@ -520,17 +519,17 @@ public class KeyChainGroupTest {
     public void addAndActivateHDChain_freshCurrentAddress() {
         DeterministicSeed seed = new DeterministicSeed(ENTROPY, "", 0);
         DeterministicKeyChain chain1 = DeterministicKeyChain.builder().seed(seed)
-                .accountPath(DeterministicKeyChain.ACCOUNT_ZERO_PATH).outputScriptType(Script.ScriptType.P2PKH).build();
+                .accountPath(DeterministicKeyChain.ACCOUNT_ZERO_PATH).outputScriptType(ScriptType.P2PKH).build();
         group = KeyChainGroup.builder(MAINNET).addChain(chain1).build();
         assertEquals("1M5T5k9yKtGWRtWYMjQtGx3K2sshrABzCT", group.currentAddress(KeyPurpose.RECEIVE_FUNDS).toString());
 
         final DeterministicKeyChain chain2 = DeterministicKeyChain.builder().seed(seed)
-                .accountPath(DeterministicKeyChain.ACCOUNT_ONE_PATH).outputScriptType(Script.ScriptType.P2PKH).build();
+                .accountPath(DeterministicKeyChain.ACCOUNT_ONE_PATH).outputScriptType(ScriptType.P2PKH).build();
         group.addAndActivateHDChain(chain2);
         assertEquals("1JLnjJEXcyByAaW6sqSxNvGiiSEWRhdvPb", group.currentAddress(KeyPurpose.RECEIVE_FUNDS).toString());
 
         final DeterministicKeyChain chain3 = DeterministicKeyChain.builder().seed(seed)
-                .accountPath(DeterministicKeyChain.BIP44_ACCOUNT_ZERO_PATH).outputScriptType(Script.ScriptType.P2WPKH)
+                .accountPath(DeterministicKeyChain.BIP44_ACCOUNT_ZERO_PATH).outputScriptType(ScriptType.P2WPKH)
                 .build();
         group.addAndActivateHDChain(chain3);
         assertEquals("bc1q5fa84aghxd6uzk5g2ywkppmzlut5d77vg8cd20",
@@ -542,29 +541,29 @@ public class KeyChainGroupTest {
         // Check that if we try to use HD features in a KCG that only has random keys, we get an exception.
         group = KeyChainGroup.builder(MAINNET).build();
         group.importKeys(new ECKey(), new ECKey());
-        assertTrue(group.isDeterministicUpgradeRequired(Script.ScriptType.P2PKH, 0));
-        assertTrue(group.isDeterministicUpgradeRequired(Script.ScriptType.P2WPKH, 0));
+        assertTrue(group.isDeterministicUpgradeRequired(ScriptType.P2PKH, 0));
+        assertTrue(group.isDeterministicUpgradeRequired(ScriptType.P2WPKH, 0));
         group.freshKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);   // throws
     }
 
     @Test
     public void deterministicUpgradeUnencrypted() throws Exception {
-        group = KeyChainGroup.builder(MAINNET).fromRandom(Script.ScriptType.P2PKH).lookaheadSize(LOOKAHEAD_SIZE).build();
+        group = KeyChainGroup.builder(MAINNET).fromRandom(ScriptType.P2PKH).lookaheadSize(LOOKAHEAD_SIZE).build();
 
         List<Protos.Key> protobufs = group.serializeToProtobuf();
-        group.upgradeToDeterministic(Script.ScriptType.P2PKH, KeyChainGroupStructure.BIP32, 0, null);
+        group.upgradeToDeterministic(ScriptType.P2PKH, KeyChainGroupStructure.BIP32, 0, null);
         assertFalse(group.isEncrypted());
-        assertFalse(group.isDeterministicUpgradeRequired(Script.ScriptType.P2PKH, 0));
-        assertTrue(group.isDeterministicUpgradeRequired(Script.ScriptType.P2WPKH, 0));
+        assertFalse(group.isDeterministicUpgradeRequired(ScriptType.P2PKH, 0));
+        assertTrue(group.isDeterministicUpgradeRequired(ScriptType.P2WPKH, 0));
         DeterministicKey dkey1 = group.freshKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         DeterministicSeed seed1 = group.getActiveKeyChain().getSeed();
         assertNotNull(seed1);
 
         group = KeyChainGroup.fromProtobufUnencrypted(MAINNET, protobufs);
-        group.upgradeToDeterministic(Script.ScriptType.P2PKH, KeyChainGroupStructure.BIP32, 0, null);  // Should give same result as last time.
+        group.upgradeToDeterministic(ScriptType.P2PKH, KeyChainGroupStructure.BIP32, 0, null);  // Should give same result as last time.
         assertFalse(group.isEncrypted());
-        assertFalse(group.isDeterministicUpgradeRequired(Script.ScriptType.P2PKH, 0));
-        assertTrue(group.isDeterministicUpgradeRequired(Script.ScriptType.P2WPKH, 0));
+        assertFalse(group.isDeterministicUpgradeRequired(ScriptType.P2PKH, 0));
+        assertTrue(group.isDeterministicUpgradeRequired(ScriptType.P2WPKH, 0));
         DeterministicKey dkey2 = group.freshKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         DeterministicSeed seed2 = group.getActiveKeyChain().getSeed();
         assertEquals(seed1, seed2);
@@ -573,11 +572,11 @@ public class KeyChainGroupTest {
 
     @Test
     public void deterministicUpgradeEncrypted() throws Exception {
-        group = KeyChainGroup.builder(MAINNET).fromRandom(Script.ScriptType.P2PKH).build();
+        group = KeyChainGroup.builder(MAINNET).fromRandom(ScriptType.P2PKH).build();
         group.encrypt(KEY_CRYPTER, AES_KEY);
         assertTrue(group.isEncrypted());
-        assertFalse(group.isDeterministicUpgradeRequired(Script.ScriptType.P2PKH, 0));
-        assertTrue(group.isDeterministicUpgradeRequired(Script.ScriptType.P2WPKH, 0));
+        assertFalse(group.isDeterministicUpgradeRequired(ScriptType.P2PKH, 0));
+        assertTrue(group.isDeterministicUpgradeRequired(ScriptType.P2WPKH, 0));
         final DeterministicSeed deterministicSeed = group.getActiveKeyChain().getSeed();
         assertNotNull(deterministicSeed);
         assertTrue(deterministicSeed.isEncrypted());
@@ -596,7 +595,7 @@ public class KeyChainGroupTest {
 
     @Test
     public void isNotWatching() {
-        group = KeyChainGroup.builder(MAINNET).fromRandom(Script.ScriptType.P2PKH).build();
+        group = KeyChainGroup.builder(MAINNET).fromRandom(ScriptType.P2PKH).build();
         final ECKey key = ECKey.fromPrivate(BigInteger.TEN);
         group.importKeys(key);
         assertFalse(group.isWatching());
@@ -607,7 +606,7 @@ public class KeyChainGroupTest {
         group = KeyChainGroup.builder(MAINNET)
                 .addChain(DeterministicKeyChain.builder().watch(DeterministicKey.deserializeB58(
                         "xpub69bjfJ91ikC5ghsqsVDHNq2dRGaV2HHVx7Y9LXi27LN9BWWAXPTQr4u8U3wAtap8bLdHdkqPpAcZmhMS5SnrMQC4ccaoBccFhh315P4UYzo",
-                        MAINNET)).outputScriptType(Script.ScriptType.P2PKH).build())
+                        MAINNET)).outputScriptType(ScriptType.P2PKH).build())
                 .build();
         final ECKey watchingKey = ECKey.fromPublicOnly(new ECKey());
         group.importKeys(watchingKey);
@@ -625,7 +624,7 @@ public class KeyChainGroupTest {
         group = KeyChainGroup.builder(MAINNET)
                 .addChain(DeterministicKeyChain.builder().watch(DeterministicKey.deserializeB58(
                         "xpub69bjfJ91ikC5ghsqsVDHNq2dRGaV2HHVx7Y9LXi27LN9BWWAXPTQr4u8U3wAtap8bLdHdkqPpAcZmhMS5SnrMQC4ccaoBccFhh315P4UYzo",
-                        MAINNET)).outputScriptType(Script.ScriptType.P2PKH).build())
+                        MAINNET)).outputScriptType(ScriptType.P2PKH).build())
                 .build();
         final ECKey key = ECKey.fromPrivate(BigInteger.TEN);
         group.importKeys(key);
@@ -635,24 +634,24 @@ public class KeyChainGroupTest {
     @Test
     public void segwitKeyChainGroup() throws Exception {
         group = KeyChainGroup.builder(MAINNET).lookaheadSize(LOOKAHEAD_SIZE)
-                .addChain(DeterministicKeyChain.builder().entropy(ENTROPY, 0).outputScriptType(Script.ScriptType.P2WPKH)
+                .addChain(DeterministicKeyChain.builder().entropy(ENTROPY, 0).outputScriptType(ScriptType.P2WPKH)
                         .accountPath(DeterministicKeyChain.ACCOUNT_ONE_PATH).build())
                 .build();
-        assertEquals(Script.ScriptType.P2WPKH, group.getActiveKeyChain().getOutputScriptType());
+        assertEquals(ScriptType.P2WPKH, group.getActiveKeyChain().getOutputScriptType());
         assertEquals("bc1qhcurdec849thpjjp3e27atvya43gy2snrechd9",
                 group.currentAddress(KeyPurpose.RECEIVE_FUNDS).toString());
         assertEquals("bc1qw8sf3mwuwn74qnhj83gjg0cwkk78fun2pxl9t2", group.currentAddress(KeyPurpose.CHANGE).toString());
 
         // round-trip through protobuf
         group = KeyChainGroup.fromProtobufUnencrypted(MAINNET, group.serializeToProtobuf());
-        assertEquals(Script.ScriptType.P2WPKH, group.getActiveKeyChain().getOutputScriptType());
+        assertEquals(ScriptType.P2WPKH, group.getActiveKeyChain().getOutputScriptType());
         assertEquals("bc1qhcurdec849thpjjp3e27atvya43gy2snrechd9",
                 group.currentAddress(KeyPurpose.RECEIVE_FUNDS).toString());
         assertEquals("bc1qw8sf3mwuwn74qnhj83gjg0cwkk78fun2pxl9t2", group.currentAddress(KeyPurpose.CHANGE).toString());
 
         // encryption
         group.encrypt(KEY_CRYPTER, AES_KEY);
-        assertEquals(Script.ScriptType.P2WPKH, group.getActiveKeyChain().getOutputScriptType());
+        assertEquals(ScriptType.P2WPKH, group.getActiveKeyChain().getOutputScriptType());
         assertEquals("bc1qhcurdec849thpjjp3e27atvya43gy2snrechd9",
                 group.currentAddress(KeyPurpose.RECEIVE_FUNDS).toString());
         assertEquals("bc1qw8sf3mwuwn74qnhj83gjg0cwkk78fun2pxl9t2", group.currentAddress(KeyPurpose.CHANGE).toString());
@@ -660,7 +659,7 @@ public class KeyChainGroupTest {
         // round-trip encrypted again, then dectypt
         group = KeyChainGroup.fromProtobufEncrypted(MAINNET, group.serializeToProtobuf(), KEY_CRYPTER);
         group.decrypt(AES_KEY);
-        assertEquals(Script.ScriptType.P2WPKH, group.getActiveKeyChain().getOutputScriptType());
+        assertEquals(ScriptType.P2WPKH, group.getActiveKeyChain().getOutputScriptType());
         assertEquals("bc1qhcurdec849thpjjp3e27atvya43gy2snrechd9",
                 group.currentAddress(KeyPurpose.RECEIVE_FUNDS).toString());
         assertEquals("bc1qw8sf3mwuwn74qnhj83gjg0cwkk78fun2pxl9t2", group.currentAddress(KeyPurpose.CHANGE).toString());

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -18,6 +18,7 @@
 package org.bitcoinj.wallet;
 
 import com.google.common.collect.Lists;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.AbstractBlockChain;
 import org.bitcoinj.core.Address;
 import org.bitcoinj.core.Block;
@@ -147,7 +148,7 @@ public class WalletTest extends TestWithWallet {
     }
 
     private void createMarriedWallet(int threshold, int numKeys, boolean addSigners) throws BlockStoreException {
-        wallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        wallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         blockStore = new MemoryBlockStore(UNITTEST);
         chain = new BlockChain(UNITTEST, wallet, blockStore);
 
@@ -205,7 +206,7 @@ public class WalletTest extends TestWithWallet {
 
     @Test
     public void basicSpendingWithEncryptedWallet() throws Exception {
-        Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         encryptedWallet.encrypt(PASSWORD1);
         Address myEncryptedAddress = LegacyAddress.fromKey(UNITTEST, encryptedWallet.freshReceiveKey());
         basicSpendingCommon(encryptedWallet, myEncryptedAddress, OTHER_ADDRESS, encryptedWallet);
@@ -216,7 +217,7 @@ public class WalletTest extends TestWithWallet {
         final byte[] ENTROPY = Sha256Hash.hash("don't use a string seed like this in real life".getBytes());
         KeyChainGroup keyChainGroup = KeyChainGroup.builder(UNITTEST)
                 .addChain(DeterministicKeyChain.builder().seed(new DeterministicSeed(ENTROPY, "", 1389353062L))
-                        .outputScriptType(Script.ScriptType.P2WPKH)
+                        .outputScriptType(ScriptType.P2WPKH)
                         .accountPath(DeterministicKeyChain.BIP44_ACCOUNT_ZERO_PATH).build())
                 .build();
         Wallet encryptedWallet = new Wallet(UNITTEST, keyChainGroup);
@@ -742,7 +743,7 @@ public class WalletTest extends TestWithWallet {
 
     @Test
     public void isTxConsistentReturnsFalseAsExpected() {
-        Wallet wallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        Wallet wallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         TransactionOutput to = createMock(TransactionOutput.class);
         EasyMock.expect(to.isAvailableForSpending()).andReturn(true);
         EasyMock.expect(to.isMineOrWatched(wallet)).andReturn(true);
@@ -758,7 +759,7 @@ public class WalletTest extends TestWithWallet {
 
     @Test
     public void isTxConsistentReturnsFalseAsExpected_WhenAvailableForSpendingEqualsFalse() {
-        Wallet wallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        Wallet wallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         TransactionOutput to = createMock(TransactionOutput.class);
         EasyMock.expect(to.isAvailableForSpending()).andReturn(false);
         EasyMock.expect(to.getSpentBy()).andReturn(null);
@@ -1473,7 +1474,7 @@ public class WalletTest extends TestWithWallet {
     public void keyCreationTime() {
         Utils.setMockClock();
         long now = Utils.currentTimeSeconds();
-        wallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        wallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         assertEquals(now, wallet.getEarliestKeyCreationTime());
         Utils.rollMockClock(60);
         wallet.freshReceiveKey();
@@ -1484,7 +1485,7 @@ public class WalletTest extends TestWithWallet {
     public void scriptCreationTime() {
         Utils.setMockClock();
         long now = Utils.currentTimeSeconds();
-        wallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        wallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         assertEquals(now, wallet.getEarliestKeyCreationTime());
         Utils.rollMockClock(-120);
         wallet.addWatchedAddress(OTHER_ADDRESS);
@@ -1570,7 +1571,7 @@ public class WalletTest extends TestWithWallet {
     public void isWatching() {
         assertFalse(wallet.isWatching());
         Wallet watchingWallet = Wallet.fromWatchingKey(UNITTEST,
-                wallet.getWatchingKey().dropPrivateBytes().dropParent(), Script.ScriptType.P2PKH);
+                wallet.getWatchingKey().dropPrivateBytes().dropParent(), ScriptType.P2PKH);
         assertTrue(watchingWallet.isWatching());
         wallet.encrypt(PASSWORD1);
         assertFalse(wallet.isWatching());
@@ -1583,7 +1584,7 @@ public class WalletTest extends TestWithWallet {
 
         // Construct watching wallet.
         Wallet watchingWallet = Wallet.fromWatchingKey(UNITTEST,
-                DeterministicKey.deserializeB58(null, serialized, UNITTEST), Script.ScriptType.P2PKH);
+                DeterministicKey.deserializeB58(null, serialized, UNITTEST), ScriptType.P2PKH);
         DeterministicKey key2 = watchingWallet.freshReceiveKey();
         assertEquals(myKey, key2);
 
@@ -1912,7 +1913,7 @@ public class WalletTest extends TestWithWallet {
 
     @Test
     public void encryptionDecryptionAESBasic() {
-        Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         encryptedWallet.encrypt(PASSWORD1);
         KeyCrypter keyCrypter = encryptedWallet.getKeyCrypter();
         KeyParameter aesKey = keyCrypter.deriveKey(PASSWORD1);
@@ -1935,7 +1936,7 @@ public class WalletTest extends TestWithWallet {
 
     @Test
     public void encryptionDecryptionPasswordBasic() {
-        Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         encryptedWallet.encrypt(PASSWORD1);
 
         assertTrue(encryptedWallet.isEncrypted());
@@ -1953,7 +1954,7 @@ public class WalletTest extends TestWithWallet {
 
     @Test
     public void encryptionDecryptionBadPassword() {
-        Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         encryptedWallet.encrypt(PASSWORD1);
         KeyCrypter keyCrypter = encryptedWallet.getKeyCrypter();
         KeyParameter wrongAesKey = keyCrypter.deriveKey(WRONG_PASSWORD);
@@ -1973,7 +1974,7 @@ public class WalletTest extends TestWithWallet {
 
     @Test
     public void changePasswordTest() {
-        Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         encryptedWallet.encrypt(PASSWORD1);
         CharSequence newPassword = "My name is Tom";
         encryptedWallet.changeEncryptionPassword(PASSWORD1, newPassword);
@@ -1983,7 +1984,7 @@ public class WalletTest extends TestWithWallet {
 
     @Test
     public void changeAesKeyTest() {
-        Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         encryptedWallet.encrypt(PASSWORD1);
 
         KeyCrypter keyCrypter = encryptedWallet.getKeyCrypter();
@@ -2000,7 +2001,7 @@ public class WalletTest extends TestWithWallet {
 
     @Test
     public void encryptionDecryptionCheckExceptions() {
-        Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         encryptedWallet.encrypt(PASSWORD1);
         KeyCrypter keyCrypter = encryptedWallet.getKeyCrypter();
         KeyParameter aesKey = keyCrypter.deriveKey(PASSWORD1);
@@ -2039,7 +2040,7 @@ public class WalletTest extends TestWithWallet {
 
     @Test(expected = KeyCrypterException.class)
     public void addUnencryptedKeyToEncryptedWallet() {
-        Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         encryptedWallet.encrypt(PASSWORD1);
 
         ECKey key1 = new ECKey();
@@ -2048,7 +2049,7 @@ public class WalletTest extends TestWithWallet {
 
     @Test(expected = KeyCrypterException.class)
     public void addEncryptedKeyToUnencryptedWallet() {
-        Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         encryptedWallet.encrypt(PASSWORD1);
         KeyCrypter keyCrypter = encryptedWallet.getKeyCrypter();
 
@@ -2059,7 +2060,7 @@ public class WalletTest extends TestWithWallet {
 
     @Test(expected = KeyCrypterException.class)
     public void mismatchedCrypter() {
-        Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         encryptedWallet.encrypt(PASSWORD1);
         KeyCrypter keyCrypter = encryptedWallet.getKeyCrypter();
         KeyParameter aesKey = keyCrypter.deriveKey(PASSWORD1);
@@ -2074,7 +2075,7 @@ public class WalletTest extends TestWithWallet {
 
     @Test
     public void importAndEncrypt() throws InsufficientMoneyException {
-        Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        Wallet encryptedWallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         encryptedWallet.encrypt(PASSWORD1);
 
         final ECKey key = new ECKey();
@@ -2664,8 +2665,8 @@ public class WalletTest extends TestWithWallet {
 
     @Test
     public void witnessTransactionGetFeeTest() throws Exception {
-        Wallet mySegwitWallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2WPKH);
-        Address mySegwitAddress = mySegwitWallet.freshReceiveAddress(Script.ScriptType.P2WPKH);
+        Wallet mySegwitWallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2WPKH);
+        Address mySegwitAddress = mySegwitWallet.freshReceiveAddress(ScriptType.P2WPKH);
 
         // Prepare wallet to spend
         StoredBlock block = new StoredBlock(makeSolvedTestBlock(blockStore, OTHER_SEGWIT_ADDRESS), BigInteger.ONE, 1);
@@ -2890,7 +2891,7 @@ public class WalletTest extends TestWithWallet {
     public void keyRotationRandom() throws Exception {
         Utils.setMockClock();
         // Start with an empty wallet (no HD chain).
-        wallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        wallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         // Watch out for wallet-initiated broadcasts.
         MockTransactionBroadcaster broadcaster = new MockTransactionBroadcaster(wallet);
         // Send three cents to two different random keys, then add a key and mark the initial keys as compromised.
@@ -2973,7 +2974,7 @@ public class WalletTest extends TestWithWallet {
         DeterministicKey rootKey = wallet.getActiveKeyChain().getRootKey();
         DeterministicKey watchingKey = activeKeyChain.getWatchingKey();
         HDPath accountPath = activeKeyChain.getAccountPath();
-        Script.ScriptType outputScriptType = activeKeyChain.getOutputScriptType();
+        ScriptType outputScriptType = activeKeyChain.getOutputScriptType();
 
         Protos.Wallet protos = new WalletProtobufSerializer().walletToProto(wallet);
         Wallet roundTrippedWallet = new WalletProtobufSerializer().readWallet(UNITTEST, null, protos);
@@ -2994,7 +2995,7 @@ public class WalletTest extends TestWithWallet {
     public void keyRotationHD() throws Exception {
         // Test that if we rotate an HD chain, a new one is created and all arrivals on the old keys are moved.
         Utils.setMockClock();
-        wallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        wallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         ECKey key1 = wallet.freshReceiveKey();
         ECKey key2 = wallet.freshReceiveKey();
         sendMoneyToWallet(wallet, AbstractBlockChain.NewBlockType.BEST_CHAIN, CENT, LegacyAddress.fromKey(UNITTEST, key1));
@@ -3069,7 +3070,7 @@ public class WalletTest extends TestWithWallet {
         for (TransactionInput input : req.tx.getInputs())
             input.clearScriptBytes();
         Wallet watching = Wallet.fromWatchingKey(UNITTEST, wallet.getWatchingKey().dropParent().dropPrivateBytes(),
-                Script.ScriptType.P2PKH);
+                ScriptType.P2PKH);
         watching.freshReceiveKey();
         watching.completeTx(SendRequest.forTx(req.tx));
     }
@@ -3207,7 +3208,7 @@ public class WalletTest extends TestWithWallet {
     @Test
     public void keyEvents() {
         // Check that we can register an event listener, generate some keys and the callbacks are invoked properly.
-        wallet = new Wallet(UNITTEST, KeyChainGroup.builder(UNITTEST).fromRandom(Script.ScriptType.P2PKH).build());
+        wallet = new Wallet(UNITTEST, KeyChainGroup.builder(UNITTEST).fromRandom(ScriptType.P2PKH).build());
         final List<ECKey> keys = new LinkedList<>();
         wallet.addKeyChainEventListener(Threading.SAME_THREAD, keys::addAll);
         wallet.freshReceiveKey();
@@ -3216,63 +3217,63 @@ public class WalletTest extends TestWithWallet {
 
     @Test
     public void upgradeToDeterministic_P2PKH_to_P2WPKH_unencrypted() {
-        wallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        wallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         assertFalse(wallet.isEncrypted());
-        assertFalse(wallet.isDeterministicUpgradeRequired(Script.ScriptType.P2PKH));
-        assertTrue(wallet.isDeterministicUpgradeRequired(Script.ScriptType.P2WPKH));
-        assertEquals(Script.ScriptType.P2PKH, wallet.currentReceiveAddress().getOutputScriptType());
-        assertEquals(Script.ScriptType.P2PKH, wallet.freshReceiveAddress().getOutputScriptType());
+        assertFalse(wallet.isDeterministicUpgradeRequired(ScriptType.P2PKH));
+        assertTrue(wallet.isDeterministicUpgradeRequired(ScriptType.P2WPKH));
+        assertEquals(ScriptType.P2PKH, wallet.currentReceiveAddress().getOutputScriptType());
+        assertEquals(ScriptType.P2PKH, wallet.freshReceiveAddress().getOutputScriptType());
 
-        wallet.upgradeToDeterministic(Script.ScriptType.P2WPKH, null);
+        wallet.upgradeToDeterministic(ScriptType.P2WPKH, null);
         assertFalse(wallet.isEncrypted());
-        assertFalse(wallet.isDeterministicUpgradeRequired(Script.ScriptType.P2PKH));
-        assertFalse(wallet.isDeterministicUpgradeRequired(Script.ScriptType.P2WPKH));
-        assertEquals(Script.ScriptType.P2WPKH, wallet.currentReceiveAddress().getOutputScriptType());
-        assertEquals(Script.ScriptType.P2WPKH, wallet.freshReceiveAddress().getOutputScriptType());
+        assertFalse(wallet.isDeterministicUpgradeRequired(ScriptType.P2PKH));
+        assertFalse(wallet.isDeterministicUpgradeRequired(ScriptType.P2WPKH));
+        assertEquals(ScriptType.P2WPKH, wallet.currentReceiveAddress().getOutputScriptType());
+        assertEquals(ScriptType.P2WPKH, wallet.freshReceiveAddress().getOutputScriptType());
     }
 
     @Test
     public void upgradeToDeterministic_P2PKH_to_P2WPKH_encrypted() {
-        wallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        wallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         assertFalse(wallet.isEncrypted());
-        assertFalse(wallet.isDeterministicUpgradeRequired(Script.ScriptType.P2PKH));
-        assertTrue(wallet.isDeterministicUpgradeRequired(Script.ScriptType.P2WPKH));
+        assertFalse(wallet.isDeterministicUpgradeRequired(ScriptType.P2PKH));
+        assertTrue(wallet.isDeterministicUpgradeRequired(ScriptType.P2WPKH));
 
         KeyParameter aesKey = new KeyCrypterScrypt(SCRYPT_ITERATIONS).deriveKey("abc");
         wallet.encrypt(new KeyCrypterScrypt(), aesKey);
         assertTrue(wallet.isEncrypted());
-        assertEquals(Script.ScriptType.P2PKH, wallet.currentReceiveAddress().getOutputScriptType());
-        assertEquals(Script.ScriptType.P2PKH, wallet.freshReceiveAddress().getOutputScriptType());
+        assertEquals(ScriptType.P2PKH, wallet.currentReceiveAddress().getOutputScriptType());
+        assertEquals(ScriptType.P2PKH, wallet.freshReceiveAddress().getOutputScriptType());
         try {
-            wallet.upgradeToDeterministic(Script.ScriptType.P2WPKH, null);
+            wallet.upgradeToDeterministic(ScriptType.P2WPKH, null);
             fail();
         } catch (DeterministicUpgradeRequiresPassword e) {
             // Expected.
         }
 
-        wallet.upgradeToDeterministic(Script.ScriptType.P2WPKH, aesKey);
+        wallet.upgradeToDeterministic(ScriptType.P2WPKH, aesKey);
         assertTrue(wallet.isEncrypted());
-        assertFalse(wallet.isDeterministicUpgradeRequired(Script.ScriptType.P2PKH));
-        assertFalse(wallet.isDeterministicUpgradeRequired(Script.ScriptType.P2WPKH));
-        assertEquals(Script.ScriptType.P2WPKH, wallet.currentReceiveAddress().getOutputScriptType());
-        assertEquals(Script.ScriptType.P2WPKH, wallet.freshReceiveAddress().getOutputScriptType());
+        assertFalse(wallet.isDeterministicUpgradeRequired(ScriptType.P2PKH));
+        assertFalse(wallet.isDeterministicUpgradeRequired(ScriptType.P2WPKH));
+        assertEquals(ScriptType.P2WPKH, wallet.currentReceiveAddress().getOutputScriptType());
+        assertEquals(ScriptType.P2WPKH, wallet.freshReceiveAddress().getOutputScriptType());
     }
 
     @Test
     public void upgradeToDeterministic_noDowngrade_unencrypted() {
-        wallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2WPKH);
+        wallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2WPKH);
         assertFalse(wallet.isEncrypted());
-        assertFalse(wallet.isDeterministicUpgradeRequired(Script.ScriptType.P2PKH));
-        assertFalse(wallet.isDeterministicUpgradeRequired(Script.ScriptType.P2WPKH));
-        assertEquals(Script.ScriptType.P2WPKH, wallet.currentReceiveAddress().getOutputScriptType());
-        assertEquals(Script.ScriptType.P2WPKH, wallet.freshReceiveAddress().getOutputScriptType());
+        assertFalse(wallet.isDeterministicUpgradeRequired(ScriptType.P2PKH));
+        assertFalse(wallet.isDeterministicUpgradeRequired(ScriptType.P2WPKH));
+        assertEquals(ScriptType.P2WPKH, wallet.currentReceiveAddress().getOutputScriptType());
+        assertEquals(ScriptType.P2WPKH, wallet.freshReceiveAddress().getOutputScriptType());
 
-        wallet.upgradeToDeterministic(Script.ScriptType.P2PKH, null);
+        wallet.upgradeToDeterministic(ScriptType.P2PKH, null);
         assertFalse(wallet.isEncrypted());
-        assertFalse(wallet.isDeterministicUpgradeRequired(Script.ScriptType.P2PKH));
-        assertFalse(wallet.isDeterministicUpgradeRequired(Script.ScriptType.P2WPKH));
-        assertEquals(Script.ScriptType.P2WPKH, wallet.currentReceiveAddress().getOutputScriptType());
-        assertEquals(Script.ScriptType.P2WPKH, wallet.freshReceiveAddress().getOutputScriptType());
+        assertFalse(wallet.isDeterministicUpgradeRequired(ScriptType.P2PKH));
+        assertFalse(wallet.isDeterministicUpgradeRequired(ScriptType.P2WPKH));
+        assertEquals(ScriptType.P2WPKH, wallet.currentReceiveAddress().getOutputScriptType());
+        assertEquals(ScriptType.P2WPKH, wallet.freshReceiveAddress().getOutputScriptType());
     }
 
     @Test(expected = IllegalStateException.class)
@@ -3488,9 +3489,9 @@ public class WalletTest extends TestWithWallet {
     public void scriptTypeKeyChainRestrictions() {
         // Set up chains: basic chain, P2PKH deterministric chain, P2WPKH deterministic chain.
         DeterministicKeyChain p2pkhChain = DeterministicKeyChain.builder().random(new SecureRandom())
-                .outputScriptType(Script.ScriptType.P2PKH).build();
+                .outputScriptType(ScriptType.P2PKH).build();
         DeterministicKeyChain p2wpkhChain = DeterministicKeyChain.builder().random(new SecureRandom())
-                .outputScriptType(Script.ScriptType.P2WPKH).build();
+                .outputScriptType(ScriptType.P2WPKH).build();
         KeyChainGroup kcg = KeyChainGroup.builder(UNITTEST).addChain(p2pkhChain).addChain(p2wpkhChain).build();
         Wallet wallet = new Wallet(UNITTEST, kcg);
 
@@ -3521,22 +3522,22 @@ public class WalletTest extends TestWithWallet {
 
     @Test
     public void roundtripViaMnemonicCode() {
-        Wallet wallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2WPKH);
+        Wallet wallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2WPKH);
         List<String> mnemonicCode = wallet.getKeyChainSeed().getMnemonicCode();
         final DeterministicSeed clonedSeed = new DeterministicSeed(mnemonicCode, null, "",
                 wallet.getEarliestKeyCreationTime());
-        Wallet clone = Wallet.fromSeed(UNITTEST, clonedSeed, Script.ScriptType.P2WPKH);
+        Wallet clone = Wallet.fromSeed(UNITTEST, clonedSeed, ScriptType.P2WPKH);
         assertEquals(wallet.currentReceiveKey(), clone.currentReceiveKey());
-        assertEquals(wallet.freshReceiveAddress(Script.ScriptType.P2PKH),
-                clone.freshReceiveAddress(Script.ScriptType.P2PKH));
+        assertEquals(wallet.freshReceiveAddress(ScriptType.P2PKH),
+                clone.freshReceiveAddress(ScriptType.P2PKH));
     }
 
     @Test
     public void oneTxTwoWallets() {
-        Wallet wallet1 = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2WPKH);
-        Wallet wallet2 = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2WPKH);
-        Address address1 = wallet1.freshReceiveAddress(Script.ScriptType.P2PKH);
-        Address address2 = wallet2.freshReceiveAddress(Script.ScriptType.P2PKH);
+        Wallet wallet1 = Wallet.createDeterministic(UNITTEST, ScriptType.P2WPKH);
+        Wallet wallet2 = Wallet.createDeterministic(UNITTEST, ScriptType.P2WPKH);
+        Address address1 = wallet1.freshReceiveAddress(ScriptType.P2PKH);
+        Address address2 = wallet2.freshReceiveAddress(ScriptType.P2PKH);
 
         // Both wallet1 and wallet2 receive coins in the same tx
         Transaction tx0 = createFakeTx(UNITTEST);

--- a/examples/src/main/java/org/bitcoinj/examples/BackupToMnemonicSeed.java
+++ b/examples/src/main/java/org/bitcoinj/examples/BackupToMnemonicSeed.java
@@ -16,10 +16,10 @@
 
 package org.bitcoinj.examples;
 
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.internal.InternalUtils;
 import org.bitcoinj.params.TestNet3Params;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.wallet.DeterministicSeed;
 import org.bitcoinj.wallet.Wallet;
 
@@ -36,7 +36,7 @@ public class BackupToMnemonicSeed {
     public static void main(String[] args) {
 
         NetworkParameters params = TestNet3Params.get();
-        Wallet wallet = Wallet.createDeterministic(params, Script.ScriptType.P2PKH);
+        Wallet wallet = Wallet.createDeterministic(params, ScriptType.P2PKH);
 
         DeterministicSeed seed = wallet.getKeyChainSeed();
         System.out.println("seed: " + seed.toString());

--- a/examples/src/main/java/org/bitcoinj/examples/DoubleSpend.java
+++ b/examples/src/main/java/org/bitcoinj/examples/DoubleSpend.java
@@ -16,11 +16,10 @@
 
 package org.bitcoinj.examples;
 
-import org.bitcoinj.core.listeners.PreMessageReceivedEventListener;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.*;
 import org.bitcoinj.kits.WalletAppKit;
 import org.bitcoinj.params.RegTestParams;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.utils.BriefLogFormatter;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.KeyChainGroupStructure;
@@ -39,7 +38,7 @@ public class DoubleSpend {
     public static void main(String[] args) throws Exception {
         BriefLogFormatter.init();
         final RegTestParams params = RegTestParams.get();
-        WalletAppKit kit = new WalletAppKit(params, Script.ScriptType.P2WPKH, KeyChainGroupStructure.BIP32, new File("."), "doublespend");
+        WalletAppKit kit = new WalletAppKit(params, ScriptType.P2WPKH, KeyChainGroupStructure.BIP32, new File("."), "doublespend");
         kit.connectToLocalHost();
         kit.setAutoSave(false);
         kit.startAsync();

--- a/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
@@ -17,28 +17,21 @@
 
 package org.bitcoinj.examples;
 
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.Address;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.core.InsufficientMoneyException;
 import org.bitcoinj.core.LegacyAddress;
 import org.bitcoinj.core.NetworkParameters;
-import org.bitcoinj.core.Transaction;
-import org.bitcoinj.core.TransactionConfidence;
 import org.bitcoinj.crypto.KeyCrypterException;
 import org.bitcoinj.kits.WalletAppKit;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.RegTestParams;
 import org.bitcoinj.params.TestNet3Params;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.utils.BriefLogFormatter;
 import org.bitcoinj.wallet.KeyChainGroupStructure;
 import org.bitcoinj.wallet.SendRequest;
 import org.bitcoinj.wallet.Wallet;
-import org.bitcoinj.wallet.listeners.WalletCoinsReceivedEventListener;
-
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.MoreExecutors;
 
 import java.io.File;
 
@@ -80,7 +73,7 @@ public class ForwardingService {
         System.out.println("Forwarding address: " + forwardingAddress);
 
         // Start up a basic app using a class that automates some boilerplate.
-        kit = new WalletAppKit(params, Script.ScriptType.P2WPKH, KeyChainGroupStructure.BIP32, new File("."), filePrefix);
+        kit = new WalletAppKit(params, ScriptType.P2WPKH, KeyChainGroupStructure.BIP32, new File("."), filePrefix);
 
         if (params == RegTestParams.get()) {
             // Regression test mode is designed for testing and development only, so there's no public network for it.

--- a/examples/src/main/java/org/bitcoinj/examples/GenerateLowSTests.java
+++ b/examples/src/main/java/org/bitcoinj/examples/GenerateLowSTests.java
@@ -25,6 +25,7 @@ import java.util.EnumSet;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.LegacyAddress;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.core.ECKey;
@@ -65,7 +66,7 @@ public class GenerateLowSTests {
         final ECKey key = new ECKey(secureRandom);
         final KeyBag bag = new KeyBag() {
             @Override
-            public ECKey findKeyFromPubKeyHash(byte[] pubkeyHash, Script.ScriptType scriptType) {
+            public ECKey findKeyFromPubKeyHash(byte[] pubkeyHash, ScriptType scriptType) {
                 return key;
             }
 

--- a/examples/src/main/java/org/bitcoinj/examples/Kit.java
+++ b/examples/src/main/java/org/bitcoinj/examples/Kit.java
@@ -16,21 +16,13 @@
 
 package org.bitcoinj.examples;
 
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.*;
 import org.bitcoinj.kits.WalletAppKit;
 import org.bitcoinj.params.TestNet3Params;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.wallet.KeyChainGroupStructure;
-import org.bitcoinj.wallet.Wallet;
-import org.bitcoinj.wallet.listeners.KeyChainEventListener;
-import org.bitcoinj.wallet.listeners.ScriptsChangeEventListener;
-import org.bitcoinj.wallet.listeners.WalletCoinsReceivedEventListener;
-import org.bitcoinj.wallet.listeners.WalletCoinsSentEventListener;
 
 import java.io.File;
-import java.util.List;
-
-import org.bitcoinj.core.listeners.TransactionConfidenceEventListener;
 
 /**
  * The following example shows how to use the by bitcoinj provided WalletAppKit.
@@ -56,7 +48,7 @@ public class Kit {
 
         // Now we initialize a new WalletAppKit. The kit handles all the boilerplate for us and is the easiest way to get everything up and running.
         // Have a look at the WalletAppKit documentation and its source to understand what's happening behind the scenes: https://github.com/bitcoinj/bitcoinj/blob/master/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
-        WalletAppKit kit = new WalletAppKit(params, Script.ScriptType.P2WPKH, KeyChainGroupStructure.BIP32, new File("."), "walletappkit-example");
+        WalletAppKit kit = new WalletAppKit(params, ScriptType.P2WPKH, KeyChainGroupStructure.BIP32, new File("."), "walletappkit-example");
 
         // In case you want to connect with your local bitcoind tell the kit to connect to localhost.
         // You must do that in reg test mode.

--- a/examples/src/main/java/org/bitcoinj/examples/PrivateKeys.java
+++ b/examples/src/main/java/org/bitcoinj/examples/PrivateKeys.java
@@ -17,6 +17,7 @@
 
 package org.bitcoinj.examples;
 
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.Address;
 import org.bitcoinj.core.Base58;
 import org.bitcoinj.core.BlockChain;
@@ -27,7 +28,6 @@ import org.bitcoinj.core.PeerAddress;
 import org.bitcoinj.core.PeerGroup;
 import org.bitcoinj.core.SegwitAddress;
 import org.bitcoinj.params.MainNetParams;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.wallet.Wallet;
 
@@ -64,7 +64,7 @@ public class PrivateKeys {
             Address destination = Address.fromString(params, args[1]);
 
             // Import the private key to a fresh wallet.
-            Wallet wallet = Wallet.createDeterministic(params, Script.ScriptType.P2PKH);
+            Wallet wallet = Wallet.createDeterministic(params, ScriptType.P2PKH);
             wallet.importKey(key);
 
             // Find the transactions that involve those coins.

--- a/examples/src/main/java/org/bitcoinj/examples/RestoreFromSeed.java
+++ b/examples/src/main/java/org/bitcoinj/examples/RestoreFromSeed.java
@@ -16,14 +16,13 @@
 
 package org.bitcoinj.examples;
 
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.listeners.DownloadProgressTracker;
 import org.bitcoinj.core.*;
 import org.bitcoinj.net.discovery.DnsDiscovery;
 import org.bitcoinj.params.TestNet3Params;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.store.SPVBlockStore;
 import org.bitcoinj.wallet.DeterministicSeed;
-import org.bitcoinj.wallet.KeyChainGroupStructure;
 import org.bitcoinj.wallet.Wallet;
 
 import java.io.File;
@@ -48,7 +47,7 @@ public class RestoreFromSeed {
         DeterministicSeed seed = new DeterministicSeed(seedCode, null, passphrase, creationtime);
 
         // The wallet class provides a easy fromSeed() function that loads a new wallet from a given seed.
-        Wallet wallet = Wallet.fromSeed(params, seed, Script.ScriptType.P2PKH);
+        Wallet wallet = Wallet.fromSeed(params, seed, ScriptType.P2PKH);
 
         // Because we are importing an existing wallet which might already have transactions we must re-download the blockchain to make the wallet picks up these transactions
         // You can find some information about this in the guides: https://bitcoinj.github.io/working-with-the-wallet#setup

--- a/examples/src/main/java/org/bitcoinj/examples/SendRequest.java
+++ b/examples/src/main/java/org/bitcoinj/examples/SendRequest.java
@@ -17,10 +17,10 @@
 package org.bitcoinj.examples;
 
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.*;
 import org.bitcoinj.kits.WalletAppKit;
 import org.bitcoinj.params.TestNet3Params;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.wallet.KeyChainGroupStructure;
 import org.bitcoinj.wallet.Wallet;
 import org.bitcoinj.wallet.Wallet.BalanceType;
@@ -37,7 +37,7 @@ public class SendRequest {
 
         // We use the WalletAppKit that handles all the boilerplate for us. Have a look at the Kit.java example for more details.
         NetworkParameters params = TestNet3Params.get();
-        WalletAppKit kit = new WalletAppKit(params, Script.ScriptType.P2WPKH, KeyChainGroupStructure.BIP32, new File("."), "sendrequest-example");
+        WalletAppKit kit = new WalletAppKit(params, ScriptType.P2WPKH, KeyChainGroupStructure.BIP32, new File("."), "sendrequest-example");
         kit.startAsync();
         kit.awaitRunning();
 

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -20,13 +20,13 @@ package org.bitcoinj.core;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.listeners.DownloadProgressTracker;
 import org.bitcoinj.core.listeners.PeerConnectedEventListener;
 import org.bitcoinj.core.listeners.PeerDisconnectedEventListener;
 import org.bitcoinj.core.listeners.PreMessageReceivedEventListener;
 import org.bitcoinj.net.discovery.PeerDiscovery;
 import org.bitcoinj.net.discovery.PeerDiscoveryException;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.testing.FakeTxBuilder;
 import org.bitcoinj.testing.InboundMessageQueuer;
 import org.bitcoinj.testing.TestWithPeerGroup;
@@ -267,7 +267,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         // Create a peer.
         InboundMessageQueuer p1 = connectPeer(1);
         
-        Wallet wallet2 = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        Wallet wallet2 = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         ECKey key2 = wallet2.freshReceiveKey();
         Address address2 = LegacyAddress.fromKey(UNITTEST, key2);
         
@@ -428,7 +428,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         final long now = Utils.currentTimeSeconds();
         peerGroup.start();
         assertTrue(peerGroup.getFastCatchupTimeSecs() > now - WEEK - 10000);
-        Wallet w2 = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        Wallet w2 = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         ECKey key1 = new ECKey();
         key1.setCreationTimeSeconds(now - 86400);  // One day ago.
         w2.importKey(key1);
@@ -790,7 +790,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         final int NUM_KEYS = 9;
 
         // First, grab a load of keys from the wallet, and then recreate it so it forgets that those keys were issued.
-        Wallet shadow = Wallet.fromSeed(wallet.getParams(), wallet.getKeyChainSeed(), Script.ScriptType.P2PKH);
+        Wallet shadow = Wallet.fromSeed(wallet.getParams(), wallet.getKeyChainSeed(), ScriptType.P2PKH);
         List<ECKey> keys = new ArrayList<>(NUM_KEYS);
         for (int i = 0; i < NUM_KEYS; i++) {
             keys.add(shadow.freshReceiveKey());

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -19,11 +19,10 @@ package org.bitcoinj.core;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.listeners.BlocksDownloadedEventListener;
 import org.bitcoinj.core.listeners.PreMessageReceivedEventListener;
 import org.bitcoinj.params.TestNet3Params;
-import org.bitcoinj.script.Script;
-import org.bitcoinj.testing.FakeTxBuilder;
 import org.bitcoinj.testing.InboundMessageQueuer;
 import org.bitcoinj.testing.TestWithNetworkConnections;
 import org.bitcoinj.utils.Threading;
@@ -682,7 +681,7 @@ public class PeerTest extends TestWithNetworkConnections {
         connectWithVersion(70001, VersionMessage.NODE_NETWORK);
         // Test that if we receive a relevant transaction that has a lock time, it doesn't result in a notification
         // until we explicitly opt in to seeing those.
-        Wallet wallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        Wallet wallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         ECKey key = wallet.freshReceiveKey();
         peer.addWallet(wallet);
         final Transaction[] vtx = new Transaction[1];
@@ -728,7 +727,7 @@ public class PeerTest extends TestWithNetworkConnections {
     private void checkTimeLockedDependency(boolean shouldAccept) throws Exception {
         // Initial setup.
         connectWithVersion(70001, VersionMessage.NODE_NETWORK);
-        Wallet wallet = Wallet.createDeterministic(UNITTEST, Script.ScriptType.P2PKH);
+        Wallet wallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         ECKey key = wallet.freshReceiveKey();
         wallet.setAcceptRiskyTransactions(shouldAccept);
         peer.addWallet(wallet);

--- a/integration-test/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
+++ b/integration-test/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
@@ -17,6 +17,7 @@
 
 package org.bitcoinj.testing;
 
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.Address;
 import org.bitcoinj.core.BlockChain;
 import org.bitcoinj.base.Coin;
@@ -40,7 +41,6 @@ import org.bitcoinj.net.NioServer;
 import org.bitcoinj.net.StreamConnection;
 import org.bitcoinj.net.StreamConnectionFactory;
 import org.bitcoinj.params.UnitTestParams;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.utils.BriefLogFormatter;
@@ -109,7 +109,7 @@ public class TestWithNetworkConnections {
         if (wallet == null) {
             // Reduce the number of keys we need to work with to speed up these tests.
             KeyChainGroup kcg = KeyChainGroup.builder(UNITTEST).lookaheadSize(4).lookaheadThreshold(2)
-                    .fromRandom(Script.ScriptType.P2PKH).build();
+                    .fromRandom(ScriptType.P2PKH).build();
             wallet = new Wallet(UNITTEST, kcg);
             key = wallet.freshReceiveKey();
             address = LegacyAddress.fromKey(UNITTEST, key);

--- a/integration-test/src/test/java/org/bitcoinj/wallet/WalletAccountPathTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/wallet/WalletAccountPathTest.java
@@ -16,10 +16,10 @@
 
 package org.bitcoinj.wallet;
 
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.Context;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.crypto.HDPath;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.utils.Network;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
@@ -32,8 +32,8 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.stream.Stream;
 
-import static org.bitcoinj.script.Script.ScriptType.P2PKH;
-import static org.bitcoinj.script.Script.ScriptType.P2WPKH;
+import static org.bitcoinj.base.ScriptType.P2PKH;
+import static org.bitcoinj.base.ScriptType.P2WPKH;
 import static org.bitcoinj.utils.Network.MAIN;
 import static org.bitcoinj.utils.Network.TEST;
 import static org.bitcoinj.wallet.KeyChainGroupStructure.BIP43;
@@ -56,7 +56,7 @@ public class WalletAccountPathTest {
 
     @MethodSource("walletStructureParams")
     @ParameterizedTest(name = "path {1} generated for {2}, {3}")
-    void walletStructurePathTest2(KeyChainGroupStructure structure, HDPath expectedPath, Script.ScriptType scriptType,
+    void walletStructurePathTest2(KeyChainGroupStructure structure, HDPath expectedPath, ScriptType scriptType,
                                   Network network) throws IOException, UnreadableWalletException {
         // When we create a wallet with parameterized structure, network, and scriptType
         Wallet wallet = createWallet(walletFile, network.networkParameters(), structure, scriptType);
@@ -80,7 +80,7 @@ public class WalletAccountPathTest {
     }
 
     // Create a wallet, save it to a file, then reload from a file
-    private static Wallet createWallet(File walletFile, NetworkParameters params, KeyChainGroupStructure structure, Script.ScriptType outputScriptType) throws IOException, UnreadableWalletException {
+    private static Wallet createWallet(File walletFile, NetworkParameters params, KeyChainGroupStructure structure, ScriptType outputScriptType) throws IOException, UnreadableWalletException {
         Context.propagate(new Context(params));
         DeterministicSeed seed = new DeterministicSeed(testWalletMnemonic, null, "", Instant.now().getEpochSecond());
         Wallet wallet = Wallet.fromSeed(params, seed, outputScriptType, structure);

--- a/tools/src/main/java/org/bitcoinj/tools/TestFeeLevel.java
+++ b/tools/src/main/java/org/bitcoinj/tools/TestFeeLevel.java
@@ -17,12 +17,10 @@
 package org.bitcoinj.tools;
 
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.*;
-import org.bitcoinj.core.listeners.PeerConnectedEventListener;
-import org.bitcoinj.core.listeners.PeerDisconnectedEventListener;
 import org.bitcoinj.kits.WalletAppKit;
 import org.bitcoinj.params.MainNetParams;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.utils.BriefLogFormatter;
 import org.bitcoinj.wallet.KeyChainGroupStructure;
 import org.bitcoinj.wallet.SendRequest;
@@ -50,7 +48,7 @@ public class TestFeeLevel {
         Coin feeRateToTest = Coin.valueOf(Long.parseLong(args[0]));
         System.out.println("Fee rate to test is " + feeRateToTest.toFriendlyString() + "/kB");
 
-        kit = new WalletAppKit(PARAMS, Script.ScriptType.P2WPKH, KeyChainGroupStructure.BIP32, new File("."), "testfeelevel");
+        kit = new WalletAppKit(PARAMS, ScriptType.P2WPKH, KeyChainGroupStructure.BIP32, new File("."), "testfeelevel");
         kit.startAsync();
         kit.awaitRunning();
         try {

--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/application/WalletApplication.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/application/WalletApplication.java
@@ -20,11 +20,11 @@ import com.google.common.util.concurrent.Service;
 import javafx.application.Platform;
 import javafx.scene.input.KeyCombination;
 import javafx.stage.Stage;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Utils;
 import org.bitcoinj.kits.WalletAppKit;
 import org.bitcoinj.params.RegTestParams;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.utils.AppDataDirectory;
 import org.bitcoinj.utils.BriefLogFormatter;
 import org.bitcoinj.utils.Threading;
@@ -48,11 +48,11 @@ public abstract class WalletApplication implements AppDelegate {
     private final String applicationName;
     private final NetworkParameters params;
     private final KeyChainGroupStructure keyChainGroupStructure;
-    private final Script.ScriptType preferredOutputScriptType;
+    private final ScriptType preferredOutputScriptType;
     private final String walletFileName;
     private MainWindowController controller;
 
-    public WalletApplication(String applicationName, NetworkParameters params, Script.ScriptType preferredOutputScriptType, KeyChainGroupStructure keyChainGroupStructure) {
+    public WalletApplication(String applicationName, NetworkParameters params, ScriptType preferredOutputScriptType, KeyChainGroupStructure keyChainGroupStructure) {
         instance = this;
         this.applicationName = applicationName;
         this.walletFileName = applicationName.replaceAll("[^a-zA-Z0-9.-]", "_") + "-" + params.getPaymentProtocolId();
@@ -61,7 +61,7 @@ public abstract class WalletApplication implements AppDelegate {
         this.keyChainGroupStructure = keyChainGroupStructure;
     }
 
-    public WalletApplication(String applicationName, NetworkParameters params, Script.ScriptType preferredOutputScriptType) {
+    public WalletApplication(String applicationName, NetworkParameters params, ScriptType preferredOutputScriptType) {
         this(applicationName, params, preferredOutputScriptType, KeyChainGroupStructure.BIP43);
     }
 
@@ -81,7 +81,7 @@ public abstract class WalletApplication implements AppDelegate {
         return params;
     }
 
-    public Script.ScriptType preferredOutputScriptType() {
+    public ScriptType preferredOutputScriptType() {
         return preferredOutputScriptType;
     }
 

--- a/wallettemplate/src/main/java/wallettemplate/Main.java
+++ b/wallettemplate/src/main/java/wallettemplate/Main.java
@@ -18,9 +18,9 @@ package wallettemplate;
 
 import javafx.application.Application;
 import javafx.stage.Stage;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.params.TestNet3Params;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.walletfx.application.AppDelegate;
 
 /**
@@ -29,7 +29,7 @@ import org.bitcoinj.walletfx.application.AppDelegate;
  */
 public class Main extends Application {
     private static final NetworkParameters params = TestNet3Params.get();
-    private static final Script.ScriptType PREFERRED_OUTPUT_SCRIPT_TYPE = Script.ScriptType.P2WPKH;
+    private static final ScriptType PREFERRED_OUTPUT_SCRIPT_TYPE = ScriptType.P2WPKH;
     private static final String APP_NAME = "WalletTemplate";
 
     private final AppDelegate delegate;

--- a/wallettemplate/src/main/java/wallettemplate/WalletTemplate.java
+++ b/wallettemplate/src/main/java/wallettemplate/WalletTemplate.java
@@ -18,8 +18,8 @@ package wallettemplate;
 
 import javafx.fxml.FXMLLoader;
 import javafx.scene.layout.Pane;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.NetworkParameters;
-import org.bitcoinj.script.Script;
 import org.bitcoinj.walletfx.application.WalletApplication;
 
 import java.io.IOException;
@@ -30,7 +30,7 @@ import java.net.URL;
  */
 public class WalletTemplate extends WalletApplication {
 
-    public WalletTemplate(String applicationName, NetworkParameters params, Script.ScriptType preferredOutputScriptType) {
+    public WalletTemplate(String applicationName, NetworkParameters params, ScriptType preferredOutputScriptType) {
         super(applicationName, params, preferredOutputScriptType);
     }
 

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -24,8 +24,7 @@ import org.bitcoinj.params.RegTestParams;
 import org.bitcoinj.protocols.payments.PaymentProtocol;
 import org.bitcoinj.protocols.payments.PaymentProtocolException;
 import org.bitcoinj.protocols.payments.PaymentSession;
-import org.bitcoinj.script.Script;
-import org.bitcoinj.script.Script.ScriptType;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.script.ScriptException;
 import org.bitcoinj.store.*;
 import org.bitcoinj.uri.BitcoinURI;
@@ -104,7 +103,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -186,7 +184,7 @@ public class WalletTool implements Callable<Integer> {
     @CommandLine.Option(names = "--watchkey", description = "Describes a watching wallet using the specified base58 xpub.")
     private String watchKeyStr = null;
     @CommandLine.Option(names = "--output-script-type", description = "Provide an output script type to any action that requires one. Valid values: P2PKH, P2WPKH. Default: ${DEFAULT-VALUE}")
-    private Script.ScriptType outputScriptType = Script.ScriptType.P2PKH;
+    private ScriptType outputScriptType = ScriptType.P2PKH;
     @CommandLine.Option(names = "--date", description = "Provide a date in form YYYY-MM-DD to any action that requires one.")
     private Date date = null;
     @CommandLine.Option(names = "--unixtime", description = "Provide a date in seconds since epoch.")


### PR DESCRIPTION
`Script.ScriptType` is a fundamental type and used in many classes in **bitcoinj** that do not need to depend on `Script` or the `o.b.script` package. It should be a standalone type in `o.b.base`.