### PR TITLE
Github graalvm.yml: Run `test` task

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -27,7 +27,7 @@ jobs:
         uses: gradle/gradle-build-action@v1
         with:
           gradle-version: ${{ matrix.gradle }}
-          arguments: nativeCompile --info --stacktrace
+          arguments: test nativeCompile --info --stacktrace
       - name: Upload wallet-tool as artifact
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
This makes sure that unit and integration tests are run before doing the native compile.

The GraalVM tasks should fail if the tests are failing.