### PR TITLE
TransactionBroadcast: refactor loop that broadcasts to each peer

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
@@ -212,10 +212,7 @@ public class TransactionBroadcast {
             if (dropPeersAfterBroadcast) {
                 // We drop the peer shortly after the transaction has been sent, because this peer will not
                 // send us back useful broadcast confirmations.
-                future.thenRunAsync(() -> {
-                    Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
-                    peer.close();
-                }, Threading.THREAD_POOL);
+                future.thenRunAsync(dropPeerAfterBroadcastHandler(peer), Threading.THREAD_POOL);
             }
             // We don't record the peer as having seen the tx in the memory pool because we want to track only
             // how many peers announced to us.
@@ -224,6 +221,13 @@ public class TransactionBroadcast {
             log.error("Caught exception sending to {}", peer, e);
             return ListenableCompletableFuture.failedFuture(e);
         }
+    }
+
+    private static Runnable dropPeerAfterBroadcastHandler(Peer peer) {
+        return () ->  {
+            Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+            peer.close();
+        };
     }
 
     /**


### PR DESCRIPTION
There are three separate commits that could be reviewed and merged separately or reviewed once and merged without squash.

There is one (almost) behavior change in fe193d6acb8455107c7158c1a15b937226a7d97f -- an exception that was swallowed is now captured in the per-peer `CompletableFuture`. Of course, the per-peer CFs (in `sendFutures`) and the combined CF (`sentFuture`) are still private/inaccessible at this point so it doesn't really change any behavior. Once we capture the per-peer success/failure information we can decide how to report failures in a more logical way.