### PR TITLE
PrivateKey: provide abstract .toBase58() for existing DumpedPrivateKey and BIP38PrivateKey implementations

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/Base58.java
+++ b/core/src/main/java/org/bitcoinj/base/Base58.java
@@ -28,7 +28,7 @@ import java.util.Arrays;
  * <p>
  * Note that this is not the same base58 as used by Flickr, which you may find referenced around the Internet.
  * <p>
- * You may want to consider working with {@code org.bitcoinj.core.PrefixedChecksummedBytes} instead, which
+ * You may want to consider working with {@code org.bitcoinj.core.PrivateKey} instead, which
  * adds support for testing the prefix and suffix bytes commonly found in addresses.
  * <p>
  * Satoshi explains: why base-58 instead of standard base-64 encoding?

--- a/core/src/main/java/org/bitcoinj/base/exceptions/AddressFormatException.java
+++ b/core/src/main/java/org/bitcoinj/base/exceptions/AddressFormatException.java
@@ -31,7 +31,7 @@ public class AddressFormatException extends IllegalArgumentException {
     }
 
     /**
-     * This exception is thrown by {@link Base58}, {@link Bech32} and the {@code PrefixedChecksummedBytes} hierarchy of
+     * This exception is thrown by {@link Base58}, {@link Bech32} and the {@code PrivateKey} hierarchy of
      * classes when you try to decode data and a character isn't valid. You shouldn't allow the user to proceed in this
      * case.
      */
@@ -47,7 +47,7 @@ public class AddressFormatException extends IllegalArgumentException {
     }
 
     /**
-     * This exception is thrown by {@link Base58}, {@link Bech32} and the {@code PrefixedChecksummedBytes} hierarchy of
+     * This exception is thrown by {@link Base58}, {@link Bech32} and the {@code PrivateKey} hierarchy of
      * classes when you try to decode data and the data isn't of the right size. You shouldn't allow the user to proceed
      * in this case.
      */
@@ -62,7 +62,7 @@ public class AddressFormatException extends IllegalArgumentException {
     }
 
     /**
-     * This exception is thrown by {@link Base58}, {@link Bech32} and the {@code PrefixedChecksummedBytes} hierarchy of
+     * This exception is thrown by {@link Base58}, {@link Bech32} and the {@code PrivateKey} hierarchy of
      * classes when you try to decode data and the checksum isn't valid. You shouldn't allow the user to proceed in this
      * case.
      */
@@ -91,7 +91,7 @@ public class AddressFormatException extends IllegalArgumentException {
     }
 
     /**
-     * This exception is thrown by the {@code PrefixedChecksummedBytes} hierarchy of classes when you try and decode an
+     * This exception is thrown by the {@code PrivateKey} hierarchy of classes when you try and decode an
      * address or private key with an invalid prefix (version header or human-readable part). You shouldn't allow the
      * user to proceed in this case.
      */
@@ -106,7 +106,7 @@ public class AddressFormatException extends IllegalArgumentException {
     }
 
     /**
-     * This exception is thrown by the {@code PrefixedChecksummedBytes} hierarchy of classes when you try and decode an
+     * This exception is thrown by the {@code PrivateKey} hierarchy of classes when you try and decode an
      * address with a prefix (version header or human-readable part) that used by another network (usually: mainnet vs
      * testnet). You shouldn't allow the user to proceed in this case as they are trying to send money across different
      * chains, an operation that is guaranteed to destroy the money.

--- a/core/src/main/java/org/bitcoinj/core/DumpedPrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/core/DumpedPrivateKey.java
@@ -77,6 +77,7 @@ public class DumpedPrivateKey extends PrivateKey {
      * 
      * @return textual form
      */
+    @Override
     public String toBase58() {
         return Base58.encodeChecked(params.getDumpedPrivateKeyHeader(), bytes);
     }

--- a/core/src/main/java/org/bitcoinj/core/DumpedPrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/core/DumpedPrivateKey.java
@@ -30,7 +30,7 @@ import java.util.Arrays;
  * bytes with a header byte and 4 checksum bytes at the end. If there are 33 private key bytes instead of 32, then
  * the last byte is a discriminator value for the compressed pubkey.
  */
-public class DumpedPrivateKey extends PrefixedChecksummedBytes {
+public class DumpedPrivateKey extends PrivateKey {
 
     /**
      * Construct a private key from its Base58 representation.

--- a/core/src/main/java/org/bitcoinj/core/PrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/core/PrivateKey.java
@@ -23,23 +23,13 @@ import java.util.Objects;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * <p>
- * The following format is often used to represent some type of data (e.g. key or hash of key):
- * </p>
- * 
- * <pre>
- * [prefix] [data bytes] [checksum]
- * </pre>
- * <p>
- * and the result is then encoded with some variant of base. This format is most commonly used for addresses and private
- * keys exported using Bitcoin Core's dumpprivkey command.
- * </p>
+ * Some form of Base58-encoded private key. This form is useful for noting them down, e.g. on paper wallets.
  */
-public abstract class PrefixedChecksummedBytes {
+public abstract class PrivateKey {
     protected final NetworkParameters params;
     protected final byte[] bytes;
 
-    protected PrefixedChecksummedBytes(NetworkParameters params, byte[] bytes) {
+    protected PrivateKey(NetworkParameters params, byte[] bytes) {
         this.params = checkNotNull(params);
         this.bytes = checkNotNull(bytes);
     }
@@ -60,7 +50,7 @@ public abstract class PrefixedChecksummedBytes {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        PrefixedChecksummedBytes other = (PrefixedChecksummedBytes) o;
+        PrivateKey other = (PrivateKey) o;
         return this.params.equals(other.params) && Arrays.equals(this.bytes, other.bytes);
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/PrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/core/PrivateKey.java
@@ -41,6 +41,13 @@ public abstract class PrivateKey {
         return params;
     }
 
+    /**
+     * Returns the base58-encoded textual form, including version and checksum bytes.
+     *
+     * @return textual form
+     */
+    public abstract String toBase58();
+
     @Override
     public int hashCode() {
         return Objects.hash(params, Arrays.hashCode(bytes));

--- a/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
@@ -116,6 +116,7 @@ public class BIP38PrivateKey extends PrivateKey {
      * 
      * @return textual form
      */
+    @Override
     public String toBase58() {
         return Base58.encodeChecked(1, bytes);
     }

--- a/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
@@ -23,7 +23,7 @@ import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.Base58;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.NetworkParameters;
-import org.bitcoinj.core.PrefixedChecksummedBytes;
+import org.bitcoinj.core.PrivateKey;
 import org.bitcoinj.base.Sha256Hash;
 import org.bouncycastle.crypto.generators.SCrypt;
 
@@ -41,7 +41,7 @@ import static com.google.common.base.Preconditions.checkState;
  * Implementation of <a href="https://github.com/bitcoin/bips/blob/master/bip-0038.mediawiki">BIP 38</a>
  * passphrase-protected private keys. Currently, only decryption is supported.
  */
-public class BIP38PrivateKey extends PrefixedChecksummedBytes {
+public class BIP38PrivateKey extends PrivateKey {
     public final boolean ecMultiply;
     public final boolean compressed;
     public final boolean hasLotAndSequence;

--- a/core/src/test/java/org/bitcoinj/core/PrivateKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PrivateKeyTest.java
@@ -45,8 +45,13 @@ public class PrivateKeyTest {
         }
 
         @Override
-        public String toString() {
+        public String toBase58() {
             return Base58.encodeChecked(params.getAddressHeader(), bytes);
+        }
+
+        @Override
+        public String toString() {
+            return toBase58();
         }
     }
 

--- a/core/src/test/java/org/bitcoinj/core/PrivateKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PrivateKeyTest.java
@@ -34,13 +34,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 
 @RunWith(EasyMockRunner.class)
-public class PrefixedChecksummedBytesTest {
+public class PrivateKeyTest {
 
     @Mock
     NetworkParameters params;
 
-    private static class PrefixedChecksummedBytesToTest extends PrefixedChecksummedBytes {
-        public PrefixedChecksummedBytesToTest(NetworkParameters params, byte[] bytes) {
+    private static class PrivateKeyToTest extends PrivateKey {
+        public PrivateKeyToTest(NetworkParameters params, byte[] bytes) {
             super(params, bytes);
         }
 
@@ -52,7 +52,7 @@ public class PrefixedChecksummedBytesTest {
 
     @Test
     public void equalsContract() {
-        EqualsVerifier.forClass(PrefixedChecksummedBytes.class)
+        EqualsVerifier.forClass(PrivateKey.class)
                 .withPrefabValues(NetworkParameters.class, MainNetParams.get(), TestNet3Params.get())
                 .suppress(Warning.NULL_FIELDS)
                 .suppress(Warning.TRANSIENT_FIELDS)
@@ -66,10 +66,10 @@ public class PrefixedChecksummedBytesTest {
         expect(params.getAddressHeader()).andReturn(111).andReturn(0);
         replay(params);
 
-        PrefixedChecksummedBytes a = new PrefixedChecksummedBytesToTest(params, HEX.decode("fda79a24e50ff70ff42f7d89585da5bd19d9e5cc"));
+        PrivateKey a = new PrivateKeyToTest(params, HEX.decode("fda79a24e50ff70ff42f7d89585da5bd19d9e5cc"));
         assertEquals("n4eA2nbYqErp7H6jebchxAN59DmNpksexv", a.toString());
 
-        PrefixedChecksummedBytes b = new PrefixedChecksummedBytesToTest(params, HEX.decode("4a22c3c4cbb31e4d03b15550636762bda0baf85a"));
+        PrivateKey b = new PrivateKeyToTest(params, HEX.decode("4a22c3c4cbb31e4d03b15550636762bda0baf85a"));
         assertEquals("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL", b.toString());
     }
 }


### PR DESCRIPTION
This PR depends on #2620, but could be rewritten to do without.