### PR TITLE
Add ForwardingServiceTest to integration-test

### DIFF
--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -6,6 +6,7 @@ plugins {
 
 dependencies {
     implementation project(':bitcoinj-core')
+    implementation project(':bitcoinj-examples')
 
     testImplementation 'org.slf4j:slf4j-jdk14:1.7.36'
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.0"

--- a/integration-test/src/test/java/org/bitcoinj/examples/ForwardingServiceTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/examples/ForwardingServiceTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.examples;
+
+import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.ScriptType;
+import org.bitcoinj.core.Address;
+import org.bitcoinj.core.Context;
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.NetworkParameters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+
+/**
+ * Forwarding Service Functional/Integration test. Uses {@link BitcoinNetwork#TESTNET} so is {@code @Disabled}.
+ * To run this test comment-out the {@code @Disabled} annotation.
+ */
+@Disabled
+public class ForwardingServiceTest {
+    static final BitcoinNetwork network = BitcoinNetwork.TESTNET;
+    static final Address forwardingAddress = Address.fromKey(NetworkParameters.of(network), new ECKey(), ScriptType.P2WPKH);
+
+    @BeforeEach
+    void setupTest() {
+        Context.propagate(new Context());
+    }
+
+    // Start the service via the static forward() method and immediately interrupt
+    @Test
+    public void startViaStaticForwardAndImmediatelyInterrupt(@TempDir File tempDir) {
+        Thread thread = new Thread(
+                () -> ForwardingService.forward(tempDir, network, forwardingAddress)
+        );
+        thread.start();
+        thread.interrupt();
+    }
+
+    // Instantiate the service, start it, and immediately close it
+    // Because ForwardingService disables "blocking mode" in WalletAppKit, start() returns as soon
+    // the PeerGroup was asynchronously started and the WalletAppKit enters the (Guava) RUNNING state.
+    @Test
+    public void startAndImmediatelyClose(@TempDir File tempDir) {
+        ForwardingService service = new ForwardingService(tempDir, forwardingAddress, network);
+        service.start();
+        service.close();
+    }
+}


### PR DESCRIPTION
Because the tests use TESTNET, the class is `@Ignore`d.

Dependent upon  PR #2570 

This is just a starting point for testing that we should do on `ForwardingService` and `WalletAppKit`.

Also see Issue #2517 which has some ideas for how we can run integration tests that use an actual Bitcoin Core instance but can still be run via CI automation.
