### PR TITLE
Transaction/TransactionOutput: move methods to TransactionBag

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -248,7 +248,7 @@ public class PeerGroup implements TransactionBroadcaster {
         for (TransactionOutput output : tx.getOutputs()) {
             Script scriptPubKey = output.getScriptPubKey();
             if (ScriptPattern.isP2PK(scriptPubKey) || ScriptPattern.isP2WPKH(scriptPubKey)) {
-                if (output.isMine(wallet)) {
+                if (wallet.isMine(output)) {
                     if (tx.getConfidence().getConfidenceType() == TransactionConfidence.ConfidenceType.BUILDING)
                         recalculateFastCatchupAndFilter(FilterRecalculateMode.SEND_IF_CHANGED);
                     else

--- a/core/src/main/java/org/bitcoinj/core/TransactionBag.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionBag.java
@@ -17,19 +17,27 @@
 
 package org.bitcoinj.core;
 
+import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.script.Script;
-import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.script.ScriptException;
+import org.bitcoinj.script.ScriptPattern;
 import org.bitcoinj.wallet.WalletTransaction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 /**
- * This interface is used to abstract the {@link Wallet} and the {@link Transaction}
+ * This interface is used to abstract the {@link org.bitcoinj.wallet.Wallet} and the {@link Transaction}
  */
 public interface TransactionBag {
+    Logger log = LoggerFactory.getLogger(TransactionOutput.class);
+
     /**
      * Look for a public key which hashes to the given hash and (optionally) is used for a specific script type.
      * @param pubKeyHash hash of the public key to look for
@@ -49,4 +57,138 @@ public interface TransactionBag {
 
     /** Returns transactions from a specific pool. */
     Map<Sha256Hash, Transaction> getTransactionPool(WalletTransaction.Pool pool);
+
+    /**
+     * Returns false if this transaction has at least one output that is owned by the given wallet and unspent, true
+     * otherwise.
+     */
+    default boolean isEveryOwnedOutputSpent(Transaction tx) {
+        for (TransactionOutput output : tx.getOutputs()) {
+            if (output.isAvailableForSpending() && isMineOrWatched(output))
+                return false;
+        }
+        return true;
+    }
+
+    /**
+     * <p>Returns the list of transaction outputs, whether spent or unspent, that match a wallet by address or that are
+     * watched by a wallet, i.e., transaction outputs whose script's address is controlled by the wallet and transaction
+     * outputs whose script is watched by the wallet.</p>
+     *
+     * @param tx The transaction.
+     * @return linked list of outputs relevant to the wallet in this transaction
+     */
+    default List<TransactionOutput> getWalletOutputs(Transaction tx) {
+        List<TransactionOutput> walletOutputs = new LinkedList<>();
+        for (TransactionOutput o : tx.getOutputs()) {
+            if (!isMineOrWatched(o)) continue;
+            walletOutputs.add(o);
+        }
+
+        return walletOutputs;
+    }
+
+    /**
+     * Returns the difference of {@link #getValueSentToMe(Transaction)} and {@link #getValueSentFromMe(Transaction)}.
+     */
+    default Coin getValue(Transaction tx) throws ScriptException {
+        // TODO: Can we lose the commented-out caching code?
+        // FIXME: TEMP PERF HACK FOR ANDROID - this crap can go away once we have a real payments API.
+//        boolean isAndroid = Utils.isAndroidRuntime();
+//        if (isAndroid && cachedValue != null && cachedForBag == wallet)
+//            return cachedValue;
+        Coin result = getValueSentToMe(tx).subtract(getValueSentFromMe(tx));
+//        if (isAndroid) {
+//            cachedValue = result;
+//            cachedForBag = wallet;
+//        }
+        return result;
+    }
+
+    /**
+     * Calculates the sum of the outputs that are sending coins to a key in the wallet.
+     */
+    default Coin getValueSentToMe(Transaction tx) {
+        // This is tested in WalletTest.
+        Coin v = Coin.ZERO;
+        for (TransactionOutput o : tx.getOutputs()) {
+            if (!this.isMineOrWatched(o)) continue;
+            v = v.add(o.getValue());
+        }
+        return v;
+    }
+
+    /**
+     * Calculates the sum of the inputs that are spending coins with keys in the wallet. This requires the
+     * transactions sending coins to those keys to be in the wallet. This method will not attempt to download the
+     * blocks containing the input transactions if the key is in the wallet but the transactions are not.
+     *
+     * @return sum of the inputs that are spending coins with keys in the wallet
+     */
+    default Coin getValueSentFromMe(Transaction tx) throws ScriptException {
+        // This is tested in WalletTest.
+        Coin v = Coin.ZERO;
+        for (TransactionInput input : tx.getInputs()) {
+            // This input is taking value from a transaction in our wallet. To discover the value,
+            // we must find the connected transaction.
+            TransactionOutput connected = input.getConnectedOutput(getTransactionPool(WalletTransaction.Pool.UNSPENT));
+            if (connected == null)
+                connected = input.getConnectedOutput(getTransactionPool(WalletTransaction.Pool.SPENT));
+            if (connected == null)
+                connected = input.getConnectedOutput(getTransactionPool(WalletTransaction.Pool.PENDING));
+            if (connected == null)
+                continue;
+            // The connected output may be the change to the sender of a previous input sent to this wallet. In this
+            // case we ignore it.
+            if (!isMineOrWatched(connected))
+                continue;
+            v = v.add(connected.getValue());
+        }
+        return v;
+    }
+
+
+    default boolean isMineOrWatched(TransactionOutput output) {
+        return isMine(output) || isWatched(output);
+    }
+
+    /**
+     * Returns true if this output is to a key, or an address we have the keys for, in the wallet.
+     */
+    default boolean isWatched(TransactionOutput output) {
+        try {
+            Script script = output.getScriptPubKey();
+            return isWatchedScript(script);
+        } catch (ScriptException e) {
+            // Just means we didn't understand the output of this transaction: ignore it.
+            log.debug("Could not parse tx output script: {}", e.toString());
+            return false;
+        }
+    }
+
+    /**
+     * Returns true if this output is to a key, or an address we have the keys for, in the wallet.
+     */
+    default boolean isMine(TransactionOutput output) {
+        try {
+            Script script = output.getScriptPubKey();
+            if (ScriptPattern.isP2PK(script))
+                return isPubKeyMine(ScriptPattern.extractKeyFromP2PK(script));
+            else if (ScriptPattern.isP2SH(script))
+                return isPayToScriptHashMine(ScriptPattern.extractHashFromP2SH(script));
+            else if (ScriptPattern.isP2PKH(script))
+                return isPubKeyHashMine(ScriptPattern.extractHashFromP2PKH(script),
+                        ScriptType.P2PKH);
+            else if (ScriptPattern.isP2WPKH(script))
+                return isPubKeyHashMine(ScriptPattern.extractHashFromP2WH(script),
+                        ScriptType.P2WPKH);
+            else
+                return false;
+        } catch (ScriptException e) {
+            // Just means we didn't understand the output of this transaction: ignore it.
+            log.debug("Could not parse tx {} output script: {}",
+                    output.getParentTransaction() != null ? output.getParentTransaction().getTxId() : "(no parent)", e.toString());
+            return false;
+        }
+    }
 }

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -18,14 +18,12 @@
 package org.bitcoinj.core;
 
 import org.bitcoinj.base.Coin;
-import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptException;
 import org.bitcoinj.script.ScriptPattern;
-import org.bitcoinj.wallet.Wallet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -274,7 +272,7 @@ public class TransactionOutput extends ChildMessage {
 
     /**
      * Returns whether {@link TransactionOutput#markAsSpent(TransactionInput)} has been called on this class. A
-     * {@link Wallet} will mark a transaction output as spent once it sees a transaction input that is connected to it.
+     * {@link org.bitcoinj.wallet.Wallet} will mark a transaction output as spent once it sees a transaction input that is connected to it.
      * Note that this flag can be false when an output has in fact been spent according to the rest of the network if
      * the spending transaction wasn't downloaded yet, and it can be marked as spent when in reality the rest of the
      * network believes it to be unspent if the signature or script connecting to it was not actually valid.
@@ -293,49 +291,29 @@ public class TransactionOutput extends ChildMessage {
 
     /**
      * Returns true if this output is to a key in the wallet or to an address/script we are watching.
+     * @deprecated Use {@link TransactionBag#isMineOrWatched(TransactionOutput)}
      */
+    @Deprecated
     public boolean isMineOrWatched(TransactionBag transactionBag) {
-        return isMine(transactionBag) || isWatched(transactionBag);
+        return transactionBag.isMineOrWatched(this);
     }
 
     /**
      * Returns true if this output is to a key, or an address we have the keys for, in the wallet.
+     * @deprecated Use {@link TransactionBag#isWatched(TransactionOutput)}
      */
+    @Deprecated
     public boolean isWatched(TransactionBag transactionBag) {
-        try {
-            Script script = getScriptPubKey();
-            return transactionBag.isWatchedScript(script);
-        } catch (ScriptException e) {
-            // Just means we didn't understand the output of this transaction: ignore it.
-            log.debug("Could not parse tx output script: {}", e.toString());
-            return false;
-        }
+        return transactionBag.isWatched(this);
     }
 
     /**
      * Returns true if this output is to a key, or an address we have the keys for, in the wallet.
+     * @deprecated Use {@link TransactionBag#isMine(TransactionOutput)}
      */
+    @Deprecated
     public boolean isMine(TransactionBag transactionBag) {
-        try {
-            Script script = getScriptPubKey();
-            if (ScriptPattern.isP2PK(script))
-                return transactionBag.isPubKeyMine(ScriptPattern.extractKeyFromP2PK(script));
-            else if (ScriptPattern.isP2SH(script))
-                return transactionBag.isPayToScriptHashMine(ScriptPattern.extractHashFromP2SH(script));
-            else if (ScriptPattern.isP2PKH(script))
-                return transactionBag.isPubKeyHashMine(ScriptPattern.extractHashFromP2PKH(script),
-                        ScriptType.P2PKH);
-            else if (ScriptPattern.isP2WPKH(script))
-                return transactionBag.isPubKeyHashMine(ScriptPattern.extractHashFromP2WH(script),
-                        ScriptType.P2WPKH);
-            else
-                return false;
-        } catch (ScriptException e) {
-            // Just means we didn't understand the output of this transaction: ignore it.
-            log.debug("Could not parse tx {} output script: {}",
-                    parent != null ? ((Transaction) parent).getTxId() : "(no parent)", e.toString());
-            return false;
-        }
+        return transactionBag.isMine(this);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/wallet/SendRequest.java
+++ b/core/src/main/java/org/bitcoinj/wallet/SendRequest.java
@@ -217,7 +217,7 @@ public class SendRequest {
     public static SendRequest childPaysForParent(Wallet wallet, Transaction parentTransaction, Coin feeRaise) {
         TransactionOutput outputToSpend = null;
         for (final TransactionOutput output : parentTransaction.getOutputs()) {
-            if (output.isMine(wallet) && output.isAvailableForSpending()
+            if (wallet.isMine(output) && output.isAvailableForSpending()
                     && output.getValue().isGreaterThan(feeRaise)) {
                 outputToSpend = output;
                 break;

--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -352,7 +352,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         assertEquals("Wrong number of PENDING.4", 1, wallet.getPoolSize(WalletTransaction.Pool.PENDING));
         Coin totalPendingTxAmount = Coin.ZERO;
         for (Transaction tx : wallet.getPendingTransactions()) {
-            totalPendingTxAmount = totalPendingTxAmount.add(tx.getValueSentToMe(wallet));
+            totalPendingTxAmount = totalPendingTxAmount.add(wallet.getValueSentToMe(tx));
         }
 
         // The available balance should be the 0 (as we spent the 1 BTC that's pending) and estimated should be 1/2 - fee BTC

--- a/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
@@ -123,7 +123,7 @@ public class ForwardingService {
             // Runs in the dedicated "user thread" (see bitcoinj docs for more info on this).
             //
             // The transaction "tx" can either be pending, or included into a block (we didn't see the broadcast).
-            Coin value = tx.getValueSentToMe(w);
+            Coin value = w.getValueSentToMe(tx);
             System.out.println("Received tx for " + value.toFriendlyString() + ": " + tx);
             System.out.println("Transaction will be forwarded after it confirms.");
             // Wait until it's made it into the block chain (may run immediately if it's already there).

--- a/examples/src/main/java/org/bitcoinj/examples/Kit.java
+++ b/examples/src/main/java/org/bitcoinj/examples/Kit.java
@@ -71,7 +71,7 @@ public class Kit {
 
         kit.wallet().addCoinsReceivedEventListener((wallet, tx, prevBalance, newBalance) -> {
             System.out.println("-----> coins resceived: " + tx.getTxId());
-            System.out.println("received: " + tx.getValue(wallet));
+            System.out.println("received: " + wallet.getValue(tx));
         });
 
         kit.wallet().addCoinsSentEventListener((wallet, tx, prevBalance, newBalance) -> System.out.println("coins sent"));

--- a/integration-test/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
@@ -226,7 +226,7 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
         }
         assertNotNull(t1);
         // 49 BTC in change.
-        assertEquals(valueOf(49, 0), t1.getValueSentToMe(wallet));
+        assertEquals(valueOf(49, 0), wallet.getValueSentToMe(t1));
         // The future won't complete until it's heard back from the network on p2.
         InventoryMessage inv = new InventoryMessage(UNITTEST);
         inv.addTransaction(t1);


### PR DESCRIPTION
* Move methods from Transaction/TransactionOutput that take a wallet/TransactionBag parameter
  to TransactionBag
* Deprecated existing methods
* Update existing code to use new calls

There are two outstanding issues (which is why I marked this as DRAFT):

1. TODO about commented out Android caching code in TransactionBag
2. @Ignore on isTxConsistentReturnsFalseAsExpected() method in WalletTest (EasyMock is being applied to `TransactionOutput` and so with the functionality moved to `TransactionBag` that seems to have broken the test)