### PR TITLE
TransactionBroadcast: make 2 private members final

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
@@ -61,7 +61,7 @@ public class TransactionBroadcast {
     public static Random random = new Random();
     
     // Tracks which nodes sent us a reject message about this broadcast, if any. Useful for debugging.
-    private Map<Peer, RejectMessage> rejects = Collections.synchronizedMap(new HashMap<Peer, RejectMessage>());
+    private final Map<Peer, RejectMessage> rejects = Collections.synchronizedMap(new HashMap<Peer, RejectMessage>());
 
     TransactionBroadcast(PeerGroup peerGroup, Transaction tx) {
         this.peerGroup = peerGroup;
@@ -106,7 +106,7 @@ public class TransactionBroadcast {
         this.dropPeersAfterBroadcast = dropPeersAfterBroadcast;
     }
 
-    private PreMessageReceivedEventListener rejectionListener = new PreMessageReceivedEventListener() {
+    private final PreMessageReceivedEventListener rejectionListener = new PreMessageReceivedEventListener() {
         @Override
         public Message onPreMessageReceived(Peer peer, Message m) {
             if (m instanceof RejectMessage) {


### PR DESCRIPTION
A minor change I made while refactoring, but it's alway helpful to be more clear about what's `final` (and to remove yellow in IntelliJ)
