### PR TITLE
Removes unused method Peer.isNotFoundMessageSupported

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -1605,10 +1605,6 @@ public class Peer extends PeerSocketHandler {
         return chainHeight - blockChain.getBestChainHeight();
     }
 
-    private boolean isNotFoundMessageSupported() {
-        return vPeerVersionMessage.clientVersion >= NotFoundMessage.MIN_PROTOCOL_VERSION;
-    }
-
     /**
      * Returns true if this peer will try and download things it is sent in "inv" messages. Normally you only need
      * one peer to be downloading data. Defaults to true.


### PR DESCRIPTION
@schildbach & @msgilligan removes another unused method. This is the only place where `NotFoundMessage.MIN_PROTOCOL_VERSION` is used so perhaps remove that too?