### PR TITLE
ForwardingService: Improve the implementation of close()

### DIFF
--- a/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
@@ -133,11 +133,20 @@ public class ForwardingService implements AutoCloseable {
         kit.wallet().addCoinsReceivedEventListener(listener);
     }
 
+    /**
+     * Close the service. {@link AutoCloseable} will be triggered if an unhandled exception occurs within
+     * a <i>try-with-resources</i> block.
+     * <p>
+     * Note that {@link WalletAppKit#setAutoStop(boolean)} is set by default and installs a shutdown handler
+     * via {@link Runtime#addShutdownHook(Thread)} so we do not need to worry about explicitly shutting down
+     * the {@code WalletAppKit} if the process is terminated.
+     */
     @Override
     public void close() {
-        kit.wallet().removeCoinsReceivedEventListener(listener);
+        if (kit.isRunning()) {
+            kit.wallet().removeCoinsReceivedEventListener(listener);
+        }
         kit.stopAsync();
-        kit.awaitTerminated();
     }
 
     /**


### PR DESCRIPTION
* Don't try to remove listener (access .wallet()) unless kit.isRunning()
* Don't wait for termination, just call kit.stopAsync()
* Add some JavaDoc

@schildbach I actually tested this a little bit by adding code to throw interrupts within the _try-with-resources_ block. That's how I figured out to add the `.isRunning()`.