### PR TITLE
Add Network.segwitAddressHrp(), deprecate NetworkParameters.getSegwitAddressHrp()

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/BitcoinNetwork.java
+++ b/core/src/main/java/org/bitcoinj/base/BitcoinNetwork.java
@@ -101,6 +101,16 @@ public enum BitcoinNetwork implements Network {
         return id;
     }
 
+
+    /**
+     * Return the standard Bech32 {@link org.bitcoinj.base.SegwitAddress.SegwitHrp} (as a {@code String}) for
+     * this network.
+     * @return The HRP as a (lowercase) string.
+     */
+    public String segwitAddressHrp() {
+        return SegwitAddress.SegwitHrp.ofNetwork(this).toString();
+    }
+
     /**
      * The URI scheme for Bitcoin.
      * @see <a href="https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki">BIP 0021</a>

--- a/core/src/main/java/org/bitcoinj/base/Network.java
+++ b/core/src/main/java/org/bitcoinj/base/Network.java
@@ -27,6 +27,12 @@ public interface Network {
     String id();
 
     /**
+     * Human-readable part (HRP) of bech32 encoded segwit addresses for this network.
+     * @return HRP (lowercase)
+     */
+    String segwitAddressHrp();
+
+    /**
      * The URI scheme for this network. See {@link BitcoinNetwork#uriScheme()}.
      * @return The URI scheme for this network
      */

--- a/core/src/main/java/org/bitcoinj/base/SegwitAddress.java
+++ b/core/src/main/java/org/bitcoinj/base/SegwitAddress.java
@@ -59,7 +59,10 @@ public class SegwitAddress extends Address {
 
 
     /**
-     * Human-readable part of Segwit addresses for standard Bitcoin networks
+     * Human-readable part (HRP) of Segwit addresses for standard Bitcoin networks.
+     * <p>
+     * See <a href="https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#user-content-Segwit_address_format">BIP 173 definition of {@code bc} and {@code tb} HRPs</a> and
+     *  <a href="https://github.com/bitcoin/bitcoin/issues/12314">Bitcoin Core Issue 1234 - discussion of {@code bcrt} HRP</a> for details.
      */
     public enum SegwitHrp {
         BC(MAINNET),

--- a/core/src/main/java/org/bitcoinj/base/SegwitAddress.java
+++ b/core/src/main/java/org/bitcoinj/base/SegwitAddress.java
@@ -26,6 +26,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -65,10 +66,14 @@ public class SegwitAddress extends Address {
         TB(TESTNET, SIGNET),
         BCRT(REGTEST);
 
-        private final BitcoinNetwork[] networks;
+        private final EnumSet<BitcoinNetwork> networks;
 
-        SegwitHrp(BitcoinNetwork... networks) {
-            this.networks = networks;
+        SegwitHrp(BitcoinNetwork n) {
+            networks = EnumSet.of(n);
+        }
+
+        SegwitHrp(BitcoinNetwork n1, BitcoinNetwork n2) {
+            networks = EnumSet.of(n1, n2);
         }
 
         /**
@@ -106,14 +111,9 @@ public class SegwitAddress extends Address {
          */
         public static SegwitHrp ofNetwork(BitcoinNetwork network) {
             return Stream.of(SegwitHrp.values())
-                    .filter(hrp -> hrp.hasNetwork(network))
+                    .filter(hrp -> hrp.networks.contains(network))
                     .findFirst()
                     .orElseThrow(IllegalStateException::new);
-        }
-
-        private boolean hasNetwork(BitcoinNetwork network) {
-            return Stream.of(networks)
-                    .anyMatch(n -> n == network);
         }
     }
 

--- a/core/src/main/java/org/bitcoinj/core/DefaultAddressParser.java
+++ b/core/src/main/java/org/bitcoinj/core/DefaultAddressParser.java
@@ -131,10 +131,9 @@ public class DefaultAddressParser implements AddressParser {
             throws AddressFormatException {
         String hrp = Bech32.decode(bech32).hrp;
         return segwitNetworks.stream()
-                .map(NetworkParameters::of)
-                .filter(p -> hrp.equals(p.getSegwitAddressHrp()))
+                .filter(n -> hrp.equals(n.segwitAddressHrp()))
                 .findFirst()
-                .map(p -> SegwitAddress.fromBech32(p.network(), bech32))
+                .map(n -> SegwitAddress.fromBech32(n, bech32))
                 .orElseThrow(() -> new AddressFormatException.InvalidPrefix("No network found for " + bech32));
     }
 

--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -330,7 +330,9 @@ public abstract class NetworkParameters {
     /**
      * Human-readable part of bech32 encoded segwit address.
      * @return the human-readable part value
+     * @deprecated Use {@link Network#segwitAddressHrp()} or {@link org.bitcoinj.base.SegwitAddress.SegwitHrp}
      */
+    @Deprecated
     public String getSegwitAddressHrp() {
         return segwitAddressHrp;
     }

--- a/core/src/main/java/org/bitcoinj/testing/MockAltNetwork.java
+++ b/core/src/main/java/org/bitcoinj/testing/MockAltNetwork.java
@@ -30,6 +30,11 @@ public class MockAltNetwork implements Network {
     }
 
     @Override
+    public String segwitAddressHrp() {
+        return "mock";
+    }
+
+    @Override
     public String uriScheme() {
         return "mockcoin";
     }


### PR DESCRIPTION
This PR makes the following changes:

* Add `String segwitAddressHrp()` method to `Network` interface
* Add implementation of `segwitAddressHrp()` to `BitcoinNetwork` interface
* Deprecate `public String getSegwitAddressHrp()` in `NetworkParameters`
* Add `SegwitAddress.SegwitHrp` Java `enum` defining 3 HRPs for the 4 `BitcoinNetwork` values.
* Migrate `SegwitAddress` from `NetworkParameters` to `Network` (and using `SegwitAddress.SegwitHrp`)
* Simplify `DefaultAddressParser` by using `Network.segwitAddressHrp()`
* Add a simple implementation of `segwitAddressHrp()` to `MockAltNetwork` (i.e. `return "mock";`)