### PR TITLE
NetworkParameters: deprecate/move fromID() to AbstractBitcoinNetParams

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -19,6 +19,7 @@ package org.bitcoinj.core;
 
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Sha256Hash;
+import org.bitcoinj.params.AbstractBitcoinNetParams;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.RegTestParams;
 import org.bitcoinj.params.SigNetParams;
@@ -167,23 +168,12 @@ public abstract class NetworkParameters {
      * Return network parameters for a network id
      * @param id the network id
      * @return the network parameters for the given string ID or NULL if not recognized
+     * @deprecated Use {@link AbstractBitcoinNetParams#fromID(String)}
      */
     @Deprecated
     @Nullable
     public static NetworkParameters fromID(String id) {
-        if (id.equals(Network.ID_MAINNET)) {
-            return MainNetParams.get();
-        } else if (id.equals(Network.ID_TESTNET)) {
-            return TestNet3Params.get();
-        } else if (id.equals(Network.ID_SIGNET)) {
-            return SigNetParams.get();
-        } else if (id.equals(Network.ID_UNITTESTNET)) {
-            return UnitTestParams.get();
-        } else if (id.equals(Network.ID_REGTEST)) {
-            return RegTestParams.get();
-        } else {
-            return null;
-        }
+        return AbstractBitcoinNetParams.fromID(id);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/params/AbstractBitcoinNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/AbstractBitcoinNetParams.java
@@ -32,9 +32,11 @@ import org.bitcoinj.protocols.payments.PaymentProtocol;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.base.utils.MonetaryFormat;
+import org.bitcoinj.utils.Network;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.math.BigInteger;
 import java.util.concurrent.TimeUnit;
 
@@ -66,6 +68,28 @@ public abstract class AbstractBitcoinNetParams extends NetworkParameters {
         super();
         interval = INTERVAL;
         subsidyDecreaseBlockCount = REWARD_HALVING_INTERVAL;
+    }
+
+    /**
+     * Return network parameters for a network id
+     * @param id the network id
+     * @return the network parameters for the given string ID or NULL if not recognized
+     */
+    @Nullable
+    public static AbstractBitcoinNetParams fromID(String id) {
+        if (id.equals(Network.ID_MAINNET)) {
+            return MainNetParams.get();
+        } else if (id.equals(Network.ID_TESTNET)) {
+            return TestNet3Params.get();
+        } else if (id.equals(Network.ID_SIGNET)) {
+            return SigNetParams.get();
+        } else if (id.equals(Network.ID_UNITTESTNET)) {
+            return UnitTestParams.get();
+        } else if (id.equals(Network.ID_REGTEST)) {
+            return RegTestParams.get();
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -34,6 +34,7 @@ import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.core.TransactionWitness;
 import org.bitcoinj.crypto.KeyCrypter;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
+import org.bitcoinj.params.AbstractBitcoinNetParams;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptException;
 import org.bitcoinj.utils.ExchangeRate;
@@ -436,7 +437,7 @@ public class WalletProtobufSerializer {
         try {
             Protos.Wallet walletProto = parseToProto(input);
             final String paramsID = walletProto.getNetworkIdentifier();
-            NetworkParameters params = NetworkParameters.fromID(paramsID);
+            NetworkParameters params = AbstractBitcoinNetParams.fromID(paramsID);
             if (params == null)
                 throw new UnreadableWalletException("Unknown network parameters ID " + paramsID);
             return readWallet(params, extensions, walletProto, forceReset);
@@ -831,7 +832,7 @@ public class WalletProtobufSerializer {
             if (field != 1) // network_identifier
                 return false;
             final String network = cis.readString();
-            return NetworkParameters.fromID(network) != null;
+            return AbstractBitcoinNetParams.fromID(network) != null;
         } catch (IOException x) {
             return false;
         }


### PR DESCRIPTION
`fromID(String)` and `fromPmtProtocolID(String)` only know about Bitcoin networks so are deprecated and
moved to AbstractBitcoinNetParams.

When they are removed from `NetworkParameters` it will no longer be dependent on its subclasses.