### PR TITLE
Discover peers via P2P network

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -481,9 +481,6 @@ public class Peer extends PeerSocketHandler {
         } else if (m instanceof GetDataMessage) {
             processGetData((GetDataMessage) m);
         } else if (m instanceof AddressMessage) {
-            // We don't care about addresses of the network right now. But in future,
-            // we should save them in the wallet so we don't put too much load on the seed nodes and can
-            // properly explore the network.
             processAddressMessage((AddressMessage) m);
         } else if (m instanceof HeadersMessage) {
             processHeaders((HeadersMessage) m);

--- a/core/src/main/java/org/bitcoinj/core/listeners/AddressEventListener.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/AddressEventListener.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.core.listeners;
+
+import org.bitcoinj.core.AddressMessage;
+import org.bitcoinj.core.Peer;
+
+/**
+ * <p>Implementors can listen to addresses being received from remote peers.</p>
+ */
+public interface AddressEventListener {
+
+    /**
+     * <p>Called when a peer receives an addr or addrv2 message, usually in response to a getaddr message.</p>
+     *
+     * @param peer    the peer that received the addr or addrv2 message
+     * @param message the addr or addrv2 message that was received
+     */
+    void onAddr(Peer peer, AddressMessage message);
+}


### PR DESCRIPTION
This has two commits:

74d54de1f6ec58c76e3a97df11df592be0a4f616 adds a new event and listener for receiving an `addr` or `addrv2` message by `Peer`.

3fffeee295f863dc1003e3ce37b72815558e52bf adds the actual discovery in `PeerGroup`.
