### PR TITLE
DefaultAddessParser: implement parse*AnyNetwork() methods

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Address.java
+++ b/core/src/main/java/org/bitcoinj/core/Address.java
@@ -35,7 +35,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * form.
  */
 public abstract class Address implements Comparable<Address> {
-    protected static final AddressParser addressParser = new DefaultAddressParser();
     protected final Network network;
     protected final byte[] bytes;
 
@@ -80,6 +79,7 @@ public abstract class Address implements Comparable<Address> {
     @Deprecated
     public static Address fromString(@Nullable NetworkParameters params, String str)
             throws AddressFormatException {
+        AddressParser addressParser = DefaultAddressParser.fromNetworks();
         return (params != null)
                     ? addressParser.parseAddress(str, params.network())
                     : addressParser.parseAddressAnyNetwork(str);

--- a/core/src/main/java/org/bitcoinj/core/DefaultAddressParser.java
+++ b/core/src/main/java/org/bitcoinj/core/DefaultAddressParser.java
@@ -16,16 +16,87 @@
 
 package org.bitcoinj.core;
 
+import org.bitcoinj.base.Base58;
+import org.bitcoinj.base.Bech32;
+import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.exceptions.AddressFormatException;
+import org.bitcoinj.base.utils.StreamUtils;
+import org.bitcoinj.params.Networks;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
- * Address Parser that knows about the address types supported by bitcoinj core.
+ * Address Parser that knows about the address types supported by bitcoinj core and is configurable
+ * with additional Network types.
  */
 public class DefaultAddressParser implements AddressParser {
+
+    // Networks to try when parsing segwit addresses
+    public static final List<Network> DEFAULT_NETWORKS_SEGWIT = unmodifiableList(
+                                                                    BitcoinNetwork.MAINNET,
+                                                                    BitcoinNetwork.TESTNET,
+                                                                    BitcoinNetwork.REGTEST);
+
+    // Networks to try when parsing legacy (base58) addresses
+    public static final List<Network> DEFAULT_NETWORKS_LEGACY = unmodifiableList(
+                                                                    BitcoinNetwork.MAINNET,
+                                                                    BitcoinNetwork.TESTNET);
+
+    // Networks to search when parsing segwit addresses
+    private final List<Network> segwitNetworks;
+    // Networks to search when parsing base58 addresses
+    private final List<Network> base58Networks;
+
+    /**
+     * DefaultAddressParser with default network lists
+     */
+    public DefaultAddressParser() {
+        this(DEFAULT_NETWORKS_SEGWIT, DEFAULT_NETWORKS_LEGACY);
+    }
+
+    /**
+     * Use this constructor if you have a custom list of networks to use when parsing addresses
+     * @param segwitNetworks Networks to search when parsing segwit addresses
+     * @param base58Networks Networks to search when parsing base58 addresses
+     */
+    public DefaultAddressParser(List<Network> segwitNetworks, List<Network> base58Networks) {
+        this.segwitNetworks = segwitNetworks;
+        this.base58Networks = base58Networks;
+    }
+
+    /**
+     * Dynamically create a new AddressParser using a snapshot of currently configured networks
+     * from Networks.get().
+     * @return A backward-compatible parser
+     */
+    @Deprecated
+    public static DefaultAddressParser fromNetworks() {
+        List<Network> nets = Networks.get().stream()
+                .map(NetworkParameters::network)
+                .collect(StreamUtils.toUnmodifiableList());
+        return new DefaultAddressParser(nets, nets);
+    }
+
     @Override
     public Address parseAddressAnyNetwork(String addressString) throws AddressFormatException {
-        return parseAddress(addressString, null);
+        try {
+            return parseBase58AnyNetwork(addressString);
+        } catch (AddressFormatException.WrongNetwork x) {
+            throw x;
+        } catch (AddressFormatException x) {
+            try {
+                return parseBech32AnyNetwork(addressString);
+            } catch (AddressFormatException.WrongNetwork x2) {
+                throw x;
+            } catch (AddressFormatException x2) {
+                //throw new AddressFormatException(addressString);
+                throw x2;
+            }
+        }
     }
 
     @Override
@@ -43,5 +114,46 @@ public class DefaultAddressParser implements AddressParser {
                 throw new AddressFormatException(addressString);
             }
         }
+    }
+
+    /**
+     * Construct a {@link SegwitAddress} from its textual form.
+     *
+     * @param bech32 bech32-encoded textual form of the address
+     * @return constructed address
+     * @throws AddressFormatException if something about the given bech32 address isn't right
+     */
+    private SegwitAddress parseBech32AnyNetwork(String bech32)
+            throws AddressFormatException {
+        String hrp = Bech32.decode(bech32).hrp;
+        return segwitNetworks.stream()
+                .map(NetworkParameters::of)
+                .filter(p -> hrp.equals(p.getSegwitAddressHrp()))
+                .findFirst()
+                .map(p -> SegwitAddress.fromBech32(p.network(), bech32))
+                .orElseThrow(() -> new AddressFormatException.InvalidPrefix("No network found for " + bech32));
+    }
+
+    /**
+     * Construct a {@link LegacyAddress} from its base58 form.
+     *
+     * @param base58 base58-encoded textual form of the address
+     * @throws AddressFormatException if the given base58 doesn't parse or the checksum is invalid
+     * @throws AddressFormatException.WrongNetwork if the given address is valid but for a different chain (eg testnet vs mainnet)
+     */
+    private LegacyAddress parseBase58AnyNetwork(String base58)
+            throws AddressFormatException, AddressFormatException.WrongNetwork {
+        int version = Base58.decodeChecked(base58)[0] & 0xFF;
+        return base58Networks.stream()
+                .map(NetworkParameters::of)
+                .filter(p ->  (version == p.getAddressHeader()) || (version == p.getP2SHHeader()))
+                .findFirst()
+                .map(p -> LegacyAddress.fromBase58(p.network(), base58))
+                .orElseThrow(() -> new AddressFormatException.InvalidPrefix("No network found for " + base58));
+    }
+
+    // Create an unmodifiable set of NetworkParameters from an array/varargs
+    private static List<Network> unmodifiableList(Network... ts) {
+        return Collections.unmodifiableList(new ArrayList<>(Arrays.asList(ts)));
     }
 }

--- a/core/src/test/java/org/bitcoinj/core/SegwitAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/SegwitAddressTest.java
@@ -39,6 +39,7 @@ import static org.junit.Assert.fail;
 public class SegwitAddressTest {
     private static final MainNetParams MAINNET = MainNetParams.get();
     private static final TestNet3Params TESTNET = TestNet3Params.get();
+    private static final AddressParser addressParser = new DefaultAddressParser();
 
     @Test
     public void equalsContract() {
@@ -120,7 +121,7 @@ public class SegwitAddressTest {
     @Test
     public void validAddresses() {
         for (AddressData valid : VALID_ADDRESSES) {
-            SegwitAddress address = SegwitAddress.fromBech32((Network) null, valid.address);
+            SegwitAddress address = (SegwitAddress) addressParser.parseAddressAnyNetwork(valid.address);
 
             assertEquals(valid.expectedParams, address.getParameters());
             assertEquals(valid.expectedScriptPubKey,
@@ -176,7 +177,7 @@ public class SegwitAddressTest {
     public void invalidAddresses() {
         for (String invalid : INVALID_ADDRESSES) {
             try {
-                SegwitAddress.fromBech32((Network) null, invalid);
+                addressParser.parseAddressAnyNetwork(invalid);
                 fail(invalid);
             } catch (AddressFormatException x) {
                 // expected
@@ -212,17 +213,17 @@ public class SegwitAddressTest {
 
     @Test(expected = AddressFormatException.InvalidDataLength.class)
     public void fromBech32_version0_invalidLength() {
-        SegwitAddress.fromBech32((Network) null, "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P");
+        addressParser.parseAddressAnyNetwork("BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P");
     }
 
     @Test(expected = AddressFormatException.InvalidDataLength.class)
     public void fromBech32_tooShort() {
-        SegwitAddress.fromBech32((Network) null, "bc1rw5uspcuh");
+        addressParser.parseAddressAnyNetwork("bc1rw5uspcuh");
     }
 
     @Test(expected = AddressFormatException.InvalidDataLength.class)
     public void fromBech32_tooLong() {
-        SegwitAddress.fromBech32((Network) null, "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90");
+        addressParser.parseAddressAnyNetwork("bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90");
     }
 
     @Test(expected = AddressFormatException.InvalidDataLength.class)
@@ -230,7 +231,7 @@ public class SegwitAddressTest {
         // Taproot, valid bech32m encoding, checksum ok, padding ok, but no valid Segwit v1 program
         // (this program is 20 bytes long, but only 32 bytes program length are valid for Segwit v1/Taproot)
         String taprootAddressWith20BytesWitnessProgram = "bc1pqypqzqspqgqsyqgzqypqzqspqgqsyqgzzezy58";
-        SegwitAddress.fromBech32((Network) null, taprootAddressWith20BytesWitnessProgram);
+        SegwitAddress.fromBech32(BitcoinNetwork.MAINNET, taprootAddressWith20BytesWitnessProgram);
     }
 
     @Test(expected = AddressFormatException.InvalidDataLength.class)
@@ -238,12 +239,12 @@ public class SegwitAddressTest {
         // Taproot, valid bech32m encoding, checksum ok, padding ok, but no valid Segwit v1 program
         // (this program is 40 bytes long, but only 32 bytes program length are valid for Segwit v1/Taproot)
         String taprootAddressWith40BytesWitnessProgram = "bc1p6t0pcqrq3mvedn884lgj9s2cm52xp9vtnlc89cv5x77f5l725rrdjhqrld6m6rza67j62a";
-        SegwitAddress.fromBech32((Network) null, taprootAddressWith40BytesWitnessProgram);
+        SegwitAddress.fromBech32(BitcoinNetwork.MAINNET, taprootAddressWith40BytesWitnessProgram);
     }
 
     @Test(expected = AddressFormatException.InvalidPrefix.class)
     public void fromBech32_invalidHrp() {
-        SegwitAddress.fromBech32((Network) null, "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty");
+        addressParser.parseAddressAnyNetwork("tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty");
     }
 
     @Test(expected = AddressFormatException.WrongNetwork.class)


### PR DESCRIPTION
This is work-in-progress that eliminates the use of `Networks.get()` in non-deprecated methods of `DefaultAddress` and `Address` and subclasses while preserving backward-compatibility for the `@Deprecated` methods.

It also introduces a distinction between the 2-network-variant LegacyAddress and 3-network-variant SegwitAdress that should help address the issues in PR #2613 and PR #2614.