### PR TITLE
use Network interface to implement partial alt-net support

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Address.java
+++ b/core/src/main/java/org/bitcoinj/core/Address.java
@@ -17,6 +17,7 @@
 package org.bitcoinj.core;
 
 import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 
@@ -30,7 +31,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Base class for addresses, e.g. native segwit addresses ({@link SegwitAddress}) or legacy addresses ({@link LegacyAddress}).
  * <p>
- * Use an implementation of {@link AddressParser#parseAddress(String, BitcoinNetwork)} to conveniently construct any kind of address from its textual
+ * Use an implementation of {@link AddressParser#parseAddress(String, Network)} to conveniently construct any kind of address from its textual
  * form.
  */
 public abstract class Address implements Comparable<Address> {
@@ -61,7 +62,7 @@ public abstract class Address implements Comparable<Address> {
      *             if the given string doesn't parse or the checksum is invalid
      * @throws AddressFormatException.WrongNetwork
      *             if the given string is valid but not for the expected network (eg testnet vs mainnet)
-     * @deprecated Use {@link org.bitcoinj.wallet.Wallet#parseAddress(String)} or {@link AddressParser#parseAddress(String, BitcoinNetwork)}
+     * @deprecated Use {@link org.bitcoinj.wallet.Wallet#parseAddress(String)} or {@link AddressParser#parseAddress(String, Network)}
      */
     @Deprecated
     public static Address fromString(@Nullable NetworkParameters params, String str)
@@ -81,7 +82,7 @@ public abstract class Address implements Comparable<Address> {
      * @param outputScriptType
      *            script type the address should use
      * @return constructed address
-     * @deprecated Use {@link ECKey#toAddress(ScriptType, BitcoinNetwork)}
+     * @deprecated Use {@link ECKey#toAddress(ScriptType, Network)}
      */
     @Deprecated
     public static Address fromKey(final NetworkParameters params, final ECKey key, final ScriptType outputScriptType) {
@@ -146,7 +147,7 @@ public abstract class Address implements Comparable<Address> {
      * when you need to know what network an address is for.
      * @return the Network.
      */
-    public BitcoinNetwork network() {
+    public Network network() {
         return params.network();
     }
 

--- a/core/src/main/java/org/bitcoinj/core/AddressParser.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressParser.java
@@ -17,6 +17,7 @@
 package org.bitcoinj.core;
 
 import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 
 
@@ -40,7 +41,7 @@ public interface AddressParser {
      * @return A validated address object
      * @throws AddressFormatException invalid address string or not valid for specified network
      */
-    Address parseAddress(String addressString, BitcoinNetwork network) throws AddressFormatException;
+    Address parseAddress(String addressString, Network network) throws AddressFormatException;
 
     @FunctionalInterface
     interface Strict {

--- a/core/src/main/java/org/bitcoinj/core/DefaultAddressParser.java
+++ b/core/src/main/java/org/bitcoinj/core/DefaultAddressParser.java
@@ -17,6 +17,7 @@
 package org.bitcoinj.core;
 
 import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 
 /**
@@ -29,7 +30,7 @@ public class DefaultAddressParser implements AddressParser {
     }
 
     @Override
-    public Address parseAddress(String addressString, BitcoinNetwork network) throws AddressFormatException {
+    public Address parseAddress(String addressString, Network network) throws AddressFormatException {
         NetworkParameters params = (network != null) ? NetworkParameters.of(network) : null;
         try {
             return LegacyAddress.fromBase58(params, addressString);

--- a/core/src/main/java/org/bitcoinj/core/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/core/ECKey.java
@@ -25,6 +25,7 @@ import org.bitcoin.NativeSecp256k1;
 import org.bitcoin.NativeSecp256k1Util;
 import org.bitcoin.Secp256k1Context;
 import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.utils.ByteUtils;
@@ -418,7 +419,7 @@ public class ECKey implements EncryptableItem {
         return pub.isCompressed();
     }
 
-    public Address toAddress(ScriptType scriptType, BitcoinNetwork network) {
+    public Address toAddress(ScriptType scriptType, Network network) {
         NetworkParameters params = NetworkParameters.of(network);
         if (scriptType == ScriptType.P2PKH) {
             return LegacyAddress.fromPubKeyHash(params, this.getPubKeyHash());

--- a/core/src/main/java/org/bitcoinj/core/LegacyAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/LegacyAddress.java
@@ -20,7 +20,7 @@ package org.bitcoinj.core;
 
 import com.google.common.primitives.UnsignedBytes;
 import org.bitcoinj.base.Base58;
-import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.params.Networks;
 import org.bitcoinj.base.ScriptType;
@@ -53,7 +53,7 @@ public class LegacyAddress extends Address {
     /**
      * Private constructor. Use {@link #fromBase58(NetworkParameters, String)},
      * {@link #fromPubKeyHash(NetworkParameters, byte[])}, {@link #fromScriptHash(NetworkParameters, byte[])} or
-     * {@link ECKey#toAddress(ScriptType, BitcoinNetwork)}.
+     * {@link ECKey#toAddress(ScriptType, Network)}.
      * 
      * @param params
      *            network this address is valid for
@@ -93,7 +93,7 @@ public class LegacyAddress extends Address {
      * @param key
      *            only the public part is used
      * @return constructed address
-     * @deprecated Use {@link ECKey#toAddress(ScriptType, BitcoinNetwork)}
+     * @deprecated Use {@link ECKey#toAddress(ScriptType, Network)}
      */
     @Deprecated
     public static LegacyAddress fromKey(NetworkParameters params, ECKey key) {

--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -140,8 +140,8 @@ public abstract class NetworkParameters {
     /**
      * @return Network enum for this network
      */
-    public BitcoinNetwork network() {
-        return (BitcoinNetwork) network;
+    public Network network() {
+        return network;
     }
 
     /**
@@ -204,7 +204,7 @@ public abstract class NetworkParameters {
     /**
      * Get a NetworkParameters from an Address.
      * Addresses should not be used for storing NetworkParameters. In the future Address will
-     * be an {@code interface} that only makes a {@link BitcoinNetwork} available.
+     * be an {@code interface} that only makes a {@link Network} available.
      * @param address An address
      * @return network parameters
      * @deprecated You should be using {@link Address#network()} instead

--- a/core/src/main/java/org/bitcoinj/core/SegwitAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/SegwitAddress.java
@@ -237,7 +237,7 @@ public class SegwitAddress extends Address {
      * @param key
      *            only the public part is used
      * @return constructed address
-     * @deprecated Use {@link ECKey#toAddress(ScriptType, org.bitcoinj.base.BitcoinNetwork)}
+     * @deprecated Use {@link ECKey#toAddress(ScriptType, org.bitcoinj.base.Network)}
      */
     @Deprecated
     public static SegwitAddress fromKey(NetworkParameters params, ECKey key) {

--- a/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
+++ b/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
@@ -116,7 +116,7 @@ public class WalletAppKit extends AbstractIdleService {
      */
     @Deprecated
     public WalletAppKit(NetworkParameters params, File directory, String filePrefix) {
-        this(params.network(), ScriptType.P2PKH, KeyChainGroupStructure.BIP32, directory, filePrefix);
+        this((BitcoinNetwork) params.network(), ScriptType.P2PKH, KeyChainGroupStructure.BIP32, directory, filePrefix);
     }
 
     /**
@@ -126,7 +126,7 @@ public class WalletAppKit extends AbstractIdleService {
     @Deprecated
     public WalletAppKit(NetworkParameters params, ScriptType preferredOutputScriptType,
             @Nullable KeyChainGroupStructure structure, File directory, String filePrefix) {
-        this(params.network(), preferredOutputScriptType, structure, directory, filePrefix);
+        this((BitcoinNetwork) params.network(), preferredOutputScriptType, structure, directory, filePrefix);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroupStructure.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroupStructure.java
@@ -17,6 +17,7 @@
 package org.bitcoinj.wallet;
 
 import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.crypto.ChildNumber;
@@ -41,7 +42,7 @@ public interface KeyChainGroupStructure {
      *  Default to MainNet, BIP-32 Keychains use the same path for MainNet and TestNet
      * @param outputScriptType the script/address type
      * @return account path
-     * @deprecated Use {@link #accountPathFor(ScriptType, BitcoinNetwork)} or {@link #accountPathFor(ScriptType, NetworkParameters)}
+     * @deprecated Use {@link #accountPathFor(ScriptType, Network)} or {@link #accountPathFor(ScriptType, NetworkParameters)}
      */
     @Deprecated
     default HDPath accountPathFor(ScriptType outputScriptType) {
@@ -54,7 +55,7 @@ public interface KeyChainGroupStructure {
      * @param network network/coin type
      * @return The HD Path: purpose / coinType / accountIndex
      */
-    HDPath accountPathFor(ScriptType outputScriptType, BitcoinNetwork network);
+    HDPath accountPathFor(ScriptType outputScriptType, Network network);
 
     /**
      * Map desired output script type and network to an account path
@@ -114,8 +115,11 @@ public interface KeyChainGroupStructure {
      * Return coin type path component for a network id
      * @param network network id string, eg. {@link BitcoinNetwork#ID_MAINNET}
      */
-    static ChildNumber coinType(BitcoinNetwork network) {
-        switch (network) {
+    static ChildNumber coinType(Network network) {
+        if (!(network instanceof BitcoinNetwork)) {
+            throw new IllegalArgumentException("coinType: Unknown network");
+        }
+        switch ((BitcoinNetwork) network) {
             case MAINNET:
                 return ChildNumber.COINTYPE_BTC;
             case TESTNET:

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -508,7 +508,7 @@ public class Wallet extends BaseTaggableObject
      */
     @Override
     public Address parseAddress(String addressString) throws AddressFormatException {
-        return addressParser.parseAddress(addressString, params.network());
+        return addressParser.parseAddress(addressString, (BitcoinNetwork) params.network());
     }
 
     /**
@@ -3728,7 +3728,7 @@ public class Wallet extends BaseTaggableObject
         try {
             checkNotNull(selector);
             List<TransactionOutput> candidates = calculateAllSpendCandidates(true, false);
-            CoinSelection selection = selector.select(params.network().maxMoney(), candidates);
+            CoinSelection selection = selector.select((Coin) params.network().maxMoney(), candidates);
             return selection.totalValue();
         } finally {
             lock.unlock();
@@ -4251,7 +4251,7 @@ public class Wallet extends BaseTaggableObject
                 // of the total value we can currently spend as determined by the selector, and then subtracting the fee.
                 checkState(req.tx.getOutputs().size() == 1, "Empty wallet TX must have a single output only.");
                 CoinSelector selector = req.coinSelector == null ? coinSelector : req.coinSelector;
-                bestCoinSelection = selector.select(params.network().maxMoney(), candidates);
+                bestCoinSelection = selector.select((Coin) params.network().maxMoney(), candidates);
                 candidates = null;  // Selector took ownership and might have changed candidates. Don't access again.
                 req.tx.getOutput(0).setValue(bestCoinSelection.totalValue());
                 log.info("  emptying {}", bestCoinSelection.totalValue().toFriendlyString());

--- a/core/src/test/java/org/bitcoinj/uri/BitcoinURITest.java
+++ b/core/src/test/java/org/bitcoinj/uri/BitcoinURITest.java
@@ -21,9 +21,7 @@ import org.bitcoinj.core.Address;
 import org.bitcoinj.core.DefaultAddressParser;
 import org.bitcoinj.core.LegacyAddress;
 import org.bitcoinj.core.NetworkParameters;
-import org.bitcoinj.core.SegwitAddress;
-import org.bitcoinj.params.MainNetParams;
-import org.bitcoinj.params.TestNet3Params;
+import org.bitcoinj.testing.MockAltNetworkParams;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -84,17 +82,11 @@ public class BitcoinURITest {
         assertEquals("bitcoin:" + MAINNET_GOOD_ADDRESS, BitcoinURI.convertToBitcoinURI(goodAddress, null, "", ""));
 
         // different scheme
-        // TODO: Reimplement this test after we finish our alt-net support via refactoring
-        final NetworkParameters alternativeParameters = new MainNetParams() {
-            @Override
-            public String getUriScheme() {
-                return "test";
-            }
-        };
+        NetworkParameters alternativeParameters = new MockAltNetworkParams();
+        String mockNetGoodAddress = MockAltNetworkParams.MOCKNET_GOOD_ADDRESS;
 
-        // TODO: change the expected URL back to "test" when we finish the alt-net support refactoring
-        assertEquals("bitcoin:" + MAINNET_GOOD_ADDRESS + "?amount=12.34&label=Hello&message=AMessage",
-             BitcoinURI.convertToBitcoinURI(LegacyAddress.fromBase58(alternativeParameters, MAINNET_GOOD_ADDRESS), parseCoin("12.34"), "Hello", "AMessage"));
+        assertEquals("mockcoin:" + mockNetGoodAddress + "?amount=12.34&label=Hello&message=AMessage",
+             BitcoinURI.convertToBitcoinURI(LegacyAddress.fromBase58(alternativeParameters, mockNetGoodAddress), parseCoin("12.34"), "Hello", "AMessage"));
     }
 
     @Test

--- a/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
@@ -78,7 +78,7 @@ public class ForwardingService implements AutoCloseable {
         } else {
             // Infer network from address
             address = addressParser.parseAddressAnyNetwork(args[0]);
-            network = address.network();
+            network = (BitcoinNetwork) address.network();
         }
 
         forward(new File("."), network, address);


### PR DESCRIPTION
-  Distinguish between `Network` and `BitcoinNetwork` in the code (parts of our implementation supports alt-networks better than others and this commit doesn't try to fix them all, just make it more clear what is going on. Some may never be made 'generic')

The following two items were originally part of this PR, but were implemented via separate PRs and this PR rebased:

- Add `MockAltNetParams` and `MockAltNetwork` classes for testing
- Partially update BitcoinURI to support alt-networks via `Network`
