### PR TITLE
TransactionBroadcast: add broadcastOnly() and broadcastAndAwaitRelay(), deprecate broadcast()

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -2122,7 +2122,7 @@ public class PeerGroup implements TransactionBroadcaster {
         // eventually be collected. This in turn could result in the transaction not being committed to the wallet
         // at all.
         runningBroadcasts.add(broadcast);
-        broadcast.broadcast();
+        broadcast.broadcastOnly();
         return broadcast;
     }
 

--- a/integration-test/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
@@ -85,7 +85,7 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
         TransactionBroadcast broadcast = new TransactionBroadcast(peerGroup, tx);
         final AtomicDouble lastProgress = new AtomicDouble();
         broadcast.setProgressCallback(lastProgress::set);
-        CompletableFuture<Transaction> future = broadcast.broadcast();
+        CompletableFuture<TransactionBroadcast> future = broadcast.broadcastAndAwaitRelay();
         assertFalse(future.isDone());
         assertEquals(0.0, lastProgress.get(), 0.0);
         // We expect two peers to receive a tx message, and at least one of the others must announce for the future to
@@ -133,7 +133,7 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
         InboundMessageQueuer[] channels = { connectPeer(0), connectPeer(1), connectPeer(2), connectPeer(3), connectPeer(4) };
         Transaction tx = FakeTxBuilder.createFakeTx(UNITTEST);
         TransactionBroadcast broadcast = new TransactionBroadcast(peerGroup, tx);
-        CompletableFuture<Transaction> future = broadcast.broadcast();
+        CompletableFuture<TransactionBroadcast> future = broadcast.broadcastAndAwaitRelay();
         // 0 and 3 are randomly selected to receive the broadcast.
         assertEquals(tx, outbound(channels[1]));
         assertEquals(tx, outbound(channels[2]));


### PR DESCRIPTION
Add 2 new methods:

* `broadcastOnly()` - returns CF that completes when broadcast "sent" to all Peers
* `broadcastAndAwaitRelay()` - returns CF that completes when broadcast confirmed relayed by _m_ Peers


` broadcast()` is deprecated and calls broadcastAndAwaitRelay() and transforms result back to `Transaction`.

DRAFT -- depends on PR #2583