### PR TITLE
WIP on using AddressKey to remove ECKey dependency from Address

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Address.java
+++ b/core/src/main/java/org/bitcoinj/core/Address.java
@@ -30,12 +30,18 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Base class for addresses, e.g. native segwit addresses ({@link SegwitAddress}) or legacy addresses ({@link LegacyAddress}).
  * <p>
- * Use {@link #fromString(NetworkParameters, String)} to conveniently construct any kind of address from its textual
+ * Use {@link AddressFactory#fromString(String, org.bitcoinj.base.Network)} to conveniently construct any kind of address from its textual
  * form.
  */
 public abstract class Address implements Comparable<Address> {
     protected final NetworkParameters params;
     protected final byte[] bytes;
+    private static final DefaultAddressFactory addressFactory = new DefaultAddressFactory();
+
+    @FunctionalInterface
+    public interface AddressParser {
+        Address parseString(String addressString) throws AddressFormatException;
+    }
 
     /**
      * Construct an address from its binary form.
@@ -61,21 +67,10 @@ public abstract class Address implements Comparable<Address> {
      * @throws AddressFormatException.WrongNetwork
      *             if the given string is valid but not for the expected network (eg testnet vs mainnet)
      */
+    @Deprecated
     public static Address fromString(@Nullable NetworkParameters params, String str)
             throws AddressFormatException {
-        try {
-            return LegacyAddress.fromBase58(params, str);
-        } catch (AddressFormatException.WrongNetwork x) {
-            throw x;
-        } catch (AddressFormatException x) {
-            try {
-                return SegwitAddress.fromBech32(params, str);
-            } catch (AddressFormatException.WrongNetwork x2) {
-                throw x;
-            } catch (AddressFormatException x2) {
-                throw new AddressFormatException(str);
-            }
-        }
+        return addressFactory.fromString(str, params);
     }
 
     /**
@@ -89,13 +84,9 @@ public abstract class Address implements Comparable<Address> {
      *            script type the address should use
      * @return constructed address
      */
+    @Deprecated
     public static Address fromKey(final NetworkParameters params, final ECKey key, final ScriptType outputScriptType) {
-        if (outputScriptType == ScriptType.P2PKH)
-            return LegacyAddress.fromKey(params, key);
-        else if (outputScriptType == ScriptType.P2WPKH)
-            return SegwitAddress.fromKey(params, key);
-        else
-            throw new IllegalArgumentException(outputScriptType.toString());
+        return key.toAddress(outputScriptType, params);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/AddressFactory.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressFactory.java
@@ -1,0 +1,26 @@
+package org.bitcoinj.core;
+
+import org.bitcoinj.base.ScriptType;
+import org.bitcoinj.base.exceptions.AddressFormatException;
+import org.bitcoinj.base.Network;
+
+/**
+ * A factory interface for creating addresses
+ */
+public interface AddressFactory {
+
+    /**
+     * Parse a string and return an address if it is valid on any known network
+     */
+    Address fromString(String addressString) throws AddressFormatException;
+
+    /**
+     * Parse a string and return an address if it is valid on the specified network
+     */
+    Address fromString(String addressString, Network network) throws AddressFormatException;
+
+    default Address fromKey(AddressKey key, ScriptType scriptType, Network network) {
+        return key.toAddress(scriptType, network);
+    }
+
+}

--- a/core/src/main/java/org/bitcoinj/core/AddressKey.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressKey.java
@@ -1,0 +1,20 @@
+package org.bitcoinj.core;
+
+import org.bitcoinj.base.ScriptType;
+import org.bitcoinj.base.Network;
+
+/**
+ * A public or private key that can be used to generate an address. Currently the only
+ * implementation of this interface is {@code ECKey} in `core`.
+ *
+ * Keys should know how to make addresses not address know how to make themselves from keys.
+ * If ECKey implements `AddressKey`, this allows us to move LegacyAddress and SegwitAddress to `o.b.base`
+ *
+ * This approach should actually allow us to generate keys from the EC implementation in Java, I think.
+ */
+public interface AddressKey {
+    Address toAddress(ScriptType scriptType, Network network);
+
+    @Deprecated
+    Address toAddress(ScriptType scriptType, NetworkParameters params);
+}

--- a/core/src/main/java/org/bitcoinj/core/DefaultAddressFactory.java
+++ b/core/src/main/java/org/bitcoinj/core/DefaultAddressFactory.java
@@ -1,0 +1,40 @@
+package org.bitcoinj.core;
+
+import org.bitcoinj.base.exceptions.AddressFormatException;
+import org.bitcoinj.base.Network;
+
+import javax.annotation.Nullable;
+
+/**
+ *
+ */
+public class DefaultAddressFactory implements AddressFactory {
+    @Override
+    public Address fromString(String addressString) {
+        return fromString(addressString, (NetworkParameters) null);
+    }
+
+    @Override
+    public Address fromString(String addressString, Network network) {
+        return fromString(addressString, NetworkParameters.of(network));
+    }
+
+    @Deprecated
+    public Address fromString(String str, @Nullable NetworkParameters params)
+            throws AddressFormatException {
+        try {
+            return LegacyAddress.fromBase58(params, str);
+        } catch (AddressFormatException.WrongNetwork x) {
+            throw x;
+        } catch (AddressFormatException x) {
+            try {
+                return SegwitAddress.fromBech32(params, str);
+            } catch (AddressFormatException.WrongNetwork x2) {
+                throw x;
+            } catch (AddressFormatException x2) {
+                throw new AddressFormatException(str);
+            }
+        }
+    }
+
+}

--- a/core/src/main/java/org/bitcoinj/core/DumpedPrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/core/DumpedPrivateKey.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import org.bitcoinj.base.Base58;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.params.Networks;
+import org.bitcoinj.base.Network;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -31,6 +32,15 @@ import java.util.Arrays;
  * the last byte is a discriminator value for the compressed pubkey.
  */
 public class DumpedPrivateKey extends PrefixedChecksummedBytes {
+
+
+    public static DumpedPrivateKey fromBase58(String base58, Network network) {
+        return fromBase58(NetworkParameters.of(network), base58);
+    }
+
+    public static DumpedPrivateKey fromBase58(String base58) {
+        return fromBase58(null, base58);
+    }
 
     /**
      * Construct a private key from its Base58 representation.
@@ -43,6 +53,7 @@ public class DumpedPrivateKey extends PrefixedChecksummedBytes {
      * @throws AddressFormatException.WrongNetwork
      *             if the given private key is valid but for a different chain (eg testnet vs mainnet)
      */
+    @Deprecated
     public static DumpedPrivateKey fromBase58(@Nullable NetworkParameters params, String base58)
             throws AddressFormatException, AddressFormatException.WrongNetwork {
         byte[] versionAndDataBytes = Base58.decodeChecked(base58);

--- a/core/src/main/java/org/bitcoinj/core/LegacyAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/LegacyAddress.java
@@ -51,9 +51,8 @@ public class LegacyAddress extends Address {
 
     /**
      * Private constructor. Use {@link #fromBase58(NetworkParameters, String)},
-     * {@link #fromPubKeyHash(NetworkParameters, byte[])}, {@link #fromScriptHash(NetworkParameters, byte[])} or
-     * {@link #fromKey(NetworkParameters, ECKey)}.
-     * 
+     * {@link #fromPubKeyHash(NetworkParameters, byte[])}, {@link #fromScriptHash(NetworkParameters, byte[])}
+     *
      * @param params
      *            network this address is valid for
      * @param p2sh
@@ -93,8 +92,9 @@ public class LegacyAddress extends Address {
      *            only the public part is used
      * @return constructed address
      */
+    @Deprecated
     public static LegacyAddress fromKey(NetworkParameters params, ECKey key) {
-        return fromPubKeyHash(params, key.getPubKeyHash());
+        return (LegacyAddress) key.toAddress(ScriptType.P2PKH, params);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/SegwitAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/SegwitAddress.java
@@ -21,6 +21,7 @@ import org.bitcoinj.base.Bech32;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.params.Networks;
+import org.bitcoinj.base.Network;
 
 import javax.annotation.Nullable;
 import java.io.ByteArrayOutputStream;
@@ -237,7 +238,9 @@ public class SegwitAddress extends Address {
      * @param key
      *            only the public part is used
      * @return constructed address
+     * @deprecated Use {@link ECKey#toAddress(ScriptType, Network)}
      */
+    @Deprecated
     public static SegwitAddress fromKey(NetworkParameters params, ECKey key) {
         checkArgument(key.isCompressed(), "only compressed keys allowed");
         return fromHash(params, key.getPubKeyHash());

--- a/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
@@ -17,6 +17,7 @@
 package org.bitcoinj.crypto;
 
 import com.google.common.primitives.Bytes;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.Base58;
@@ -123,7 +124,7 @@ public class BIP38PrivateKey extends PrefixedChecksummedBytes {
     public ECKey decrypt(String passphrase) throws BadPassphraseException {
         String normalizedPassphrase = Normalizer.normalize(passphrase, Normalizer.Form.NFC);
         ECKey key = ecMultiply ? decryptEC(normalizedPassphrase) : decryptNoEC(normalizedPassphrase);
-        Sha256Hash hash = Sha256Hash.twiceOf(LegacyAddress.fromKey(params, key).toString().getBytes(StandardCharsets.US_ASCII));
+        Sha256Hash hash = Sha256Hash.twiceOf(key.toAddress(ScriptType.P2PKH, params).toString().getBytes(StandardCharsets.US_ASCII));
         byte[] actualAddressHash = Arrays.copyOfRange(hash.getBytes(), 0, 4);
         if (!Arrays.equals(actualAddressHash, addressHash))
             throw new BadPassphraseException();

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -677,7 +677,7 @@ public class DeterministicKey extends ECKey {
     @Override
     public void formatKeyWithAddress(boolean includePrivateKeys, @Nullable KeyParameter aesKey, StringBuilder builder,
                                      NetworkParameters params, ScriptType outputScriptType, @Nullable String comment) {
-        builder.append("  addr:").append(Address.fromKey(params, this, outputScriptType).toString());
+        builder.append("  addr:").append(this.toAddress(outputScriptType, params).toString());
         builder.append("  hash160:").append(ByteUtils.HEX.encode(getPubKeyHash()));
         builder.append("  (").append(getPathAsString());
         if (comment != null)

--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -398,7 +398,7 @@ public class Script {
         else if (ScriptPattern.isP2SH(this))
             return LegacyAddress.fromScriptHash(params, ScriptPattern.extractHashFromP2SH(this));
         else if (forcePayToPubKey && ScriptPattern.isP2PK(this))
-            return LegacyAddress.fromKey(params, ECKey.fromPublicOnly(ScriptPattern.extractKeyFromP2PK(this)));
+            return ECKey.fromPublicOnly(ScriptPattern.extractKeyFromP2PK(this)).toAddress(ScriptType.P2PKH, params);
         else if (ScriptPattern.isP2WH(this))
             return SegwitAddress.fromHash(params, ScriptPattern.extractHashFromP2WH(this));
         else if (ScriptPattern.isP2TR(this))

--- a/core/src/main/java/org/bitcoinj/store/DatabaseFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/DatabaseFullPrunedBlockStore.java
@@ -1158,7 +1158,7 @@ public abstract class DatabaseFullPrunedBlockStore implements FullPrunedBlockSto
             s = conn.get().prepareStatement(getTransactionOutputSelectSQL());
             for (ECKey key : keys) {
                 // TODO switch to pubKeyHash in order to support native segwit addresses
-                s.setString(1, LegacyAddress.fromKey(params, key).toString());
+                s.setString(1, key.toAddress(ScriptType.P2PKH, params.network()).toString());
                 ResultSet rs = s.executeQuery();
                 while (rs.next()) {
                     Sha256Hash hash = Sha256Hash.wrap(rs.getBytes(1));

--- a/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
@@ -17,6 +17,7 @@
 package org.bitcoinj.store;
 
 import com.google.common.base.Preconditions;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.Address;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.LegacyAddress;
@@ -434,7 +435,7 @@ public class MemoryFullPrunedBlockStore implements FullPrunedBlockStore {
         for (UTXO output : outputsList) {
             for (ECKey key : keys) {
                 // TODO switch to pubKeyHash in order to support native segwit addresses
-                Address address = LegacyAddress.fromKey(params, key);
+                Address address = key.toAddress(ScriptType.P2PKH, params);
                 if (output.getAddress().equals(address.toString())) {
                     foundOutputs.add(output);
                 }

--- a/core/src/main/java/org/bitcoinj/testing/FakeTxBuilder.java
+++ b/core/src/main/java/org/bitcoinj/testing/FakeTxBuilder.java
@@ -18,6 +18,7 @@
 package org.bitcoinj.testing;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.Address;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.base.Coin;
@@ -58,12 +59,12 @@ import static org.bitcoinj.base.Coin.valueOf;
 public class FakeTxBuilder {
     /** Create a fake transaction, without change. */
     public static Transaction createFakeTx(final NetworkParameters params) {
-        return createFakeTxWithoutChangeAddress(params, Coin.COIN, LegacyAddress.fromKey(params, new ECKey()));
+        return createFakeTxWithoutChangeAddress(params, Coin.COIN, randomAddress(params));
     }
 
     /** Create a fake transaction, without change. */
     public static Transaction createFakeTxWithoutChange(final NetworkParameters params, final TransactionOutput output) {
-        Transaction prevTx = FakeTxBuilder.createFakeTx(params, Coin.COIN, LegacyAddress.fromKey(params, new ECKey()));
+        Transaction prevTx = FakeTxBuilder.createFakeTx(params, Coin.COIN, randomAddress(params));
         Transaction tx = new Transaction(params);
         tx.addOutput(output);
         tx.addInput(prevTx.getOutput(0));
@@ -77,7 +78,7 @@ public class FakeTxBuilder {
         Transaction tx = new Transaction(params);
         tx.addInput(input);
         TransactionOutput outputToMe = new TransactionOutput(params, tx, Coin.FIFTY_COINS,
-                LegacyAddress.fromKey(params, new ECKey()));
+                randomAddress(params));
         tx.addOutput(outputToMe);
 
         checkState(tx.isCoinBase());
@@ -147,7 +148,7 @@ public class FakeTxBuilder {
      * else to simulate change. There is one random input.
      */
     public static Transaction createFakeTx(NetworkParameters params, Coin value, Address to) {
-        return createFakeTxWithChangeAddress(params, value, to, LegacyAddress.fromKey(params, new ECKey()));
+        return createFakeTxWithChangeAddress(params, value, to, randomAddress(params));
     }
 
     /**
@@ -181,7 +182,7 @@ public class FakeTxBuilder {
         Transaction t = new Transaction(params);
         TransactionOutput outputToMe = new TransactionOutput(params, t, value, to);
         t.addOutput(outputToMe);
-        TransactionOutput change = new TransactionOutput(params, t, valueOf(1, 11), LegacyAddress.fromKey(params, new ECKey()));
+        TransactionOutput change = new TransactionOutput(params, t, valueOf(1, 11), randomAddress(params));
         t.addOutput(change);
         // Make a feeder tx that sends to the from address specified. This feeder tx is not really valid but it doesn't
         // matter for our purposes.
@@ -227,7 +228,7 @@ public class FakeTxBuilder {
     public static DoubleSpends createFakeDoubleSpendTxns(NetworkParameters params, Address to) {
         DoubleSpends doubleSpends = new DoubleSpends();
         Coin value = COIN;
-        Address someBadGuy = LegacyAddress.fromKey(params, new ECKey());
+        Address someBadGuy = randomAddress(params);
 
         doubleSpends.prevTx = new Transaction(params);
         TransactionOutput prevOut = new TransactionOutput(params, doubleSpends.prevTx, value, someBadGuy);
@@ -269,7 +270,7 @@ public class FakeTxBuilder {
                                             Transaction... transactions) {
         try {
             Block previousBlock = previousStoredBlock.getHeader();
-            Address to = LegacyAddress.fromKey(previousBlock.getParams(), new ECKey());
+            Address to = randomAddress(previousBlock.getParams());
             Block b = previousBlock.createNextBlock(to, version, timeSeconds, height);
             // Coinbase tx was already added.
             for (Transaction tx : transactions) {
@@ -319,7 +320,7 @@ public class FakeTxBuilder {
     }
 
     public static Block makeSolvedTestBlock(Block prev, Transaction... transactions) throws BlockStoreException {
-        Address to = LegacyAddress.fromKey(prev.getParams(), new ECKey());
+        Address to = randomAddress(prev.getParams());
         Block b = prev.createNextBlock(to);
         // Coinbase tx already exists.
         for (Transaction tx : transactions) {
@@ -337,5 +338,10 @@ public class FakeTxBuilder {
         }
         b.solve();
         return b;
+    }
+
+    @Deprecated
+    private static Address randomAddress(NetworkParameters params) {
+        return ECKey.randomAddress(ScriptType.P2PKH, params);
     }
 }

--- a/core/src/main/java/org/bitcoinj/uri/BitcoinURI.java
+++ b/core/src/main/java/org/bitcoinj/uri/BitcoinURI.java
@@ -19,6 +19,7 @@ package org.bitcoinj.uri;
 import org.bitcoinj.core.Address;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.core.DefaultAddressFactory;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.params.AbstractBitcoinNetParams;
 
@@ -94,6 +95,8 @@ public class BitcoinURI {
     private static final String ENCODED_SPACE_CHARACTER = "%20";
     private static final String AMPERSAND_SEPARATOR = "&";
     private static final String QUESTION_MARK_SEPARATOR = "?";
+
+    private DefaultAddressFactory addressFactory = new DefaultAddressFactory();
 
     /**
      * Contains all the parameters in the order in which they were processed
@@ -176,7 +179,7 @@ public class BitcoinURI {
         if (!addressToken.isEmpty()) {
             // Attempt to parse the addressToken as a Bitcoin address for this network
             try {
-                Address address = Address.fromString(params, addressToken);
+                Address address = addressFactory.fromString(addressToken, params);
                 putWithValidation(FIELD_ADDRESS, address);
             } catch (final AddressFormatException e) {
                 throw new BitcoinURIParseException("Bad address", e);

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
@@ -384,7 +384,7 @@ public class KeyChainGroup implements KeyBag {
             }
             return current;
         } else if (outputScriptType == ScriptType.P2PKH || outputScriptType == ScriptType.P2WPKH) {
-            return Address.fromKey(params, currentKey(purpose), outputScriptType);
+            return currentKey(purpose).toAddress(outputScriptType, params);
         } else {
             throw new IllegalStateException(chain.getOutputScriptType().toString());
         }
@@ -436,7 +436,7 @@ public class KeyChainGroup implements KeyBag {
      */
     public Address freshAddress(KeyChain.KeyPurpose purpose, ScriptType outputScriptType, long keyRotationTimeSecs) {
         DeterministicKeyChain chain = getActiveKeyChain(outputScriptType, keyRotationTimeSecs);
-        return Address.fromKey(params, chain.getKey(purpose), outputScriptType);
+        return chain.getKey(purpose).toAddress(outputScriptType, params);
     }
 
     /**
@@ -454,7 +454,7 @@ public class KeyChainGroup implements KeyBag {
             currentAddresses.put(purpose, freshAddress);
             return freshAddress;
         } else if (outputScriptType == ScriptType.P2PKH || outputScriptType == ScriptType.P2WPKH) {
-            return Address.fromKey(params, freshKey(purpose), outputScriptType);
+            return freshKey(purpose).toAddress(outputScriptType, params);
         } else {
             throw new IllegalStateException(chain.getOutputScriptType().toString());
         }

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -732,7 +732,7 @@ public class Wallet extends BaseTaggableObject
             for (final DeterministicKeyChain chain : keyChainGroup.getActiveKeyChains(keyRotationTimeSecs)) {
                 ScriptType outputScriptType = chain.getOutputScriptType();
                 for (ECKey key : chain.getIssuedReceiveKeys())
-                    addresses.add(Address.fromKey(getParams(), key, outputScriptType));
+                    addresses.add(key.toAddress(outputScriptType, getParams()));
             }
             return addresses;
         } finally {

--- a/core/src/test/java/org/bitcoinj/core/AddressComparatorSortTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AddressComparatorSortTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertEquals;
  * the default comparators.
  */
 public class AddressComparatorSortTest {
+    private static final AddressFactory addressFactory = new DefaultAddressFactory();
     /**
      * A manually sorted list of address for verifying sorting with our default comparator.
      * See {@link Address#compareTo}.
@@ -49,7 +50,7 @@ public class AddressComparatorSortTest {
                     // Test net, Segwit
                     "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
                     "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
-            ).map(s -> Address.fromString(null, s))
+            ).map(addressFactory::fromString)
             .collect(collectingAndThen(toList(), Collections::unmodifiableList));
 
     @Test

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -194,13 +194,13 @@ public class TransactionTest {
 
     @Test
     public void addSignedInput_P2PKH() {
-        final Address toAddr = Address.fromKey(TESTNET, new ECKey(), ScriptType.P2PKH);
+        final Address toAddr = new ECKey().toAddress(ScriptType.P2PKH, Network.TEST);
         final Sha256Hash utxo_id = Sha256Hash.wrap("81b4c832d70cb56ff957589752eb4125a4cab78a25a8fc52d6a09e5bd4404d48");
         final Coin inAmount = Coin.ofSat(91234);
         final Coin outAmount = Coin.ofSat(91234);
 
         ECKey fromKey = new ECKey();
-        Address fromAddress = Address.fromKey(TESTNET, fromKey, ScriptType.P2PKH);
+        Address fromAddress = fromKey.toAddress(ScriptType.P2PKH, Network.TEST);
         Transaction tx = new Transaction(TESTNET);
         TransactionOutPoint outPoint = new TransactionOutPoint(TESTNET, 0, utxo_id);
         TransactionOutput output = new TransactionOutput(TESTNET, null, inAmount, fromAddress);
@@ -217,13 +217,13 @@ public class TransactionTest {
 
     @Test
     public void addSignedInput_P2WPKH() {
-        final Address toAddr = Address.fromKey(TESTNET, new ECKey(), ScriptType.P2WPKH);
+        final Address toAddr = new ECKey().toAddress(ScriptType.P2WPKH, Network.TEST);
         final Sha256Hash utxo_id = Sha256Hash.wrap("81b4c832d70cb56ff957589752eb4125a4cab78a25a8fc52d6a09e5bd4404d48");
         final Coin inAmount = Coin.ofSat(91234);
         final Coin outAmount = Coin.ofSat(91234);
 
         ECKey fromKey = new ECKey();
-        Address fromAddress = Address.fromKey(TESTNET, fromKey, ScriptType.P2WPKH);
+        Address fromAddress = fromKey.toAddress(ScriptType.P2WPKH, Network.TEST);
         Transaction tx = new Transaction(TESTNET);
         TransactionOutPoint outPoint = new TransactionOutPoint(TESTNET, 0, utxo_id);
         tx.addOutput(outAmount, toAddr);

--- a/examples/src/main/java/org/bitcoinj/examples/DoubleSpend.java
+++ b/examples/src/main/java/org/bitcoinj/examples/DoubleSpend.java
@@ -19,8 +19,8 @@ package org.bitcoinj.examples;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.*;
 import org.bitcoinj.kits.WalletAppKit;
-import org.bitcoinj.params.RegTestParams;
 import org.bitcoinj.utils.BriefLogFormatter;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.KeyChainGroupStructure;
 import org.bitcoinj.wallet.Wallet;
@@ -35,10 +35,11 @@ import static org.bitcoinj.base.Coin.*;
  * you would normally want to do.
  */
 public class DoubleSpend {
+    private static final AddressFactory addressFactory = new DefaultAddressFactory();
     public static void main(String[] args) throws Exception {
         BriefLogFormatter.init();
-        final RegTestParams params = RegTestParams.get();
-        WalletAppKit kit = new WalletAppKit(params, ScriptType.P2WPKH, KeyChainGroupStructure.BIP32, new File("."), "doublespend");
+        final Network network = Network.REGTEST;
+        WalletAppKit kit = new WalletAppKit(NetworkParameters.of(network), ScriptType.P2WPKH, KeyChainGroupStructure.BIP32, new File("."), "doublespend");
         kit.connectToLocalHost();
         kit.setAutoSave(false);
         kit.startAsync();
@@ -47,8 +48,8 @@ public class DoubleSpend {
         System.out.println(kit.wallet());
 
         kit.wallet().getBalanceFuture(COIN, Wallet.BalanceType.AVAILABLE).get();
-        Transaction tx1 = kit.wallet().createSend(Address.fromString(params, "bcrt1qsmf9envp5dphlu6my2tpwfmce0793jvpvlg5ez"), CENT);
-        Transaction tx2 = kit.wallet().createSend(Address.fromString(params, "bcrt1qsmf9envp5dphlu6my2tpwfmce0793jvpvlg5ez"), CENT.add(SATOSHI.multiply(10)));
+        Transaction tx1 = kit.wallet().createSend(addressFactory.fromString("bcrt1qsmf9envp5dphlu6my2tpwfmce0793jvpvlg5ez", network), CENT);
+        Transaction tx2 = kit.wallet().createSend(addressFactory.fromString("bcrt1qsmf9envp5dphlu6my2tpwfmce0793jvpvlg5ez", network), CENT.add(SATOSHI.multiply(10)));
         final Peer peer = kit.peerGroup().getConnectedPeers().get(0);
         peer.addPreMessageReceivedEventListener(Threading.SAME_THREAD,
                 (peer1, m) -> {

--- a/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
@@ -20,25 +20,17 @@ package org.bitcoinj.examples;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.Address;
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.core.AddressFactory;
+import org.bitcoinj.core.DefaultAddressFactory;
 import org.bitcoinj.core.InsufficientMoneyException;
-import org.bitcoinj.core.LegacyAddress;
 import org.bitcoinj.core.NetworkParameters;
-import org.bitcoinj.core.Transaction;
-import org.bitcoinj.core.TransactionConfidence;
 import org.bitcoinj.crypto.KeyCrypterException;
 import org.bitcoinj.kits.WalletAppKit;
-import org.bitcoinj.params.MainNetParams;
-import org.bitcoinj.params.RegTestParams;
-import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.utils.BriefLogFormatter;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.wallet.KeyChainGroupStructure;
 import org.bitcoinj.wallet.SendRequest;
 import org.bitcoinj.wallet.Wallet;
-import org.bitcoinj.wallet.listeners.WalletCoinsReceivedEventListener;
-
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.MoreExecutors;
 
 import java.io.File;
 
@@ -49,6 +41,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * sends them onwards to an address given on the command line.
  */
 public class ForwardingService {
+    private static final AddressFactory addressFactory = new DefaultAddressFactory();
     private static Address forwardingAddress;
     private static WalletAppKit kit;
 
@@ -61,28 +54,28 @@ public class ForwardingService {
         }
 
         // Figure out which network we should connect to. Each one gets its own set of files.
-        NetworkParameters params;
+        Network network;
         String filePrefix;
         if (args.length > 1 && args[1].equals("testnet")) {
-            params = TestNet3Params.get();
+            network = Network.TEST;
             filePrefix = "forwarding-service-testnet";
         } else if (args.length > 1 && args[1].equals("regtest")) {
-            params = RegTestParams.get();
+            network = Network.REGTEST;
             filePrefix = "forwarding-service-regtest";
         } else {
-            params = MainNetParams.get();
+            network = Network.MAIN;
             filePrefix = "forwarding-service";
         }
         // Parse the address given as the first parameter.
-        forwardingAddress = Address.fromString(params, args[0]);
+        forwardingAddress = addressFactory.fromString(args[0], network);
 
-        System.out.println("Network: " + params.getId());
+        System.out.println("Network: " + network.id());
         System.out.println("Forwarding address: " + forwardingAddress);
 
         // Start up a basic app using a class that automates some boilerplate.
-        kit = new WalletAppKit(params, ScriptType.P2WPKH, KeyChainGroupStructure.BIP32, new File("."), filePrefix);
+        kit = new WalletAppKit(NetworkParameters.of(network), ScriptType.P2WPKH, KeyChainGroupStructure.BIP32, new File("."), filePrefix);
 
-        if (params == RegTestParams.get()) {
+        if (network == Network.REGTEST) {
             // Regression test mode is designed for testing and development only, so there's no public network for it.
             // If you pick this mode, you're expected to be running a local "bitcoind -regtest" instance.
             kit.connectToLocalHost();
@@ -118,7 +111,7 @@ public class ForwardingService {
             });
         });
 
-        Address sendToAddress = LegacyAddress.fromKey(params, kit.wallet().currentReceiveKey());
+        Address sendToAddress = kit.wallet().currentReceiveKey().toAddress(ScriptType.P2PKH, network);
         System.out.println("Send coins to: " + sendToAddress);
         System.out.println("Waiting for coins to arrive. Press Ctrl-C to quit.");
 

--- a/examples/src/main/java/org/bitcoinj/examples/GenerateLowSTests.java
+++ b/examples/src/main/java/org/bitcoinj/examples/GenerateLowSTests.java
@@ -87,11 +87,11 @@ public class GenerateLowSTests {
 
         final Transaction outputTransaction = new Transaction(params);
         final Transaction inputTransaction = new Transaction(params);
-        final TransactionOutput output = new TransactionOutput(params, inputTransaction, Coin.ZERO, LegacyAddress.fromKey(params, key));
+        final TransactionOutput output = new TransactionOutput(params, inputTransaction, Coin.ZERO, key.toAddress(ScriptType.P2PKH, params));
 
         inputTransaction.addOutput(output);
         outputTransaction.addInput(output);
-        outputTransaction.addOutput(Coin.ZERO, LegacyAddress.fromKey(params, new ECKey(secureRandom)));
+        outputTransaction.addOutput(Coin.ZERO, new ECKey(secureRandom).toAddress(ScriptType.P2PKH, params));
 
         addOutputs(outputTransaction, bag);
 

--- a/examples/src/main/java/org/bitcoinj/examples/SendRequest.java
+++ b/examples/src/main/java/org/bitcoinj/examples/SendRequest.java
@@ -20,7 +20,7 @@ import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.*;
 import org.bitcoinj.kits.WalletAppKit;
-import org.bitcoinj.params.TestNet3Params;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.wallet.KeyChainGroupStructure;
 import org.bitcoinj.wallet.Wallet;
 import org.bitcoinj.wallet.Wallet.BalanceType;
@@ -32,12 +32,13 @@ import java.util.concurrent.CompletableFuture;
  * The following example shows you how to create a SendRequest to send coins from a wallet to a given address.
  */
 public class SendRequest {
+    private static final AddressFactory addressFactory = new DefaultAddressFactory();
 
     public static void main(String[] args) throws Exception {
 
         // We use the WalletAppKit that handles all the boilerplate for us. Have a look at the Kit.java example for more details.
-        NetworkParameters params = TestNet3Params.get();
-        WalletAppKit kit = new WalletAppKit(params, ScriptType.P2WPKH, KeyChainGroupStructure.BIP32, new File("."), "sendrequest-example");
+        Network network = Network.TEST;
+        WalletAppKit kit = new WalletAppKit(NetworkParameters.of(network), ScriptType.P2WPKH, KeyChainGroupStructure.BIP32, new File("."), "sendrequest-example");
         kit.startAsync();
         kit.awaitRunning();
 
@@ -49,7 +50,7 @@ public class SendRequest {
 
         // To which address you want to send the coins?
         // The Address class represents a Bitcoin address.
-        Address to = Address.fromString(params, "bcrt1qspfueag7fvty7m8htuzare3xs898zvh30fttu2");
+        Address to = addressFactory.fromString("bcrt1qspfueag7fvty7m8htuzare3xs898zvh30fttu2", network);
         System.out.println("Send money to: " + to.toString());
 
         // There are different ways to create and publish a SendRequest. This is probably the easiest one.

--- a/integration-test/src/test/java/org/bitcoinj/wallet/WalletLoadTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/wallet/WalletLoadTest.java
@@ -44,4 +44,9 @@ public class WalletLoadTest {
         HDPath accountPath = wallet.getActiveKeyChain().getAccountPath();
         assertEquals(HDPath.parsePath("M/0H"), accountPath);
     }
+
+    @Test
+    void simple() {
+        assertEquals(1, 1);
+    }
 }

--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/application/WalletApplication.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/application/WalletApplication.java
@@ -22,6 +22,9 @@ import javafx.scene.input.KeyCombination;
 import javafx.stage.Stage;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.AddressFactory;
+import org.bitcoinj.core.DefaultAddressFactory;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Utils;
 import org.bitcoinj.kits.WalletAppKit;
@@ -52,6 +55,7 @@ public abstract class WalletApplication implements AppDelegate {
     private final ScriptType preferredOutputScriptType;
     private final String walletFileName;
     private MainWindowController controller;
+    private final AddressFactory addressFactory = new DefaultAddressFactory();
 
     public WalletApplication(String applicationName, NetworkParameters params, ScriptType preferredOutputScriptType, KeyChainGroupStructure keyChainGroupStructure) {
         instance = this;
@@ -84,6 +88,10 @@ public abstract class WalletApplication implements AppDelegate {
 
     public ScriptType preferredOutputScriptType() {
         return preferredOutputScriptType;
+    }
+
+    public AddressFactory addressFactory() {
+        return this.addressFactory;
     }
 
     public MainWindowController mainWindowController() {

--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/controls/BitcoinAddressValidator.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/controls/BitcoinAddressValidator.java
@@ -16,9 +16,8 @@
 
 package org.bitcoinj.walletfx.controls;
 
-import org.bitcoinj.core.Address;
 import org.bitcoinj.base.exceptions.AddressFormatException;
-import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.Address;
 
 import javafx.scene.Node;
 import javafx.scene.control.TextField;
@@ -29,11 +28,11 @@ import org.bitcoinj.walletfx.utils.TextFieldValidator;
  * if the address is invalid for those params, and enable/disable the nodes.
  */
 public class BitcoinAddressValidator {
-    private NetworkParameters params;
-    private Node[] nodes;
+    private final Address.AddressParser addressParser;
+    private final Node[] nodes;
 
-    public BitcoinAddressValidator(NetworkParameters params, TextField field, Node... nodes) {
-        this.params = params;
+    public BitcoinAddressValidator(Address.AddressParser addressParser, TextField field, Node... nodes) {
+        this.addressParser = addressParser;
         this.nodes = nodes;
 
         // Handle the red highlighting, but don't highlight in red just when the field is empty because that makes
@@ -51,7 +50,7 @@ public class BitcoinAddressValidator {
 
     private boolean testAddr(String text) {
         try {
-            Address.fromString(params, text);
+            addressParser.parseString(text);
             return true;
         } catch (AddressFormatException e) {
             return false;

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -20,6 +20,8 @@ package org.bitcoinj.wallettool;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.utils.ByteUtils;
+import org.bitcoinj.core.AddressFactory;
+import org.bitcoinj.core.DefaultAddressFactory;
 import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.crypto.*;
 import org.bitcoinj.params.RegTestParams;
@@ -246,6 +248,7 @@ public class WalletTool implements Callable<Integer> {
     private static final Logger log = LoggerFactory.getLogger(WalletTool.class);
     private static final BaseEncoding HEX = BaseEncoding.base16().lowerCase();
 
+    private static AddressFactory addressFactory = new DefaultAddressFactory();
     private static NetworkParameters params;
     private static BlockStore store;
     private static AbstractBlockChain chain;
@@ -462,7 +465,7 @@ public class WalletTool implements Callable<Integer> {
                     if (selectAddrStr != null) {
                         Address selectAddr;
                         try {
-                            selectAddr = Address.fromString(params, selectAddrStr);
+                            selectAddr = addressFactory.fromString(selectAddrStr, net);
                         } catch (AddressFormatException x) {
                             System.err.println("Could not parse given address, or wrong network: " + selectAddrStr);
                             return 1;
@@ -783,7 +786,7 @@ public class WalletTool implements Callable<Integer> {
                 addr = null;
             } else {
                 // Treat as an address.
-                addr = Address.fromString(params, destination);
+                addr = addressFactory.fromString(destination, params.network());
                 key = null;
             }
         }
@@ -1193,9 +1196,9 @@ public class WalletTool implements Callable<Integer> {
         if (!key.isCompressed())
             System.out.println("WARNING: Importing an uncompressed key");
         wallet.importKey(key);
-        System.out.print("Addresses: " + LegacyAddress.fromKey(params, key));
+        System.out.print("Addresses: " + key.toAddress(ScriptType.P2PKH, params.network()));
         if (key.isCompressed())
-            System.out.print("," + SegwitAddress.fromKey(params, key));
+            System.out.print("," + key.toAddress(ScriptType.P2WPKH, params.network()));
         System.out.println();
     }
 
@@ -1250,7 +1253,7 @@ public class WalletTool implements Callable<Integer> {
             key = wallet.findKeyFromPubKey(HEX.decode(pubKeyStr));
         } else {
             try {
-                Address address = Address.fromString(wallet.getParams(), addrStr);
+                Address address = addressFactory.fromString(addrStr, wallet.getParams().network());
                 key = wallet.findKeyFromAddress(address);
             } catch (AddressFormatException e) {
                 System.err.println(addrStr + " does not parse as a Bitcoin address of the right network parameters.");


### PR DESCRIPTION
The AddressKey interface allows a key implementation (in our case just `ECKey`) to create an `Address`.

The idea here is to remove the ECKey-dependent constructors and factory methods in `Address` and subclasses and move that logic to `ECKey`. This simplified the address implementation and removes their dependency on `ECKey` which brings in many other dependencies from `o.b.core` and `o.b.crypto`.

I believe this set of changes is the last one needed to move `Address` and subclasses to `o.b.base`