### PR TITLE
DumpedPrivateKey,BIP38PrivateKey: inline PrefixedChecksummedBytes

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/DumpedPrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/core/DumpedPrivateKey.java
@@ -25,12 +25,16 @@ import org.bitcoinj.params.Networks;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * Parses and generates private keys in the form used by the Bitcoin "dumpprivkey" command. This is the private key
  * bytes with a header byte and 4 checksum bytes at the end. If there are 33 private key bytes instead of 32, then
  * the last byte is a discriminator value for the compressed pubkey.
  */
-public class DumpedPrivateKey extends PrefixedChecksummedBytes {
+public class DumpedPrivateKey {
+    protected final NetworkParameters params;
+    protected final byte[] bytes;
 
     /**
      * Construct a private key from its Base58 representation.
@@ -61,7 +65,8 @@ public class DumpedPrivateKey extends PrefixedChecksummedBytes {
     }
 
     private DumpedPrivateKey(NetworkParameters params, byte[] bytes) {
-        super(params, bytes);
+        this.params = checkNotNull(params);
+        this.bytes = checkNotNull(bytes);
         if (bytes.length != 32 && bytes.length != 33)
             throw new AddressFormatException.InvalidDataLength(
                     "Wrong number of bytes for a private key (32 or 33): " + bytes.length);

--- a/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
@@ -35,13 +35,16 @@ import java.security.GeneralSecurityException;
 import java.text.Normalizer;
 import java.util.Arrays;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 /**
  * Implementation of <a href="https://github.com/bitcoin/bips/blob/master/bip-0038.mediawiki">BIP 38</a>
  * passphrase-protected private keys. Currently, only decryption is supported.
  */
-public class BIP38PrivateKey extends PrefixedChecksummedBytes {
+public class BIP38PrivateKey {
+    protected final NetworkParameters params;
+    protected final byte[] bytes;
     public final boolean ecMultiply;
     public final boolean compressed;
     public final boolean hasLotAndSequence;
@@ -103,7 +106,8 @@ public class BIP38PrivateKey extends PrefixedChecksummedBytes {
 
     private BIP38PrivateKey(NetworkParameters params, byte[] bytes, boolean ecMultiply, boolean compressed,
             boolean hasLotAndSequence, byte[] addressHash, byte[] content) throws AddressFormatException {
-        super(params, bytes);
+        this.params = checkNotNull(params);
+        this.bytes = checkNotNull(bytes);
         this.ecMultiply = ecMultiply;
         this.compressed = compressed;
         this.hasLotAndSequence = hasLotAndSequence;


### PR DESCRIPTION
This is a draft because:

a. `PrefixedChecksummedBytes` is not removed yet
b. The tests in `PrefixedChecksummedBytesTest` should be replicated in `DumpedPrivateKey` & `BIP38PrivateKey`. 

