### PR TITLE
Wallet: remove the output shuffling override for unit-tests

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -3972,8 +3972,6 @@ public class Wallet extends BaseTaggableObject
     public Transaction createSend(Address address, Coin value, boolean allowUnconfirmed)
             throws InsufficientMoneyException, BadWalletEncryptionKeyException {
         SendRequest req = SendRequest.to(address, value);
-        if (params.getId().equals(BitcoinNetwork.ID_UNITTESTNET))
-            req.shuffleOutputs = false;
         if (allowUnconfirmed)
             req.allowUnconfirmed();
         completeTx(req);

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -803,7 +803,10 @@ public class WalletTest extends TestWithWallet {
         Coin coinHalf = valueOf(0, 50);
         assertEquals(1, wallet.getPoolSize(WalletTransaction.Pool.UNSPENT));
         assertEquals(1, wallet.getTransactions(true).size());
-        Transaction outbound1 = wallet.createSend(OTHER_ADDRESS, coinHalf);
+        SendRequest req = SendRequest.to(OTHER_ADDRESS, coinHalf);
+        req.shuffleOutputs = false;
+        wallet.completeTx(req);
+        Transaction outbound1 = req.tx;
         wallet.commitTx(outbound1);
         sendMoneyToWallet(AbstractBlockChain.NewBlockType.BEST_CHAIN, outbound1);
         assertTrue(outbound1.getWalletOutputs(wallet).size() <= 1); //the change address at most


### PR DESCRIPTION
Only one unit-test was dependent on it. That test has been changed to manually disable the shuffling.