### PR TITLE
Peer/TransactionBroadcast: use thenRunAsync() instead of addListener()

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -1709,7 +1709,7 @@ public class Peer extends PeerSocketHandler {
             }
             // Ping/pong to wait for blocks that are still being streamed to us to finish being downloaded and
             // discarded.
-            ping().addListener(() -> {
+            ping().thenRunAsync(() -> {
                 lock.lock();
                 checkNotNull(awaitingFreshFilter);
                 GetDataMessage getdata = new GetDataMessage(params);

--- a/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
@@ -128,7 +128,7 @@ public class TransactionBroadcast {
     public ListenableCompletableFuture<Transaction> broadcast() {
         peerGroup.addPreMessageReceivedEventListener(Threading.SAME_THREAD, rejectionListener);
         log.info("Waiting for {} peers required for broadcast, we have {} ...", minConnections, peerGroup.getConnectedPeers().size());
-        peerGroup.waitForPeers(minConnections).addListener(new EnoughAvailablePeers(), Threading.SAME_THREAD);
+        peerGroup.waitForPeers(minConnections).thenRunAsync(new EnoughAvailablePeers(), Threading.SAME_THREAD);
         return ListenableCompletableFuture.of(future);
     }
 


### PR DESCRIPTION
* Use CompletableFuture.thenRunAsync() rather than rely on the converter method ListenableCompletableFuture.addListener().

This is a minor change that reduces our reliance on our adapter class `ListenableCompletableFuture`.