### PR TITLE
Use (new and deprecated) NetworkParameters.fromAddress to isolate incorrect usage

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Address.java
+++ b/core/src/main/java/org/bitcoinj/core/Address.java
@@ -100,7 +100,9 @@ public abstract class Address implements Comparable<Address> {
 
     /**
      * @return network this data is valid for
+     * @deprecated Use {@link #network()}
      */
+    @Deprecated
     public final NetworkParameters getParameters() {
         return params;
     }

--- a/core/src/main/java/org/bitcoinj/core/LegacyAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/LegacyAddress.java
@@ -188,8 +188,10 @@ public class LegacyAddress extends Address {
      * @return network the address is valid for
      * @throws AddressFormatException if the given base58 doesn't parse or the checksum is invalid
      */
+    @Deprecated
     public static NetworkParameters getParametersFromAddress(String address) throws AddressFormatException {
-        return LegacyAddress.fromBase58(null, address).getParameters();
+        // TODO: Provide a `Network`-based mechanism for resolving "alt addresses"
+        return NetworkParameters.fromAddress(LegacyAddress.fromBase58(null, address));
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -209,6 +209,19 @@ public abstract class NetworkParameters {
         return PaymentProtocol.paramsFromPmtProtocolID(pmtProtocolId);
     }
 
+    /**
+     * Get a NetworkParameters from an Address.
+     * Addresses should not be used for storing NetworkParameters. In the future Address will
+     * be an {@code interface} that only makes a {@link Network} available.
+     * @param address An address
+     * @return network parameters
+     * @deprecated You should be using {@link Address#network()} instead
+     */
+    @Deprecated
+    public static NetworkParameters fromAddress(Address address) {
+        return address.getParameters();
+    }
+
     public int getSpendableCoinbaseDepth() {
         return spendableCoinbaseDepth;
     }

--- a/core/src/main/java/org/bitcoinj/protocols/payments/PaymentProtocol.java
+++ b/core/src/main/java/org/bitcoinj/protocols/payments/PaymentProtocol.java
@@ -427,7 +427,7 @@ public class PaymentProtocol {
     public static Protos.Output createPayToAddressOutput(@Nullable Coin amount, Address address) {
         Protos.Output.Builder output = Protos.Output.newBuilder();
         if (amount != null) {
-            final NetworkParameters params = address.getParameters();
+            final NetworkParameters params = NetworkParameters.of(address.network());
             if (params.hasMaxMoney() && amount.compareTo(params.getMaxMoney()) > 0)
                 throw new IllegalArgumentException("Amount too big: " + amount);
             output.setAmount(amount.value);

--- a/core/src/main/java/org/bitcoinj/uri/BitcoinURI.java
+++ b/core/src/main/java/org/bitcoinj/uri/BitcoinURI.java
@@ -69,6 +69,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * <li>{@code label} any URL encoded alphanumeric</li>
  * <li>{@code message} any URL encoded alphanumeric</li>
  * </ul>
+ * TODO: Find a method other than NetworkParameters for getting the URI scheme.
  * 
  * @author Andreas Schildbach (initial code)
  * @author Jim Burton (enhancements for MultiBit)
@@ -347,7 +348,7 @@ public class BitcoinURI {
      */
     public static String convertToBitcoinURI(Address address, Coin amount,
                                              String label, String message) {
-        return convertToBitcoinURI(address.getParameters(), address.toString(), amount, label, message);
+        return convertToBitcoinURI(NetworkParameters.fromAddress(address), address.toString(), amount, label, message);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/wallet/SendRequest.java
+++ b/core/src/main/java/org/bitcoinj/wallet/SendRequest.java
@@ -170,7 +170,7 @@ public class SendRequest {
      */
     public static SendRequest to(Address destination, Coin value) {
         SendRequest req = new SendRequest();
-        final NetworkParameters parameters = destination.getParameters();
+        final NetworkParameters parameters = NetworkParameters.fromAddress(destination);
         checkNotNull(parameters, "Address is for an unknown network");
         req.tx = new Transaction(parameters);
         req.tx.addOutput(value, destination);
@@ -201,7 +201,7 @@ public class SendRequest {
 
     public static SendRequest emptyWallet(Address destination) {
         SendRequest req = new SendRequest();
-        final NetworkParameters parameters = destination.getParameters();
+        final NetworkParameters parameters = NetworkParameters.fromAddress(destination);
         checkNotNull(parameters, "Address is for an unknown network");
         req.tx = new Transaction(parameters);
         req.tx.addOutput(Coin.ZERO, destination);

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -3349,7 +3349,7 @@ public class WalletTest extends TestWithWallet {
     @Test(expected = java.lang.IllegalStateException.class)
     public void sendCoinsNoBroadcasterTest() throws InsufficientMoneyException {
         ECKey key = ECKey.fromPrivate(BigInteger.TEN);
-        SendRequest req = SendRequest.to(OTHER_ADDRESS.getParameters(), key, SATOSHI.multiply(12));
+        SendRequest req = SendRequest.to(UNITTEST, key, SATOSHI.multiply(12));
         wallet.sendCoins(req);
     }
 
@@ -3359,7 +3359,7 @@ public class WalletTest extends TestWithWallet {
         receiveATransactionAmount(wallet, myAddress, Coin.COIN);
         MockTransactionBroadcaster broadcaster = new MockTransactionBroadcaster(wallet);
         wallet.setTransactionBroadcaster(broadcaster);
-        SendRequest req = SendRequest.to(OTHER_ADDRESS.getParameters(), key, Coin.CENT);
+        SendRequest req = SendRequest.to(UNITTEST, key, Coin.CENT);
         wallet.sendCoins(req);
     }
 


### PR DESCRIPTION
* Add NetworkParameters.fromAddress() method to consolidate the use cases
  where an Address is used to get a NetworkParameters
* Deprecate NetworkParameters.fromAddress() to indicate code must be rewritten
* This also removes one dependency on NetworkParameters in Address and helps
  prepare for moving Address (perhaps as an interface) to `o.b.base`
  
  Draft PR since it depends on PR #2492 (though it might be possible to cherry-pick)
