### PR TITLE
Peer: Removes deprecated method toStringServices

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -391,11 +391,6 @@ public class Peer extends PeerSocketHandler {
         return helper.toString();
     }
 
-    @Deprecated
-    public String toStringServices(long services) {
-        return VersionMessage.toStringServices(services);
-    }
-
     @Override
     protected void timeoutOccurred() {
         super.timeoutOccurred();


### PR DESCRIPTION
@schildbach removes deprecated method in Peer.