### PR TITLE
rename Network to BitcoinNetwork create new Network interface (improved PR)

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -28,7 +28,7 @@ import org.bitcoinj.script.Script;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.base.utils.MonetaryFormat;
-import org.bitcoinj.utils.Network;
+import org.bitcoinj.utils.BitcoinNetwork;
 import org.bitcoinj.utils.VersionTally;
 
 import javax.annotation.Nullable;
@@ -86,7 +86,7 @@ public abstract class NetworkParameters {
      * by looking at the port number.
      */
     protected String id;
-    protected Network network;
+    protected BitcoinNetwork network;
 
     /**
      * The depth of blocks required for a coinbase transaction to be spendable.
@@ -134,7 +134,7 @@ public abstract class NetworkParameters {
     /**
      * @return Network enum for this network
      */
-    public Network network() {
+    public BitcoinNetwork network() {
         return network;
     }
 
@@ -159,15 +159,15 @@ public abstract class NetworkParameters {
      */
     @Nullable
     public static NetworkParameters fromID(String id) {
-        if (id.equals(Network.ID_MAINNET)) {
+        if (id.equals(BitcoinNetwork.ID_MAINNET)) {
             return MainNetParams.get();
-        } else if (id.equals(Network.ID_TESTNET)) {
+        } else if (id.equals(BitcoinNetwork.ID_TESTNET)) {
             return TestNet3Params.get();
-        } else if (id.equals(Network.ID_SIGNET)) {
+        } else if (id.equals(BitcoinNetwork.ID_SIGNET)) {
             return SigNetParams.get();
-        } else if (id.equals(Network.ID_UNITTESTNET)) {
+        } else if (id.equals(BitcoinNetwork.ID_UNITTESTNET)) {
             return UnitTestParams.get();
-        } else if (id.equals(Network.ID_REGTEST)) {
+        } else if (id.equals(BitcoinNetwork.ID_REGTEST)) {
             return RegTestParams.get();
         } else {
             return null;
@@ -175,12 +175,12 @@ public abstract class NetworkParameters {
     }
 
     /**
-     * Return network parameters for a {@link Network} enum
+     * Return network parameters for a {@link BitcoinNetwork} enum
      * @param network the network
      * @return the network parameters for the given string ID
      * @throws IllegalArgumentException if unknown network
      */
-    public static NetworkParameters of(Network network) {
+    public static NetworkParameters of(BitcoinNetwork network) {
         switch (network) {
             case MAIN:
                 return MainNetParams.get();

--- a/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
+++ b/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
@@ -34,7 +34,7 @@ import org.bitcoinj.net.discovery.PeerDiscovery;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.store.SPVBlockStore;
-import org.bitcoinj.utils.Network;
+import org.bitcoinj.utils.BitcoinNetwork;
 import org.bitcoinj.wallet.DeterministicSeed;
 import org.bitcoinj.wallet.KeyChainGroup;
 import org.bitcoinj.wallet.KeyChainGroupStructure;
@@ -364,7 +364,7 @@ public class WalletAppKit extends AbstractIdleService {
                 for (PeerAddress addr : peerAddresses) vPeerGroup.addAddress(addr);
                 vPeerGroup.setMaxConnections(peerAddresses.length);
                 peerAddresses = null;
-            } else if (!params.getId().equals(Network.ID_REGTEST)) {
+            } else if (!params.getId().equals(BitcoinNetwork.ID_REGTEST)) {
                 vPeerGroup.addPeerDiscovery(discovery != null ? discovery : new DnsDiscovery(params));
             }
             vChain.addWallet(vWallet);

--- a/core/src/main/java/org/bitcoinj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/MainNetParams.java
@@ -20,7 +20,7 @@ package org.bitcoinj.params;
 import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.base.Sha256Hash;
-import org.bitcoinj.utils.Network;
+import org.bitcoinj.utils.BitcoinNetwork;
 
 import static com.google.common.base.Preconditions.checkState;
 
@@ -37,8 +37,8 @@ public class MainNetParams extends AbstractBitcoinNetParams {
 
     public MainNetParams() {
         super();
-        network = Network.MAIN;
-        id = Network.ID_MAINNET;
+        network = BitcoinNetwork.MAIN;
+        id = BitcoinNetwork.ID_MAINNET;
 
         targetTimespan = TARGET_TIMESPAN;
         maxTarget = ByteUtils.decodeCompactBits(Block.STANDARD_MAX_DIFFICULTY_TARGET);

--- a/core/src/main/java/org/bitcoinj/params/RegTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/RegTestParams.java
@@ -20,7 +20,7 @@ package org.bitcoinj.params;
 import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.base.Sha256Hash;
-import org.bitcoinj.utils.Network;
+import org.bitcoinj.utils.BitcoinNetwork;
 
 import static com.google.common.base.Preconditions.checkState;
 
@@ -34,8 +34,8 @@ public class RegTestParams extends AbstractBitcoinNetParams {
 
     public RegTestParams() {
         super();
-        network = Network.REGTEST;
-        id = Network.ID_REGTEST;
+        network = BitcoinNetwork.REGTEST;
+        id = BitcoinNetwork.ID_REGTEST;
         
         targetTimespan = TARGET_TIMESPAN;
         maxTarget = ByteUtils.decodeCompactBits(Block.EASIEST_DIFFICULTY_TARGET);

--- a/core/src/main/java/org/bitcoinj/params/SigNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/SigNetParams.java
@@ -19,7 +19,7 @@ package org.bitcoinj.params;
 import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.base.Sha256Hash;
-import org.bitcoinj.utils.Network;
+import org.bitcoinj.utils.BitcoinNetwork;
 
 import static com.google.common.base.Preconditions.checkState;
 
@@ -39,8 +39,8 @@ public class SigNetParams extends AbstractBitcoinNetParams {
 
     public SigNetParams() {
         super();
-        network = Network.SIGNET;
-        id = Network.ID_SIGNET;
+        network = BitcoinNetwork.SIGNET;
+        id = BitcoinNetwork.ID_SIGNET;
 
         targetTimespan = TARGET_TIMESPAN;
         maxTarget = ByteUtils.decodeCompactBits(Block.EASIEST_DIFFICULTY_TARGET);

--- a/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
@@ -25,7 +25,7 @@ import org.bitcoinj.core.StoredBlock;
 import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.BlockStoreException;
-import org.bitcoinj.utils.Network;
+import org.bitcoinj.utils.BitcoinNetwork;
 
 import java.math.BigInteger;
 import java.util.Date;
@@ -46,8 +46,8 @@ public class TestNet3Params extends AbstractBitcoinNetParams {
 
     public TestNet3Params() {
         super();
-        network = Network.TEST;
-        id = Network.ID_TESTNET;
+        network = BitcoinNetwork.TEST;
+        id = BitcoinNetwork.ID_TESTNET;
 
         targetTimespan = TARGET_TIMESPAN;
         maxTarget = ByteUtils.decodeCompactBits(Block.STANDARD_MAX_DIFFICULTY_TARGET);

--- a/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
@@ -20,7 +20,7 @@ package org.bitcoinj.params;
 import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.core.Utils;
-import org.bitcoinj.utils.Network;
+import org.bitcoinj.utils.BitcoinNetwork;
 
 /**
  * Network parameters used by the bitcoinj unit tests (and potentially your own). This lets you solve a block using
@@ -35,8 +35,8 @@ public class UnitTestParams extends AbstractBitcoinNetParams {
         super();
         // Unit Test Params are BY DEFINITION on the Bitcoin TEST network (i.e. not REGTEST or SIGNET)
         // This means that tests that run against UnitTestParams expect TEST network behavior.
-        network = Network.TEST;
-        id = Network.ID_UNITTESTNET;
+        network = BitcoinNetwork.TEST;
+        id = BitcoinNetwork.ID_UNITTESTNET;
 
         targetTimespan = 200000000;  // 6 years. Just a very big number.
         maxTarget = ByteUtils.decodeCompactBits(Block.EASIEST_DIFFICULTY_TARGET);

--- a/core/src/main/java/org/bitcoinj/utils/BitcoinNetwork.java
+++ b/core/src/main/java/org/bitcoinj/utils/BitcoinNetwork.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 /**
  * A convenient {@code enum} representation of a network.
  */
-public enum BitcoinNetwork {
+public enum BitcoinNetwork implements Network {
     MAIN("org.bitcoin.production"),
     TEST("org.bitcoin.test"),
     SIGNET("org.bitcoin.signet"),
@@ -49,6 +49,7 @@ public enum BitcoinNetwork {
      *
      * @return The network id string
      */
+    @Override
     public String id() {
         return id;
     }

--- a/core/src/main/java/org/bitcoinj/utils/BitcoinNetwork.java
+++ b/core/src/main/java/org/bitcoinj/utils/BitcoinNetwork.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 /**
  * A convenient {@code enum} representation of a network.
  */
-public enum Network {
+public enum BitcoinNetwork {
     MAIN("org.bitcoin.production"),
     TEST("org.bitcoin.test"),
     SIGNET("org.bitcoin.signet"),
@@ -40,7 +40,7 @@ public enum Network {
 
     private final String id;
 
-    Network(String networkId) {
+    BitcoinNetwork(String networkId) {
         id = networkId;
     }
 
@@ -60,7 +60,7 @@ public enum Network {
      * @param idString specifies the network
      * @return the enum
      */
-    public static Network of(String idString) {
+    public static BitcoinNetwork of(String idString) {
         return Arrays.stream(values())
                 .filter(n -> n.id.equals(idString))
                 .findFirst()

--- a/core/src/main/java/org/bitcoinj/utils/Network.java
+++ b/core/src/main/java/org/bitcoinj/utils/Network.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.utils;
+
+/**
+ * Cryptocurrency network identifier. In <b>bitcoinj</b> the only implementation of this
+ * class is the {@link BitcoinNetwork} {@code enum}. This interface is provided for experimental Bitcoin networks,
+ * sidechains, and implementations of Bitcoin-like alt-coins that are based on <b>bitcoinj</b>. It is recommended
+ * that implementations of this interface be {@code enum}s that enumerate the available networks
+ * for each environment.
+ */
+public interface Network {
+    /**
+     * Return a network id string similar to those specified in {@link BitcoinNetwork}
+     *
+     * @return The network id string
+     */
+    String id();
+}

--- a/core/src/main/java/org/bitcoinj/wallet/DefaultCoinSelector.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DefaultCoinSelector.java
@@ -22,7 +22,7 @@ import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionConfidence;
 import org.bitcoinj.core.TransactionOutput;
-import org.bitcoinj.utils.Network;
+import org.bitcoinj.utils.BitcoinNetwork;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -102,7 +102,7 @@ public class DefaultCoinSelector implements CoinSelector {
                type.equals(TransactionConfidence.ConfidenceType.PENDING) &&
                confidence.getSource().equals(TransactionConfidence.Source.SELF) &&
                // In regtest mode we expect to have only one peer, so we won't see transactions propagate.
-               (confidence.numBroadcastPeers() > 0 || tx.getParams().getId().equals(Network.ID_REGTEST));
+               (confidence.numBroadcastPeers() > 0 || tx.getParams().getId().equals(BitcoinNetwork.ID_REGTEST));
     }
 
     private static DefaultCoinSelector instance;

--- a/core/src/main/java/org/bitcoinj/wallet/DefaultRiskAnalysis.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DefaultRiskAnalysis.java
@@ -26,7 +26,7 @@ import org.bitcoinj.core.TransactionInput;
 import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.script.ScriptChunk;
-import org.bitcoinj.utils.Network;
+import org.bitcoinj.utils.BitcoinNetwork;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -200,7 +200,7 @@ public class DefaultRiskAnalysis implements RiskAnalysis {
     private Result analyzeIsStandard() {
         // The IsStandard rules don't apply on testnet, because they're just a safety mechanism and we don't want to
         // crush innovation with valueless test coins.
-        if (wallet != null && !wallet.getNetworkParameters().getId().equals(Network.ID_MAINNET))
+        if (wallet != null && !wallet.getNetworkParameters().getId().equals(BitcoinNetwork.ID_MAINNET))
             return Result.OK;
 
         RuleViolation ruleViolation = isStandard(tx);

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
@@ -29,13 +29,12 @@ import org.bitcoinj.crypto.DeterministicKey;
 import org.bitcoinj.crypto.KeyCrypter;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
 import org.bitcoinj.crypto.LinuxSecureRandom;
-import org.bitcoinj.params.UnitTestParams;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptPattern;
 import org.bitcoinj.utils.ListenerRegistration;
-import org.bitcoinj.utils.Network;
+import org.bitcoinj.utils.BitcoinNetwork;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.listeners.CurrentKeyChangeEventListener;
 import org.bitcoinj.wallet.listeners.KeyChainEventListener;
@@ -271,7 +270,7 @@ public class KeyChainGroup implements KeyBag {
         if (chains != null) {
             if (lookaheadSize > -1)
                 this.lookaheadSize = lookaheadSize;
-            else if (params.getId().equals(Network.ID_UNITTESTNET))
+            else if (params.getId().equals(BitcoinNetwork.ID_UNITTESTNET))
                 this.lookaheadSize = 5; // Cut down excess computation for unit tests.
             if (lookaheadThreshold > -1)
                 this.lookaheadThreshold = lookaheadThreshold;
@@ -1013,7 +1012,7 @@ public class KeyChainGroup implements KeyBag {
             log.info("Upgrading from P2PKH to P2WPKH deterministic keychain. Using seed: {}", seed);
             DeterministicKeyChain chain = DeterministicKeyChain.builder().seed(seed)
                     .outputScriptType(ScriptType.P2WPKH)
-                    .accountPath(structure.accountPathFor(ScriptType.P2WPKH, Network.MAIN)).build();
+                    .accountPath(structure.accountPathFor(ScriptType.P2WPKH, BitcoinNetwork.MAIN)).build();
             if (seedWasEncrypted)
                 chain = chain.toEncrypted(checkNotNull(keyCrypter), aesKey);
             addAndActivateHDChain(chain);

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroupStructure.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroupStructure.java
@@ -20,7 +20,7 @@ import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.crypto.ChildNumber;
 import org.bitcoinj.crypto.HDPath;
-import org.bitcoinj.utils.Network;
+import org.bitcoinj.utils.BitcoinNetwork;
 
 /**
  *  Defines a structure for hierarchical deterministic wallets.
@@ -41,11 +41,11 @@ public interface KeyChainGroupStructure {
      *  Default to MainNet, BIP-32 Keychains use the same path for MainNet and TestNet
      * @param outputScriptType the script/address type
      * @return account path
-     * @deprecated Use {@link #accountPathFor(ScriptType, Network)} or {@link #accountPathFor(ScriptType, NetworkParameters)}
+     * @deprecated Use {@link #accountPathFor(ScriptType, BitcoinNetwork)} or {@link #accountPathFor(ScriptType, NetworkParameters)}
      */
     @Deprecated
     default HDPath accountPathFor(ScriptType outputScriptType) {
-        return accountPathFor(outputScriptType, Network.MAIN);
+        return accountPathFor(outputScriptType, BitcoinNetwork.MAIN);
     }
 
     /**
@@ -54,7 +54,7 @@ public interface KeyChainGroupStructure {
      * @param network network/coin type
      * @return The HD Path: purpose / coinType / accountIndex
      */
-    HDPath accountPathFor(ScriptType outputScriptType, Network network);
+    HDPath accountPathFor(ScriptType outputScriptType, BitcoinNetwork network);
 
     /**
      * Map desired output script type and network to an account path
@@ -112,9 +112,9 @@ public interface KeyChainGroupStructure {
 
     /**
      * Return coin type path component for a network id
-     * @param network network id string, eg. {@link Network#ID_MAINNET}
+     * @param network network id string, eg. {@link BitcoinNetwork#ID_MAINNET}
      */
-    static ChildNumber coinType(Network network) {
+    static ChildNumber coinType(BitcoinNetwork network) {
         switch (network) {
             case MAIN:
                 return ChildNumber.COINTYPE_BTC;

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -81,7 +81,7 @@ import org.bitcoinj.utils.BaseTaggableObject;
 import org.bitcoinj.utils.FutureUtils;
 import org.bitcoinj.utils.ListenableCompletableFuture;
 import org.bitcoinj.utils.ListenerRegistration;
-import org.bitcoinj.utils.Network;
+import org.bitcoinj.utils.BitcoinNetwork;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.Protos.Wallet.EncryptionType;
 import org.bitcoinj.wallet.WalletTransaction.Pool;
@@ -3999,7 +3999,7 @@ public class Wallet extends BaseTaggableObject
     public Transaction createSend(Address address, Coin value, boolean allowUnconfirmed)
             throws InsufficientMoneyException, BadWalletEncryptionKeyException {
         SendRequest req = SendRequest.to(address, value);
-        if (params.getId().equals(Network.ID_UNITTESTNET))
+        if (params.getId().equals(BitcoinNetwork.ID_UNITTESTNET))
             req.shuffleOutputs = false;
         if (allowUnconfirmed)
             req.allowUnconfirmed();

--- a/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
@@ -28,7 +28,7 @@ import org.bitcoinj.script.Script;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptPattern;
-import org.bitcoinj.utils.Network;
+import org.bitcoinj.utils.BitcoinNetwork;
 import org.junit.Test;
 
 import java.io.BufferedReader;
@@ -124,7 +124,7 @@ public class LegacyAddressTest {
         class AltNetwork extends MainNetParams {
             AltNetwork() {
                 super();
-                network = Network.REGTEST; // TODO: Solution for enums for alt networks??
+                network = BitcoinNetwork.REGTEST; // TODO: Solution for enums for alt networks??
                 id = "alt.network";
                 addressHeader = 48;
                 p2shHeader = 5;

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -29,7 +29,7 @@ import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptError;
 import org.bitcoinj.script.ScriptException;
 import org.bitcoinj.testing.FakeTxBuilder;
-import org.bitcoinj.utils.Network;
+import org.bitcoinj.utils.BitcoinNetwork;
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
@@ -246,7 +246,7 @@ public class TransactionTest {
 
         // Roundtrip without witness
         hex = "0100000003362c10b042d48378b428d60c5c98d8b8aca7a03e1a2ca1048bfd469934bbda95010000008b483045022046c8bc9fb0e063e2fc8c6b1084afe6370461c16cbf67987d97df87827917d42d022100c807fa0ab95945a6e74c59838cc5f9e850714d8850cec4db1e7f3bcf71d5f5ef0141044450af01b4cc0d45207bddfb47911744d01f768d23686e9ac784162a5b3a15bc01e6653310bdd695d8c35d22e9bb457563f8de116ecafea27a0ec831e4a3e9feffffffffc19529a54ae15c67526cc5e20e535973c2d56ef35ff51bace5444388331c4813000000008b48304502201738185959373f04cc73dbbb1d061623d51dc40aac0220df56dabb9b80b72f49022100a7f76bde06369917c214ee2179e583fefb63c95bf876eb54d05dfdf0721ed772014104e6aa2cf108e1c650e12d8dd7ec0a36e478dad5a5d180585d25c30eb7c88c3df0c6f5fd41b3e70b019b777abd02d319bf724de184001b3d014cb740cb83ed21a6ffffffffbaae89b5d2e3ca78fd3f13cf0058784e7c089fb56e1e596d70adcfa486603967010000008b483045022055efbaddb4c67c1f1a46464c8f770aab03d6b513779ad48735d16d4c5b9907c2022100f469d50a5e5556fc2c932645f6927ac416aa65bc83d58b888b82c3220e1f0b73014104194b3f8aa08b96cae19b14bd6c32a92364bea3051cb9f018b03e3f09a57208ff058f4b41ebf96b9911066aef3be22391ac59175257af0984d1432acb8f2aefcaffffffff0340420f00000000001976a914c0fbb13eb10b57daa78b47660a4ffb79c29e2e6b88ac204e0000000000001976a9142cae94ffdc05f8214ccb2b697861c9c07e3948ee88ac1c2e0100000000001976a9146e03561cd4d6033456cc9036d409d2bf82721e9888ac00000000";
-        tx = new Transaction(NetworkParameters.of(Network.MAIN), HEX.decode(hex));
+        tx = new Transaction(NetworkParameters.of(BitcoinNetwork.MAIN), HEX.decode(hex));
         assertFalse(tx.hasWitnesses());
         assertEquals(3, tx.getInputs().size());
         for (TransactionInput in : tx.getInputs())
@@ -260,7 +260,7 @@ public class TransactionTest {
 
         // Roundtrip with witness
         hex = "0100000000010213206299feb17742091c3cb2ab45faa3aa87922d3c030cafb3f798850a2722bf0000000000feffffffa12f2424b9599898a1d30f06e1ce55eba7fabfeee82ae9356f07375806632ff3010000006b483045022100fcc8cf3014248e1a0d6dcddf03e80f7e591605ad0dbace27d2c0d87274f8cd66022053fcfff64f35f22a14deb657ac57f110084fb07bb917c3b42e7d033c54c7717b012102b9e4dcc33c9cc9cb5f42b96dddb3b475b067f3e21125f79e10c853e5ca8fba31feffffff02206f9800000000001976a9144841b9874d913c430048c78a7b18baebdbea440588ac8096980000000000160014e4873ef43eac347471dd94bc899c51b395a509a502483045022100dd8250f8b5c2035d8feefae530b10862a63030590a851183cb61b3672eb4f26e022057fe7bc8593f05416c185d829b574290fb8706423451ebd0a0ae50c276b87b43012102179862f40b85fa43487500f1d6b13c864b5eb0a83999738db0f7a6b91b2ec64f00db080000";
-        tx = new Transaction(NetworkParameters.of(Network.MAIN), HEX.decode(hex));
+        tx = new Transaction(NetworkParameters.of(BitcoinNetwork.MAIN), HEX.decode(hex));
         assertTrue(tx.hasWitnesses());
         assertEquals(2, tx.getInputs().size());
         assertTrue(tx.getInput(0).hasWitness());

--- a/integration-test/src/test/java/org/bitcoinj/wallet/WalletAccountPathTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/wallet/WalletAccountPathTest.java
@@ -20,7 +20,7 @@ import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.Context;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.crypto.HDPath;
-import org.bitcoinj.utils.Network;
+import org.bitcoinj.utils.BitcoinNetwork;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -34,8 +34,8 @@ import java.util.stream.Stream;
 
 import static org.bitcoinj.base.ScriptType.P2PKH;
 import static org.bitcoinj.base.ScriptType.P2WPKH;
-import static org.bitcoinj.utils.Network.MAIN;
-import static org.bitcoinj.utils.Network.TEST;
+import static org.bitcoinj.utils.BitcoinNetwork.MAIN;
+import static org.bitcoinj.utils.BitcoinNetwork.TEST;
 import static org.bitcoinj.wallet.KeyChainGroupStructure.BIP43;
 import static org.bitcoinj.wallet.KeyChainGroupStructure.BIP32;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -57,7 +57,7 @@ public class WalletAccountPathTest {
     @MethodSource("walletStructureParams")
     @ParameterizedTest(name = "path {1} generated for {2}, {3}")
     void walletStructurePathTest2(KeyChainGroupStructure structure, HDPath expectedPath, ScriptType scriptType,
-                                  Network network) throws IOException, UnreadableWalletException {
+                                  BitcoinNetwork network) throws IOException, UnreadableWalletException {
         // When we create a wallet with parameterized structure, network, and scriptType
         Wallet wallet = createWallet(walletFile, NetworkParameters.of(network), structure, scriptType);
 

--- a/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
@@ -23,7 +23,7 @@ import org.bitcoinj.net.discovery.DnsDiscovery;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.utils.BriefLogFormatter;
-import org.bitcoinj.utils.Network;
+import org.bitcoinj.utils.BitcoinNetwork;
 import org.bitcoinj.utils.Threading;
 import picocli.CommandLine;
 
@@ -55,7 +55,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 @CommandLine.Command(name = "build-checkpoints", usageHelpAutoWidth = true, sortOptions = false, description = "Create checkpoint files to use with CheckpointManager.")
 public class BuildCheckpoints implements Callable<Integer> {
     @CommandLine.Option(names = "--net", description = "Which network to connect to. Valid values: ${COMPLETION-CANDIDATES}. Default: ${DEFAULT-VALUE}")
-    private Network net = Network.MAIN;
+    private BitcoinNetwork net = BitcoinNetwork.MAIN;
     @CommandLine.Option(names = "--peer", description = "IP address/domain name for connection instead of localhost.")
     private String peer = null;
     @CommandLine.Option(names = "--days", description = "How many days to keep as a safety margin. Checkpointing will be done up to this many days ago.")
@@ -220,17 +220,17 @@ public class BuildCheckpoints implements Callable<Integer> {
 
         checkState(manager.numCheckpoints() == expectedSize);
 
-        if (params.getId().equals(Network.ID_MAINNET)) {
+        if (params.getId().equals(BitcoinNetwork.ID_MAINNET)) {
             StoredBlock test = manager.getCheckpointBefore(1390500000); // Thu Jan 23 19:00:00 CET 2014
             checkState(test.getHeight() == 280224);
             checkState(test.getHeader().getHashAsString()
                     .equals("00000000000000000b5d59a15f831e1c45cb688a4db6b0a60054d49a9997fa34"));
-        } else if (params.getId().equals(Network.ID_TESTNET)) {
+        } else if (params.getId().equals(BitcoinNetwork.ID_TESTNET)) {
             StoredBlock test = manager.getCheckpointBefore(1390500000); // Thu Jan 23 19:00:00 CET 2014
             checkState(test.getHeight() == 167328);
             checkState(test.getHeader().getHashAsString()
                     .equals("0000000000035ae7d5025c2538067fe7adb1cf5d5d9c31b024137d9090ed13a9"));
-        } else if (params.getId().equals(Network.ID_SIGNET)) {
+        } else if (params.getId().equals(BitcoinNetwork.ID_SIGNET)) {
             StoredBlock test = manager.getCheckpointBefore(1642000000); // 2022-01-12
             checkState(test.getHeight() == 72576);
             checkState(test.getHeader().getHashAsString()

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -31,7 +31,7 @@ import org.bitcoinj.store.*;
 import org.bitcoinj.uri.BitcoinURI;
 import org.bitcoinj.uri.BitcoinURIParseException;
 import org.bitcoinj.utils.BriefLogFormatter;
-import org.bitcoinj.utils.Network;
+import org.bitcoinj.utils.BitcoinNetwork;
 import org.bitcoinj.wallet.CoinSelection;
 import org.bitcoinj.wallet.CoinSelector;
 import org.bitcoinj.wallet.DeterministicKeyChain;
@@ -173,7 +173,7 @@ public class WalletTool implements Callable<Integer> {
             "                       If you omit both options, the creation time is being cleared (set to 0).%n")
     private String actionStr;
     @CommandLine.Option(names = "--net", description = "Which network to connect to. Valid values: ${COMPLETION-CANDIDATES}. Default: ${DEFAULT-VALUE}")
-    private Network net = Network.MAIN;
+    private BitcoinNetwork net = BitcoinNetwork.MAIN;
     @CommandLine.Option(names = "--debuglog", description = "Enables logging from the core library.")
     private boolean debugLog = false;
     @CommandLine.Option(names = "--force", description = "Overrides any safety checks on the requested action.")


### PR DESCRIPTION
This change give us flexibility and preservers the useful abstraction that we currently have with `NetworkParameters`.

This PR replaces PR #2473. It has some minor improvements, but more importantly it contains two commits which preservers the file history of `Network` -> `BitcoinNetwork`.