### PR TITLE
NetworkParameters: Removes deprecated method getMinNonDustOutput

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -409,13 +409,6 @@ public abstract class NetworkParameters {
     public abstract Coin getMaxMoney();
 
     /**
-     * @return coin value
-     * @deprecated use {@link TransactionOutput#getMinNonDustValue()}
-     */
-    @Deprecated
-    public abstract Coin getMinNonDustOutput();
-
-    /**
      * The monetary object for this currency.
      * @return formatting utility object
      * @deprecated Get one another way or construct your own {@link MonetaryFormat} as needed.

--- a/core/src/main/java/org/bitcoinj/params/BitcoinNetworkParams.java
+++ b/core/src/main/java/org/bitcoinj/params/BitcoinNetworkParams.java
@@ -26,8 +26,6 @@ import org.bitcoinj.base.Coin;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.core.StoredBlock;
-import org.bitcoinj.core.Transaction;
-import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.protocols.payments.PaymentProtocol;
 import org.bitcoinj.store.BlockStore;
@@ -230,13 +228,6 @@ public abstract class BitcoinNetworkParams extends NetworkParameters {
     @Deprecated
     public Coin getMaxMoney() {
         return BitcoinNetwork.MAX_MONEY;
-    }
-
-    /** @deprecated use {@link TransactionOutput#getMinNonDustValue()} */
-    @Override
-    @Deprecated
-    public Coin getMinNonDustOutput() {
-        return Transaction.MIN_NONDUST_OUTPUT;
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/testing/MockAltNetworkParams.java
+++ b/core/src/main/java/org/bitcoinj/testing/MockAltNetworkParams.java
@@ -59,11 +59,6 @@ public class MockAltNetworkParams extends NetworkParameters {
     }
 
     @Override
-    public Coin getMinNonDustOutput() {
-        return null;
-    }
-
-    @Override
     public MonetaryFormat getMonetaryFormat() {
         return null;
     }


### PR DESCRIPTION
@schildbach removes getMinNonDustOutput method from NetworkParameters.