### PR TITLE
NetworkParameters: remove obsolete reference to acceptableAddress in JavaDoc

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -301,9 +301,7 @@ public abstract class NetworkParameters {
     }
 
     /**
-     * First byte of a base58 encoded address. See {@link LegacyAddress}. This is the same as acceptableAddressCodes[0] and
-     * is the one used for "normal" addresses. Other types of address may be encountered with version codes found in
-     * the acceptableAddressCodes array.
+     * First byte of a base58 encoded address. See {@link LegacyAddress}.
      * @return the header value
      */
     public int getAddressHeader() {


### PR DESCRIPTION
`acceptableAddressCodes[]` was removed in 2018.