### PR TITLE
NetworkParameters: deprecate getMonetaryFormat()

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -430,7 +430,9 @@ public abstract class NetworkParameters {
     /**
      * The monetary object for this currency.
      * @return formatting utility object
+     * @deprecated Get one another way or construct your own {@link MonetaryFormat} as needed.
      */
+    @Deprecated
     public abstract MonetaryFormat getMonetaryFormat();
 
     /**

--- a/core/src/main/java/org/bitcoinj/params/AbstractBitcoinNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/AbstractBitcoinNetParams.java
@@ -215,7 +215,11 @@ public abstract class AbstractBitcoinNetParams extends NetworkParameters {
         return Transaction.MIN_NONDUST_OUTPUT;
     }
 
+    /**
+     * @deprecated Get one another way or construct your own {@link MonetaryFormat} as needed.
+     */
     @Override
+    @Deprecated
     public MonetaryFormat getMonetaryFormat() {
         return new MonetaryFormat();
     }


### PR DESCRIPTION
`getMonetaryFormat()` is not used within **bitcoinj** and ``MonetaryFormat` isn't strictly tied to a "network" and can be instantiated or found via other mechanisms, so let's deprecate it as part of our effort to deemphasize `NetworkParameters`.
