### PR TITLE
GitHub Actions: upgrade action versions to avoid Node.js 12 warning

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -24,12 +24,12 @@ jobs:
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           gradle-version: ${{ matrix.gradle }}
           arguments: test nativeCompile --info --stacktrace
       - name: Upload wallet-tool as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wallet-tool-${{ matrix.os }}
           path: wallettool/build/native/nativeCompile/wallet-tool

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,12 +28,12 @@ jobs:
           distribution: ${{ matrix.distribution }}
           java-version: ${{ matrix.java }}
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           gradle-version: ${{ matrix.gradle }}
           arguments: -PtestJdk8=true build --stacktrace
       - name: Upload Test Results and Reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: bitcoinj-core-test-results-jdk${{ matrix.java }}-${{ matrix.os }}


### PR DESCRIPTION
We are seeing messages like this in Github Actions:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: DeLaGuardo/setup-graalvm@4.0, gradle/gradle-build-action@v1, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

This PR should eliminate the warnings by upgrading the relevant actions to newer versions.