### PR TITLE
Bech32Test: Test that Bech32m is invalid Bech32 and vice-versa

### DIFF
--- a/core/src/test/java/org/bitcoinj/base/Bech32Test.java
+++ b/core/src/test/java/org/bitcoinj/base/Bech32Test.java
@@ -71,11 +71,17 @@ public class Bech32Test {
     public void invalid_bech32() {
         for (String invalid : INVALID_BECH32)
             invalid(invalid);
+        // Valid BECH32M codes are invalid BECH32
+        for (String invalid : VALID_BECH32M)
+            invalid(invalid);
     }
 
     @Test
     public void invalid_bech32m() {
         for (String invalid : INVALID_BECH32M)
+            invalid(invalid);
+        // Valid BECH32 codes are invalid BECH32M
+        for (String invalid : VALID_BECH32)
             invalid(invalid);
     }
 


### PR DESCRIPTION
* Use the array of valid Bech32m addresses and make sure they are invalid Bech32
* Use the array of valid Bech32 addresses and make sure they are invalid Bech32m
