### PR TITLE
PrefixedChecksummedBytes: remove unused transient keyword

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PrefixedChecksummedBytes.java
+++ b/core/src/main/java/org/bitcoinj/core/PrefixedChecksummedBytes.java
@@ -36,7 +36,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * </p>
  */
 public abstract class PrefixedChecksummedBytes {
-    protected final transient NetworkParameters params;
+    protected final NetworkParameters params;
     protected final byte[] bytes;
 
     protected PrefixedChecksummedBytes(NetworkParameters params, byte[] bytes) {


### PR DESCRIPTION
Now that serialization support has been removed from PrefixedChecksummedBytes, we no longer need the `transient` keyword.