### PR TITLE
SegwitAddress: include length check for Taproot witness programs

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/SegwitAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/SegwitAddressTest.java
@@ -162,8 +162,6 @@ public class SegwitAddressTest {
                     "0014751e76e8199196d454941c45d1b3a323f1433bd6", 0),
             new AddressData("tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7", TESTNET,
                     "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262", 0),
-            new AddressData("bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kt5nd6y", MAINNET,
-                    "5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6", 1),
             new AddressData("BC1SW50QGDZ25J", MAINNET, "6002751e", 16),
             new AddressData("bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs", MAINNET, "5210751e76e8199196d454941c45d1b3a323", 2),
             new AddressData("tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy", TESTNET,
@@ -225,6 +223,22 @@ public class SegwitAddressTest {
     @Test(expected = AddressFormatException.InvalidDataLength.class)
     public void fromBech32_tooLong() {
         SegwitAddress.fromBech32((Network) null, "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90");
+    }
+
+    @Test(expected = AddressFormatException.InvalidDataLength.class)
+    public void fromBech32m_taprootTooShort() {
+        // Taproot, valid bech32m encoding, checksum ok, padding ok, but no valid Segwit v1 program
+        // (this program is 20 bytes long, but only 32 bytes program length are valid for Segwit v1/Taproot)
+        String taprootAddressWith20BytesWitnessProgram = "bc1pqypqzqspqgqsyqgzqypqzqspqgqsyqgzzezy58";
+        SegwitAddress.fromBech32((Network) null, taprootAddressWith20BytesWitnessProgram);
+    }
+
+    @Test(expected = AddressFormatException.InvalidDataLength.class)
+    public void fromBech32m_taprootTooLong() {
+        // Taproot, valid bech32m encoding, checksum ok, padding ok, but no valid Segwit v1 program
+        // (this program is 40 bytes long, but only 32 bytes program length are valid for Segwit v1/Taproot)
+        String taprootAddressWith40BytesWitnessProgram = "bc1p6t0pcqrq3mvedn884lgj9s2cm52xp9vtnlc89cv5x77f5l725rrdjhqrld6m6rza67j62a";
+        SegwitAddress.fromBech32((Network) null, taprootAddressWith40BytesWitnessProgram);
     }
 
     @Test(expected = AddressFormatException.InvalidPrefix.class)


### PR DESCRIPTION
Hi @schildbach ! I have another PR, this time a very little change, but a little bit more reasoning behind it. So I'm very curious to hear your feedback. 🙂 

## Overview

- This PR just adds a size check for Segwit v1 (Taproot) addresses to the `SegwitAddress` constructor so that it only accepts 32-byte long witness programs (the only valid length for Taproot as defined in [BIP 341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#script-validation-rules)). 
- Adding this check means that `AddressParser.parseAddress(...)` will in future throw an exception for too short or too long Segwit v1 addresses (as it already does today for Segwit v0 addresses with invalid lengths). Currently too short/long Taproot addresses are accepted as valid by `AddressParser.parseAddress(...)`.

## Current state

- Currently in bitcoinJ there [is already a check for witness program length for Segwit v0](https://github.com/bitcoinj/bitcoinj/blob/master/core/src/main/java/org/bitcoinj/core/SegwitAddress.java#L117-L120) in the constructor. So it is impossible to instantiate a v0 `SegwitAddress` with an invalid length.
- This is not the case for Taproot addresses (Segwit v1), so one can instantiate a `SegwitAddress` instance with too short or too long Taproot addresses without exception.
- I am aware of the fact that there is a semantic difference in v0 an v1 addresses with invalid lengths:
  - **Segwit v0:** [BIP 141](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#witness-program) specifies that all v0 witness programs with invalid length (not 20 or 32 bytes) MUST fail (_"the script must fail"_). This means: any coins sent to such an address **will become unspendable**.
  - **Segwit v1**: This is different from v0: [BIP 341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#script-validation-rules) specifies that Taproot validation rules only apply to witness programs with a length of 32 bytes. This implies that if the witness program has any other length, then no rules will be applied to v1 witness scripts. In short: sending coins to too long or too short Taproot addresses **will become anyonce-can-spend** (unless changed in a future soft fork).
  - These BIP descriptions match the code in Bitcoin Core, where invalid length v0 scripts will immediately fail [here in the else branch](https://github.com/bitcoin/bitcoin/blob/58da1619be7ac13e686cb8bbfc2ab0f836eb3fa5/src/script/interpreter.cpp#L1880-L1902) and invalid v1 lengths are just not covered by [this if-condition (which includes length)](https://github.com/bitcoin/bitcoin/blob/58da1619be7ac13e686cb8bbfc2ab0f836eb3fa5/src/script/interpreter.cpp#L1903) so that they end up below in the [default else branch returning always `true`](https://github.com/bitcoin/bitcoin/blob/58da1619be7ac13e686cb8bbfc2ab0f836eb3fa5/src/script/interpreter.cpp#L1950-L1951).
- Nevertheless, v1 addresses with invalid lengths are still covered by transaction policy by marking them as non-standard (the flag `SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM` is set [here in `policy.h`](https://github.com/bitcoin/bitcoin/blob/306ccd4927a2efe325c8d84be1bdb79edeb29b04/src/policy/policy.h#L72-L90), which will lead to [returning an error on validation here](https://github.com/bitcoin/bitcoin/blob/58da1619be7ac13e686cb8bbfc2ab0f836eb3fa5/src/script/interpreter.cpp#L1947-L1949)). This makes it more difficult to spend such an invalid Taproot anyone-can-spend address as nodes will not accept such transactions in their mempool by default.

## Rationale

I was unsure if this PR is reasonable (and you might still argue about it) as BIP 351 not explicitly marks these scripts as invalid. But from a practical point of view I still would argue that we should treat them as invalid addresses. Implementors of Bitcoin services (ATMs, exchanges) use `AddressParser.parseAddress(...)` as an easy check to see if a given address is valid. And while invalid-length-v1 addresses technically still might be valid I think in most cases it is not what the user intends.

So if there are buggy wallets out there which create crap addresses (example: v1 addresses with length 20 like v0), it would be nice if such addresses would raise attention (to prevent services from just blindly sending coins there). Many callers of `AddressParser.parseAddress(...)` may not dive that deep into these semantics and just use it as a simple validation check (without the need for a deeper understanding).

I also understand if you don't agree with my reasoning and don't accept this PR. But then maybe we could add some "dangerous" flag, so that validation fails by default on such addresses (and also currently unused Segwit versions) but instantiation of such addresses can still be enforced by providing the "dangerous" flag (or something similiar).
