### PR TITLE
DefaultRiskAnalysisTest: initialize Context in setup()

### DIFF
--- a/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
@@ -20,6 +20,7 @@ package org.bitcoinj.wallet;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.utils.ByteUtils;
+import org.bitcoinj.core.Context;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Transaction;
@@ -57,6 +58,7 @@ public class DefaultRiskAnalysisTest {
 
     @Before
     public void setup() {
+        Context.getOrCreate();
         wallet = Wallet.createDeterministic(MAINNET, ScriptType.P2PKH);
         wallet.setLastBlockSeenHeight(1000);
         wallet.setLastBlockSeenTimeSecs(TIMESTAMP);


### PR DESCRIPTION
This is a (possible) fix for issue #2691.