### PR TITLE
Wallet.SendRequest: construct from TransactionBroadcast only

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
@@ -74,6 +74,10 @@ public class TransactionBroadcast {
         this.tx = tx;
     }
 
+    public Transaction transaction() {
+        return tx;
+    }
+
     @VisibleForTesting
     public static TransactionBroadcast createMockBroadcast(Transaction tx, final CompletableFuture<Transaction> future) {
         return new TransactionBroadcast(tx) {

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -3901,8 +3901,16 @@ public class Wallet extends BaseTaggableObject
         /** The broadcast object returned by the linked TransactionBroadcaster */
         public final TransactionBroadcast broadcast;
 
+        /**
+         * @deprecated Use {@link #SendResult(TransactionBroadcast)}
+         */
+        @Deprecated
         public SendResult(Transaction tx, TransactionBroadcast broadcast) {
-            this.tx = tx;
+            this(broadcast);
+        }
+
+        public SendResult(TransactionBroadcast broadcast) {
+            this.tx = broadcast.transaction();
             this.broadcast = broadcast;
             this.broadcastComplete = broadcast.future();
         }
@@ -4098,7 +4106,7 @@ public class Wallet extends BaseTaggableObject
         // Commit the TX to the wallet immediately so the spent coins won't be reused.
         // TODO: We should probably allow the request to specify tx commit only after the network has accepted it.
         Transaction tx = sendCoinsOffline(request);
-        SendResult result = new SendResult(tx, broadcaster.broadcastTransaction(tx));
+        SendResult result = new SendResult(broadcaster.broadcastTransaction(tx));
         // The tx has been committed to the pending pool by this point (via sendCoinsOffline -> commitTx), so it has
         // a txConfidenceListener registered. Once the tx is broadcast the peers will update the memory pool with the
         // count of seen peers, the memory pool will update the transaction confidence object, that will invoke the


### PR DESCRIPTION
Simplify the constructor for Wallet.SendRequest to only take
a TransactionBroadcast object. The transaction was inside
the TransactionBroadcast object anyway, we just had to create
an accessor.

This paves the way for removing SendResult entirely and replacing
it with TransactionBroadcast. (The question is how to do this
smoothly -- i.e. what gets deprecated etc.)