### PR TITLE
Github graalvm.yml workflow: use official setup-graalvm action

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        java: [ 'java17' ]
+        java: [ '17' ]
         graalvm: [ '22.1.0' ]
         gradle: ['7.4.2']
       fail-fast: false
@@ -17,12 +17,12 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v1
       - name: Set up GraalVM
-        uses: DeLaGuardo/setup-graalvm@4.0
+        uses: graalvm/setup-graalvm@v1
         with:
-          graalvm: ${{ matrix.graalvm }}
-          java: ${{ matrix.java }}
-      - name: Install native-image plugin
-        run: gu install native-image
+          version: ${{ matrix.graalvm }}
+          java-version: ${{ matrix.java }}
+          components: 'native-image'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v1
         with:


### PR DESCRIPTION
Switch from the DeLaGuardo/setup-graalvm  action to the "official" [graalvm/setup-graalvm](https://github.com/graalvm/setup-graalvm) action.

There are three advantages to using this action:

1. It uses a newer Node.js and eliminates a warning message we are seeing with the other action
2. It combines installing `native-image` with the installation of GraalVM JDK
3. In theory it should be better supported because it is from the GraalVM team