### PR TITLE
PeerGroup: migrate constructors to Network from NetworkParameters

### DIFF
--- a/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
+++ b/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
@@ -465,7 +465,7 @@ public class WalletAppKit extends AbstractIdleService {
     }
 
     protected PeerGroup createPeerGroup() {
-        return new PeerGroup(params, vChain);
+        return new PeerGroup(network, vChain);
     }
 
     private void installShutdownHook() {

--- a/examples/src/main/java/org/bitcoinj/examples/FetchBlock.java
+++ b/examples/src/main/java/org/bitcoinj/examples/FetchBlock.java
@@ -58,7 +58,7 @@ public class FetchBlock implements Callable<Integer> {
         final NetworkParameters params = TestNet3Params.get();
         BlockStore blockStore = new MemoryBlockStore(params);
         BlockChain chain = new BlockChain(params, blockStore);
-        PeerGroup peerGroup = new PeerGroup(params, chain);
+        PeerGroup peerGroup = new PeerGroup(params.network(), chain);
         if (localhost) {
             peerGroup.addPeerDiscovery(new DnsDiscovery(params));
         } else {

--- a/examples/src/main/java/org/bitcoinj/examples/FetchTransactions.java
+++ b/examples/src/main/java/org/bitcoinj/examples/FetchTransactions.java
@@ -39,7 +39,7 @@ public class FetchTransactions {
 
         BlockStore blockStore = new MemoryBlockStore(params);
         BlockChain chain = new BlockChain(params, blockStore);
-        PeerGroup peerGroup = new PeerGroup(params, chain);
+        PeerGroup peerGroup = new PeerGroup(params.network(), chain);
         peerGroup.start();
         peerGroup.addAddress(new PeerAddress(params, InetAddress.getLocalHost()));
         peerGroup.waitForPeers(1).get();

--- a/examples/src/main/java/org/bitcoinj/examples/PeerMonitor.java
+++ b/examples/src/main/java/org/bitcoinj/examples/PeerMonitor.java
@@ -68,7 +68,7 @@ public class PeerMonitor {
 
     private void setupNetwork() {
         params = MainNetParams.get();
-        peerGroup = new PeerGroup(params, null /* no chain */);
+        peerGroup = new PeerGroup(params.network(), null /* no chain */);
         peerGroup.setUserAgent("PeerMonitor", "1.0");
         peerGroup.setMaxConnections(4);
         peerGroup.addPeerDiscovery(new DnsDiscovery(params));

--- a/examples/src/main/java/org/bitcoinj/examples/PrivateKeys.java
+++ b/examples/src/main/java/org/bitcoinj/examples/PrivateKeys.java
@@ -71,7 +71,7 @@ public class PrivateKeys {
             final MemoryBlockStore blockStore = new MemoryBlockStore(params);
             BlockChain chain = new BlockChain(params, wallet, blockStore);
 
-            final PeerGroup peerGroup = new PeerGroup(params, chain);
+            final PeerGroup peerGroup = new PeerGroup(params.network(), chain);
             peerGroup.addAddress(new PeerAddress(params, InetAddress.getLocalHost()));
             peerGroup.startAsync();
             peerGroup.downloadBlockChain();

--- a/examples/src/main/java/org/bitcoinj/examples/RefreshWallet.java
+++ b/examples/src/main/java/org/bitcoinj/examples/RefreshWallet.java
@@ -42,7 +42,7 @@ public class RefreshWallet {
         BlockStore blockStore = new MemoryBlockStore(params);
         BlockChain chain = new BlockChain(params, wallet, blockStore);
 
-        final PeerGroup peerGroup = new PeerGroup(params, chain);
+        final PeerGroup peerGroup = new PeerGroup(params.network(), chain);
         peerGroup.startAsync();
 
         wallet.addCoinsReceivedEventListener(new WalletCoinsReceivedEventListener() {

--- a/examples/src/main/java/org/bitcoinj/examples/RestoreFromSeed.java
+++ b/examples/src/main/java/org/bitcoinj/examples/RestoreFromSeed.java
@@ -63,7 +63,7 @@ public class RestoreFromSeed {
         // Setting up the BlochChain, the BlocksStore and connecting to the network.
         SPVBlockStore chainStore = new SPVBlockStore(params, chainFile);
         BlockChain chain = new BlockChain(params, chainStore);
-        PeerGroup peerGroup = new PeerGroup(params, chain);
+        PeerGroup peerGroup = new PeerGroup(params.network(), chain);
         peerGroup.addPeerDiscovery(new DnsDiscovery(params));
 
         // Now we need to hook the wallet up to the blockchain and the peers. This registers event listeners that notify our wallet about new transactions.

--- a/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
@@ -98,7 +98,7 @@ public class BuildCheckpoints implements Callable<Integer> {
         // node and to save block headers that are on interval boundaries, as long as they are <1 month old.
         final BlockStore store = new MemoryBlockStore(params);
         final BlockChain chain = new BlockChain(params, store);
-        final PeerGroup peerGroup = new PeerGroup(params, chain);
+        final PeerGroup peerGroup = new PeerGroup(net, chain);
 
         final InetAddress ipAddress;
 

--- a/tools/src/main/java/org/bitcoinj/tools/WatchMempool.java
+++ b/tools/src/main/java/org/bitcoinj/tools/WatchMempool.java
@@ -46,7 +46,7 @@ public class WatchMempool {
 
     public static void main(String[] args) throws InterruptedException {
         BriefLogFormatter.init();
-        PeerGroup peerGroup = new PeerGroup(PARAMS);
+        PeerGroup peerGroup = new PeerGroup(PARAMS.network());
         peerGroup.setMaxConnections(32);
         peerGroup.addPeerDiscovery(new DnsDiscovery(PARAMS));
         peerGroup.addOnTransactionBroadcastListener((peer, tx) -> {

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -1007,7 +1007,7 @@ public class WalletTool implements Callable<Integer> {
         // This will ensure the wallet is saved when it changes.
         wallet.autosaveToFile(walletFile, 5, TimeUnit.SECONDS, null);
         if (peerGroup == null) {
-            peerGroup = new PeerGroup(params, chain);
+            peerGroup = new PeerGroup(net, chain);
         }
         peerGroup.setUserAgent("WalletTool", "1.0");
         if (params == RegTestParams.get())


### PR DESCRIPTION
* Add 3 new constructors which take network
* Deprecate (2 of 3) constructors that take NetworkParameters
* Mark 3-arg NetworkParameters constructor as @VisibleForTesting