### PR TITLE
NetworkParameters: make id final

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -83,10 +83,9 @@ public abstract class NetworkParameters {
     protected int majorityWindow;
 
     /**
-     * See getId(). This may be null for old deserialized wallets. In that case we derive it heuristically
-     * by looking at the port number.
+     * See getId()
      */
-    protected String id;
+    protected final String id;
     protected final Network network;
 
     /**
@@ -102,6 +101,7 @@ public abstract class NetworkParameters {
 
     protected NetworkParameters(Network network) {
         this.network = network;
+        this.id = network.id();
     }
 
     public static final int TARGET_TIMESPAN = 14 * 24 * 60 * 60;  // 2 weeks per difficulty cycle, on average.

--- a/core/src/main/java/org/bitcoinj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/MainNetParams.java
@@ -37,7 +37,6 @@ public class MainNetParams extends BitcoinNetworkParams {
 
     public MainNetParams() {
         super(BitcoinNetwork.MAINNET);
-        id = BitcoinNetwork.ID_MAINNET;
 
         targetTimespan = TARGET_TIMESPAN;
         maxTarget = ByteUtils.decodeCompactBits(Block.STANDARD_MAX_DIFFICULTY_TARGET);

--- a/core/src/main/java/org/bitcoinj/params/RegTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/RegTestParams.java
@@ -34,8 +34,7 @@ public class RegTestParams extends BitcoinNetworkParams {
 
     public RegTestParams() {
         super(BitcoinNetwork.REGTEST);
-        id = BitcoinNetwork.ID_REGTEST;
-        
+
         targetTimespan = TARGET_TIMESPAN;
         maxTarget = ByteUtils.decodeCompactBits(Block.EASIEST_DIFFICULTY_TARGET);
         // Difficulty adjustments are disabled for regtest.

--- a/core/src/main/java/org/bitcoinj/params/SigNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/SigNetParams.java
@@ -39,7 +39,6 @@ public class SigNetParams extends BitcoinNetworkParams {
 
     public SigNetParams() {
         super(BitcoinNetwork.SIGNET);
-        id = BitcoinNetwork.ID_SIGNET;
 
         targetTimespan = TARGET_TIMESPAN;
         maxTarget = ByteUtils.decodeCompactBits(Block.EASIEST_DIFFICULTY_TARGET);

--- a/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
@@ -46,7 +46,6 @@ public class TestNet3Params extends BitcoinNetworkParams {
 
     public TestNet3Params() {
         super(BitcoinNetwork.TESTNET);
-        id = BitcoinNetwork.ID_TESTNET;
 
         targetTimespan = TARGET_TIMESPAN;
         maxTarget = ByteUtils.decodeCompactBits(Block.STANDARD_MAX_DIFFICULTY_TARGET);

--- a/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
@@ -35,7 +35,6 @@ public class UnitTestParams extends BitcoinNetworkParams {
         // Unit Test Params are BY DEFINITION on the Bitcoin TEST network (i.e. not REGTEST or SIGNET)
         // This means that tests that run against UnitTestParams expect TEST network behavior.
         super(BitcoinNetwork.TESTNET);
-        id = BitcoinNetwork.ID_UNITTESTNET;
 
         targetTimespan = 200000000;  // 6 years. Just a very big number.
         maxTarget = ByteUtils.decodeCompactBits(Block.EASIEST_DIFFICULTY_TARGET);

--- a/core/src/main/java/org/bitcoinj/testing/MockAltNetworkParams.java
+++ b/core/src/main/java/org/bitcoinj/testing/MockAltNetworkParams.java
@@ -34,7 +34,6 @@ public class MockAltNetworkParams extends NetworkParameters {
 
     public MockAltNetworkParams() {
         super(new MockAltNetwork());
-        id = network.id();
         addressHeader = 48;
         p2shHeader = 5;
     }


### PR DESCRIPTION
and initialize it from Network.id()

Note that I removed the following comment:

> This may be null for old deserialized wallets. In that case we derive it heuristically by looking at the port number.

I don't see the code that derives it heuristically, so I'm assuming it's ok to remove the comment and it's ok to make `id` final.