### PR TITLE
PeerGroup: create a context as a convenience for apps that mainly operate on a PeerGroup

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -352,6 +352,7 @@ public class PeerGroup implements TransactionBroadcaster {
      */
     protected PeerGroup(NetworkParameters params, @Nullable AbstractBlockChain chain, ClientConnectionManager connectionManager) {
         checkNotNull(params);
+        Context.getOrCreate(); // create a context for convenience
         this.params = params;
         this.chain = chain;
         fastCatchupTimeSecs = params.getGenesisBlock().getTimeSeconds();


### PR DESCRIPTION
This fixes the missing context with PeerMonitor. See #2590. 