### PR TITLE
P2WPKH fallback for P2PKH Script

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/Bech32.java
+++ b/core/src/main/java/org/bitcoinj/base/Bech32.java
@@ -144,6 +144,12 @@ public class Bech32 {
         return sb.toString();
     }
 
+    /** @deprecated use {@link #encode(Encoding, String, byte[])} */
+    @Deprecated
+    public static String encode(String hrp, byte[] values) {
+        return encode(Encoding.BECH32, hrp, values);
+    }
+
     /** Decode a Bech32 string. */
     public static Bech32Data decode(final String str) throws AddressFormatException {
         boolean lower = false, upper = false;

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -152,7 +152,11 @@ public class TransactionOutPoint extends ChildMessage {
         Script connectedScript = connectedOutput.getScriptPubKey();
         if (ScriptPattern.isP2PKH(connectedScript)) {
             byte[] addressBytes = ScriptPattern.extractHashFromP2PKH(connectedScript);
-            return keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2PKH);
+            ECKey key = keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2PKH);
+            if (key == null) {
+                key = keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2WPKH);
+            }
+            return key;
         } else if (ScriptPattern.isP2WPKH(connectedScript)) {
             byte[] addressBytes = ScriptPattern.extractHashFromP2WH(connectedScript);
             return keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2WPKH);
@@ -178,7 +182,11 @@ public class TransactionOutPoint extends ChildMessage {
         Script connectedScript = connectedOutput.getScriptPubKey();
         if (ScriptPattern.isP2PKH(connectedScript)) {
             byte[] addressBytes = ScriptPattern.extractHashFromP2PKH(connectedScript);
-            return RedeemData.of(keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2PKH), connectedScript);
+            ECKey key = keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2PKH);
+            if (key == null) {
+                key = keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2WPKH);
+            }
+            return RedeemData.of(key, connectedScript);
         } else if (ScriptPattern.isP2WPKH(connectedScript)) {
             byte[] addressBytes = ScriptPattern.extractHashFromP2WH(connectedScript);
             return RedeemData.of(keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2WPKH), connectedScript);

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -211,7 +211,7 @@ public class TransactionOutput extends ChildMessage {
         // 294 satoshis at the default rate of 3000 sat/kB.
         long size = this.unsafeBitcoinSerialize().length;
         final Script script = getScriptPubKey();
-        if (ScriptPattern.isP2PKH(script) || ScriptPattern.isP2PK(script) || ScriptPattern.isP2SH(script))
+        if (ScriptPattern.isP2PKH(script) || ScriptPattern.isP2PK(script) || ScriptPattern.isP2SH(script) || ScriptPattern.isSentToMultisig(script))
             size += 32 + 4 + 1 + 107 + 4; // 148
         else if (ScriptPattern.isP2WH(script))
             size += 32 + 4 + 1 + (107 / 4) + 4; // 68
@@ -307,7 +307,8 @@ public class TransactionOutput extends ChildMessage {
                 return transactionBag.isPayToScriptHashMine(ScriptPattern.extractHashFromP2SH(script));
             else if (ScriptPattern.isP2PKH(script))
                 return transactionBag.isPubKeyHashMine(ScriptPattern.extractHashFromP2PKH(script),
-                        ScriptType.P2PKH);
+                        ScriptType.P2PKH) || transactionBag.isPubKeyHashMine(ScriptPattern.extractHashFromP2PKH(script),
+                        ScriptType.P2WPKH);
             else if (ScriptPattern.isP2WPKH(script))
                 return transactionBag.isPubKeyHashMine(ScriptPattern.extractHashFromP2WH(script),
                         ScriptType.P2WPKH);

--- a/core/src/main/java/org/bitcoinj/wallet/KeyTimeCoinSelector.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyTimeCoinSelector.java
@@ -69,6 +69,9 @@ public class KeyTimeCoinSelector implements CoinSelector {
                     controllingKey = wallet.findKeyFromPubKey(ScriptPattern.extractKeyFromP2PK(scriptPubKey));
                 } else if (ScriptPattern.isP2PKH(scriptPubKey)) {
                     controllingKey = wallet.findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2PKH(scriptPubKey), ScriptType.P2PKH);
+                    if (controllingKey == null) {
+                        controllingKey = wallet.findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2PKH(scriptPubKey), ScriptType.P2WPKH);
+                    }
                 } else if (ScriptPattern.isP2WPKH(scriptPubKey)) {
                     controllingKey = wallet.findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2WH(scriptPubKey), ScriptType.P2WPKH);
                 } else {

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -17,6 +17,15 @@
 
 package org.bitcoinj.wallet;
 
+import com.google.common.annotations.*;
+import com.google.common.collect.*;
+import com.google.common.math.IntMath;
+import com.google.common.util.concurrent.*;
+import com.google.protobuf.*;
+import net.jcip.annotations.*;
+import org.bitcoinj.core.listeners.*;
+import org.bitcoinj.core.Address;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Iterables;
@@ -28,6 +37,7 @@ import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.utils.StreamUtils;
+
 import org.bitcoinj.core.AbstractBlockChain;
 import org.bitcoinj.core.Address;
 import org.bitcoinj.base.Base58;
@@ -4433,6 +4443,10 @@ public class Wallet extends BaseTaggableObject
         } else if (ScriptPattern.isP2PKH(script)) {
             ECKey key = findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2PKH(script),
                     ScriptType.P2PKH);
+            if (key == null) {
+                key = findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2PKH(script),
+                        ScriptType.P2WPKH);
+            }
             return key != null && (key.isEncrypted() || key.hasPrivKey());
         } else if (ScriptPattern.isP2WPKH(script)) {
             ECKey key = findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2WH(script),
@@ -5166,6 +5180,9 @@ public class Wallet extends BaseTaggableObject
                 Script redeemScript = null;
                 if (ScriptPattern.isP2PKH(script)) {
                     key = findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2PKH(script), ScriptType.P2PKH);
+                    if (key == null) {
+                        key = findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2PKH(script), ScriptType.P2WPKH);
+                    }
                     checkNotNull(key, "Coin selection includes unspendable outputs");
                     vsize += script.getNumberOfBytesRequiredToSpend(key, redeemScript);
                 } else if (ScriptPattern.isP2WPKH(script)) {


### PR DESCRIPTION
When we create a wallet with one keychain i.e of P2WPKH, and if we want to add the support for P2PKH for that same wallet. So, this code contains only fallback when for P2PKH it fails.