### PR TITLE
ForwardingService: reduce redundant console output at startup

### DIFF
--- a/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
@@ -86,9 +86,8 @@ public class ForwardingService implements AutoCloseable {
             forwardingService.start();
 
             // After we start listening, we can tell the user the receiving address
-            System.out.printf("Waiting to receive coins on %s\n", forwardingService.receivingAddress());
-            System.out.printf("Will send coins to %s\n", address);
-            System.out.println("Waiting for coins to arrive. Press Ctrl-C to quit.");
+            System.out.printf("Waiting to receive coins on: %s\n", forwardingService.receivingAddress());
+            System.out.println("Press Ctrl-C to quit.");
 
             try {
                 Thread.sleep(Long.MAX_VALUE);


### PR DESCRIPTION
This reduces console output at startup to

```
Network: org.bitcoin.test
Forwarding address: tb1qemczz9rc49y5xzlmsr0r2qmhp9wsv9v3t5dtlv
Waiting to receive coins on: tb1qwx8sjz4vcnj4h9r3u7dnn56d7cydt9a7f6d2j3
Press Ctrl-C to quit.
```

Before this PR:

```
Network: org.bitcoin.test
Forwarding address: tb1qemczz9rc49y5xzlmsr0r2qmhp9wsv9v3t5dtlv
Waiting to receive coins on tb1qh6wf2njcvzlcjhdzacsvd2kemf40l5dqwwchnq
Will send coins to tb1qemczz9rc49y5xzlmsr0r2qmhp9wsv9v3t5dtlv
Waiting for coins to arrive. Press Ctrl-C to quit.
```