### PR TITLE
Context: introduce `relaxProofOfWork` property

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -564,6 +564,10 @@ public class Block extends Message {
 
     /** Returns true if the hash of the block is OK (lower than difficulty target). */
     protected boolean checkProofOfWork(boolean throwException) throws VerificationException {
+        // shortcut for unit-testing
+        if (Context.get().isRelaxProofOfWork())
+            return true;
+
         // This part is key - it is what proves the block was as difficult to make as it claims
         // to be. Note however that in the context of this function, the block can claim to be
         // as difficult as it wants to be .... if somebody was able to take control of our network

--- a/core/src/main/java/org/bitcoinj/core/Context.java
+++ b/core/src/main/java/org/bitcoinj/core/Context.java
@@ -52,13 +52,14 @@ public class Context {
     final private int eventHorizon;
     final private boolean ensureMinRequiredFee;
     final private Coin feePerKb;
+    final private boolean relaxProofOfWork;
 
     /**
      * Creates a new context object. For now, this will be done for you by the framework. Eventually you will be
      * expected to do this yourself in the same manner as fetching a NetworkParameters object (at the start of your app).
      */
     public Context() {
-        this(DEFAULT_EVENT_HORIZON, Transaction.DEFAULT_TX_FEE, true);
+        this(DEFAULT_EVENT_HORIZON, Transaction.DEFAULT_TX_FEE, true, false);
     }
 
     /**
@@ -76,23 +77,25 @@ public class Context {
      * @param eventHorizon Number of blocks after which the library will delete data and be unable to always process reorgs. See {@link #getEventHorizon()}.
      * @param feePerKb The default fee per 1000 virtual bytes of transaction data to pay when completing transactions. For details, see {@link SendRequest#feePerKb}.
      * @param ensureMinRequiredFee Whether to ensure the minimum required fee by default when completing transactions. For details, see {@link SendRequest#ensureMinRequiredFee}.
+     * @param relaxProofOfWork If true, proof of work is not enforced. This is useful for unit-testing. See {@link Block#checkProofOfWork(boolean)}.
      */
-    public Context(int eventHorizon, Coin feePerKb, boolean ensureMinRequiredFee) {
+    public Context(int eventHorizon, Coin feePerKb, boolean ensureMinRequiredFee, boolean relaxProofOfWork) {
         log.info("Creating bitcoinj {} context.", VersionMessage.BITCOINJ_VERSION);
         this.confidenceTable = new TxConfidenceTable();
         this.eventHorizon = eventHorizon;
         this.ensureMinRequiredFee = ensureMinRequiredFee;
         this.feePerKb = feePerKb;
+        this.relaxProofOfWork = relaxProofOfWork;
         lastConstructed = this;
     }
 
     /**
      * Note that NetworkParameters have been removed from this class. Thus, this constructor just swallows them.
-     * @deprecated Use {@link Context#Context(int, Coin, boolean)}
+     * @deprecated Use {@link Context#Context(int, Coin, boolean, boolean)}
      */
     @Deprecated
     public Context(NetworkParameters params, int eventHorizon, Coin feePerKb, boolean ensureMinRequiredFee) {
-        this(eventHorizon, feePerKb, ensureMinRequiredFee);
+        this(eventHorizon, feePerKb, ensureMinRequiredFee, false);
     }
 
     private static volatile Context lastConstructed;
@@ -204,5 +207,13 @@ public class Context {
      */
     public boolean isEnsureMinRequiredFee() {
         return ensureMinRequiredFee;
+    }
+
+    /**
+     * If this is set to true, proof of work is not enforced. This is useful for unit-testing, as we need to create
+     * and solve fake blocks quite often.
+     */
+    public boolean isRelaxProofOfWork() {
+        return relaxProofOfWork;
     }
 }

--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -77,7 +77,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
     @Before
     public void setUp() {
         BriefLogFormatter.init();
-        Context.propagate(new Context(100, Coin.ZERO, false));
+        Context.propagate(new Context(100, Coin.ZERO, false, false));
     }
 
     public abstract FullPrunedBlockStore createStore(NetworkParameters params, int blockCount)

--- a/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
@@ -86,9 +86,9 @@ public class BlockChainTest {
     public void setUp() throws Exception {
         BriefLogFormatter.initVerbose();
         Utils.setMockClock(); // Use mock clock
-        Context.propagate(new Context(100, Coin.ZERO, false));
+        Context.propagate(new Context(100, Coin.ZERO, false, false));
         testNetChain = new BlockChain(TESTNET, Wallet.createDeterministic(TESTNET, ScriptType.P2PKH), new MemoryBlockStore(TESTNET));
-        Context.propagate(new Context(100, Coin.ZERO, false));
+        Context.propagate(new Context(100, Coin.ZERO, false, false));
         NetworkParameters params = TESTNET;
         wallet = new Wallet(params, KeyChainGroup.builder(params).fromRandom(ScriptType.P2PKH).build()) {
             @Override

--- a/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
@@ -65,7 +65,7 @@ public class ChainSplitTest {
     public void setUp() throws Exception {
         BriefLogFormatter.init();
         Utils.setMockClock(); // Use mock clock
-        Context.propagate(new Context(100, Coin.ZERO, false));
+        Context.propagate(new Context(100, Coin.ZERO, false, false));
         MemoryBlockStore blockStore = new MemoryBlockStore(UNITTEST);
         wallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
         ECKey key1 = wallet.freshReceiveKey();

--- a/core/src/test/java/org/bitcoinj/testing/TestWithWallet.java
+++ b/core/src/test/java/org/bitcoinj/testing/TestWithWallet.java
@@ -69,7 +69,7 @@ public class TestWithWallet {
 
     public void setUp() throws Exception {
         BriefLogFormatter.init();
-        Context.propagate(new Context(100, Coin.ZERO, false));
+        Context.propagate(new Context(100, Coin.ZERO, false, false));
         wallet = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH, KeyChainGroupStructure.BIP32);
         myKey = wallet.freshReceiveKey();
         myAddress = wallet.freshReceiveAddress(ScriptType.P2PKH);

--- a/integration-test/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
+++ b/integration-test/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
@@ -102,7 +102,7 @@ public class TestWithNetworkConnections {
     
     public void setUp(BlockStore blockStore) throws Exception {
         BriefLogFormatter.init();
-        Context.propagate(new Context(100, Coin.ZERO, false));
+        Context.propagate(new Context(100, Coin.ZERO, false, false));
         this.blockStore = blockStore;
         // Allow subclasses to override the wallet object with their own.
         if (wallet == null) {


### PR DESCRIPTION
This allows unit-tests to disable enforcement of proof of work, so that fake blocks
can be created and solved in short time.

This PR is working towards getting rid of `UnitTestParams`.