### PR TITLE
TransactionOutput: remove deprecated getAddressFrom* methods

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -128,23 +128,6 @@ public class TransactionOutput extends ChildMessage {
         return scriptPubKey;
     }
 
-    @Nullable
-    @Deprecated
-    public LegacyAddress getAddressFromP2PKHScript(NetworkParameters params) throws ScriptException {
-        if (ScriptPattern.isP2PKH(getScriptPubKey()))
-            return LegacyAddress.fromPubKeyHash(params,
-                    ScriptPattern.extractHashFromP2PKH(getScriptPubKey()));
-        return null;
-    }
-
-    @Nullable
-    @Deprecated
-    public LegacyAddress getAddressFromP2SH(NetworkParameters params) throws ScriptException {
-        if (ScriptPattern.isP2SH(getScriptPubKey()))
-            return LegacyAddress.fromScriptHash(params, ScriptPattern.extractHashFromP2SH(getScriptPubKey()));
-        return null;
-    }
-
     @Override
     protected void parse() throws ProtocolException {
         value = readInt64();


### PR DESCRIPTION
* Remove deprecated `getAddressFromP2PKHScript()` and `getAddressFromP2SH()` methods

They have been deprecated for more than one release.