### PR TITLE
Forcibly remove error handling from MesageWriteTarget.writeBytes

### DIFF
--- a/core/src/main/java/org/bitcoinj/net/BlockingClient.java
+++ b/core/src/main/java/org/bitcoinj/net/BlockingClient.java
@@ -146,7 +146,7 @@ public class BlockingClient implements MessageWriteTarget {
     }
 
     @Override
-    public synchronized ListenableCompletableFuture<Void> writeBytes(byte[] message) throws IOException {
+    public synchronized ListenableCompletableFuture<Void> writeBytes(byte[] message) {
         try {
             OutputStream stream = socket.getOutputStream();
             stream.write(message);
@@ -155,7 +155,7 @@ public class BlockingClient implements MessageWriteTarget {
         } catch (IOException e) {
             log.error("Error writing message to connection, closing connection", e);
             closeConnection();
-            throw e;
+            throw new RuntimeException(e);
         }
     }
 

--- a/core/src/main/java/org/bitcoinj/net/ConnectionHandler.java
+++ b/core/src/main/java/org/bitcoinj/net/ConnectionHandler.java
@@ -147,7 +147,7 @@ class ConnectionHandler implements MessageWriteTarget {
     }
 
     @Override
-    public ListenableCompletableFuture<Void> writeBytes(byte[] message) throws IOException {
+    public ListenableCompletableFuture<Void> writeBytes(byte[] message) {
         boolean andUnlock = true;
         lock.lock();
         try {
@@ -157,7 +157,7 @@ class ConnectionHandler implements MessageWriteTarget {
             // register our SelectionKey to wakeup when we have free outbound buffer space available.
 
             if (bytesToWriteRemaining + message.length > OUTBOUND_BUFFER_BYTE_COUNT)
-                throw new IOException("Outbound buffer overflowed");
+                throw new RuntimeException("Outbound buffer overflowed");
             // Just dump the message onto the write buffer and call tryWriteBytes
             // TODO: Kill the needless message duplication when the write completes right away
             final ListenableCompletableFuture<Void> future = new ListenableCompletableFuture<>();
@@ -165,18 +165,18 @@ class ConnectionHandler implements MessageWriteTarget {
             bytesToWriteRemaining += message.length;
             setWriteOps();
             return future;
-        } catch (IOException e) {
-            lock.unlock();
-            andUnlock = false;
-            log.warn("Error writing message to connection, closing connection", e);
-            closeConnection();
-            throw e;
+//        } catch (IOException e) {
+//            lock.unlock();
+//            andUnlock = false;
+//            log.warn("Error writing message to connection, closing connection", e);
+//            closeConnection();
+//            throw new RuntimeException(e);
         } catch (CancelledKeyException e) {
             lock.unlock();
             andUnlock = false;
             log.warn("Error writing message to connection, closing connection", e);
             closeConnection();
-            throw new IOException(e);
+            throw new RuntimeException(e);
         } finally {
             if (andUnlock)
                 lock.unlock();

--- a/core/src/main/java/org/bitcoinj/net/MessageWriteTarget.java
+++ b/core/src/main/java/org/bitcoinj/net/MessageWriteTarget.java
@@ -28,7 +28,7 @@ public interface MessageWriteTarget {
      * Writes the given bytes to the remote server. The returned future will complete when all bytes
      * have been written to the OS network buffer.
      */
-    ListenableCompletableFuture<Void> writeBytes(byte[] message) throws IOException;
+    ListenableCompletableFuture<Void> writeBytes(byte[] message);
     /**
      * Closes the connection to the server, triggering the {@link StreamConnection#connectionClosed()}
      * event on the network-handling thread where all callbacks occur.

--- a/core/src/main/java/org/bitcoinj/net/NioClient.java
+++ b/core/src/main/java/org/bitcoinj/net/NioClient.java
@@ -128,7 +128,7 @@ public class NioClient implements MessageWriteTarget {
     }
 
     @Override
-    public synchronized ListenableCompletableFuture<Void> writeBytes(byte[] message) throws IOException {
+    public synchronized ListenableCompletableFuture<Void> writeBytes(byte[] message)  {
         return handler.writeTarget.writeBytes(message);
     }
 }

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -788,13 +788,13 @@ public class PeerTest extends TestWithNetworkConnections {
         // thread when it disconnects.
         Uninterruptibles.getUninterruptibly(connectedFuture);
         Uninterruptibles.getUninterruptibly(disconnectedFuture);
-        try {
+        //try {
             peer.writeTarget.writeBytes(new byte[1]);
             fail();
-        } catch (IOException e) {
-            assertTrue((e.getCause() != null && e.getCause() instanceof CancelledKeyException)
-                    || (e instanceof SocketException && e.getMessage().equals("Socket is closed")));
-        }
+//        } catch (IOException e) {
+//            assertTrue((e.getCause() != null && e.getCause() instanceof CancelledKeyException)
+//                    || (e instanceof SocketException && e.getMessage().equals("Socket is closed")));
+//        }
     }
 
     @Test
@@ -862,12 +862,12 @@ public class PeerTest extends TestWithNetworkConnections {
             assertTrue(e.getCause() instanceof ProtocolException);
         }
         peerDisconnected.get();
-        try {
+        //try {
             peer.writeTarget.writeBytes(new byte[1]);
             fail();
-        } catch (IOException e) {
-            assertTrue((e.getCause() != null && e.getCause() instanceof CancelledKeyException)
-                    || (e instanceof SocketException && e.getMessage().equals("Socket is closed")));
-        }
+//        } catch (IOException e) {
+//            assertTrue((e.getCause() != null && e.getCause() instanceof CancelledKeyException)
+//                    || (e instanceof SocketException && e.getMessage().equals("Socket is closed")));
+//        }
     }
 }


### PR DESCRIPTION
* Comment out throws clause in MesageWriteTarget.writeBytes.
* Disable throw statements that generate compiler errors

Note that PeerTest is currently disabled by integration-test/build.gradle so
we are lacking some coverage.

But, the fact that I can make these changes and no tests fail shows we
are not testing our error handling as thoroughly as I would like to see.