### PR TITLE
Examples: always use BitcoinNetwork enum to specify network

### DIFF
--- a/examples/src/main/java/org/bitcoinj/examples/BackupToMnemonicSeed.java
+++ b/examples/src/main/java/org/bitcoinj/examples/BackupToMnemonicSeed.java
@@ -16,10 +16,11 @@
 
 package org.bitcoinj.examples;
 
+import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.internal.InternalUtils;
-import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.wallet.DeterministicSeed;
 import org.bitcoinj.wallet.Wallet;
 
@@ -35,8 +36,8 @@ public class BackupToMnemonicSeed {
 
     public static void main(String[] args) {
 
-        NetworkParameters params = TestNet3Params.get();
-        Wallet wallet = Wallet.createDeterministic(params, ScriptType.P2PKH);
+        Network network = BitcoinNetwork.TESTNET;
+        Wallet wallet = Wallet.createDeterministic(NetworkParameters.of(network), ScriptType.P2PKH);
 
         DeterministicSeed seed = wallet.getKeyChainSeed();
         System.out.println("seed: " + seed.toString());

--- a/examples/src/main/java/org/bitcoinj/examples/FetchBlock.java
+++ b/examples/src/main/java/org/bitcoinj/examples/FetchBlock.java
@@ -17,10 +17,11 @@
 
 package org.bitcoinj.examples;
 
+import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.core.*;
 import org.bitcoinj.net.discovery.DnsDiscovery;
-import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.utils.BriefLogFormatter;
@@ -55,10 +56,11 @@ public class FetchBlock implements Callable<Integer> {
     public Integer call() throws Exception {
         // Connect to testnet and find a peer
         System.out.println("Connecting to node");
-        final NetworkParameters params = TestNet3Params.get();
+        final Network network = BitcoinNetwork.TESTNET;
+        final NetworkParameters params = NetworkParameters.of(network);
         BlockStore blockStore = new MemoryBlockStore(params);
         BlockChain chain = new BlockChain(params, blockStore);
-        PeerGroup peerGroup = new PeerGroup(params.network(), chain);
+        PeerGroup peerGroup = new PeerGroup(network, chain);
         if (localhost) {
             peerGroup.addPeerDiscovery(new DnsDiscovery(params));
         } else {

--- a/examples/src/main/java/org/bitcoinj/examples/FetchTransactions.java
+++ b/examples/src/main/java/org/bitcoinj/examples/FetchTransactions.java
@@ -17,9 +17,10 @@
 
 package org.bitcoinj.examples;
 
+import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.core.*;
-import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.utils.BriefLogFormatter;
@@ -35,11 +36,12 @@ public class FetchTransactions {
     public static void main(String[] args) throws Exception {
         BriefLogFormatter.init();
         System.out.println("Connecting to node");
-        final NetworkParameters params = TestNet3Params.get();
+        final Network network = BitcoinNetwork.TESTNET;
+        final NetworkParameters params = NetworkParameters.of(network);
 
         BlockStore blockStore = new MemoryBlockStore(params);
         BlockChain chain = new BlockChain(params, blockStore);
-        PeerGroup peerGroup = new PeerGroup(params.network(), chain);
+        PeerGroup peerGroup = new PeerGroup(network, chain);
         peerGroup.start();
         peerGroup.addAddress(new PeerAddress(params, InetAddress.getLocalHost()));
         peerGroup.waitForPeers(1).get();

--- a/examples/src/main/java/org/bitcoinj/examples/GenerateLowSTests.java
+++ b/examples/src/main/java/org/bitcoinj/examples/GenerateLowSTests.java
@@ -25,6 +25,8 @@ import java.util.EnumSet;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.base.Coin;
@@ -36,7 +38,6 @@ import org.bitcoinj.core.TransactionInput;
 import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.crypto.TransactionSignature;
-import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptChunk;
@@ -59,7 +60,8 @@ public class GenerateLowSTests {
 
     public static void main(final String[] argv)
             throws NoSuchAlgorithmException, IOException, VerificationException, SignatureDecodeException {
-        final NetworkParameters params = new MainNetParams();
+        final Network network = BitcoinNetwork.MAINNET;
+        final NetworkParameters params = NetworkParameters.of(network);
         final LocalTransactionSigner signer = new LocalTransactionSigner();
         final SecureRandom secureRandom = SecureRandom.getInstanceStrong();
         final ECKey key = new ECKey(secureRandom);
@@ -86,11 +88,11 @@ public class GenerateLowSTests {
 
         final Transaction outputTransaction = new Transaction(params);
         final Transaction inputTransaction = new Transaction(params);
-        final TransactionOutput output = new TransactionOutput(params, inputTransaction, Coin.ZERO, key.toAddress(ScriptType.P2PKH, params.network()));
+        final TransactionOutput output = new TransactionOutput(params, inputTransaction, Coin.ZERO, key.toAddress(ScriptType.P2PKH, network));
 
         inputTransaction.addOutput(output);
         outputTransaction.addInput(output);
-        outputTransaction.addOutput(Coin.ZERO, new ECKey(secureRandom).toAddress(ScriptType.P2PKH, params.network()));
+        outputTransaction.addOutput(Coin.ZERO, new ECKey(secureRandom).toAddress(ScriptType.P2PKH, network));
 
         addOutputs(outputTransaction, bag);
 

--- a/examples/src/main/java/org/bitcoinj/examples/Kit.java
+++ b/examples/src/main/java/org/bitcoinj/examples/Kit.java
@@ -20,7 +20,6 @@ import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.*;
 import org.bitcoinj.kits.WalletAppKit;
-import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.wallet.KeyChainGroupStructure;
 import org.bitcoinj.wallet.Wallet;
 import org.bitcoinj.wallet.listeners.KeyChainEventListener;

--- a/examples/src/main/java/org/bitcoinj/examples/PeerMonitor.java
+++ b/examples/src/main/java/org/bitcoinj/examples/PeerMonitor.java
@@ -17,6 +17,8 @@
 
 package org.bitcoinj.examples;
 
+import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.core.AddressMessage;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.core.NetworkParameters;
@@ -24,7 +26,6 @@ import org.bitcoinj.core.Peer;
 import org.bitcoinj.core.PeerAddress;
 import org.bitcoinj.core.PeerGroup;
 import org.bitcoinj.net.discovery.DnsDiscovery;
-import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.utils.BriefLogFormatter;
 
 import javax.swing.*;
@@ -46,7 +47,6 @@ import java.util.concurrent.TimeUnit;
  * Shows connected peers in a table view, so you can watch as they come and go.
  */
 public class PeerMonitor {
-    private NetworkParameters params;
     private PeerGroup peerGroup;
     private final Executor reverseDnsThreadPool = Executors.newCachedThreadPool();
     private PeerTableModel peerTableModel;
@@ -67,11 +67,11 @@ public class PeerMonitor {
     }
 
     private void setupNetwork() {
-        params = MainNetParams.get();
-        peerGroup = new PeerGroup(params.network(), null /* no chain */);
+        Network network = BitcoinNetwork.MAINNET;
+        peerGroup = new PeerGroup(network, null /* no chain */);
         peerGroup.setUserAgent("PeerMonitor", "1.0");
         peerGroup.setMaxConnections(4);
-        peerGroup.addPeerDiscovery(new DnsDiscovery(params));
+        peerGroup.addPeerDiscovery(new DnsDiscovery(NetworkParameters.of(network)));
         peerGroup.addConnectedEventListener((peer, peerCount) -> {
             refreshUI();
             lookupReverseDNS(peer);

--- a/examples/src/main/java/org/bitcoinj/examples/PrintPeers.java
+++ b/examples/src/main/java/org/bitcoinj/examples/PrintPeers.java
@@ -16,6 +16,8 @@
 
 package org.bitcoinj.examples;
 
+import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.core.listeners.PeerConnectedEventListener;
 import org.bitcoinj.core.listeners.PeerDisconnectedEventListener;
 import org.bitcoinj.core.NetworkParameters;
@@ -25,7 +27,6 @@ import org.bitcoinj.core.VersionMessage;
 import org.bitcoinj.net.discovery.DnsDiscovery;
 import org.bitcoinj.net.discovery.PeerDiscoveryException;
 import org.bitcoinj.net.NioClientManager;
-import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.utils.BriefLogFormatter;
 import com.google.common.util.concurrent.Futures;
 
@@ -54,9 +55,9 @@ public class PrintPeers {
         }
     }
 
-    private static void printDNS() throws PeerDiscoveryException {
+    private static void printDNS(Network network) throws PeerDiscoveryException {
         long start = System.currentTimeMillis();
-        DnsDiscovery dns = new DnsDiscovery(MainNetParams.get());
+        DnsDiscovery dns = new DnsDiscovery(NetworkParameters.of(network));
         dnsPeers = dns.getPeers(0, 10, TimeUnit.SECONDS);
         printPeers(dnsPeers);
         printElapsed(start);
@@ -64,15 +65,16 @@ public class PrintPeers {
 
     public static void main(String[] args) throws Exception {
         BriefLogFormatter.init();
+        final Network network = BitcoinNetwork.MAINNET;
+        final NetworkParameters params = NetworkParameters.of(network);
         System.out.println("=== DNS ===");
-        printDNS();
+        printDNS(network);
         System.out.println("=== Version/chain heights ===");
 
         ArrayList<InetAddress> addrs = new ArrayList<>();
         for (InetSocketAddress peer : dnsPeers) addrs.add(peer.getAddress());
         System.out.println("Scanning " + addrs.size() + " peers:");
 
-        final NetworkParameters params = MainNetParams.get();
         final Object lock = new Object();
         final long[] bestHeight = new long[1];
 

--- a/examples/src/main/java/org/bitcoinj/examples/PrivateKeys.java
+++ b/examples/src/main/java/org/bitcoinj/examples/PrivateKeys.java
@@ -17,6 +17,8 @@
 
 package org.bitcoinj.examples;
 
+import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.Base58;
@@ -26,7 +28,6 @@ import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.PeerAddress;
 import org.bitcoinj.core.PeerGroup;
-import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.wallet.Wallet;
 
@@ -45,20 +46,21 @@ import java.net.InetAddress;
 public class PrivateKeys {
     public static void main(String[] args) throws Exception {
         // TODO: Assumes main network not testnet. Make it selectable.
-        NetworkParameters params = MainNetParams.get();
+        Network network = BitcoinNetwork.MAINNET;
+        NetworkParameters params = NetworkParameters.of(network);
         try {
             // Decode the private key from Satoshis Base58 variant. If 51 characters long then it's from Bitcoins
             // dumpprivkey command and includes a version byte and checksum, or if 52 characters long then it has 
             // compressed pub key. Otherwise assume it's a raw key.
             ECKey key;
             if (args[0].length() == 51 || args[0].length() == 52) {
-                DumpedPrivateKey dumpedPrivateKey = DumpedPrivateKey.fromBase58(params.network(), args[0]);
+                DumpedPrivateKey dumpedPrivateKey = DumpedPrivateKey.fromBase58(network, args[0]);
                 key = dumpedPrivateKey.getKey();
             } else {
                 BigInteger privKey = Base58.decodeToBigInteger(args[0]);
                 key = ECKey.fromPrivate(privKey);
             }
-            System.out.println("Address from private key is: " + key.toAddress(ScriptType.P2WPKH, params.network()).toString());
+            System.out.println("Address from private key is: " + key.toAddress(ScriptType.P2WPKH, network).toString());
 
             // Import the private key to a fresh wallet.
             Wallet wallet = Wallet.createDeterministic(params, ScriptType.P2PKH);
@@ -71,7 +73,7 @@ public class PrivateKeys {
             final MemoryBlockStore blockStore = new MemoryBlockStore(params);
             BlockChain chain = new BlockChain(params, wallet, blockStore);
 
-            final PeerGroup peerGroup = new PeerGroup(params.network(), chain);
+            final PeerGroup peerGroup = new PeerGroup(network, chain);
             peerGroup.addAddress(new PeerAddress(params, InetAddress.getLocalHost()));
             peerGroup.startAsync();
             peerGroup.downloadBlockChain();

--- a/examples/src/main/java/org/bitcoinj/examples/RefreshWallet.java
+++ b/examples/src/main/java/org/bitcoinj/examples/RefreshWallet.java
@@ -17,9 +17,10 @@
 
 package org.bitcoinj.examples;
 
+import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.core.*;
-import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.wallet.Wallet;
@@ -38,11 +39,12 @@ public class RefreshWallet {
         System.out.println(wallet.toString());
 
         // Set up the components and link them together.
-        final NetworkParameters params = TestNet3Params.get();
+        final Network network = BitcoinNetwork.TESTNET;
+        final NetworkParameters params = NetworkParameters.of(network);
         BlockStore blockStore = new MemoryBlockStore(params);
         BlockChain chain = new BlockChain(params, wallet, blockStore);
 
-        final PeerGroup peerGroup = new PeerGroup(params.network(), chain);
+        final PeerGroup peerGroup = new PeerGroup(network, chain);
         peerGroup.startAsync();
 
         wallet.addCoinsReceivedEventListener(new WalletCoinsReceivedEventListener() {

--- a/examples/src/main/java/org/bitcoinj/examples/RestoreFromSeed.java
+++ b/examples/src/main/java/org/bitcoinj/examples/RestoreFromSeed.java
@@ -16,11 +16,12 @@
 
 package org.bitcoinj.examples;
 
+import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.listeners.DownloadProgressTracker;
 import org.bitcoinj.core.*;
 import org.bitcoinj.net.discovery.DnsDiscovery;
-import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.store.SPVBlockStore;
 import org.bitcoinj.wallet.DeterministicSeed;
 import org.bitcoinj.wallet.KeyChainGroupStructure;
@@ -35,7 +36,8 @@ import java.io.File;
 public class RestoreFromSeed {
 
     public static void main(String[] args) throws Exception {
-        NetworkParameters params = TestNet3Params.get();
+        Network network = BitcoinNetwork.TESTNET;
+        NetworkParameters params = NetworkParameters.of(network);
 
         // Bitcoinj supports hierarchical deterministic wallets (or "HD Wallets"): https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
         // HD wallets allow you to restore your wallet simply from a root seed. This seed can be represented using a short mnemonic sentence as described in BIP 39: https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
@@ -63,7 +65,7 @@ public class RestoreFromSeed {
         // Setting up the BlochChain, the BlocksStore and connecting to the network.
         SPVBlockStore chainStore = new SPVBlockStore(params, chainFile);
         BlockChain chain = new BlockChain(params, chainStore);
-        PeerGroup peerGroup = new PeerGroup(params.network(), chain);
+        PeerGroup peerGroup = new PeerGroup(network, chain);
         peerGroup.addPeerDiscovery(new DnsDiscovery(params));
 
         // Now we need to hook the wallet up to the blockchain and the peers. This registers event listeners that notify our wallet about new transactions.


### PR DESCRIPTION
* Replace all usages of `*Net*Params.get()` with `BitcoinNetwork.*` enum
* Where `NetworkParameters` is needed, get it with `NetworkParameters.of(network)`

This change does the following:

* Makes it clear that BitcoinNetwork.* is the preferred method of specifying/declaring the active network.
* Prepares the way for examples to get the network string as a command-line arg
* Continues the general migration from NetworkParameters to Network