### PR TITLE
Rename AbstractBitcoinNetParams to BitcoinNetworkParams

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -23,7 +23,7 @@ import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.core.internal.InternalUtils;
-import org.bitcoinj.params.AbstractBitcoinNetParams;
+import org.bitcoinj.params.BitcoinNetworkParams;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptOpCodes;
@@ -215,10 +215,10 @@ public class Block extends Message {
         this.transactions.addAll(transactions);
     }
 
-    /** @deprecated Use {@link AbstractBitcoinNetParams#getBlockInflation(int)} */
+    /** @deprecated Use {@link BitcoinNetworkParams#getBlockInflation(int)} */
     @Deprecated
     public Coin getBlockInflation(int height) {
-        return ((AbstractBitcoinNetParams) params).getBlockInflation(height);
+        return ((BitcoinNetworkParams) params).getBlockInflation(height);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
@@ -19,7 +19,7 @@ package org.bitcoinj.core;
 
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Sha256Hash;
-import org.bitcoinj.params.AbstractBitcoinNetParams;
+import org.bitcoinj.params.BitcoinNetworkParams;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.Script.VerifyFlag;
 import org.bitcoinj.script.ScriptPattern;
@@ -507,6 +507,6 @@ public class FullPrunedBlockChain extends AbstractBlockChain {
     }
 
     private Coin getBlockInflation(int height) {
-        return ((AbstractBitcoinNetParams) params).getBlockInflation(height);
+        return ((BitcoinNetworkParams) params).getBlockInflation(height);
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -21,7 +21,7 @@ import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.Sha256Hash;
-import org.bitcoinj.params.AbstractBitcoinNetParams;
+import org.bitcoinj.params.BitcoinNetworkParams;
 import org.bitcoinj.protocols.payments.PaymentProtocol;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.store.BlockStore;
@@ -167,12 +167,12 @@ public abstract class NetworkParameters {
      * Return network parameters for a network id
      * @param id the network id
      * @return the network parameters for the given string ID or NULL if not recognized
-     * @deprecated Use {@link AbstractBitcoinNetParams#fromID(String)}
+     * @deprecated Use {@link BitcoinNetworkParams#fromID(String)}
      */
     @Deprecated
     @Nullable
     public static NetworkParameters fromID(String id) {
-        return AbstractBitcoinNetParams.fromID(id);
+        return BitcoinNetworkParams.fromID(id);
     }
 
     /**
@@ -183,7 +183,7 @@ public abstract class NetworkParameters {
      */
     public static NetworkParameters of(Network network) {
         if (network instanceof BitcoinNetwork) {
-            return AbstractBitcoinNetParams.of((BitcoinNetwork) network);
+            return BitcoinNetworkParams.of((BitcoinNetwork) network);
         } else {
                 throw new IllegalArgumentException("Unknown network");
         }

--- a/core/src/main/java/org/bitcoinj/params/AbstractBitcoinNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/AbstractBitcoinNetParams.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.params;
+
+import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.core.NetworkParameters;
+
+/**
+ * Temporary class in NetworkParameters hierarchy to allow rename/migration to {@link BitcoinNetworkParams}.
+ * @deprecated Use {@link BitcoinNetworkParams}.
+ */
+public abstract class AbstractBitcoinNetParams extends NetworkParameters {
+    protected AbstractBitcoinNetParams(BitcoinNetwork network) {
+        super(network);
+    }
+}

--- a/core/src/main/java/org/bitcoinj/params/BitcoinNetworkParams.java
+++ b/core/src/main/java/org/bitcoinj/params/BitcoinNetworkParams.java
@@ -45,7 +45,7 @@ import static com.google.common.base.Preconditions.checkState;
 /**
  * Parameters for Bitcoin-like networks.
  */
-public abstract class AbstractBitcoinNetParams extends NetworkParameters {
+public abstract class BitcoinNetworkParams extends NetworkParameters {
 
     /**
      * Scheme part for Bitcoin URIs.
@@ -59,7 +59,7 @@ public abstract class AbstractBitcoinNetParams extends NetworkParameters {
      */
     public static final int REWARD_HALVING_INTERVAL = 210000;
 
-    private static final Logger log = LoggerFactory.getLogger(AbstractBitcoinNetParams.class);
+    private static final Logger log = LoggerFactory.getLogger(BitcoinNetworkParams.class);
 
     /** lazy-initialized by the first call to {@link NetworkParameters#getGenesisBlock()} */
     protected Block genesisBlock;
@@ -67,7 +67,7 @@ public abstract class AbstractBitcoinNetParams extends NetworkParameters {
     /**
      * No-args constructor
      */
-    public AbstractBitcoinNetParams(BitcoinNetwork network) {
+    public BitcoinNetworkParams(BitcoinNetwork network) {
         super(network);
         interval = INTERVAL;
         subsidyDecreaseBlockCount = REWARD_HALVING_INTERVAL;
@@ -79,7 +79,7 @@ public abstract class AbstractBitcoinNetParams extends NetworkParameters {
      * @return the network parameters for the given string ID or NULL if not recognized
      */
     @Nullable
-    public static AbstractBitcoinNetParams fromID(String id) {
+    public static BitcoinNetworkParams fromID(String id) {
         if (id.equals(BitcoinNetwork.ID_MAINNET)) {
             return MainNetParams.get();
         } else if (id.equals(BitcoinNetwork.ID_TESTNET)) {
@@ -101,7 +101,7 @@ public abstract class AbstractBitcoinNetParams extends NetworkParameters {
      * @return the network parameters for the given string ID
      * @throws IllegalArgumentException if unknown network
      */
-    public static AbstractBitcoinNetParams of(BitcoinNetwork network) {
+    public static BitcoinNetworkParams of(BitcoinNetwork network) {
         switch (network) {
             case MAINNET:
                 return MainNetParams.get();

--- a/core/src/main/java/org/bitcoinj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/MainNetParams.java
@@ -27,7 +27,7 @@ import static com.google.common.base.Preconditions.checkState;
 /**
  * Parameters for the main production network on which people trade goods and services.
  */
-public class MainNetParams extends AbstractBitcoinNetParams {
+public class MainNetParams extends BitcoinNetworkParams {
     public static final int MAINNET_MAJORITY_WINDOW = 1000;
     public static final int MAINNET_MAJORITY_REJECT_BLOCK_OUTDATED = 950;
     public static final int MAINNET_MAJORITY_ENFORCE_BLOCK_UPGRADE = 750;

--- a/core/src/main/java/org/bitcoinj/params/RegTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/RegTestParams.java
@@ -27,7 +27,7 @@ import static com.google.common.base.Preconditions.checkState;
 /**
  * Network parameters for the regression test mode of bitcoind in which all blocks are trivially solvable.
  */
-public class RegTestParams extends AbstractBitcoinNetParams {
+public class RegTestParams extends BitcoinNetworkParams {
     private static final long GENESIS_TIME = 1296688602;
     private static final long GENESIS_NONCE = 2;
     private static final Sha256Hash GENESIS_HASH = Sha256Hash.wrap("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206");

--- a/core/src/main/java/org/bitcoinj/params/SigNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/SigNetParams.java
@@ -28,7 +28,7 @@ import static com.google.common.base.Preconditions.checkState;
  * and testing of applications and new Bitcoin versions.</p>
  * <p>See <a href="https://github.com/bitcoin/bips/blob/master/bip-0325.mediawiki">BIP325</a>
  */
-public class SigNetParams extends AbstractBitcoinNetParams {
+public class SigNetParams extends BitcoinNetworkParams {
     public static final int TESTNET_MAJORITY_WINDOW = 100;
     public static final int TESTNET_MAJORITY_REJECT_BLOCK_OUTDATED = 75;
     public static final int TESTNET_MAJORITY_ENFORCE_BLOCK_UPGRADE = 51;

--- a/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
@@ -36,7 +36,7 @@ import static com.google.common.base.Preconditions.checkState;
  * Parameters for the testnet, a separate public instance of Bitcoin that has relaxed rules suitable for development
  * and testing of applications and new Bitcoin versions.
  */
-public class TestNet3Params extends AbstractBitcoinNetParams {
+public class TestNet3Params extends BitcoinNetworkParams {
     public static final int TESTNET_MAJORITY_WINDOW = 100;
     public static final int TESTNET_MAJORITY_REJECT_BLOCK_OUTDATED = 75;
     public static final int TESTNET_MAJORITY_ENFORCE_BLOCK_UPGRADE = 51;

--- a/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
@@ -26,7 +26,7 @@ import org.bitcoinj.core.Utils;
  * Network parameters used by the bitcoinj unit tests (and potentially your own). This lets you solve a block using
  * {@link Block#solve()} by setting difficulty to the easiest possible.
  */
-public class UnitTestParams extends AbstractBitcoinNetParams {
+public class UnitTestParams extends BitcoinNetworkParams {
     public static final int UNITNET_MAJORITY_WINDOW = 8;
     public static final int TESTNET_MAJORITY_REJECT_BLOCK_OUTDATED = 6;
     public static final int TESTNET_MAJORITY_ENFORCE_BLOCK_UPGRADE = 4;

--- a/core/src/main/java/org/bitcoinj/protocols/payments/PaymentProtocol.java
+++ b/core/src/main/java/org/bitcoinj/protocols/payments/PaymentProtocol.java
@@ -27,7 +27,7 @@ import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.Utils;
 import org.bitcoinj.crypto.X509Utils;
-import org.bitcoinj.params.AbstractBitcoinNetParams;
+import org.bitcoinj.params.BitcoinNetworkParams;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.RegTestParams;
 import org.bitcoinj.params.SigNetParams;
@@ -444,7 +444,7 @@ public class PaymentProtocol {
      * @return network parameters for the given string paymentProtocolID or NULL if not recognized
      */
     @Nullable
-    public static AbstractBitcoinNetParams paramsFromPmtProtocolID(String pmtProtocolId) {
+    public static BitcoinNetworkParams paramsFromPmtProtocolID(String pmtProtocolId) {
         if (pmtProtocolId.equals(PAYMENT_PROTOCOL_ID_MAINNET)) {
             return MainNetParams.get();
         } else if (pmtProtocolId.equals(PAYMENT_PROTOCOL_ID_TESTNET)) {

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -34,7 +34,7 @@ import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.core.TransactionWitness;
 import org.bitcoinj.crypto.KeyCrypter;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
-import org.bitcoinj.params.AbstractBitcoinNetParams;
+import org.bitcoinj.params.BitcoinNetworkParams;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptException;
 import org.bitcoinj.utils.ExchangeRate;
@@ -437,7 +437,7 @@ public class WalletProtobufSerializer {
         try {
             Protos.Wallet walletProto = parseToProto(input);
             final String paramsID = walletProto.getNetworkIdentifier();
-            NetworkParameters params = AbstractBitcoinNetParams.fromID(paramsID);
+            NetworkParameters params = BitcoinNetworkParams.fromID(paramsID);
             if (params == null)
                 throw new UnreadableWalletException("Unknown network parameters ID " + paramsID);
             return readWallet(params, extensions, walletProto, forceReset);
@@ -832,7 +832,7 @@ public class WalletProtobufSerializer {
             if (field != 1) // network_identifier
                 return false;
             final String network = cis.readString();
-            return AbstractBitcoinNetParams.fromID(network) != null;
+            return BitcoinNetworkParams.fromID(network) != null;
         } catch (IOException x) {
             return false;
         }

--- a/core/src/test/java/org/bitcoinj/params/BitcoinNetworkParamsTest.java
+++ b/core/src/test/java/org/bitcoinj/params/BitcoinNetworkParamsTest.java
@@ -25,8 +25,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class AbstractBitcoinNetParamsTest {
-    private final AbstractBitcoinNetParams BITCOIN_PARAMS = new AbstractBitcoinNetParams(BitcoinNetwork.TESTNET) {
+public class BitcoinNetworkParamsTest {
+    private final BitcoinNetworkParams BITCOIN_PARAMS = new BitcoinNetworkParams(BitcoinNetwork.TESTNET) {
         @Override
         public Block getGenesisBlock() {
             return null;


### PR DESCRIPTION
I don't think the `Abstract` qualifier is necessary in the class name. We're also changing `Net` to `Network`.,

This PR does things in a non-breaking way, by temporarily inserting a `@Deprecated` shim class named `AbstractBitcoinNetParams` into the hierarchy to allow transition.

This is an improved version of PR #2595 and replaces it.