### PR TITLE
Fix minor JavaDoc error that broke build.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -167,7 +167,6 @@ public abstract class NetworkParameters {
      * Return network parameters for a network id
      * @param id the network id
      * @return the network parameters for the given string ID or NULL if not recognized
-     * @deprecated Use {@link AbstractBitcoinNetParams#fromID(String)}
      */
     @Deprecated
     @Nullable


### PR DESCRIPTION
Removing the whole line because the suggested method doesn't exist yet.
(It's in PR #2483 and merging 2483 will also fix the broken build.)