### PR TITLE
Upgrade JUnit 5 JARs to 5.9.0

### DIFF
--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -8,14 +8,14 @@ dependencies {
     implementation project(':bitcoinj-core')
 
     testImplementation 'org.slf4j:slf4j-jdk14:1.7.36'
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.8.2"
-    testImplementation "org.junit.jupiter:junit-jupiter-params:5.8.2"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.0"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:5.9.0"
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.easymock:easymock:4.3'
     testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.10'
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.8.2"
-    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:5.8.2"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.9.0"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:5.9.0"
 }
 
 sourceCompatibility = 11

--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -26,8 +26,8 @@ dependencies {
         compileOnly 'info.picocli:picocli-codegen:4.6.3'
     }
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.8.2"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.8.2"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.0"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.9.0"
 
     testImplementation 'org.slf4j:slf4j-jdk14:1.7.36'
 }


### PR DESCRIPTION
Maybe this will help with the `@TempDir` annotation issues we were seeing on Windows. (it doesn't see PR #2576)

We should upgrade to the latest version anyway.