### PR TITLE
Add Address.network() to allow migration away from using NetworkParameters

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Address.java
+++ b/core/src/main/java/org/bitcoinj/core/Address.java
@@ -18,6 +18,7 @@ package org.bitcoinj.core;
 
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.exceptions.AddressFormatException;
+import org.bitcoinj.utils.Network;
 
 import javax.annotation.Nullable;
 import java.util.Comparator;
@@ -120,6 +121,15 @@ public abstract class Address extends PrefixedChecksummedBytes implements Compar
      */
     @Override
     abstract public int compareTo(Address o);
+
+    /**
+     * Get the network this address works on. Use of {@link Network} is preferred to use of {@link NetworkParameters}
+     * when you need to know what network an address is for.
+     * @return the Network.
+     */
+    public Network network() {
+        return params.network();
+    }
 
     /**
      * Comparator for the first two comparison fields in {@code Address} comparisons, see {@link Address#compareTo(Address)}.


### PR DESCRIPTION
This is possible now that `NetworkParameters` always contains a `Network` property.