### PR TITLE
Remove recached

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -138,10 +138,6 @@ public abstract class Message {
         return payload != null;
     }
 
-    public boolean isRecached() {
-        return recached;
-    }
-
     /**
      * Overrides the message serializer.
      * @param serializer the new serializer

--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -55,7 +55,6 @@ public abstract class Message {
     // The raw message payload bytes themselves.
     protected byte[] payload;
 
-    protected boolean recached = false;
     protected MessageSerializer serializer;
 
     protected NetworkParameters params;
@@ -112,7 +111,6 @@ public abstract class Message {
      */
     protected void unCache() {
         payload = null;
-        recached = false;
     }
 
     protected void adjustLength(int newArraySize, int adjustment) {
@@ -214,7 +212,6 @@ public abstract class Message {
             payload = stream.toByteArray();
             cursor = cursor - offset;
             offset = 0;
-            recached = true;
             length = payload.length;
             return payload;
         }

--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -341,10 +341,6 @@ public abstract class Message {
         return Sha256Hash.wrapReversed(readBytes(32));
     }
 
-    protected boolean hasMoreBytes() {
-        return cursor < payload.length;
-    }
-
     /** Network parameters this message was created with. */
     public NetworkParameters getParams() {
         return params;

--- a/core/src/test/java/org/bitcoinj/core/PeerAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerAddressTest.java
@@ -41,7 +41,7 @@ public class PeerAddressTest {
     public void equalsContract() {
         EqualsVerifier.forClass(PeerAddress.class)
                 .suppress(Warning.NONFINAL_FIELDS)
-                .withIgnoredFields("time", "parent", "params", "offset", "cursor", "length", "payload", "recached", "serializer")
+                .withIgnoredFields("time", "parent", "params", "offset", "cursor", "length", "payload", "serializer")
                 .usingGetClass()
                 .verify();
     }


### PR DESCRIPTION
@schildbach Was having a browse through the code and noticed that `Message.recached` was unused so decided to remove it.