### PR TITLE
wallettemplate: migrate from params to BitcoinNetwork in core classes

### DIFF
--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/application/WalletApplication.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/application/WalletApplication.java
@@ -25,7 +25,6 @@ import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Utils;
 import org.bitcoinj.kits.WalletAppKit;
-import org.bitcoinj.params.RegTestParams;
 import org.bitcoinj.utils.AppDataDirectory;
 import org.bitcoinj.utils.BriefLogFormatter;
 import org.bitcoinj.utils.Threading;
@@ -47,23 +46,23 @@ public abstract class WalletApplication implements AppDelegate {
     private static WalletApplication instance;
     private WalletAppKit walletAppKit;
     private final String applicationName;
-    private final NetworkParameters params;
+    private final BitcoinNetwork network;
     private final KeyChainGroupStructure keyChainGroupStructure;
     private final ScriptType preferredOutputScriptType;
     private final String walletFileName;
     private MainWindowController controller;
 
-    public WalletApplication(String applicationName, NetworkParameters params, ScriptType preferredOutputScriptType, KeyChainGroupStructure keyChainGroupStructure) {
+    public WalletApplication(String applicationName, BitcoinNetwork network, ScriptType preferredOutputScriptType, KeyChainGroupStructure keyChainGroupStructure) {
         instance = this;
         this.applicationName = applicationName;
-        this.walletFileName = applicationName.replaceAll("[^a-zA-Z0-9.-]", "_") + "-" + suffixFromNetParams(params);
-        this.params = params;
+        this.walletFileName = applicationName.replaceAll("[^a-zA-Z0-9.-]", "_") + "-" + suffixFromNetwork(network);
+        this.network = network;
         this.preferredOutputScriptType = preferredOutputScriptType;
         this.keyChainGroupStructure = keyChainGroupStructure;
     }
 
-    public WalletApplication(String applicationName, NetworkParameters params, ScriptType preferredOutputScriptType) {
-        this(applicationName, params, preferredOutputScriptType, KeyChainGroupStructure.BIP43);
+    public WalletApplication(String applicationName, BitcoinNetwork network, ScriptType preferredOutputScriptType) {
+        this(applicationName, network, preferredOutputScriptType, KeyChainGroupStructure.BIP43);
     }
 
     public static WalletApplication instance() {
@@ -78,8 +77,17 @@ public abstract class WalletApplication implements AppDelegate {
         return applicationName;
     }
 
+    /**
+     * @return Parameters for network this wallet is running on
+     * @deprecated Use {@link #network} (or {@link NetworkParameters#of} if you really need a {@link NetworkParameters}.)
+     */
+    @Deprecated
     public NetworkParameters params() {
-        return params;
+        return NetworkParameters.of(network);
+    }
+
+    public BitcoinNetwork network() {
+        return network;
     }
 
     public ScriptType preferredOutputScriptType() {
@@ -151,7 +159,7 @@ public abstract class WalletApplication implements AppDelegate {
     public void setupWalletKit(@Nullable DeterministicSeed seed) {
         // If seed is non-null it means we are restoring from backup.
         File appDataDirectory = AppDataDirectory.get(applicationName).toFile();
-        walletAppKit = new WalletAppKit(params.network(), preferredOutputScriptType, keyChainGroupStructure, appDataDirectory, walletFileName) {
+        walletAppKit = new WalletAppKit(network, preferredOutputScriptType, keyChainGroupStructure, appDataDirectory, walletFileName) {
             @Override
             protected void onSetupCompleted() {
                 Platform.runLater(controller::onBitcoinSetup);
@@ -159,7 +167,7 @@ public abstract class WalletApplication implements AppDelegate {
         };
         // Now configure and start the appkit. This will take a second or two - we could show a temporary splash screen
         // or progress widget to keep the user engaged whilst we initialise, but we don't.
-        if (params == RegTestParams.get()) {
+        if (network == BitcoinNetwork.REGTEST) {
             walletAppKit.connectToLocalHost();   // You should run a regtest mode bitcoind locally.
         }
         walletAppKit.setDownloadListener(controller.progressBarUpdater())
@@ -175,10 +183,6 @@ public abstract class WalletApplication implements AppDelegate {
         walletAppKit.awaitTerminated();
         // Forcibly terminate the JVM because Orchid likes to spew non-daemon threads everywhere.
         Runtime.getRuntime().exit(0);
-    }
-
-    protected String suffixFromNetParams(NetworkParameters params) {
-        return suffixFromNetwork(params.network());
     }
 
     protected String suffixFromNetwork(BitcoinNetwork network) {

--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/controls/BitcoinAddressValidator.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/controls/BitcoinAddressValidator.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.walletfx.controls;
 
+import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.core.Address;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.core.NetworkParameters;
@@ -29,11 +30,11 @@ import org.bitcoinj.walletfx.utils.TextFieldValidator;
  * if the address is invalid for those params, and enable/disable the nodes.
  */
 public class BitcoinAddressValidator {
-    private NetworkParameters params;
+    private BitcoinNetwork network;
     private Node[] nodes;
 
-    public BitcoinAddressValidator(NetworkParameters params, TextField field, Node... nodes) {
-        this.params = params;
+    public BitcoinAddressValidator(BitcoinNetwork network, TextField field, Node... nodes) {
+        this.network = network;
         this.nodes = nodes;
 
         // Handle the red highlighting, but don't highlight in red just when the field is empty because that makes
@@ -51,7 +52,7 @@ public class BitcoinAddressValidator {
 
     private boolean testAddr(String text) {
         try {
-            Address.fromString(params, text);
+            Address.fromString(NetworkParameters.of(network), text);
             return true;
         } catch (AddressFormatException e) {
             return false;

--- a/wallettemplate/src/main/java/wallettemplate/Main.java
+++ b/wallettemplate/src/main/java/wallettemplate/Main.java
@@ -18,9 +18,8 @@ package wallettemplate;
 
 import javafx.application.Application;
 import javafx.stage.Stage;
+import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.ScriptType;
-import org.bitcoinj.core.NetworkParameters;
-import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.walletfx.application.AppDelegate;
 
 /**
@@ -28,7 +27,7 @@ import org.bitcoinj.walletfx.application.AppDelegate;
  * to {@link WalletTemplate}
  */
 public class Main extends Application {
-    private static final NetworkParameters params = TestNet3Params.get();
+    private static final BitcoinNetwork network = BitcoinNetwork.TESTNET;
     private static final ScriptType PREFERRED_OUTPUT_SCRIPT_TYPE = ScriptType.P2WPKH;
     private static final String APP_NAME = "WalletTemplate";
 
@@ -39,7 +38,7 @@ public class Main extends Application {
     }
 
     public Main() {
-        delegate = new WalletTemplate(APP_NAME, params, PREFERRED_OUTPUT_SCRIPT_TYPE);
+        delegate = new WalletTemplate(APP_NAME, network, PREFERRED_OUTPUT_SCRIPT_TYPE);
     }
 
     @Override

--- a/wallettemplate/src/main/java/wallettemplate/SendMoneyController.java
+++ b/wallettemplate/src/main/java/wallettemplate/SendMoneyController.java
@@ -69,11 +69,11 @@ public class SendMoneyController implements OverlayController<SendMoneyControlle
         app = WalletApplication.instance();
         Coin balance = app.walletAppKit().wallet().getBalance();
         checkState(!balance.isZero());
-        new BitcoinAddressValidator(app.params(), address, sendBtn);
+        new BitcoinAddressValidator(app.network(), address, sendBtn);
         new TextFieldValidator(amountEdit, text ->
                 !WTUtils.didThrow(() -> checkState(Coin.parseCoin(text).compareTo(balance) <= 0)));
         amountEdit.setText(balance.toPlainString());
-        address.setPromptText(Address.fromKey(app.params(), new ECKey(), app.preferredOutputScriptType()).toString());
+        address.setPromptText(Address.fromKey(NetworkParameters.of(app.network()), new ECKey(), app.preferredOutputScriptType()).toString());
     }
 
     public void cancel(ActionEvent event) {
@@ -84,7 +84,7 @@ public class SendMoneyController implements OverlayController<SendMoneyControlle
         // Address exception cannot happen as we validated it beforehand.
         try {
             Coin amount = Coin.parseCoin(amountEdit.getText());
-            Address destination = Address.fromString(app.params(), address.getText());
+            Address destination = Address.fromString(NetworkParameters.of(app.network()), address.getText());
             SendRequest req;
             if (amount.equals(app.walletAppKit().wallet().getBalance()))
                 req = SendRequest.emptyWallet(destination);

--- a/wallettemplate/src/main/java/wallettemplate/WalletTemplate.java
+++ b/wallettemplate/src/main/java/wallettemplate/WalletTemplate.java
@@ -18,8 +18,8 @@ package wallettemplate;
 
 import javafx.fxml.FXMLLoader;
 import javafx.scene.layout.Pane;
+import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.ScriptType;
-import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.walletfx.application.WalletApplication;
 
 import java.io.IOException;
@@ -30,8 +30,8 @@ import java.net.URL;
  */
 public class WalletTemplate extends WalletApplication {
 
-    public WalletTemplate(String applicationName, NetworkParameters params, ScriptType preferredOutputScriptType) {
-        super(applicationName, params, preferredOutputScriptType);
+    public WalletTemplate(String applicationName, BitcoinNetwork network, ScriptType preferredOutputScriptType) {
+        super(applicationName, network, preferredOutputScriptType);
     }
 
     @Override


### PR DESCRIPTION
When base/core adds the ability to create an `Address` from a `Network` we should be able to use `Network`/`BitcoinNetwork` for everything.