### PR TITLE
Wallet: add network()

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/DefaultRiskAnalysis.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DefaultRiskAnalysis.java
@@ -200,7 +200,7 @@ public class DefaultRiskAnalysis implements RiskAnalysis {
     private Result analyzeIsStandard() {
         // The IsStandard rules don't apply on testnet, because they're just a safety mechanism and we don't want to
         // crush innovation with valueless test coins.
-        if (wallet != null && !wallet.getNetworkParameters().getId().equals(BitcoinNetwork.ID_MAINNET))
+        if (wallet != null && wallet.network() != BitcoinNetwork.MAINNET)
             return Result.OK;
 
         RuleViolation ruleViolation = isStandard(tx);

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -25,6 +25,7 @@ import com.google.common.math.IntMath;
 import com.google.protobuf.ByteString;
 import net.jcip.annotations.GuardedBy;
 import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.utils.StreamUtils;
 import org.bitcoinj.core.AbstractBlockChain;
 import org.bitcoinj.core.Address;
@@ -483,6 +484,10 @@ public class Wallet extends BaseTaggableObject
             }
         };
         acceptRiskyTransactions = false;
+    }
+
+    public Network network() {
+        return params.network();
     }
 
     public NetworkParameters getNetworkParameters() {

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -410,9 +410,9 @@ public class WalletTool implements Callable<Integer> {
             e.printStackTrace();
             return 1;
         }
-        if (!wallet.getParams().equals(params)) {
-            System.err.println("Wallet does not match requested network parameters: " +
-                    wallet.getParams().getId() + " vs " + params.getId());
+        if (wallet.network() != net) {
+            System.err.println("Wallet does not match requested network: " +
+                    wallet.network() + " vs " + net);
             return 1;
         }
 


### PR DESCRIPTION
Perhaps in the future, we'll want a `network` private or protected member,
but for now that doesn't seem needed.

When we start using Network for address and transaction creation, this
will be used even more.