### PR TITLE
Deprecate TaggableObject/BaseTaggableObject/Wallet.setTag()

### DIFF
--- a/core/src/main/java/org/bitcoinj/utils/BaseTaggableObject.java
+++ b/core/src/main/java/org/bitcoinj/utils/BaseTaggableObject.java
@@ -27,17 +27,21 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * A simple implementation of {@link TaggableObject} that uses a hashmap that is
  * synchronized on this object's Java monitor.
+ * @deprecated Applications should use another mechanism to persist application state data
  */
+@Deprecated
 public class BaseTaggableObject implements TaggableObject {
     protected final Map<String, ByteString> tags = new HashMap<>();
 
     @Override
     @Nullable
+    @Deprecated
     public synchronized ByteString maybeGetTag(String tag) {
         return tags.get(tag);
     }
 
     @Override
+    @Deprecated
     public ByteString getTag(String tag) {
         ByteString b = maybeGetTag(tag);
         if (b == null)
@@ -46,6 +50,7 @@ public class BaseTaggableObject implements TaggableObject {
     }
 
     @Override
+    @Deprecated
     public synchronized void setTag(String tag, ByteString value) {
         // HashMap allows null keys and values, but we don't
         checkNotNull(tag);
@@ -54,6 +59,7 @@ public class BaseTaggableObject implements TaggableObject {
     }
 
     @Override
+    @Deprecated
     public synchronized Map<String, ByteString> getTags() {
         return new HashMap<>(tags);
     }

--- a/core/src/main/java/org/bitcoinj/utils/TaggableObject.java
+++ b/core/src/main/java/org/bitcoinj/utils/TaggableObject.java
@@ -33,20 +33,26 @@ import java.util.Map;
  * like "com.example:keyowner:02b7e6dc316dfaa19c5a599f63d88ffeae398759b857ca56b2f69de3e815381343" instead of
  * "owner" or just "o". Also, it's good practice to create constants for each string you use, to help avoid typos
  * in string parameters causing confusing bugs!</p>
+ * @deprecated Applications should use another mechanism to persist application state data
  */
+@Deprecated
 public interface TaggableObject {
     /** Returns the immutable byte array associated with the given tag name, or null if there is none. */
+    @Deprecated
     @Nullable ByteString maybeGetTag(String tag);
 
     /**
      * Returns the immutable byte array associated with the given tag name, or throws {@link IllegalArgumentException}
      * if that tag wasn't set yet.
      */
+    @Deprecated
     ByteString getTag(String tag);
 
     /** Associates the given immutable byte array with the string tag. See the docs for TaggableObject to learn more. */
+    @Deprecated
     void setTag(String tag, ByteString value);
 
     /** Returns a copy of all the tags held by this object. */
+    @Deprecated
     Map<String, ByteString> getTags();
 }

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -5029,6 +5029,9 @@ public class Wallet extends BaseTaggableObject
         }
     }
 
+    /**
+     * @deprecated Applications should use another mechanism to persist application state information
+     */
     @Override
     public void setTag(String tag, ByteString value) {
         super.setTag(tag, value);


### PR DESCRIPTION
The only known usage of this feature is in the JavaFX wallettemplate where it is used to save the estimated elapsed time for deriving a key for purposes of displaying a progress bar.  See `WalletPasswordController.getTargetTime()`.