### PR TITLE
Message: deprecate method getHash()

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -458,7 +458,6 @@ public class Block extends Message {
      * Returns the hash of the block (which for a valid, solved block should be
      * below the target). Big endian.
      */
-    @Override
     public Sha256Hash getHash() {
         if (hash == null)
             hash = calculateHash();

--- a/core/src/main/java/org/bitcoinj/core/FilteredBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/FilteredBlock.java
@@ -98,7 +98,6 @@ public class FilteredBlock extends Message {
     }
     
     /** Gets the hash of the block represented in this Filtered Block */
-    @Override
     public Sha256Hash getHash() {
         return header.getHash();
     }

--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -257,10 +257,8 @@ public abstract class Message {
         log.error("Error: {} class has not implemented bitcoinSerializeToStream method.  Generating message with no payload", getClass());
     }
 
-    /**
-     * This method is a NOP for all classes except Block and Transaction.  It is only declared in Message
-     * so BitcoinSerializer can avoid 2 instanceof checks + a casting.
-     */
+    /** @deprecated use {@link Transaction#getTxId()}, {@link Block#getHash()}, {@link FilteredBlock#getHash()} or {@link TransactionOutPoint#getHash()} */
+    @Deprecated
     public Sha256Hash getHash() {
         throw new UnsupportedOperationException();
     }

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -201,7 +201,6 @@ public class TransactionOutPoint extends ChildMessage {
     /**
      * Returns the hash of the transaction this outpoint references/spends/is connected to.
      */
-    @Override
     public Sha256Hash getHash() {
         return hash;
     }


### PR DESCRIPTION
It's not implemented anyways and only used as a generalization of some subclass implementations.