### PR TITLE
Remove gethash methods

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -273,12 +273,6 @@ public class Transaction extends ChildMessage {
         return getTxId();
     }
 
-    /** @deprecated use {@link #getTxId()}.toString() */
-    @Deprecated
-    public String getHashAsString() {
-        return getTxId().toString();
-    }
-
     /**
      * Returns the transaction id as you see them in block explorers. It is used as a reference by transaction inputs
      * via outpoints.

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -266,13 +266,6 @@ public class Transaction extends ChildMessage {
         super(params, payload, 0, parent, setSerializer, length);
     }
 
-    /** @deprecated use {@link #getTxId()} */
-    @Override
-    @Deprecated
-    public Sha256Hash getHash() {
-        return getTxId();
-    }
-
     /**
      * Returns the transaction id as you see them in block explorers. It is used as a reference by transaction inputs
      * via outpoints.


### PR DESCRIPTION
@schildbach removes deprecated `Transaction.getHash...` methods.