### PR TITLE
Wallet/WalletFiles: improve error handling on save

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -104,6 +104,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -1478,6 +1479,12 @@ public class Wallet extends BaseTaggableObject
 
     /** Saves the wallet first to the given temp file, then renames to the dest file. */
     public void saveToFile(File temp, File destFile) throws IOException {
+        if (!temp.getParentFile().exists()) {
+            throw new FileNotFoundException(temp.getParentFile().getPath() + " (wallet directory not found)");
+        }
+        if (!destFile.getParentFile().exists()) {
+            throw new FileNotFoundException(destFile.getParentFile().getPath() + " (wallet directory not found)");
+        }
         FileOutputStream stream = null;
         lock.lock();
         try {
@@ -1518,9 +1525,15 @@ public class Wallet extends BaseTaggableObject
      * Uses protobuf serialization to save the wallet to the given file. To learn more about this file format, see
      * {@link WalletProtobufSerializer}. Writes out first to a temporary file in the same directory and then renames
      * once written.
+     * @param f File to save wallet
+     * @throws FileNotFoundException if directory doesn't exist
+     * @throws IOException if an error occurs while saving
      */
     public void saveToFile(File f) throws IOException {
         File directory = f.getAbsoluteFile().getParentFile();
+        if (!directory.exists()) {
+            throw new FileNotFoundException(directory.getPath() + " (wallet directory not found)");
+        }
         File temp = File.createTempFile("wallet", null, directory);
         saveToFile(temp, f);
     }

--- a/core/src/main/java/org/bitcoinj/wallet/WalletFiles.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletFiles.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Date;
 import java.util.concurrent.Callable;
@@ -131,6 +132,9 @@ public class WalletFiles {
     private void saveNowInternal() throws IOException {
         final Stopwatch watch = Stopwatch.createStarted();
         File directory = file.getAbsoluteFile().getParentFile();
+        if (!directory.exists()) {
+            throw new FileNotFoundException(directory.getPath() + " (wallet directory not found)");
+        }
         File temp = File.createTempFile("wallet", null, directory);
         final Listener listener = vListener;
         if (listener != null)


### PR DESCRIPTION
Catch FileNotFound error earlier and provide more informative exception when it happens.

I discovered this issue running the WalletTool with an invalid directory path to the wallet file. Before this fix the error/exception message is:

    java.io.IOException: No such file or directory

After the fix it is:

    java.io.FileNotFoundException: /Users/sean/bitcoinj (wallet directory not found)