### PR TITLE
Context: fix implicit context propagation by constructor

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Context.java
+++ b/core/src/main/java/org/bitcoinj/core/Context.java
@@ -80,7 +80,6 @@ public class Context {
         this.ensureMinRequiredFee = ensureMinRequiredFee;
         this.feePerKb = feePerKb;
         lastConstructed = this;
-        slot.set(this);
     }
 
     private static volatile Context lastConstructed;

--- a/core/src/test/java/org/bitcoinj/core/TxConfidenceTableTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TxConfidenceTableTest.java
@@ -46,6 +46,7 @@ public class TxConfidenceTableTest {
     public void setup() throws Exception {
         BriefLogFormatter.init();
         Context context = new Context(UNITTEST);
+        Context.propagate(context);
         table = context.getConfidenceTable();
 
         Address to = LegacyAddress.fromKey(UNITTEST, new ECKey());

--- a/integration-test/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTest.java
@@ -66,7 +66,7 @@ public class FilteredBlockAndPartialMerkleTreeTest extends TestWithPeerGroup {
 
     @Before
     public void setUp() throws Exception {
-        new Context(UNITTEST);
+        Context.propagate(new Context(UNITTEST));
         MemoryBlockStore store = new MemoryBlockStore(UNITTEST);
 
         // Cheat and place the previous block (block 100000) at the head of the block store without supporting blocks


### PR DESCRIPTION
We used to do this a long time ago, but switched the codebase to explicit propagation.
Generally, constructors should not have any side-effects.