### PR TITLE
BitcoinNetwork: simplify/standardize and canonicalize lowercase for user-facing

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/BitcoinNetwork.java
+++ b/core/src/main/java/org/bitcoinj/base/BitcoinNetwork.java
@@ -17,12 +17,19 @@
 package org.bitcoinj.base;
 
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Optional;
 
 import static org.bitcoinj.base.Coin.COIN;
 
 /**
- * A convenient {@code enum} representation of a network.
+ * A convenient {@code enum} representation of a Bitcoin network.
+ * <p>
+ * Note that the name of each {@code enum} constant is defined in <i>uppercase</i> as is the convention in Java.
+ * However, the <q>canonical</q> representation in <b>bitcoinj</b> for user-facing display and input
+ * of Bitcoin network names is <i>lowercase</i> (e.g. as a command-line parameter.)
+ * Implementations should use the {@link #toString()} method for output and the {@link #fromString(String)}
+ * method for input of network values.
  */
 public enum BitcoinNetwork implements Network {
     MAIN("org.bitcoin.production"),
@@ -58,9 +65,18 @@ public enum BitcoinNetwork implements Network {
     }
 
     /**
-     * Get the network id string (previously specified in {@code NetworkParameters})
+     * Return the canonical, lowercase, user-facing {@code String} for an {@code enum}
+     * @return canonical lowercase value
+     */
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Return the network ID string (previously specified in {@code NetworkParameters})
      *
-     * @return The network id string
+     * @return The network ID string
      */
     @Override
     public String id() {
@@ -78,46 +94,24 @@ public enum BitcoinNetwork implements Network {
     }
 
     /**
-     * Get the {@code BitcoinNetwork} from a <i>validated</i> name String
-     * @param nameString A name string (e.g. "MAIN", "TEST", "SIGNET")
-     * @return The matching enum
-     * @throws IllegalArgumentException if there is no matching enum
-     */
-    public static BitcoinNetwork of(String nameString) {
-        return find(nameString)
-                .orElseThrow(() -> new IllegalArgumentException("Unrecognized network name : " + nameString));
-    }
-
-    /**
-     * Find the {@code BitcoinNetwork} from a name String
-     * @param nameString A name string (e.g. "MAIN", "TEST", "SIGNET")
+     * Find the {@code BitcoinNetwork} from a name String.
+     * @param nameString A name string (e.g. "main", "test", "signet")
      * @return An {@code Optional} containing the matching enum or empty
      */
-    public static Optional<BitcoinNetwork> find(String nameString) {
+    public static Optional<BitcoinNetwork> fromString(String nameString) {
         return Arrays.stream(values())
-                .filter(n -> n.toString().equals(nameString.toUpperCase()))
+                .filter(n -> n.toString().equals(nameString))
                 .findFirst();
     }
 
     /**
-     * Get the correct enum for a network id string
-     * <p>
-     * Note: UNITTEST is not supported as an enum
-     * @param idString specifies the network
-     * @return the enum
-     * @throws IllegalArgumentException if there is no matching enum
-     */
-    public static BitcoinNetwork ofId(String idString) {
-        return findById(idString)
-                .orElseThrow(() -> new IllegalArgumentException("Illegal network ID: " + idString));
-    }
-
-    /**
      * Find the {@code BitcoinNetwork} from an ID String
+     * <p>
+     * Note: {@link #ID_UNITTESTNET} is not supported as an enum
      * @param idString specifies the network
      * @return An {@code Optional} containing the matching enum or empty
      */
-    public static Optional<BitcoinNetwork> findById(String idString) {
+    public static Optional<BitcoinNetwork> fromIdString(String idString) {
         return Arrays.stream(values())
                 .filter(n -> n.id.equals(idString))
                 .findFirst();

--- a/core/src/test/java/org/bitcoinj/base/BitcoinNetworkTest.java
+++ b/core/src/test/java/org/bitcoinj/base/BitcoinNetworkTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.base;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class BitcoinNetworkTest {
+    @Test
+    public void valueOf() {
+        assertEquals(BitcoinNetwork.MAIN, BitcoinNetwork.valueOf("MAIN"));
+        assertEquals(BitcoinNetwork.TEST, BitcoinNetwork.valueOf("TEST"));
+        assertEquals(BitcoinNetwork.SIGNET, BitcoinNetwork.valueOf("SIGNET"));
+        assertEquals(BitcoinNetwork.REGTEST, BitcoinNetwork.valueOf("REGTEST"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValueOf_alternate() {
+        BitcoinNetwork.valueOf("PROD");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValueOf_notExisting() {
+        BitcoinNetwork.valueOf("xxx");
+    }
+
+    @Test
+    public void testFromString() {
+        assertEquals(BitcoinNetwork.MAIN, BitcoinNetwork.fromString("main").get());
+        assertEquals(BitcoinNetwork.TEST, BitcoinNetwork.fromString("test").get());
+        assertEquals(BitcoinNetwork.SIGNET, BitcoinNetwork.fromString("signet").get());
+        assertEquals(BitcoinNetwork.REGTEST, BitcoinNetwork.fromString("regtest").get());
+    }
+
+    @Test
+    public void testFromString_uppercase() {
+        assertFalse(BitcoinNetwork.fromString("MAIN").isPresent());
+    }
+
+    @Test
+    public void testFromString_notExisting() {
+        assertFalse(BitcoinNetwork.fromString("xxx").isPresent());
+    }
+
+    @Test
+    public void testFromIdString() {
+        assertEquals(BitcoinNetwork.MAIN, BitcoinNetwork.fromIdString("org.bitcoin.production").get());
+        assertEquals(BitcoinNetwork.TEST, BitcoinNetwork.fromIdString("org.bitcoin.test").get());
+        assertEquals(BitcoinNetwork.SIGNET, BitcoinNetwork.fromIdString("org.bitcoin.signet").get());
+        assertEquals(BitcoinNetwork.REGTEST, BitcoinNetwork.fromIdString("org.bitcoin.regtest").get());
+    }
+
+    @Test
+    public void testFromIdString_uppercase() {
+        assertFalse(BitcoinNetwork.fromIdString("ORG.BITCOIN.PRODUCTION").isPresent());
+    }
+
+    @Test
+    public void testFromIdString_notExisting() {
+        assertFalse(BitcoinNetwork.fromIdString("a.b.c").isPresent());
+    }
+}


### PR DESCRIPTION
This PR corrects some issues with b375a96565aa4c51587451cb7dea2654f37d5425 and brings things more in alignment with Java conventions (see _Effective Java (Third Edition)_, **Item 34: Use enums instead of int constants** -- especially the discussion of `valueOf(String)`, `toString()` and `fromString(String)` on p. 164)

Specifically:
* Add an override of `toString()` to output the string in canonical, lower-case format.
* Remove the `.of(String)` method from b375a96565aa4c51587451cb7dea2654f37d5425 as it duplicates the built-in `.valueOf()`
* Remove the `ofId(String)` method from b375a96565aa4c51587451cb7dea2654f37d5425 in favor of the using the `fromIdString(String)` method with `orElseThrow()` or similar if throwing an exception is desired.
* Rename `.find(String)` to `.fromString(String)` to use the suggested name from _Effective Java_.
* Rename `.findById(String)` to `.fromIdString(String)` for consistency.
* Improve the JavaDoc.

In summary, this reduces the number of static factory methods from 5 to 3, conforms better with Java conventions, and clarifies our preference for lowercase strings as canonical for user-facing input/output.