### PR TITLE
ECKey: add toAddress() method, deprecate *Address.fromKey()

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Address.java
+++ b/core/src/main/java/org/bitcoinj/core/Address.java
@@ -88,14 +88,11 @@ public abstract class Address implements Comparable<Address> {
      * @param outputScriptType
      *            script type the address should use
      * @return constructed address
+     * @deprecated Use {@link ECKey#toAddress(ScriptType, BitcoinNetwork)}
      */
+    @Deprecated
     public static Address fromKey(final NetworkParameters params, final ECKey key, final ScriptType outputScriptType) {
-        if (outputScriptType == ScriptType.P2PKH)
-            return LegacyAddress.fromKey(params, key);
-        else if (outputScriptType == ScriptType.P2WPKH)
-            return SegwitAddress.fromKey(params, key);
-        else
-            throw new IllegalArgumentException(outputScriptType.toString());
+        return key.toAddress(outputScriptType, params.network());
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/LegacyAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/LegacyAddress.java
@@ -20,6 +20,7 @@ package org.bitcoinj.core;
 
 import com.google.common.primitives.UnsignedBytes;
 import org.bitcoinj.base.Base58;
+import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.params.Networks;
 import org.bitcoinj.base.ScriptType;
@@ -52,7 +53,7 @@ public class LegacyAddress extends Address {
     /**
      * Private constructor. Use {@link #fromBase58(NetworkParameters, String)},
      * {@link #fromPubKeyHash(NetworkParameters, byte[])}, {@link #fromScriptHash(NetworkParameters, byte[])} or
-     * {@link #fromKey(NetworkParameters, ECKey)}.
+     * {@link ECKey#toAddress(ScriptType, BitcoinNetwork)}.
      * 
      * @param params
      *            network this address is valid for
@@ -92,9 +93,11 @@ public class LegacyAddress extends Address {
      * @param key
      *            only the public part is used
      * @return constructed address
+     * @deprecated Use {@link ECKey#toAddress(ScriptType, BitcoinNetwork)}
      */
+    @Deprecated
     public static LegacyAddress fromKey(NetworkParameters params, ECKey key) {
-        return fromPubKeyHash(params, key.getPubKeyHash());
+        return (LegacyAddress) key.toAddress(ScriptType.P2PKH, params.network());
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/SegwitAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/SegwitAddress.java
@@ -237,10 +237,11 @@ public class SegwitAddress extends Address {
      * @param key
      *            only the public part is used
      * @return constructed address
+     * @deprecated Use {@link ECKey#toAddress(ScriptType, org.bitcoinj.base.BitcoinNetwork)}
      */
+    @Deprecated
     public static SegwitAddress fromKey(NetworkParameters params, ECKey key) {
-        checkArgument(key.isCompressed(), "only compressed keys allowed");
-        return fromHash(params, key.getPubKeyHash());
+        return (SegwitAddress) key.toAddress(ScriptType.P2WPKH, params.network());
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/testing/FakeTxBuilder.java
+++ b/core/src/main/java/org/bitcoinj/testing/FakeTxBuilder.java
@@ -18,6 +18,7 @@
 package org.bitcoinj.testing;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.Address;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.base.Coin;
@@ -340,6 +341,6 @@ public class FakeTxBuilder {
     }
 
     private static Address randomAddress(NetworkParameters params) {
-        return LegacyAddress.fromKey(params, new ECKey());
+        return new ECKey().toAddress(ScriptType.P2PKH, params.network());
     }
 }


### PR DESCRIPTION
This (after deprecated methods are removed) eliminates all dependencies in the address classes and is a step towards moving address to o.b.base.

TODO: Update all the deprecated usages.