### PR TITLE
CoinSelection: encapsulate fields

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/CoinSelection.java
+++ b/core/src/main/java/org/bitcoinj/wallet/CoinSelection.java
@@ -24,14 +24,20 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Represents the results of a
- * {@link CoinSelector#select(Coin, List)} operation. A
- * coin selection represents a list of spendable transaction outputs that sum together to give valueGathered.
- * Different coin selections could be produced by different coin selectors from the same input set, according
- * to their varying policies.
+ * Represents the results of a {@link CoinSelector#select(Coin, List)} operation. A coin selection represents a list
+ * of spendable transaction outputs that sum together to a {@link #totalValue()} value gathered. Different coin selections
+ * could be produced by different coin selectors from the same input set, according to their varying policies.
  */
 public class CoinSelection {
+    /**
+     * @deprecated Use {@link #totalValue()}
+     */
+    @Deprecated
     public final Coin valueGathered;
+    /**
+     * @deprecated Use {@link #outputs()}
+     */
+    @Deprecated
     public final List<TransactionOutput> gathered;
 
     public CoinSelection(List<TransactionOutput> gathered) {
@@ -52,5 +58,19 @@ public class CoinSelection {
         return outputs.stream()
                 .map(TransactionOutput::getValue)
                 .reduce(Coin.ZERO, Coin::add);
+    }
+
+    /**
+     * @return Total value of gathered outputs.
+     */
+    public Coin totalValue() {
+        return valueGathered;
+    }
+
+    /**
+     * @return List of gathered outputs
+     */
+    public List<TransactionOutput> outputs() {
+        return gathered;
     }
 }

--- a/core/src/main/java/org/bitcoinj/wallet/CoinSelection.java
+++ b/core/src/main/java/org/bitcoinj/wallet/CoinSelection.java
@@ -19,6 +19,7 @@ package org.bitcoinj.wallet;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.core.TransactionOutput;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -31,23 +32,23 @@ import java.util.List;
  */
 public class CoinSelection {
     public final Coin valueGathered;
-    public final Collection<TransactionOutput> gathered;
+    public final List<TransactionOutput> gathered;
 
-    public CoinSelection(Collection<TransactionOutput> gathered) {
+    public CoinSelection(List<TransactionOutput> gathered) {
         this.valueGathered = sumOutputValues(gathered);
         this.gathered = gathered;
     }
 
     /**
-     * @deprecated use {@link #CoinSelection(Collection)}
+     * @deprecated use {@link #CoinSelection(List)}
      */
     @Deprecated
     public CoinSelection(Coin valueGathered, Collection<TransactionOutput> gathered) {
         // ignore valueGathered
-        this(gathered);
+        this(new ArrayList<>(gathered));
     }
 
-    private static Coin sumOutputValues(Collection<TransactionOutput> outputs) {
+    private static Coin sumOutputValues(List<TransactionOutput> outputs) {
         return outputs.stream()
                 .map(TransactionOutput::getValue)
                 .reduce(Coin.ZERO, Coin::add);

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -3681,7 +3681,7 @@ public class Wallet extends BaseTaggableObject
             if (balanceType == BalanceType.AVAILABLE || balanceType == BalanceType.AVAILABLE_SPENDABLE) {
                 List<TransactionOutput> candidates = calculateAllSpendCandidates(true, balanceType == BalanceType.AVAILABLE_SPENDABLE);
                 CoinSelection selection = coinSelector.select(BitcoinNetwork.MAX_MONEY, candidates);
-                return selection.valueGathered;
+                return selection.totalValue();
             } else if (balanceType == BalanceType.ESTIMATED || balanceType == BalanceType.ESTIMATED_SPENDABLE) {
                 List<TransactionOutput> all = calculateAllSpendCandidates(false, balanceType == BalanceType.ESTIMATED_SPENDABLE);
                 Coin value = Coin.ZERO;
@@ -3706,7 +3706,7 @@ public class Wallet extends BaseTaggableObject
             checkNotNull(selector);
             List<TransactionOutput> candidates = calculateAllSpendCandidates(true, false);
             CoinSelection selection = selector.select(params.network().maxMoney(), candidates);
-            return selection.valueGathered;
+            return selection.totalValue();
         } finally {
             lock.unlock();
         }
@@ -4232,11 +4232,11 @@ public class Wallet extends BaseTaggableObject
                 CoinSelector selector = req.coinSelector == null ? coinSelector : req.coinSelector;
                 bestCoinSelection = selector.select(params.network().maxMoney(), candidates);
                 candidates = null;  // Selector took ownership and might have changed candidates. Don't access again.
-                req.tx.getOutput(0).setValue(bestCoinSelection.valueGathered);
-                log.info("  emptying {}", bestCoinSelection.valueGathered.toFriendlyString());
+                req.tx.getOutput(0).setValue(bestCoinSelection.totalValue());
+                log.info("  emptying {}", bestCoinSelection.totalValue().toFriendlyString());
             }
 
-            for (TransactionOutput output : bestCoinSelection.gathered)
+            for (TransactionOutput output : bestCoinSelection.outputs())
                 req.tx.addInput(output);
 
             if (req.emptyWallet) {
@@ -5065,11 +5065,11 @@ public class Wallet extends BaseTaggableObject
             CoinSelection selection = selector.select(valueNeeded, new LinkedList<>(candidates));
             result.bestCoinSelection = selection;
             // Can we afford this?
-            if (selection.valueGathered.compareTo(valueNeeded) < 0) {
-                Coin valueMissing = valueNeeded.subtract(selection.valueGathered);
+            if (selection.totalValue().compareTo(valueNeeded) < 0) {
+                Coin valueMissing = valueNeeded.subtract(selection.totalValue());
                 throw new InsufficientMoneyException(valueMissing);
             }
-            Coin change = selection.valueGathered.subtract(valueNeeded);
+            Coin change = selection.totalValue().subtract(valueNeeded);
             if (change.isGreaterThan(Coin.ZERO)) {
                 // The value of the inputs is greater than what we want to send. Just like in real life then,
                 // we need to take back some coins ... this is called "change". Add another output that sends the change
@@ -5105,7 +5105,7 @@ public class Wallet extends BaseTaggableObject
                 }
             }
 
-            for (TransactionOutput selectedOutput : selection.gathered) {
+            for (TransactionOutput selectedOutput : selection.outputs()) {
                 TransactionInput input = tx.addInput(selectedOutput);
                 // If the scriptBytes don't default to none, our size calculations will be thrown off.
                 checkState(input.getScriptBytes().length == 0);
@@ -5138,7 +5138,7 @@ public class Wallet extends BaseTaggableObject
 
     private int estimateVirtualBytesForSigning(CoinSelection selection) {
         int vsize = 0;
-        for (TransactionOutput output : selection.gathered) {
+        for (TransactionOutput output : selection.outputs()) {
             try {
                 Script script = output.getScriptPubKey();
                 ECKey key = null;
@@ -5452,13 +5452,13 @@ public class Wallet extends BaseTaggableObject
                 selector.excludeOutputsSpentBy(other);
             // TODO: Make this use the standard SendRequest.
             CoinSelection toMove = selector.select(Coin.ZERO, calculateAllSpendCandidates());
-            if (toMove.valueGathered.equals(Coin.ZERO)) return null;  // Nothing to do.
+            if (toMove.totalValue().equals(Coin.ZERO)) return null;  // Nothing to do.
             Transaction rekeyTx = new Transaction(params);
-            for (TransactionOutput output : toMove.gathered) {
+            for (TransactionOutput output : toMove.outputs()) {
                 rekeyTx.addInput(output);
             }
             // When not signing, don't waste addresses.
-            rekeyTx.addOutput(toMove.valueGathered, sign ? freshReceiveAddress() : currentReceiveAddress());
+            rekeyTx.addOutput(toMove.totalValue(), sign ? freshReceiveAddress() : currentReceiveAddress());
             if (!adjustOutputDownwardsForFee(rekeyTx, toMove, Transaction.DEFAULT_TX_FEE, true)) {
                 log.error("Failed to adjust rekey tx for fees.");
                 return null;

--- a/core/src/test/java/org/bitcoinj/wallet/DefaultCoinSelectorTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DefaultCoinSelectorTest.java
@@ -92,8 +92,8 @@ public class DefaultCoinSelectorTest extends TestWithWallet {
         // Check we selected just the oldest one.
         DefaultCoinSelector selector = DefaultCoinSelector.get();
         CoinSelection selection = selector.select(COIN, wallet.calculateAllSpendCandidates());
-        assertTrue(selection.gathered.contains(t1.getOutputs().get(0)));
-        assertEquals(COIN, selection.valueGathered);
+        assertTrue(selection.outputs().contains(t1.getOutputs().get(0)));
+        assertEquals(COIN, selection.totalValue());
 
         // Check we ordered them correctly (by depth).
         ArrayList<TransactionOutput> candidates = new ArrayList<>();
@@ -141,6 +141,6 @@ public class DefaultCoinSelectorTest extends TestWithWallet {
         DefaultCoinSelector selector = DefaultCoinSelector.get();
         CoinSelection selection = selector.select(COIN.multiply(2), outputs);
 
-        assertTrue(selection.gathered.size() == 4);
+        assertTrue(selection.outputs().size() == 4);
     }
 }


### PR DESCRIPTION
* Encapsulate `valueGathered` as `total()`
* Encapsulate `gathered` as `outputs()`
* Deprecate public members
* Update clients to use accessors

This is dependent upon PR #2559 (thought it doesn't strictly need to be)