### PR TITLE
LegacyAddress/SegwitAddress: normalize network type

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/LegacyAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/LegacyAddress.java
@@ -20,6 +20,7 @@ package org.bitcoinj.core;
 
 import com.google.common.primitives.UnsignedBytes;
 import org.bitcoinj.base.Base58;
+import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.params.Networks;
@@ -63,11 +64,22 @@ public class LegacyAddress extends Address {
      *            20-byte hash of pubkey or script
      */
     private LegacyAddress(Network network, boolean p2sh, byte[] hash160) throws AddressFormatException {
-        super(network, hash160);
+        super(normalizeNetwork(network), hash160);
         if (hash160.length != 20)
             throw new AddressFormatException.InvalidDataLength(
                     "Legacy addresses are 20 byte (160 bit) hashes, but got: " + hash160.length);
         this.p2sh = p2sh;
+    }
+
+    private static Network normalizeNetwork(Network network) {
+        // LegacyAddress does not distinguish between the different testnet types, normalize to TESTNET
+        if (network instanceof BitcoinNetwork) {
+            BitcoinNetwork bitcoinNetwork = (BitcoinNetwork) network;
+            if (bitcoinNetwork == BitcoinNetwork.SIGNET || bitcoinNetwork == BitcoinNetwork.REGTEST) {
+                return BitcoinNetwork.TESTNET;
+            }
+        }
+        return network;
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/SegwitAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/SegwitAddress.java
@@ -18,6 +18,7 @@ package org.bitcoinj.core;
 
 import com.google.common.primitives.UnsignedBytes;
 import org.bitcoinj.base.Bech32;
+import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.exceptions.AddressFormatException;
@@ -69,6 +70,17 @@ public class SegwitAddress extends Address {
         this(network, encode(witnessVersion, witnessProgram));
     }
 
+    private static Network normalizeNetwork(Network network) {
+        // SegwitAddress does not distinguish between the SIGNET and TESTNET, normalize to TESTNET
+        if (network instanceof BitcoinNetwork) {
+            BitcoinNetwork bitcoinNetwork = (BitcoinNetwork) network;
+            if (bitcoinNetwork == BitcoinNetwork.SIGNET) {
+                return BitcoinNetwork.TESTNET;
+            }
+        }
+        return network;
+    }
+
     /**
      * Helper for the above constructor.
      */
@@ -92,7 +104,7 @@ public class SegwitAddress extends Address {
      *             if any of the sanity checks fail
      */
     private SegwitAddress(Network network, byte[] data) throws AddressFormatException {
-        super(network, data);
+        super(normalizeNetwork(network), data);
         if (data.length < 1)
             throw new AddressFormatException.InvalidDataLength("Zero data found");
         final int witnessVersion = getWitnessVersion();

--- a/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/LegacyAddressTest.java
@@ -25,6 +25,8 @@ import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.Networks;
+import org.bitcoinj.params.RegTestParams;
+import org.bitcoinj.params.SigNetParams;
 import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.base.ScriptType;
@@ -40,6 +42,7 @@ import java.util.List;
 
 import static org.bitcoinj.base.utils.ByteUtils.HEX;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -77,6 +80,19 @@ public class LegacyAddressTest {
 
         LegacyAddress b = LegacyAddress.fromBase58(BitcoinNetwork.MAINNET, "17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL");
         assertEquals("4a22c3c4cbb31e4d03b15550636762bda0baf85a", ByteUtils.HEX.encode(b.getHash()));
+    }
+
+    @Test
+    public void equalityOfEquivalentNetworks() {
+        LegacyAddress a = LegacyAddress.fromBase58(BitcoinNetwork.TESTNET, "n4eA2nbYqErp7H6jebchxAN59DmNpksexv");
+        LegacyAddress b = LegacyAddress.fromBase58(BitcoinNetwork.SIGNET, "n4eA2nbYqErp7H6jebchxAN59DmNpksexv");
+        LegacyAddress c = LegacyAddress.fromBase58(BitcoinNetwork.REGTEST, "n4eA2nbYqErp7H6jebchxAN59DmNpksexv");
+        assertEquals(a, b);
+        assertEquals(b, c);
+        assertEquals(a, c);
+        assertEquals(a.toString(), b.toString());
+        assertEquals(b.toString(), c.toString());
+        assertEquals(a.toString(), c.toString());
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/core/SegwitAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/SegwitAddressTest.java
@@ -93,6 +93,17 @@ public class SegwitAddressTest {
     }
 
     @Test
+    public void equalityOfEquivalentNetworks() {
+        String bech32 = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx";
+
+        SegwitAddress a = SegwitAddress.fromBech32(BitcoinNetwork.TESTNET, bech32);
+        SegwitAddress b = SegwitAddress.fromBech32(BitcoinNetwork.SIGNET, bech32);
+
+        assertEquals(a, b);
+        assertEquals(a.toString(), b.toString());
+    }
+
+    @Test
     public void example_p2wsh_testnet() {
         String bech32 = "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7";
 


### PR DESCRIPTION
normalize/canonicalize network member of Address types
 
`LegacyAddress`: map `SIGNET` and `REGTEST` to `TESTNET`
`SegwitAddress`: map `SIGNET` to `TESTNET`

I'm **not sure this is a good idea**, but I wanted to to at least discuss it. (**Update**: I now think it is a good idea.)

Currently...
`LegacyAddress` (Base58) supports encoding two network types in an address: `MAINNET` and `TESTNET`
`SegwitAddress` (Bech32) supports encoding three network types in an address: `MAINNET`,  `TESTNET`, and `REGTEST`.

The current code in `SegwitAddress.fromBech32(Net*, String)` will (probably?) throw an exception if given a RegTest Segwit address string. This is because `Networks.networks` contains the two entries for the networks supported by `LegacyAddress`.

This PR maps the network types that can't really be encoded into an address string into the type that a mapping from string to address would give. This might be considered a change in behavior. Although the existing behavior is a little strange.

This PR depends upon PR #2612, but would be DRAFT anyways because its main purpose is to start a discussion.