### PR TITLE
Message: add `final Network`, make `params` `final`

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/utils/UnknownNetwork.java
+++ b/core/src/main/java/org/bitcoinj/base/utils/UnknownNetwork.java
@@ -1,0 +1,38 @@
+package org.bitcoinj.base.utils;
+
+import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.Monetary;
+import org.bitcoinj.base.Network;
+
+/**
+ * Experimental subclass for use cases where we don't know what the network is
+ */
+public enum UnknownNetwork implements Network {
+    DEPRECATED,          // Unknown network resulting from usage of deprecated API
+    UNNECESSARY;         // Unknown network in subclass where network info is not needed
+
+    @Override
+    public String id() {
+        return "deprecated";
+    }
+
+    @Override
+    public String uriScheme() {
+        return "deprecated";
+    }
+
+    @Override
+    public boolean hasMaxMoney() {
+        return false;
+    }
+
+    @Override
+    public Monetary maxMoney() {
+        return Coin.ZERO;
+    }
+
+    @Override
+    public boolean exceedsMaxMoney(Monetary monetary) {
+        return false;
+    }
+}

--- a/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
@@ -255,7 +255,7 @@ public class BitcoinSerializer extends MessageSerializer {
         } else if (command.equals("notfound")) {
             return new NotFoundMessage(params, payloadBytes);
         } else if (command.equals("mempool")) {
-            return new MemoryPoolMessage();
+            return new MemoryPoolMessage(params.network());
         } else if (command.equals("reject")) {
             return new RejectMessage(params, payloadBytes);
         } else if (command.equals("sendheaders")) {

--- a/core/src/main/java/org/bitcoinj/core/BloomFilter.java
+++ b/core/src/main/java/org/bitcoinj/core/BloomFilter.java
@@ -20,6 +20,7 @@ package org.bitcoinj.core;
 import com.google.common.base.MoreObjects;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.utils.ByteUtils;
+import org.bitcoinj.base.utils.UnknownNetwork;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptChunk;
 import org.bitcoinj.script.ScriptPattern;
@@ -117,6 +118,7 @@ public class BloomFilter extends Message {
     public BloomFilter(int elements, double falsePositiveRate, long randomNonce, BloomUpdate updateFlag) {
         // The following formulas were stolen from Wikipedia's page on Bloom Filters (with the addition of min(..., MAX_...))
         //                        Size required for a given number of elements and false-positive rate
+        super(UnknownNetwork.UNNECESSARY);
         int size = (int)(-1  / (pow(log(2), 2)) * elements * log(falsePositiveRate));
         size = max(1, min(size, (int) MAX_FILTER_SIZE * 8) / 8);
         data = new byte[size];

--- a/core/src/main/java/org/bitcoinj/core/EmptyMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/EmptyMessage.java
@@ -17,6 +17,9 @@
 
 package org.bitcoinj.core;
 
+import org.bitcoinj.base.Network;
+import org.bitcoinj.base.utils.UnknownNetwork;
+
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -28,7 +31,14 @@ import java.io.OutputStream;
  */
 public abstract class EmptyMessage extends Message {
 
+    @Deprecated
     public EmptyMessage() {
+        super(UnknownNetwork.DEPRECATED);
+        length = 0;
+    }
+
+    public EmptyMessage(Network network) {
+        super(network);
         length = 0;
     }
 

--- a/core/src/main/java/org/bitcoinj/core/MemoryPoolMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/MemoryPoolMessage.java
@@ -17,6 +17,9 @@
 
 package org.bitcoinj.core;
 
+import org.bitcoinj.base.Network;
+import org.bitcoinj.base.utils.UnknownNetwork;
+
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -30,6 +33,11 @@ import java.io.OutputStream;
  * <p>Instances of this class are not safe for use by multiple threads.</p>
  */
 public class MemoryPoolMessage extends Message {
+
+    public MemoryPoolMessage(Network network) {
+        super(network);
+    }
+
     @Override
     protected void parse() throws ProtocolException {}
 

--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -17,8 +17,10 @@
 
 package org.bitcoinj.core;
 
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.utils.ByteUtils;
+import org.bitcoinj.base.utils.UnknownNetwork;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,13 +62,25 @@ public abstract class Message {
     protected boolean recached = false;
     protected MessageSerializer serializer;
 
-    protected NetworkParameters params;
+    private final Network network;
+    final NetworkParameters params;
 
+    @Deprecated
     protected Message() {
+        this(UnknownNetwork.DEPRECATED);
         serializer = DummySerializer.DEFAULT;
     }
 
+    protected Message(Network network) {
+        this.network = network;
+        this.params = network instanceof UnknownNetwork
+                        ? null
+                        : NetworkParameters.of(network);
+        this.serializer = params != null ? params.getDefaultSerializer() : DummySerializer.DEFAULT;
+    }
+
     protected Message(NetworkParameters params) {
+        this.network = params.network();
         this.params = params;
         this.serializer = params.getDefaultSerializer();
     }
@@ -82,8 +96,8 @@ public abstract class Message {
      * @throws ProtocolException
      */
     protected Message(NetworkParameters params, byte[] payload, int offset, MessageSerializer serializer, int length) throws ProtocolException {
+        this(params);
         this.serializer = serializer;
-        this.params = params;
         this.payload = payload;
         this.cursor = this.offset = offset;
         this.length = length;

--- a/core/src/main/java/org/bitcoinj/core/Ping.java
+++ b/core/src/main/java/org/bitcoinj/core/Ping.java
@@ -18,6 +18,7 @@
 package org.bitcoinj.core;
 
 import org.bitcoinj.base.utils.ByteUtils;
+import org.bitcoinj.base.utils.UnknownNetwork;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -38,6 +39,7 @@ public class Ping extends Message {
      * Only use this if the remote node has a protocol version greater than 60000
      */
     public Ping(long nonce) {
+        super(UnknownNetwork.UNNECESSARY);
         this.nonce = nonce;
         this.hasNonce = true;
     }
@@ -47,6 +49,7 @@ public class Ping extends Message {
      * Only use this if the remote node has a protocol version lower than or equal 60000
      */
     public Ping() {
+        super(UnknownNetwork.UNNECESSARY);
         this.hasNonce = false;
     }
     

--- a/core/src/main/java/org/bitcoinj/core/Pong.java
+++ b/core/src/main/java/org/bitcoinj/core/Pong.java
@@ -18,6 +18,7 @@
 package org.bitcoinj.core;
 
 import org.bitcoinj.base.utils.ByteUtils;
+import org.bitcoinj.base.utils.UnknownNetwork;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -37,6 +38,7 @@ public class Pong extends Message {
      * Only use this if the remote node has a protocol version greater than 60000
      */
     public Pong(long nonce) {
+        super(UnknownNetwork.UNNECESSARY);
         this.nonce = nonce;
     }
     

--- a/core/src/main/java/org/bitcoinj/core/SendHeadersMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/SendHeadersMessage.java
@@ -16,6 +16,8 @@
 
 package org.bitcoinj.core;
 
+import org.bitcoinj.base.utils.UnknownNetwork;
+
 /**
  * <p>
  * A new message, "sendheaders", which indicates that a node prefers to receive new block announcements via a "headers"
@@ -27,10 +29,13 @@ package org.bitcoinj.core;
  * </p>
  */
 public class SendHeadersMessage extends EmptyMessage {
+    @Deprecated
     public SendHeadersMessage() {
+        super(UnknownNetwork.DEPRECATED);
     }
 
     // this is needed by the BitcoinSerializer
     public SendHeadersMessage(NetworkParameters params, byte[] payload) {
+        super(params);
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/VersionAck.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionAck.java
@@ -16,6 +16,9 @@
 
 package org.bitcoinj.core;
 
+import org.bitcoinj.base.Network;
+import org.bitcoinj.base.utils.UnknownNetwork;
+
 /**
  * <p>The verack message, sent by a client accepting the version message they
  * received from their peer.</p>
@@ -23,10 +26,16 @@ package org.bitcoinj.core;
  * <p>Instances of this class are not safe for use by multiple threads.</p>
  */
 public class VersionAck extends EmptyMessage {
+    @Deprecated
     public VersionAck() {
+        super(UnknownNetwork.DEPRECATED);
     }
 
+    public VersionAck(Network network) {
+        super(network);
+    }
     // this is needed by the BitcoinSerializer
     public VersionAck(NetworkParameters params, byte[] payload) {
+        super(params);
     }
 }

--- a/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
@@ -240,7 +240,7 @@ public class BitcoinSerializerTest {
     public void testSerializeUnknownMessage() throws Exception {
         MessageSerializer serializer = MAINNET.getDefaultSerializer();
 
-        Message unknownMessage = new Message() {
+        Message unknownMessage = new Message(MAINNET.network()) {
             @Override
             protected void parse() throws ProtocolException {
             }

--- a/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
@@ -311,7 +311,7 @@ public class BitcoindComparisonTool {
                     preloadedBlocks.remove(nextBlock.getHash());
                 log.info("Block \"" + block.ruleName + "\" completed processing");
             } else if (rule instanceof MemoryPoolState) {
-                MemoryPoolMessage message = new MemoryPoolMessage();
+                MemoryPoolMessage message = new MemoryPoolMessage(PARAMS.network());
                 bitcoind.sendMessage(message);
                 bitcoind.ping().get();
                 if (mostRecentInv == null && !((MemoryPoolState) rule).mempool.isEmpty()) {

--- a/core/src/test/java/org/bitcoinj/core/CheckpointManagerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/CheckpointManagerTest.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.core;
 
+import org.bitcoinj.base.BitcoinNetwork;
 import org.easymock.EasyMockRunner;
 import org.easymock.Mock;
 import org.junit.Test;
@@ -55,6 +56,7 @@ public class CheckpointManagerTest {
 
     @Test
     public void canReadTextualStream() throws IOException {
+        expect(params.network()).andReturn(BitcoinNetwork.MAINNET);
         expect(params.getId()).andReturn("org/bitcoinj/core/checkpointmanagertest/validTextualFormat");
         expect(params.getSerializer(false)).andReturn(
                 new BitcoinSerializer(params, NetworkParameters.ProtocolVersion.CURRENT.getBitcoinProtocolVersion(), false));

--- a/core/src/test/java/org/bitcoinj/core/PeerAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerAddressTest.java
@@ -41,7 +41,7 @@ public class PeerAddressTest {
     public void equalsContract() {
         EqualsVerifier.forClass(PeerAddress.class)
                 .suppress(Warning.NONFINAL_FIELDS)
-                .withIgnoredFields("time", "parent", "params", "offset", "cursor", "length", "payload", "recached", "serializer")
+                .withIgnoredFields("time", "parent", "params", "network", "offset", "cursor", "length", "payload", "recached", "serializer")
                 .usingGetClass()
                 .verify();
     }

--- a/integration-test/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
+++ b/integration-test/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
@@ -190,7 +190,7 @@ public class TestWithNetworkConnections {
         // Complete handshake with the peer - send/receive version(ack)s, receive bloom filter
         checkState(!peer.getVersionHandshakeFuture().isDone());
         writeTarget.sendMessage(versionMessage);
-        writeTarget.sendMessage(new VersionAck());
+        writeTarget.sendMessage(new VersionAck(peer.network()));
         try {
             checkState(writeTarget.nextMessageBlocking() instanceof VersionMessage);
             checkState(writeTarget.nextMessageBlocking() instanceof VersionAck);

--- a/integration-test/src/test/java/org/bitcoinj/testing/TestWithPeerGroup.java
+++ b/integration-test/src/test/java/org/bitcoinj/testing/TestWithPeerGroup.java
@@ -149,7 +149,7 @@ public class TestWithPeerGroup extends TestWithNetworkConnections {
         InboundMessageQueuer writeTarget = connectPeerWithoutVersionExchange(id);
         // Complete handshake with the peer - send/receive version(ack)s, receive bloom filter
         writeTarget.sendMessage(versionMessage);
-        writeTarget.sendMessage(new VersionAck());
+        writeTarget.sendMessage(new VersionAck(writeTarget.peer.network()));
         stepThroughInit(versionMessage, writeTarget);
         return writeTarget;
     }
@@ -165,7 +165,7 @@ public class TestWithPeerGroup extends TestWithNetworkConnections {
         checkArgument(versionMessage.hasBlockChain());
         // Complete handshake with the peer - send/receive version(ack)s, receive bloom filter
         writeTarget.sendMessage(versionMessage);
-        writeTarget.sendMessage(new VersionAck());
+        writeTarget.sendMessage(new VersionAck(writeTarget.peer.network()));
         stepThroughInit(versionMessage, writeTarget);
         return writeTarget;
     }


### PR DESCRIPTION
This is an experimental first step towards migrating `Message` and subclasses from `NetworkParameters` to `Network` (and reducing mutability a bit)

* Message can be constructed with either params or network
* params member is now final (but nullable, see: rough edges)
* Network member is final and not nullable
* no-args constructors are deprecated
* Added network() accessor in Peer (to eliminate no-arg constructors)

Rough edges:

* UnknownNetwork is hopefully a temporary solution until all refactoring is finished
* params is set to null when network is UnknownNetwork

Next steps:

* More analysis around the UnknownwNetwork.UNNECESSARY cases
* More analysis around which tests require UNITTESTPARAMS (in those cases we currently must use params not network)
* Make `params` private and provide a `getParams()` accessor
* Consider using an interface to mark which messages have params and/or network
* Keep refactoring towards Network