### PR TITLE
WIP: Remove shutdownHook on shutdown

### DIFF
--- a/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
+++ b/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
@@ -470,11 +470,13 @@ public class WalletAppKit extends AbstractIdleService {
 
     private void installShutdownHook() {
         if (autoStop) {
-            Runtime.getRuntime().addShutdownHook(new Thread(this::shutdownHook, "shutdownHook"));
+            Runtime.getRuntime().addShutdownHook(shutdownHookThread);
         }
     }
 
-    private void shutdownHook() {
+    private final Thread shutdownHookThread = new Thread(this::shutdownFromHook, "shutdownHook");
+
+    private void shutdownFromHook() {
         try {
             stopAsync();
             awaitTerminated();
@@ -487,6 +489,9 @@ public class WalletAppKit extends AbstractIdleService {
     protected void shutDown() throws Exception {
         // Runs in a separate thread.
         try {
+            if (autoStop) {
+                Runtime.getRuntime().removeShutdownHook(shutdownHookThread);
+            }
             vPeerGroup.stop();
             vWallet.saveToFile(vWalletFile);
             vStore.close();


### PR DESCRIPTION
WalletAppKit can shutdown without the VM shutting down, when the VM
shuts down later, an exception can occur because the Guava service was already
shut down. At least I think that can happen.

This is a quick stab at a solution. Definitely WIP.