### PR TITLE
Network: add exceedsMaxMoney() and simplify various maxMoney checks

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/BitcoinNetwork.java
+++ b/core/src/main/java/org/bitcoinj/base/BitcoinNetwork.java
@@ -121,6 +121,15 @@ public enum BitcoinNetwork implements Network {
         return MAX_MONEY;
     }
 
+    @Override
+    public boolean exceedsMaxMoney(Monetary amount) {
+        if (amount instanceof Coin) {
+            return ((Coin)amount).compareTo(MAX_MONEY) > 0;
+        } else {
+            throw new IllegalArgumentException("amount must be a Coin type");
+        }
+    }
+
     /**
      * Find the {@code BitcoinNetwork} from a name string, e.g. "mainnet", "testnet" or "signet".
      * A number of common alternate names are allowed too, e.g. "main" or "prod".

--- a/core/src/main/java/org/bitcoinj/base/Network.java
+++ b/core/src/main/java/org/bitcoinj/base/Network.java
@@ -44,4 +44,11 @@ public interface Network {
      * @return Maximum number of coins for this network
      */
     Monetary maxMoney();
+
+    /**
+     * Check if an amount exceeds the maximum allowed for a network (if the network has one)
+     * @param monetary A monetary amount
+     * @return true if too big, false if an allowed amount
+     */
+    boolean exceedsMaxMoney(Monetary monetary);
 }

--- a/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
@@ -285,12 +285,12 @@ public class FullPrunedBlockChain extends AbstractBlockChain {
                 }
                 // All values were already checked for being non-negative (as it is verified in Transaction.verify())
                 // but we check again here just for defence in depth. Transactions with zero output value are OK.
-                if (valueOut.signum() < 0 || valueOut.compareTo(params.network().maxMoney()) > 0)
+                if (valueOut.signum() < 0 || params.network().exceedsMaxMoney(valueOut))
                     throw new VerificationException("Transaction output value out of range");
                 if (isCoinBase) {
                     coinbaseValue = valueOut;
                 } else {
-                    if (valueIn.compareTo(valueOut) < 0 || valueIn.compareTo(params.network().maxMoney()) > 0)
+                    if (valueIn.compareTo(valueOut) < 0 || params.network().exceedsMaxMoney(valueIn))
                         throw new VerificationException("Transaction input value out of range");
                     totalFees = totalFees.add(valueIn.subtract(valueOut));
                 }
@@ -302,7 +302,7 @@ public class FullPrunedBlockChain extends AbstractBlockChain {
                     listScriptVerificationResults.add(future);
                 }
             }
-            if (totalFees.compareTo(params.network().maxMoney()) > 0 || getBlockInflation(height).add(totalFees).compareTo(coinbaseValue) < 0)
+            if (params.network().exceedsMaxMoney(totalFees) || getBlockInflation(height).add(totalFees).compareTo(coinbaseValue) < 0)
                 throw new VerificationException("Transaction fees out of range");
             for (Future<VerificationException> future : listScriptVerificationResults) {
                 VerificationException e;
@@ -412,12 +412,12 @@ public class FullPrunedBlockChain extends AbstractBlockChain {
                     }
                     // All values were already checked for being non-negative (as it is verified in Transaction.verify())
                     // but we check again here just for defence in depth. Transactions with zero output value are OK.
-                    if (valueOut.signum() < 0 || valueOut.compareTo(params.network().maxMoney()) > 0)
+                    if (valueOut.signum() < 0 || params.network().exceedsMaxMoney(valueOut))
                         throw new VerificationException("Transaction output value out of range");
                     if (isCoinBase) {
                         coinbaseValue = valueOut;
                     } else {
-                        if (valueIn.compareTo(valueOut) < 0 || valueIn.compareTo(params.network().maxMoney()) > 0)
+                        if (valueIn.compareTo(valueOut) < 0 || params.network().exceedsMaxMoney(valueIn))
                             throw new VerificationException("Transaction input value out of range");
                         totalFees = totalFees.add(valueIn.subtract(valueOut));
                     }
@@ -429,7 +429,7 @@ public class FullPrunedBlockChain extends AbstractBlockChain {
                         listScriptVerificationResults.add(future);
                     }
                 }
-                if (totalFees.compareTo(params.network().maxMoney()) > 0 || getBlockInflation(newBlock.getHeight()).add(totalFees).compareTo(coinbaseValue) < 0)
+                if (params.network().exceedsMaxMoney(totalFees) || getBlockInflation(newBlock.getHeight()).add(totalFees).compareTo(coinbaseValue) < 0)
                     throw new VerificationException("Transaction fees out of range");
                 txOutChanges = new TransactionOutputChanges(txOutsCreated, txOutsSpent);
                 for (Future<VerificationException> future : listScriptVerificationResults) {

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -1761,7 +1761,7 @@ public class Transaction extends ChildMessage {
             } catch (ArithmeticException e) {
                 throw new VerificationException.ExcessiveValue();
             }
-            if (params.network().hasMaxMoney() && valueOut.compareTo(params.network().maxMoney()) > 0)
+            if (params.network().exceedsMaxMoney(valueOut))
                 throw new VerificationException.ExcessiveValue();
         }
 

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -113,7 +113,7 @@ public class TransactionOutput extends ChildMessage {
         // Negative values obviously make no sense, except for -1 which is used as a sentinel value when calculating
         // SIGHASH_SINGLE signatures, so unfortunately we have to allow that here.
         checkArgument(value.signum() >= 0 || value.equals(Coin.NEGATIVE_SATOSHI), "Negative values not allowed");
-        checkArgument(!params.network().hasMaxMoney() || value.compareTo(params.network().maxMoney()) <= 0, "Values larger than MAX_MONEY not allowed");
+        checkArgument(!params.network().exceedsMaxMoney(value), "Values larger than MAX_MONEY not allowed");
         this.value = value.value;
         this.scriptBytes = scriptBytes;
         setParent(parent);

--- a/core/src/main/java/org/bitcoinj/protocols/payments/PaymentProtocol.java
+++ b/core/src/main/java/org/bitcoinj/protocols/payments/PaymentProtocol.java
@@ -428,7 +428,7 @@ public class PaymentProtocol {
         Protos.Output.Builder output = Protos.Output.newBuilder();
         if (amount != null) {
             final NetworkParameters params = NetworkParameters.of(address.network());
-            if (params.network().hasMaxMoney() && amount.compareTo(params.network().maxMoney()) > 0)
+            if (params.network().exceedsMaxMoney(amount))
                 throw new IllegalArgumentException("Amount too big: " + amount);
             output.setAmount(amount.value);
         } else {

--- a/core/src/main/java/org/bitcoinj/protocols/payments/PaymentSession.java
+++ b/core/src/main/java/org/bitcoinj/protocols/payments/PaymentSession.java
@@ -410,7 +410,7 @@ public class PaymentSession {
             }
             // This won't ever happen in practice. It would only happen if the user provided outputs
             // that are obviously invalid. Still, we don't want to silently overflow.
-            if (params.network().hasMaxMoney() && totalValue.compareTo(params.network().maxMoney()) > 0)
+            if (params.network().exceedsMaxMoney(totalValue))
                 throw new PaymentProtocolException.InvalidOutputs("The outputs are way too big.");
         } catch (InvalidProtocolBufferException e) {
             throw new PaymentProtocolException(e);

--- a/core/src/main/java/org/bitcoinj/uri/BitcoinURI.java
+++ b/core/src/main/java/org/bitcoinj/uri/BitcoinURI.java
@@ -213,7 +213,7 @@ public class BitcoinURI {
                 // Decode the amount (contains an optional decimal component to 8dp).
                 try {
                     Coin amount = Coin.parseCoin(valueToken);
-                    if (network.hasMaxMoney() && amount.longValue() > network.maxMoney().getValue())
+                    if (network.exceedsMaxMoney(amount))
                         throw new BitcoinURIParseException("Max number of coins exceeded");
                     if (amount.signum() < 0)
                         throw new ArithmeticException("Negative coins specified");


### PR DESCRIPTION
This will also help us implement alt-net (and alt-address) support using `Network`/`BitcoinNetwork` -- see PR #2501.