### PR TITLE
ForwardingService: Don't swallow InterruptedException

### DIFF
--- a/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
@@ -92,7 +92,9 @@ public class ForwardingService implements AutoCloseable {
 
             try {
                 Thread.sleep(Long.MAX_VALUE);
-            } catch (InterruptedException ignored) {}
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 


### PR DESCRIPTION
instead rethrow a RuntimeException triggering auto-close.