### PR TITLE
ForwardingService: Use kit.setBlockingStartup(false)

### DIFF
--- a/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
@@ -124,9 +124,9 @@ public class ForwardingService implements AutoCloseable {
             kit.connectToLocalHost();
         }
 
-        // Download the blockchain and wait until it's done.
-        kit.startAsync();
-        kit.awaitRunning();
+        kit.setBlockingStartup(false);  // Don't wait for blockchain synchronization before entering RUNNING state
+        kit.startAsync();               // Connect to the network and start downloading transactions
+        kit.awaitRunning();             // Wait for the service to reach the RUNNING state
         kit.peerGroup().setMaxConnections(MAX_CONNECTIONS);
 
         // Start listening and forwarding


### PR DESCRIPTION
This will speed up synchronization because the `.setMaxConnections()` call will occur before synchronization is finished and the necessary number of `Peers` will be found sooner.

Also IMO this a better example because most apps should not block while syncing the chain.