### PR TITLE
EncodedPrivateKey: Replace NetworkParameters with Network

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/DumpedPrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/core/DumpedPrivateKey.java
@@ -61,7 +61,7 @@ public class DumpedPrivateKey extends EncodedPrivateKey {
     }
 
     private DumpedPrivateKey(NetworkParameters params, byte[] bytes) {
-        super(params, bytes);
+        super(params.network(), params.getDumpedPrivateKeyHeader(), bytes);
         if (bytes.length != 32 && bytes.length != 33)
             throw new AddressFormatException.InvalidDataLength(
                     "Wrong number of bytes for a private key (32 or 33): " + bytes.length);
@@ -78,7 +78,7 @@ public class DumpedPrivateKey extends EncodedPrivateKey {
      * @return textual form
      */
     public String toBase58() {
-        return Base58.encodeChecked(params.getDumpedPrivateKeyHeader(), bytes);
+        return Base58.encodeChecked(version, bytes);
     }
 
     private static byte[] encode(byte[] keyBytes, boolean compressed) {

--- a/core/src/main/java/org/bitcoinj/core/EncodedPrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/core/EncodedPrivateKey.java
@@ -17,6 +17,8 @@
 
 package org.bitcoinj.core;
 
+import org.bitcoinj.base.Network;
+
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -26,24 +28,27 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Some form of string-encoded private key. This form is useful for noting them down, e.g. on paper wallets.
  */
 public abstract class EncodedPrivateKey {
-    protected final NetworkParameters params;
+    protected final transient Network network;
+    protected final int version;
     protected final byte[] bytes;
 
-    protected EncodedPrivateKey(NetworkParameters params, byte[] bytes) {
-        this.params = checkNotNull(params);
+    protected EncodedPrivateKey(Network network, int version, byte[] bytes) {
+        this.network = checkNotNull(network);
+        this.version = version;
         this.bytes = checkNotNull(bytes);
     }
 
     /**
      * @return network this data is valid for
      */
+    @Deprecated
     public final NetworkParameters getParameters() {
-        return params;
+        return NetworkParameters.of(network);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(params, Arrays.hashCode(bytes));
+        return Objects.hash(version, Arrays.hashCode(bytes));
     }
 
     @Override
@@ -51,6 +56,6 @@ public abstract class EncodedPrivateKey {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         EncodedPrivateKey other = (EncodedPrivateKey) o;
-        return this.params.equals(other.params) && Arrays.equals(this.bytes, other.bytes);
+        return this.version == other.version && Arrays.equals(this.bytes, other.bytes);
     }
 }

--- a/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
@@ -103,7 +103,7 @@ public class BIP38PrivateKey extends EncodedPrivateKey {
 
     private BIP38PrivateKey(NetworkParameters params, byte[] bytes, boolean ecMultiply, boolean compressed,
             boolean hasLotAndSequence, byte[] addressHash, byte[] content) throws AddressFormatException {
-        super(params, bytes);
+        super(params.network(), 1, bytes);
         this.ecMultiply = ecMultiply;
         this.compressed = compressed;
         this.hasLotAndSequence = hasLotAndSequence;
@@ -117,13 +117,13 @@ public class BIP38PrivateKey extends EncodedPrivateKey {
      * @return textual form
      */
     public String toBase58() {
-        return Base58.encodeChecked(1, bytes);
+        return Base58.encodeChecked(version, bytes);
     }
 
     public ECKey decrypt(String passphrase) throws BadPassphraseException {
         String normalizedPassphrase = Normalizer.normalize(passphrase, Normalizer.Form.NFC);
         ECKey key = ecMultiply ? decryptEC(normalizedPassphrase) : decryptNoEC(normalizedPassphrase);
-        Sha256Hash hash = Sha256Hash.twiceOf(key.toAddress(ScriptType.P2PKH, params.network()).toString().getBytes(StandardCharsets.US_ASCII));
+        Sha256Hash hash = Sha256Hash.twiceOf(key.toAddress(ScriptType.P2PKH, network).toString().getBytes(StandardCharsets.US_ASCII));
         byte[] actualAddressHash = Arrays.copyOfRange(hash.getBytes(), 0, 4);
         if (!Arrays.equals(actualAddressHash, addressHash))
             throw new BadPassphraseException();

--- a/core/src/test/java/org/bitcoinj/core/EncodedPrivateKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/core/EncodedPrivateKeyTest.java
@@ -19,15 +19,12 @@ package org.bitcoinj.core;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.bitcoinj.params.MainNetParams;
-import org.bitcoinj.params.TestNet3Params;
 import org.junit.Test;
 
 public class EncodedPrivateKeyTest {
     @Test
     public void equalsContract() {
         EqualsVerifier.forClass(EncodedPrivateKey.class)
-                .withPrefabValues(NetworkParameters.class, MainNetParams.get(), TestNet3Params.get())
                 .suppress(Warning.NULL_FIELDS)
                 .suppress(Warning.TRANSIENT_FIELDS)
                 .usingGetClass()


### PR DESCRIPTION
* Replace NetworkParameters with Network
* new constructor with `Network` and `int version`
* Remove old constructor (POTENTIALLY BREAKING)
* Mark `network` as transient (for EqualsVerifier, etc)
* Update subclasses to work correctly with new constructor and changed members
* Update tests