### PR TITLE
Address: Implement PrefixedChecksummedBytes inline in Address rather than extend a base class

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Address.java
+++ b/core/src/main/java/org/bitcoinj/core/Address.java
@@ -20,7 +20,11 @@ import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Base class for addresses, e.g. native segwit addresses ({@link SegwitAddress}) or legacy addresses ({@link LegacyAddress}).
@@ -28,7 +32,9 @@ import java.util.Comparator;
  * Use {@link #fromString(NetworkParameters, String)} to conveniently construct any kind of address from its textual
  * form.
  */
-public abstract class Address extends PrefixedChecksummedBytes implements Comparable<Address> {
+public abstract class Address implements Comparable<Address> {
+    protected final NetworkParameters params;
+    protected final byte[] bytes;
 
     /**
      * Construct an address from its binary form.
@@ -37,7 +43,8 @@ public abstract class Address extends PrefixedChecksummedBytes implements Compar
      * @param bytes the binary address data
      */
     protected Address(NetworkParameters params, byte[] bytes) {
-        super(params, bytes);
+        this.params = checkNotNull(params);
+        this.bytes = checkNotNull(bytes);
     }
 
     /**
@@ -88,6 +95,26 @@ public abstract class Address extends PrefixedChecksummedBytes implements Compar
             return SegwitAddress.fromKey(params, key);
         else
             throw new IllegalArgumentException(outputScriptType.toString());
+    }
+
+    /**
+     * @return network this data is valid for
+     */
+    public final NetworkParameters getParameters() {
+        return params;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(params, Arrays.hashCode(bytes));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Address other = (Address) o;
+        return this.params.equals(other.params) && Arrays.equals(this.bytes, other.bytes);
     }
 
     /**

--- a/core/src/test/java/org/bitcoinj/core/AddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AddressTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.core;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.bitcoinj.params.MainNetParams;
+import org.bitcoinj.params.TestNet3Params;
+import org.junit.Test;
+
+public class AddressTest {
+    @Test
+    public void equalsContract() {
+        EqualsVerifier.forClass(Address.class)
+                .withPrefabValues(NetworkParameters.class, MainNetParams.get(), TestNet3Params.get())
+                .suppress(Warning.NULL_FIELDS)
+                .suppress(Warning.TRANSIENT_FIELDS)
+                .usingGetClass()
+                .verify();
+    }
+}


### PR DESCRIPTION
In preparation for future refactoring of Address, we don't want Address
tied to a base class with dependencies on o.b.core or NetworkParameters.

(Instead we provide the NetworkParametersSupplier interface -- removed in force-push)

We also want the option of making Address itself an interface in the future.

(I made PrefixedChecksummedBytes implement NetworkParametersSupplier, though
this was not strictly necessary. This will remind us to consider similar refactoring
for other subclasses of PrefixedChecksummedBytes -- also removed in force-push)

Yes, this results in some code duplication but there is no need or use of polymorphism in the subclasses
of PrefixedChecksummedBytes.

Since equals() was copied from NetworkParameters into Address, create AddressTest
and copy the equals() test from PrefixedChecksummedBytesTest.