### PR TITLE
ForwardingService: simplify getPrefix()

### DIFF
--- a/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
@@ -151,11 +151,7 @@ public class ForwardingService {
     }
 
     static String getPrefix(BitcoinNetwork network) {
-        switch (network) {
-            case TESTNET:   return "forwarding-service-testnet";
-            case REGTEST:   return "forwarding-service-regtest";
-            default:        return "forwarding-service";
-        }
+        return String.format("forwarding-service-%s", network.toString());
     }
 
     private void forwardCoins() {


### PR DESCRIPTION
Use network.toString(). This also adds support for SIGNET. It changes the filename for MAINNET, but as this is just an example I don't think we really need to preserve backward-compatibility for the filename.