### PR TITLE
WalletTool: Use BitcoinNetwork::toString for chain fileName

### DIFF
--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -370,23 +370,7 @@ public class WalletTool implements Callable<Integer> {
             logger.setLevel(Level.SEVERE);
         }
         params = NetworkParameters.of(net);
-        String fileName;
-        switch (net) {
-            case MAIN:
-                fileName = "mainnet.chain";
-                break;
-            case TEST:
-                fileName = "testnet.chain";
-                break;
-            case SIGNET:
-                fileName = "signet.chain";
-                break;
-            case REGTEST:
-                fileName = "regtest.chain";
-                break;
-            default:
-                throw new RuntimeException("Unreachable.");
-        }
+        String fileName = String.format("%s.chain", net);
         if (chainFile == null) {
             chainFile = new File(fileName);
         }


### PR DESCRIPTION
This is a potentially breaking change and may require existing wallets managed with the `WalletTool` to have their chain files manually renamed:

`mainnet.chain` -> `main.chain`
`testnet.chain` -> `test.chain`

or use the `--chain` command line option to specify the name.

Given that this is a test tool and only distributed as source, I think this is an acceptable change in return for code simplification and naming standardization.