### PR TITLE
Coin: add ofBTC(long coins) factory method

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/BitcoinNetwork.java
+++ b/core/src/main/java/org/bitcoinj/base/BitcoinNetwork.java
@@ -37,7 +37,7 @@ public enum BitcoinNetwork implements Network {
     /**
      * The maximum money to be generated
      */
-    public static final Coin MAX_MONEY = COIN.multiply(MAX_COINS);
+    public static final Coin MAX_MONEY = Coin.ofBtc(MAX_COINS);
 
     /** The ID string for the main, production network where people trade things. */
     public static final String ID_MAINNET = MAIN.id();

--- a/core/src/main/java/org/bitcoinj/base/Coin.java
+++ b/core/src/main/java/org/bitcoinj/base/Coin.java
@@ -47,7 +47,7 @@ public final class Coin implements Monetary, Comparable<Coin> {
     /**
      * One Bitcoin.
      */
-    public static final Coin COIN = Coin.valueOf(COIN_VALUE);
+    public static final Coin COIN = Coin.ofBtc(1);
 
     /**
      * 0.01 Bitcoins. This unit is not really used much.
@@ -69,7 +69,7 @@ public final class Coin implements Monetary, Comparable<Coin> {
      */
     public static final Coin SATOSHI = Coin.valueOf(1);
 
-    public static final Coin FIFTY_COINS = COIN.multiply(50);
+    public static final Coin FIFTY_COINS = Coin.ofBtc(50);
 
     /**
      * Represents a monetary value of minus one satoshi.
@@ -120,7 +120,7 @@ public final class Coin implements Monetary, Comparable<Coin> {
         checkArgument(cents < 100);
         checkArgument(cents >= 0);
         checkArgument(coins >= 0);
-        final Coin coin = COIN.multiply(coins).add(CENT.multiply(cents));
+        final Coin coin = ofBtc(coins).add(CENT.multiply(cents));
         return coin;
     }
 
@@ -132,6 +132,17 @@ public final class Coin implements Monetary, Comparable<Coin> {
      */
     public static long btcToSatoshi(BigDecimal coins) {
         return coins.movePointRight(SMALLEST_UNIT_EXPONENT).longValueExact();
+    }
+
+    /**
+     * Convert {@code long} amount of BTC into satoshis.
+     *
+     * @param coins number of coins
+     * @return number of satoshis
+     * @throws ArithmeticException if conversion (via multiplication) results in overflow
+     */
+    public static long btcToSatoshi(long coins) {
+        return LongMath.checkedMultiply(coins, Coin.COIN_VALUE);
     }
 
     /**
@@ -151,6 +162,16 @@ public final class Coin implements Monetary, Comparable<Coin> {
      * @return {@code Coin} object containing value in satoshis
      */
     public static Coin ofBtc(BigDecimal coins) {
+        return Coin.valueOf(btcToSatoshi(coins));
+    }
+
+    /**
+     * Create a {@code Coin} from a decimal amount of BTC.
+     *
+     * @param coins number of coins (in BTC)
+     * @return {@code Coin} object containing value in satoshis
+     */
+    public static Coin ofBtc(long coins) {
         return Coin.valueOf(btcToSatoshi(coins));
     }
 


### PR DESCRIPTION
* Add overload `Coin.ofBTC(long coins)`
* Add overload `static long btcToSatoshi(long coins)`
* Use the new `Coin.ofBTC` where appropriate to improve readability

Draft: depends on PR #2511 (though it doesn't really _need_ to, but #2511 is what showed me the need for the overload)
