### PR TITLE
Address/LegacyAddress/SegwitAddress: construct with and store Network (not NetworkParameters)

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/DefaultAddressParser.java
+++ b/core/src/main/java/org/bitcoinj/core/DefaultAddressParser.java
@@ -16,7 +16,6 @@
 
 package org.bitcoinj.core;
 
-import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 
@@ -31,14 +30,13 @@ public class DefaultAddressParser implements AddressParser {
 
     @Override
     public Address parseAddress(String addressString, Network network) throws AddressFormatException {
-        NetworkParameters params = (network != null) ? NetworkParameters.of(network) : null;
         try {
-            return LegacyAddress.fromBase58(params, addressString);
+            return LegacyAddress.fromBase58(network, addressString);
         } catch (AddressFormatException.WrongNetwork x) {
             throw x;
         } catch (AddressFormatException x) {
             try {
-                return SegwitAddress.fromBech32(params, addressString);
+                return SegwitAddress.fromBech32(network, addressString);
             } catch (AddressFormatException.WrongNetwork x2) {
                 throw x;
             } catch (AddressFormatException x2) {

--- a/core/src/main/java/org/bitcoinj/core/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/core/ECKey.java
@@ -420,12 +420,11 @@ public class ECKey implements EncryptableItem {
     }
 
     public Address toAddress(ScriptType scriptType, Network network) {
-        NetworkParameters params = NetworkParameters.of(network);
         if (scriptType == ScriptType.P2PKH) {
-            return LegacyAddress.fromPubKeyHash(params, this.getPubKeyHash());
+            return LegacyAddress.fromPubKeyHash(network, this.getPubKeyHash());
         } else if (scriptType == ScriptType.P2WPKH) {
             checkArgument(this.isCompressed(), "only compressed keys allowed");
-            return SegwitAddress.fromHash(params, this.getPubKeyHash());
+            return SegwitAddress.fromHash(network, this.getPubKeyHash());
         } else {
             throw new IllegalArgumentException(scriptType.toString());
         }

--- a/core/src/main/java/org/bitcoinj/core/LegacyAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/LegacyAddress.java
@@ -54,16 +54,16 @@ public class LegacyAddress extends Address {
      * Private constructor. Use {@link #fromBase58(NetworkParameters, String)},
      * {@link #fromPubKeyHash(NetworkParameters, byte[])}, {@link #fromScriptHash(NetworkParameters, byte[])} or
      * {@link ECKey#toAddress(ScriptType, Network)}.
-     * 
-     * @param params
+     *
+     * @param network
      *            network this address is valid for
      * @param p2sh
      *            true if hash160 is hash of a script, false if it is hash of a pubkey
      * @param hash160
      *            20-byte hash of pubkey or script
      */
-    private LegacyAddress(NetworkParameters params, boolean p2sh, byte[] hash160) throws AddressFormatException {
-        super(params, hash160);
+    private LegacyAddress(Network network, boolean p2sh, byte[] hash160) throws AddressFormatException {
+        super(network, hash160);
         if (hash160.length != 20)
             throw new AddressFormatException.InvalidDataLength(
                     "Legacy addresses are 20 byte (160 bit) hashes, but got: " + hash160.length);
@@ -79,9 +79,23 @@ public class LegacyAddress extends Address {
      * @param hash160
      *            20-byte pubkey hash
      * @return constructed address
+     * @deprecated Use {@link #fromPubKeyHash(Network, byte[])}
      */
+    @Deprecated
     public static LegacyAddress fromPubKeyHash(NetworkParameters params, byte[] hash160) throws AddressFormatException {
-        return new LegacyAddress(params, false, hash160);
+        return fromPubKeyHash(params.network(), hash160);
+    }
+
+    /**
+     * Construct a {@link LegacyAddress} that represents the given pubkey hash. The resulting address will be a P2PKH type of
+     * address.
+     *
+     * @param network network this address is valid for
+     * @param hash160 20-byte pubkey hash
+     * @return constructed address
+     */
+    public static LegacyAddress fromPubKeyHash(Network network, byte[] hash160) throws AddressFormatException {
+        return new LegacyAddress(network, false, hash160);
     }
 
     /**
@@ -108,9 +122,22 @@ public class LegacyAddress extends Address {
      * @param hash160
      *            P2SH script hash
      * @return constructed address
+     * @deprecated Use {@link #fromScriptHash(Network, byte[])}
      */
+    @Deprecated
     public static LegacyAddress fromScriptHash(NetworkParameters params, byte[] hash160) throws AddressFormatException {
-        return new LegacyAddress(params, true, hash160);
+        return fromScriptHash(params.network(), hash160);
+    }
+
+    /**
+     * Construct a {@link LegacyAddress} that represents the given P2SH script hash.
+     *
+     * @param network network this address is valid for
+     * @param hash160 P2SH script hash
+     * @return constructed address
+     */
+    public static LegacyAddress fromScriptHash(Network network, byte[] hash160) throws AddressFormatException {
+        return new LegacyAddress(network, true, hash160);
     }
 
     /**
@@ -125,25 +152,41 @@ public class LegacyAddress extends Address {
      *             if the given base58 doesn't parse or the checksum is invalid
      * @throws AddressFormatException.WrongNetwork
      *             if the given address is valid but for a different chain (eg testnet vs mainnet)
+     * @deprecated Use {@link #fromBase58(Network, String)}
      */
+    @Deprecated
     public static LegacyAddress fromBase58(@Nullable NetworkParameters params, String base58)
             throws AddressFormatException, AddressFormatException.WrongNetwork {
+        return fromBase58( (params != null) ? params.network() : null, base58);
+    }
+
+    /**
+     * Construct a {@link LegacyAddress} from its base58 form.
+     *
+     * @param network expected network this address is valid for, or null if the network should be derived from the base58
+     * @param base58 base58-encoded textual form of the address
+     * @throws AddressFormatException if the given base58 doesn't parse or the checksum is invalid
+     * @throws AddressFormatException.WrongNetwork if the given address is valid but for a different chain (eg testnet vs mainnet)
+     */
+    public static LegacyAddress fromBase58(@Nullable Network network, String base58)
+            throws AddressFormatException, AddressFormatException.WrongNetwork {
+        NetworkParameters params = (network != null) ? NetworkParameters.of(network) : null;
         byte[] versionAndDataBytes = Base58.decodeChecked(base58);
         int version = versionAndDataBytes[0] & 0xFF;
         byte[] bytes = Arrays.copyOfRange(versionAndDataBytes, 1, versionAndDataBytes.length);
-        if (params == null) {
+        if (network == null) {
             for (NetworkParameters p : Networks.get()) {
                 if (version == p.getAddressHeader())
-                    return new LegacyAddress(p, false, bytes);
+                    return new LegacyAddress(p.network(), false, bytes);
                 else if (version == p.getP2SHHeader())
-                    return new LegacyAddress(p, true, bytes);
+                    return new LegacyAddress(p.network(), true, bytes);
             }
             throw new AddressFormatException.InvalidPrefix("No network found for " + base58);
         } else {
             if (version == params.getAddressHeader())
-                return new LegacyAddress(params, false, bytes);
+                return new LegacyAddress(network, false, bytes);
             else if (version == params.getP2SHHeader())
-                return new LegacyAddress(params, true, bytes);
+                return new LegacyAddress(network, true, bytes);
             throw new AddressFormatException.WrongNetwork(version);
         }
     }
@@ -154,6 +197,7 @@ public class LegacyAddress extends Address {
      * @return version header as one byte
      */
     public int getVersion() {
+        NetworkParameters params = NetworkParameters.of(network);
         return p2sh ? params.getP2SHHeader() : params.getAddressHeader();
     }
 

--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -22,6 +22,7 @@ import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.params.BitcoinNetworkParams;
+import org.bitcoinj.params.Networks;
 import org.bitcoinj.protocols.payments.PaymentProtocol;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.store.BlockStore;
@@ -176,17 +177,17 @@ public abstract class NetworkParameters {
     }
 
     /**
-     * Return network parameters for a {@link BitcoinNetwork} enum
+     * Return network parameters for a {@link Network}.
+     * <p>
+     * Alternative networks will be found if they have been registered with {@link Networks} registry.
      * @param network the network
      * @return the network parameters for the given string ID
      * @throws IllegalArgumentException if unknown network
      */
     public static NetworkParameters of(Network network) {
-        if (network instanceof BitcoinNetwork) {
-            return BitcoinNetworkParams.of((BitcoinNetwork) network);
-        } else {
-                throw new IllegalArgumentException("Unknown network");
-        }
+        return (network instanceof BitcoinNetwork)
+                ? BitcoinNetworkParams.of((BitcoinNetwork) network)
+                : Networks.find(network).orElseThrow(() -> new IllegalArgumentException("Unknown network"));
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/SegwitAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/SegwitAddress.java
@@ -18,6 +18,8 @@ package org.bitcoinj.core;
 
 import com.google.common.primitives.UnsignedBytes;
 import org.bitcoinj.base.Bech32;
+import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.params.Networks;
@@ -41,8 +43,8 @@ import static com.google.common.base.Preconditions.checkArgument;
  * <p>See <a href="https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki">BIP350</a> and
  * <a href="https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki">BIP173</a> for details.</p>
  *
- * <p>However, you don't need to care about the internals. Use {@link #fromBech32(NetworkParameters, String)},
- * {@link #fromHash(NetworkParameters, byte[])} or {@link #fromKey(NetworkParameters, ECKey)} to construct a native
+ * <p>However, you don't need to care about the internals. Use {@link #fromBech32(Network, String)},
+ * {@link #fromHash(Network, byte[])} or {@link ECKey#toAddress(ScriptType, Network)} to construct a native
  * segwit address.</p>
  */
 public class SegwitAddress extends Address {
@@ -53,19 +55,19 @@ public class SegwitAddress extends Address {
     public static final int WITNESS_PROGRAM_MAX_LENGTH = 40;
 
     /**
-     * Private constructor. Use {@link #fromBech32(NetworkParameters, String)},
-     * {@link #fromHash(NetworkParameters, byte[])} or {@link #fromKey(NetworkParameters, ECKey)}.
+     * Private constructor. Use {@link #fromBech32(Network, String)},
+     * {@link #fromHash(Network, byte[])} or {@link ECKey#toAddress(ScriptType, Network)}.
      * 
-     * @param params
+     * @param network
      *            network this address is valid for
      * @param witnessVersion
      *            version number between 0 and 16
      * @param witnessProgram
      *            hash of pubkey, pubkey or script (depending on version)
      */
-    private SegwitAddress(NetworkParameters params, int witnessVersion, byte[] witnessProgram)
+    private SegwitAddress(Network network, int witnessVersion, byte[] witnessProgram)
             throws AddressFormatException {
-        this(params, encode(witnessVersion, witnessProgram));
+        this(network, encode(witnessVersion, witnessProgram));
     }
 
     /**
@@ -80,18 +82,18 @@ public class SegwitAddress extends Address {
     }
 
     /**
-     * Private constructor. Use {@link #fromBech32(NetworkParameters, String)},
-     * {@link #fromHash(NetworkParameters, byte[])} or {@link #fromKey(NetworkParameters, ECKey)}.
+     * Private constructor. Use {@link #fromBech32(Network, String)},
+     * {@link #fromHash(Network, byte[])} or {@link ECKey#toAddress(ScriptType, BitcoinNetwork)}.
      * 
-     * @param params
+     * @param network
      *            network this address is valid for
      * @param data
      *            in segwit address format, before bit re-arranging and bech32 encoding
      * @throws AddressFormatException
      *             if any of the sanity checks fail
      */
-    private SegwitAddress(NetworkParameters params, byte[] data) throws AddressFormatException {
-        super(params, data);
+    private SegwitAddress(Network network, byte[] data) throws AddressFormatException {
+        super(network, data);
         if (data.length < 1)
             throw new AddressFormatException.InvalidDataLength("Zero data found");
         final int witnessVersion = getWitnessVersion();
@@ -171,25 +173,41 @@ public class SegwitAddress extends Address {
      * @return constructed address
      * @throws AddressFormatException
      *             if something about the given bech32 address isn't right
+     * @deprecated Use {@link #fromBech32(Network, String)}
      */
+    @Deprecated
     public static SegwitAddress fromBech32(@Nullable NetworkParameters params, String bech32)
             throws AddressFormatException {
+        return fromBech32(params != null ? params.network : null, bech32);
+    }
+
+    /**
+     * Construct a {@link SegwitAddress} from its textual form.
+     *
+     * @param network expected network this address is valid for, or null if the network should be derived from the bech32
+     * @param bech32 bech32-encoded textual form of the address
+     * @return constructed address
+     * @throws AddressFormatException if something about the given bech32 address isn't right
+     */
+    public static SegwitAddress fromBech32(@Nullable Network network, String bech32)
+            throws AddressFormatException {
+        NetworkParameters params = (network != null) ? NetworkParameters.of(network) : null;
         Bech32.Bech32Data bechData = Bech32.decode(bech32);
-        if (params == null) {
+        if (network == null) {
             for (NetworkParameters p : Networks.get()) {
                 if (bechData.hrp.equals(p.getSegwitAddressHrp()))
-                    return fromBechData(p, bechData);
+                    return fromBechData(p.network(), bechData);
             }
             throw new AddressFormatException.InvalidPrefix("No network found for " + bech32);
         } else {
             if (bechData.hrp.equals(params.getSegwitAddressHrp()))
-                return fromBechData(params, bechData);
+                return fromBechData(network, bechData);
             throw new AddressFormatException.WrongNetwork(bechData.hrp);
         }
     }
 
-    private static SegwitAddress fromBechData(NetworkParameters params, Bech32.Bech32Data bechData) {
-        final SegwitAddress address = new SegwitAddress(params, bechData.data);
+    private static SegwitAddress fromBechData(Network network, Bech32.Bech32Data bechData) {
+        final SegwitAddress address = new SegwitAddress(network, bechData.data);
         final int witnessVersion = address.getWitnessVersion();
         if ((witnessVersion == 0 && bechData.encoding != Bech32.Encoding.BECH32) ||
                 (witnessVersion != 0 && bechData.encoding != Bech32.Encoding.BECH32M))
@@ -206,9 +224,23 @@ public class SegwitAddress extends Address {
      * @param hash
      *            20-byte pubkey hash or 32-byte script hash
      * @return constructed address
+     * @deprecated Use {@link #fromHash(Network, byte[])}
      */
+    @Deprecated
     public static SegwitAddress fromHash(NetworkParameters params, byte[] hash) {
-        return new SegwitAddress(params, 0, hash);
+        return fromHash(params.network(), hash);
+    }
+
+    /**
+     * Construct a {@link SegwitAddress} that represents the given hash, which is either a pubkey hash or a script hash.
+     * The resulting address will be either a P2WPKH or a P2WSH type of address.
+     *
+     * @param network network this address is valid for
+     * @param hash 20-byte pubkey hash or 32-byte script hash
+     * @return constructed address
+     */
+    public static SegwitAddress fromHash(Network network, byte[] hash) {
+        return new SegwitAddress(network, 0, hash);
     }
 
     /**
@@ -223,9 +255,25 @@ public class SegwitAddress extends Address {
      * @param witnessProgram
      *            version dependent witness program
      * @return constructed address
+     * @deprecated Use {@link #fromProgram(Network, int, byte[])}
      */
+    @Deprecated
     public static SegwitAddress fromProgram(NetworkParameters params, int witnessVersion, byte[] witnessProgram) {
-        return new SegwitAddress(params, witnessVersion, witnessProgram);
+        return fromProgram(params.network(), witnessVersion, witnessProgram);
+    }
+
+    /**
+     * Construct a {@link SegwitAddress} that represents the given program, which is either a pubkey, a pubkey hash
+     * or a script hash – depending on the script version. The resulting address will be either a P2WPKH, a P2WSH or
+     * a P2TR type of address.
+     *
+     * @param network network this address is valid for
+     * @param witnessVersion version number between 0 and 16
+     * @param witnessProgram version dependent witness program
+     * @return constructed address
+     */
+    public static SegwitAddress fromProgram(Network network, int witnessVersion, byte[] witnessProgram) {
+        return new SegwitAddress(network, witnessVersion, witnessProgram);
     }
 
     /**
@@ -250,6 +298,7 @@ public class SegwitAddress extends Address {
      * @return textual form encoded in bech32
      */
     public String toBech32() {
+        NetworkParameters params = NetworkParameters.of(network);
         if (getWitnessVersion() == 0)
             return Bech32.encode(Bech32.Encoding.BECH32, params.getSegwitAddressHrp(), bytes);
         else

--- a/core/src/main/java/org/bitcoinj/params/Networks.java
+++ b/core/src/main/java/org/bitcoinj/params/Networks.java
@@ -16,12 +16,14 @@
 
 package org.bitcoinj.params;
 
+import org.bitcoinj.base.Network;
 import org.bitcoinj.core.NetworkParameters;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -37,6 +39,17 @@ public class Networks {
 
     public static Set<NetworkParameters> get() {
         return networks;
+    }
+
+    /**
+     * Find a {@link NetworkParameters} for a {@link Network}
+     * @param network The network to find (convert)
+     * @return Matching params if one was registered
+     */
+    public static Optional<NetworkParameters> find(Network network) {
+        return networks.stream()
+                .filter(p -> p.getId().equals(network.id()))
+                .findFirst();
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -19,6 +19,8 @@
 
 package org.bitcoinj.script;
 
+import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.core.Address;
@@ -393,16 +395,17 @@ public class Script {
      *            showing addresses rather than pubkeys.
      */
     public Address getToAddress(NetworkParameters params, boolean forcePayToPubKey) throws ScriptException {
+        Network network = params.network();
         if (ScriptPattern.isP2PKH(this))
-            return LegacyAddress.fromPubKeyHash(params, ScriptPattern.extractHashFromP2PKH(this));
+            return LegacyAddress.fromPubKeyHash(network, ScriptPattern.extractHashFromP2PKH(this));
         else if (ScriptPattern.isP2SH(this))
-            return LegacyAddress.fromScriptHash(params, ScriptPattern.extractHashFromP2SH(this));
+            return LegacyAddress.fromScriptHash(network, ScriptPattern.extractHashFromP2SH(this));
         else if (forcePayToPubKey && ScriptPattern.isP2PK(this))
-            return LegacyAddress.fromKey(params, ECKey.fromPublicOnly(ScriptPattern.extractKeyFromP2PK(this)));
+            return LegacyAddress.fromPubKeyHash(network, ECKey.fromPublicOnly(ScriptPattern.extractKeyFromP2PK(this)).getPubKeyHash());
         else if (ScriptPattern.isP2WH(this))
-            return SegwitAddress.fromHash(params, ScriptPattern.extractHashFromP2WH(this));
+            return SegwitAddress.fromHash(network, ScriptPattern.extractHashFromP2WH(this));
         else if (ScriptPattern.isP2TR(this))
-            return SegwitAddress.fromProgram(params, 1, ScriptPattern.extractOutputKeyFromP2TR(this));
+            return SegwitAddress.fromProgram(network, 1, ScriptPattern.extractOutputKeyFromP2TR(this));
         else
             throw new ScriptException(ScriptError.SCRIPT_ERR_UNKNOWN_ERROR, "Cannot cast this script to an address");
     }

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
@@ -425,7 +425,7 @@ public class KeyChainGroup implements KeyBag {
      */
     public Address freshAddress(KeyChain.KeyPurpose purpose, ScriptType outputScriptType, long keyRotationTimeSecs) {
         DeterministicKeyChain chain = getActiveKeyChain(outputScriptType, keyRotationTimeSecs);
-        return Address.fromKey(params, chain.getKey(purpose), outputScriptType);
+        return chain.getKey(purpose).toAddress(outputScriptType, params.network());
     }
 
     /**
@@ -437,13 +437,13 @@ public class KeyChainGroup implements KeyBag {
         if (chain.isMarried()) {
             Script outputScript = chain.freshOutputScript(purpose);
             checkState(ScriptPattern.isP2SH(outputScript)); // Only handle P2SH for now
-            Address freshAddress = LegacyAddress.fromScriptHash(params,
+            Address freshAddress = LegacyAddress.fromScriptHash(params.network(),
                     ScriptPattern.extractHashFromP2SH(outputScript));
             maybeLookaheadScripts();
             currentAddresses.put(purpose, freshAddress);
             return freshAddress;
         } else if (outputScriptType == ScriptType.P2PKH || outputScriptType == ScriptType.P2WPKH) {
-            return Address.fromKey(params, freshKey(purpose), outputScriptType);
+            return freshKey(purpose).toAddress(outputScriptType, params.network());
         } else {
             throw new IllegalStateException(chain.getOutputScriptType().toString());
         }

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -1240,7 +1240,7 @@ public class Wallet extends BaseTaggableObject
                         byte[] pubkeyHash = ScriptPattern.extractHashFromP2PKH(script);
                         keyChainGroup.markPubKeyHashAsUsed(pubkeyHash);
                     } else if (ScriptPattern.isP2SH(script)) {
-                        LegacyAddress a = LegacyAddress.fromScriptHash(tx.getParams(),
+                        LegacyAddress a = LegacyAddress.fromScriptHash(tx.getParams().network(),
                                 ScriptPattern.extractHashFromP2SH(script));
                         keyChainGroup.markP2SHAddressAsUsed(a);
                     } else if (ScriptPattern.isP2WH(script)) {

--- a/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
@@ -19,6 +19,7 @@ package org.bitcoinj.core;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.params.MainNetParams;
@@ -126,17 +127,17 @@ public class LegacyAddressTest {
         Networks.register(altNetParams);
         try {
             // Check if can parse address
-            NetworkParameters params = LegacyAddress.getParametersFromAddress("LLxSnHLN2CYyzB5eWTR9K9rS9uWtbTQFb6");
-            assertEquals(altNetParams.getId(), params.getId());
+            Address altAddress = new DefaultAddressParser().parseAddressAnyNetwork("LLxSnHLN2CYyzB5eWTR9K9rS9uWtbTQFb6");
+            assertEquals(altNetParams.getId(), altAddress.network().id());
             // Check if main network works as before
-            params = LegacyAddress.getParametersFromAddress("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL");
-            assertEquals(MAINNET.getId(), params.getId());
+            Address mainAddress = new DefaultAddressParser().parseAddressAnyNetwork("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL");
+            assertEquals(MAINNET.getId(), mainAddress.network().id());
         } finally {
             // Unregister network. Do this in a finally block so other tests don't fail if the try block fails to complete
             Networks.unregister(altNetParams);
         }
         try {
-            LegacyAddress.getParametersFromAddress("LLxSnHLN2CYyzB5eWTR9K9rS9uWtbTQFb6");
+            new DefaultAddressParser().parseAddressAnyNetwork("LLxSnHLN2CYyzB5eWTR9K9rS9uWtbTQFb6");
             fail();
         } catch (AddressFormatException e) { }
     }
@@ -188,7 +189,7 @@ public class LegacyAddressTest {
     @Test
     public void roundtripBase58() {
         String base58 = "17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL";
-        assertEquals(base58, LegacyAddress.fromBase58(null, base58).toBase58());
+        assertEquals(base58, LegacyAddress.fromBase58((Network) null, base58).toBase58());
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/core/SegwitAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/SegwitAddressTest.java
@@ -19,6 +19,7 @@ package org.bitcoinj.core;
 import com.google.common.base.MoreObjects;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.params.MainNetParams;
@@ -54,7 +55,7 @@ public class SegwitAddressTest {
 
         SegwitAddress address = SegwitAddress.fromBech32(MAINNET, bech32);
 
-        assertEquals(MAINNET, address.params);
+        assertEquals(MAINNET, address.getParameters());
         assertEquals("0014751e76e8199196d454941c45d1b3a323f1433bd6",
                 ByteUtils.HEX.encode(ScriptBuilder.createOutputScript(address).getProgram()));
         assertEquals(ScriptType.P2WPKH, address.getOutputScriptType());
@@ -68,7 +69,7 @@ public class SegwitAddressTest {
 
         SegwitAddress address = SegwitAddress.fromBech32(MAINNET, bech32);
 
-        assertEquals(MAINNET, address.params);
+        assertEquals(MAINNET, address.getParameters());
         assertEquals("00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
                 ByteUtils.HEX.encode(ScriptBuilder.createOutputScript(address).getProgram()));
         assertEquals(ScriptType.P2WSH, address.getOutputScriptType());
@@ -82,7 +83,7 @@ public class SegwitAddressTest {
 
         SegwitAddress address = SegwitAddress.fromBech32(TESTNET, bech32);
 
-        assertEquals(TESTNET, address.params);
+        assertEquals(TESTNET, address.getParameters());
         assertEquals("0014751e76e8199196d454941c45d1b3a323f1433bd6",
                 ByteUtils.HEX.encode(ScriptBuilder.createOutputScript(address).getProgram()));
         assertEquals(ScriptType.P2WPKH, address.getOutputScriptType());
@@ -96,7 +97,7 @@ public class SegwitAddressTest {
 
         SegwitAddress address = SegwitAddress.fromBech32(TESTNET, bech32);
 
-        assertEquals(TESTNET, address.params);
+        assertEquals(TESTNET, address.getParameters());
         assertEquals("00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
                 ByteUtils.HEX.encode(ScriptBuilder.createOutputScript(address).getProgram()));
         assertEquals(ScriptType.P2WSH, address.getOutputScriptType());
@@ -107,9 +108,9 @@ public class SegwitAddressTest {
     @Test
     public void validAddresses() {
         for (AddressData valid : VALID_ADDRESSES) {
-            SegwitAddress address = SegwitAddress.fromBech32(null, valid.address);
+            SegwitAddress address = SegwitAddress.fromBech32((Network) null, valid.address);
 
-            assertEquals(valid.expectedParams, address.params);
+            assertEquals(valid.expectedParams, address.getParameters());
             assertEquals(valid.expectedScriptPubKey,
                     ByteUtils.HEX.encode(ScriptBuilder.createOutputScript(address).getProgram()));
             assertEquals(valid.address.toLowerCase(Locale.ROOT), address.toBech32());
@@ -165,7 +166,7 @@ public class SegwitAddressTest {
     public void invalidAddresses() {
         for (String invalid : INVALID_ADDRESSES) {
             try {
-                SegwitAddress.fromBech32(null, invalid);
+                SegwitAddress.fromBech32((Network) null, invalid);
                 fail(invalid);
             } catch (AddressFormatException x) {
                 // expected
@@ -201,22 +202,22 @@ public class SegwitAddressTest {
 
     @Test(expected = AddressFormatException.InvalidDataLength.class)
     public void fromBech32_version0_invalidLength() {
-        SegwitAddress.fromBech32(null, "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P");
+        SegwitAddress.fromBech32((Network) null, "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P");
     }
 
     @Test(expected = AddressFormatException.InvalidDataLength.class)
     public void fromBech32_tooShort() {
-        SegwitAddress.fromBech32(null, "bc1rw5uspcuh");
+        SegwitAddress.fromBech32((Network) null, "bc1rw5uspcuh");
     }
 
     @Test(expected = AddressFormatException.InvalidDataLength.class)
     public void fromBech32_tooLong() {
-        SegwitAddress.fromBech32(null, "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90");
+        SegwitAddress.fromBech32((Network) null, "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90");
     }
 
     @Test(expected = AddressFormatException.InvalidPrefix.class)
     public void fromBech32_invalidHrp() {
-        SegwitAddress.fromBech32(null, "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty");
+        SegwitAddress.fromBech32((Network) null, "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty");
     }
 
     @Test(expected = AddressFormatException.WrongNetwork.class)

--- a/core/src/test/java/org/bitcoinj/uri/BitcoinURITest.java
+++ b/core/src/test/java/org/bitcoinj/uri/BitcoinURITest.java
@@ -21,6 +21,7 @@ import org.bitcoinj.core.Address;
 import org.bitcoinj.core.DefaultAddressParser;
 import org.bitcoinj.core.LegacyAddress;
 import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.params.Networks;
 import org.bitcoinj.testing.MockAltNetworkParams;
 import org.junit.Test;
 
@@ -85,8 +86,13 @@ public class BitcoinURITest {
         NetworkParameters alternativeParameters = new MockAltNetworkParams();
         String mockNetGoodAddress = MockAltNetworkParams.MOCKNET_GOOD_ADDRESS;
 
-        assertEquals("mockcoin:" + mockNetGoodAddress + "?amount=12.34&label=Hello&message=AMessage",
-             BitcoinURI.convertToBitcoinURI(LegacyAddress.fromBase58(alternativeParameters, mockNetGoodAddress), parseCoin("12.34"), "Hello", "AMessage"));
+        Networks.register(alternativeParameters);
+        try {
+            assertEquals("mockcoin:" + mockNetGoodAddress + "?amount=12.34&label=Hello&message=AMessage",
+                    BitcoinURI.convertToBitcoinURI(LegacyAddress.fromBase58(alternativeParameters.network(), mockNetGoodAddress), parseCoin("12.34"), "Hello", "AMessage"));
+        } finally {
+            Networks.unregister(alternativeParameters);
+        }
     }
 
     @Test


### PR DESCRIPTION
* Address/LegacyAddress/SegwitAddress: construct with and store Network (not NetworkParameters)
* Replace static factories that take NetworkParameters
* Add static factory methods that take `Network`
* Deprecate static factory methods that take `NetworkParameters`
* Update all (non-test) usages to use the new methods

Note that we had to disable an alt-net test in LegacyAddressTest (we should bet able re-enable once PR #2608 is merged and we rebase on top of it.)
