### PR TITLE
LinuxSecureRandom: don't automatically install RNG workaround any more

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/core/ECKey.java
@@ -32,7 +32,6 @@ import org.bitcoinj.crypto.EncryptedData;
 import org.bitcoinj.crypto.KeyCrypter;
 import org.bitcoinj.crypto.KeyCrypterException;
 import org.bitcoinj.crypto.LazyECPoint;
-import org.bitcoinj.crypto.LinuxSecureRandom;
 import org.bitcoinj.wallet.Protos;
 import org.bitcoinj.wallet.Wallet;
 import org.bouncycastle.asn1.ASN1InputStream;
@@ -138,10 +137,6 @@ public class ECKey implements EncryptableItem {
     private static final SecureRandom secureRandom;
 
     static {
-        // Init proper random number generator, as some old Android installations have bugs that make it unsecure.
-        if (Utils.isAndroidRuntime())
-            new LinuxSecureRandom();
-
         // Tell Bouncy Castle to precompute data that's needed during secp256k1 calculations.
         FixedPointUtil.precompute(CURVE_PARAMS.getG());
         CURVE = new ECDomainParameters(CURVE_PARAMS.getCurve(), CURVE_PARAMS.getG(), CURVE_PARAMS.getN(),

--- a/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
@@ -37,10 +37,6 @@ import static com.google.common.base.Preconditions.checkState;
  */
 public final class HDKeyDerivation {
     static {
-        // Init proper random number generator, as some old Android installations have bugs that make it unsecure.
-        if (Utils.isAndroidRuntime())
-            new LinuxSecureRandom();
-
         RAND_INT = new BigInteger(256, new SecureRandom());
     }
 

--- a/core/src/main/java/org/bitcoinj/crypto/KeyCrypterScrypt.java
+++ b/core/src/main/java/org/bitcoinj/crypto/KeyCrypterScrypt.java
@@ -19,7 +19,6 @@ package org.bitcoinj.crypto;
 
 import com.google.common.base.Stopwatch;
 import com.google.protobuf.ByteString;
-import org.bitcoinj.core.Utils;
 import org.bitcoinj.wallet.Protos;
 import org.bitcoinj.wallet.Protos.ScryptParameters;
 import org.bitcoinj.wallet.Protos.Wallet.EncryptionType;
@@ -75,10 +74,6 @@ public class KeyCrypterScrypt implements KeyCrypter {
     public static final int SALT_LENGTH = 8;
 
     static {
-        // Init proper random number generator, as some old Android installations have bugs that make it unsecure.
-        if (Utils.isAndroidRuntime())
-            new LinuxSecureRandom();
-
         secureRandom = new SecureRandom();
     }
 

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
@@ -24,12 +24,10 @@ import org.bitcoinj.core.BloomFilter;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.LegacyAddress;
 import org.bitcoinj.core.NetworkParameters;
-import org.bitcoinj.core.Utils;
 import org.bitcoinj.crypto.ChildNumber;
 import org.bitcoinj.crypto.DeterministicKey;
 import org.bitcoinj.crypto.KeyCrypter;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
-import org.bitcoinj.crypto.LinuxSecureRandom;
 import org.bitcoinj.params.UnitTestParams;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.base.ScriptType;
@@ -226,12 +224,6 @@ public class KeyChainGroup implements KeyBag {
         public KeyChainGroup build() {
             return new KeyChainGroup(params, null, chains, lookaheadSize, lookaheadThreshold, null, null);
         }
-    }
-
-    static {
-        // Init proper random number generator, as some old Android installations have bugs that make it unsecure.
-        if (Utils.isAndroidRuntime())
-            new LinuxSecureRandom();
     }
 
     private static final Logger log = LoggerFactory.getLogger(KeyChainGroup.class);


### PR DESCRIPTION
LinuxSecureRandom used to be initialized on Android because very old Android versions had a bug
in the random number generator. We don't support those old versions any more, so the workaround
has become unnecessary. It is still possible to initialize it manually if desired.