### PR TITLE
LegacyAddressTest/SegwitAddressTest: convert to Network from NetParams

### DIFF
--- a/core/src/test/java/org/bitcoinj/base/LegacyAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/base/LegacyAddressTest.java
@@ -19,22 +19,14 @@ package org.bitcoinj.base;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.bitcoinj.base.Address;
-import org.bitcoinj.base.AddressParser;
-import org.bitcoinj.base.BitcoinNetwork;
-import org.bitcoinj.base.LegacyAddress;
-import org.bitcoinj.base.Network;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.core.DefaultAddressParser;
 import org.bitcoinj.core.DumpedPrivateKey;
 import org.bitcoinj.core.ECKey;
 import org.bitcoinj.core.NetworkParameters;
-import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.Networks;
-import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.script.Script;
-import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptPattern;
 import org.bitcoinj.testing.MockAltNetworkParams;
@@ -48,18 +40,19 @@ import java.util.List;
 
 import static org.bitcoinj.base.utils.ByteUtils.HEX;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class LegacyAddressTest {
-    private static final NetworkParameters TESTNET = TestNet3Params.get();
-    private static final NetworkParameters MAINNET = MainNetParams.get();
+import static org.bitcoinj.base.BitcoinNetwork.MAINNET;
+import static org.bitcoinj.base.BitcoinNetwork.TESTNET;
+import static org.bitcoinj.base.BitcoinNetwork.SIGNET;
+import static org.bitcoinj.base.BitcoinNetwork.REGTEST;
 
+public class LegacyAddressTest {
     @Test
     public void equalsContract() {
         EqualsVerifier.forClass(LegacyAddress.class)
-                .withPrefabValues(NetworkParameters.class, MAINNET, TESTNET)
+                .withPrefabValues(BitcoinNetwork.class, MAINNET, TESTNET)
                 .suppress(Warning.NULL_FIELDS)
                 .suppress(Warning.TRANSIENT_FIELDS)
                 .usingGetClass()
@@ -69,29 +62,29 @@ public class LegacyAddressTest {
     @Test
     public void stringification() {
         // Test a testnet address.
-        LegacyAddress a = LegacyAddress.fromPubKeyHash(BitcoinNetwork.TESTNET, HEX.decode("fda79a24e50ff70ff42f7d89585da5bd19d9e5cc"));
+        LegacyAddress a = LegacyAddress.fromPubKeyHash(TESTNET, HEX.decode("fda79a24e50ff70ff42f7d89585da5bd19d9e5cc"));
         assertEquals("n4eA2nbYqErp7H6jebchxAN59DmNpksexv", a.toString());
         assertEquals(ScriptType.P2PKH, a.getOutputScriptType());
 
-        LegacyAddress b = LegacyAddress.fromPubKeyHash(BitcoinNetwork.MAINNET, HEX.decode("4a22c3c4cbb31e4d03b15550636762bda0baf85a"));
+        LegacyAddress b = LegacyAddress.fromPubKeyHash(MAINNET, HEX.decode("4a22c3c4cbb31e4d03b15550636762bda0baf85a"));
         assertEquals("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL", b.toString());
         assertEquals(ScriptType.P2PKH, b.getOutputScriptType());
     }
 
     @Test
     public void decoding() {
-        LegacyAddress a = LegacyAddress.fromBase58(BitcoinNetwork.TESTNET, "n4eA2nbYqErp7H6jebchxAN59DmNpksexv");
+        LegacyAddress a = LegacyAddress.fromBase58(TESTNET, "n4eA2nbYqErp7H6jebchxAN59DmNpksexv");
         assertEquals("fda79a24e50ff70ff42f7d89585da5bd19d9e5cc", ByteUtils.HEX.encode(a.getHash()));
 
-        LegacyAddress b = LegacyAddress.fromBase58(BitcoinNetwork.MAINNET, "17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL");
+        LegacyAddress b = LegacyAddress.fromBase58(MAINNET, "17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL");
         assertEquals("4a22c3c4cbb31e4d03b15550636762bda0baf85a", ByteUtils.HEX.encode(b.getHash()));
     }
 
     @Test
     public void equalityOfEquivalentNetworks() {
-        LegacyAddress a = LegacyAddress.fromBase58(BitcoinNetwork.TESTNET, "n4eA2nbYqErp7H6jebchxAN59DmNpksexv");
-        LegacyAddress b = LegacyAddress.fromBase58(BitcoinNetwork.SIGNET, "n4eA2nbYqErp7H6jebchxAN59DmNpksexv");
-        LegacyAddress c = LegacyAddress.fromBase58(BitcoinNetwork.REGTEST, "n4eA2nbYqErp7H6jebchxAN59DmNpksexv");
+        LegacyAddress a = LegacyAddress.fromBase58(TESTNET, "n4eA2nbYqErp7H6jebchxAN59DmNpksexv");
+        LegacyAddress b = LegacyAddress.fromBase58(SIGNET, "n4eA2nbYqErp7H6jebchxAN59DmNpksexv");
+        LegacyAddress c = LegacyAddress.fromBase58(REGTEST, "n4eA2nbYqErp7H6jebchxAN59DmNpksexv");
         assertEquals(a, b);
         assertEquals(b, c);
         assertEquals(a, c);
@@ -104,7 +97,7 @@ public class LegacyAddressTest {
     public void errorPaths() {
         // Check what happens if we try and decode garbage.
         try {
-            LegacyAddress.fromBase58(BitcoinNetwork.TESTNET, "this is not a valid address!");
+            LegacyAddress.fromBase58(TESTNET, "this is not a valid address!");
             fail();
         } catch (AddressFormatException.WrongNetwork e) {
             fail();
@@ -114,7 +107,7 @@ public class LegacyAddressTest {
 
         // Check the empty case.
         try {
-            LegacyAddress.fromBase58(BitcoinNetwork.TESTNET, "");
+            LegacyAddress.fromBase58(TESTNET, "");
             fail();
         } catch (AddressFormatException.WrongNetwork e) {
             fail();
@@ -124,7 +117,7 @@ public class LegacyAddressTest {
 
         // Check the case of a mismatched network.
         try {
-            LegacyAddress.fromBase58(BitcoinNetwork.TESTNET, "17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL");
+            LegacyAddress.fromBase58(TESTNET, "17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL");
             fail();
         } catch (AddressFormatException.WrongNetwork e) {
             // Success.
@@ -134,13 +127,23 @@ public class LegacyAddressTest {
     }
 
     @Test
-    public void getNetwork() {
+    @Deprecated
+    // Test a deprecated method just to make sure we didn't break it
+    public void getNetworkViaParameters() {
         NetworkParameters params = LegacyAddress.getParametersFromAddress("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL");
-        assertEquals(MAINNET.getId(), params.getId());
+        assertEquals(MAINNET.id(), params.getId());
         params = LegacyAddress.getParametersFromAddress("n4eA2nbYqErp7H6jebchxAN59DmNpksexv");
-        assertEquals(TESTNET.getId(), params.getId());
+        assertEquals(TESTNET.id(), params.getId());
     }
 
+    @Test
+    public void getNetwork() {
+        AddressParser parser = new DefaultAddressParser();
+        Network mainNet = parser.parseAddressAnyNetwork("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL").network();
+        assertEquals(MAINNET, mainNet);
+        Network testNet = parser.parseAddressAnyNetwork("n4eA2nbYqErp7H6jebchxAN59DmNpksexv").network();
+        assertEquals(TESTNET, testNet);
+    }
     @Test
     public void getAltNetworkUsingNetworks() {
         // An alternative network
@@ -153,7 +156,7 @@ public class LegacyAddressTest {
             assertEquals(altNetParams.getId(), altAddress.network().id());
             // Check if main network works as before
             Address mainAddress = new DefaultAddressParser().parseAddressAnyNetwork("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL");
-            assertEquals(MAINNET.getId(), mainAddress.network().id());
+            assertEquals(MAINNET.id(), mainAddress.network().id());
         } finally {
             // Unregister network. Do this in a finally block so other tests don't fail if the try block fails to complete
             Networks.unregister(altNetParams);
@@ -184,7 +187,7 @@ public class LegacyAddressTest {
 
             // Check if main network works with custom parser
             Address mainAddress = customParser.parseAddressAnyNetwork("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL");
-            assertEquals(MAINNET.getId(), mainAddress.network().id());
+            assertEquals(MAINNET.id(), mainAddress.network().id());
 
         } finally {
             // Unregister network. Do this in a finally block so other tests don't fail if the try block fails to complete
@@ -201,26 +204,27 @@ public class LegacyAddressTest {
     @Test
     public void p2shAddress() {
         // Test that we can construct P2SH addresses
-        LegacyAddress mainNetP2SHAddress = LegacyAddress.fromBase58(BitcoinNetwork.MAINNET, "35b9vsyH1KoFT5a5KtrKusaCcPLkiSo1tU");
-        assertEquals(mainNetP2SHAddress.getVersion(), MAINNET.getP2SHHeader());
+        LegacyAddress mainNetP2SHAddress = LegacyAddress.fromBase58(MAINNET, "35b9vsyH1KoFT5a5KtrKusaCcPLkiSo1tU");
+        assertEquals(mainNetP2SHAddress.getVersion(), NetworkParameters.of(MAINNET).getP2SHHeader());
         assertEquals(ScriptType.P2SH, mainNetP2SHAddress.getOutputScriptType());
-        LegacyAddress testNetP2SHAddress = LegacyAddress.fromBase58(BitcoinNetwork.TESTNET, "2MuVSxtfivPKJe93EC1Tb9UhJtGhsoWEHCe");
-        assertEquals(testNetP2SHAddress.getVersion(), TESTNET.getP2SHHeader());
+        LegacyAddress testNetP2SHAddress = LegacyAddress.fromBase58(TESTNET, "2MuVSxtfivPKJe93EC1Tb9UhJtGhsoWEHCe");
+        assertEquals(testNetP2SHAddress.getVersion(), NetworkParameters.of(TESTNET).getP2SHHeader());
         assertEquals(ScriptType.P2SH, testNetP2SHAddress.getOutputScriptType());
 
+        AddressParser parser = new DefaultAddressParser();
         // Test that we can determine what network a P2SH address belongs to
-        NetworkParameters mainNetParams = LegacyAddress.getParametersFromAddress("35b9vsyH1KoFT5a5KtrKusaCcPLkiSo1tU");
-        assertEquals(MAINNET.getId(), mainNetParams.getId());
-        NetworkParameters testNetParams = LegacyAddress.getParametersFromAddress("2MuVSxtfivPKJe93EC1Tb9UhJtGhsoWEHCe");
-        assertEquals(TESTNET.getId(), testNetParams.getId());
+        Network mainNet = parser.parseAddressAnyNetwork("35b9vsyH1KoFT5a5KtrKusaCcPLkiSo1tU").network();
+        assertEquals(MAINNET, mainNet);
+        Network testNet = parser.parseAddressAnyNetwork("2MuVSxtfivPKJe93EC1Tb9UhJtGhsoWEHCe").network();
+        assertEquals(TESTNET, testNet);
 
         // Test that we can convert them from hashes
         byte[] hex = HEX.decode("2ac4b0b501117cc8119c5797b519538d4942e90e");
-        LegacyAddress a = LegacyAddress.fromScriptHash(BitcoinNetwork.MAINNET, hex);
+        LegacyAddress a = LegacyAddress.fromScriptHash(MAINNET, hex);
         assertEquals("35b9vsyH1KoFT5a5KtrKusaCcPLkiSo1tU", a.toString());
-        LegacyAddress b = LegacyAddress.fromScriptHash(BitcoinNetwork.TESTNET, HEX.decode("18a0e827269b5211eb51a4af1b2fa69333efa722"));
+        LegacyAddress b = LegacyAddress.fromScriptHash(TESTNET, HEX.decode("18a0e827269b5211eb51a4af1b2fa69333efa722"));
         assertEquals("2MuVSxtfivPKJe93EC1Tb9UhJtGhsoWEHCe", b.toString());
-        LegacyAddress c = LegacyAddress.fromScriptHash(BitcoinNetwork.MAINNET,
+        LegacyAddress c = LegacyAddress.fromScriptHash(MAINNET,
                 ScriptPattern.extractHashFromP2SH(ScriptBuilder.createP2SHOutputScript(hex)));
         assertEquals("35b9vsyH1KoFT5a5KtrKusaCcPLkiSo1tU", c.toString());
     }
@@ -228,16 +232,16 @@ public class LegacyAddressTest {
     @Test
     public void p2shAddressCreationFromKeys() {
         // import some keys from this example: https://gist.github.com/gavinandresen/3966071
-        ECKey key1 = DumpedPrivateKey.fromBase58(BitcoinNetwork.MAINNET, "5JaTXbAUmfPYZFRwrYaALK48fN6sFJp4rHqq2QSXs8ucfpE4yQU").getKey();
+        ECKey key1 = DumpedPrivateKey.fromBase58(MAINNET, "5JaTXbAUmfPYZFRwrYaALK48fN6sFJp4rHqq2QSXs8ucfpE4yQU").getKey();
         key1 = ECKey.fromPrivate(key1.getPrivKeyBytes());
-        ECKey key2 = DumpedPrivateKey.fromBase58(BitcoinNetwork.MAINNET, "5Jb7fCeh1Wtm4yBBg3q3XbT6B525i17kVhy3vMC9AqfR6FH2qGk").getKey();
+        ECKey key2 = DumpedPrivateKey.fromBase58(MAINNET, "5Jb7fCeh1Wtm4yBBg3q3XbT6B525i17kVhy3vMC9AqfR6FH2qGk").getKey();
         key2 = ECKey.fromPrivate(key2.getPrivKeyBytes());
-        ECKey key3 = DumpedPrivateKey.fromBase58(BitcoinNetwork.MAINNET, "5JFjmGo5Fww9p8gvx48qBYDJNAzR9pmH5S389axMtDyPT8ddqmw").getKey();
+        ECKey key3 = DumpedPrivateKey.fromBase58(MAINNET, "5JFjmGo5Fww9p8gvx48qBYDJNAzR9pmH5S389axMtDyPT8ddqmw").getKey();
         key3 = ECKey.fromPrivate(key3.getPrivKeyBytes());
 
         List<ECKey> keys = Arrays.asList(key1, key2, key3);
         Script p2shScript = ScriptBuilder.createP2SHOutputScript(2, keys);
-        LegacyAddress address = LegacyAddress.fromScriptHash(BitcoinNetwork.MAINNET,
+        LegacyAddress address = LegacyAddress.fromScriptHash(MAINNET,
                 ScriptPattern.extractHashFromP2SH(p2shScript));
         assertEquals("3N25saC4dT24RphDAwLtD8LUN4E2gZPJke", address.toString());
     }
@@ -245,13 +249,13 @@ public class LegacyAddressTest {
     @Test
     public void roundtripBase58() {
         String base58 = "17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL";
-        assertEquals(base58, LegacyAddress.fromBase58(BitcoinNetwork.MAINNET, base58).toBase58());
+        assertEquals(base58, LegacyAddress.fromBase58(MAINNET, base58).toBase58());
     }
 
     @Test
     public void comparisonLessThan() {
-        LegacyAddress a = LegacyAddress.fromBase58(BitcoinNetwork.MAINNET, "1Dorian4RoXcnBv9hnQ4Y2C1an6NJ4UrjX");
-        LegacyAddress b = LegacyAddress.fromBase58(BitcoinNetwork.MAINNET, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P");
+        LegacyAddress a = LegacyAddress.fromBase58(MAINNET, "1Dorian4RoXcnBv9hnQ4Y2C1an6NJ4UrjX");
+        LegacyAddress b = LegacyAddress.fromBase58(MAINNET, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P");
 
         int result = a.compareTo(b);
         assertTrue(result < 0);
@@ -259,8 +263,8 @@ public class LegacyAddressTest {
 
     @Test
     public void comparisonGreaterThan() {
-        LegacyAddress a = LegacyAddress.fromBase58(BitcoinNetwork.MAINNET, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P");
-        LegacyAddress b = LegacyAddress.fromBase58(BitcoinNetwork.MAINNET, "1Dorian4RoXcnBv9hnQ4Y2C1an6NJ4UrjX");
+        LegacyAddress a = LegacyAddress.fromBase58(MAINNET, "1EXoDusjGwvnjZUyKkxZ4UHEf77z6A5S4P");
+        LegacyAddress b = LegacyAddress.fromBase58(MAINNET, "1Dorian4RoXcnBv9hnQ4Y2C1an6NJ4UrjX");
 
         int result = a.compareTo(b);
         assertTrue(result > 0);
@@ -269,8 +273,8 @@ public class LegacyAddressTest {
     @Test
     public void comparisonNotEquals() {
         // These addresses only differ by version byte
-        LegacyAddress a = LegacyAddress.fromBase58(BitcoinNetwork.MAINNET, "14wivxvNTv9THhewPotsooizZawaWbEKE2");
-        LegacyAddress b = LegacyAddress.fromBase58(BitcoinNetwork.MAINNET, "35djrWQp1pTqNsMNWuZUES5vi7EJ74m9Eh");
+        LegacyAddress a = LegacyAddress.fromBase58(MAINNET, "14wivxvNTv9THhewPotsooizZawaWbEKE2");
+        LegacyAddress b = LegacyAddress.fromBase58(MAINNET, "35djrWQp1pTqNsMNWuZUES5vi7EJ74m9Eh");
 
         int result = a.compareTo(b);
         assertTrue(result != 0);
@@ -283,8 +287,8 @@ public class LegacyAddressTest {
         String line;
         while ((line = dataSetReader.readLine()) != null) {
             String addr[] = line.split(",");
-            LegacyAddress first = LegacyAddress.fromBase58(BitcoinNetwork.MAINNET, addr[0]);
-            LegacyAddress second = LegacyAddress.fromBase58(BitcoinNetwork.MAINNET, addr[1]);
+            LegacyAddress first = LegacyAddress.fromBase58(MAINNET, addr[0]);
+            LegacyAddress second = LegacyAddress.fromBase58(MAINNET, addr[1]);
             assertTrue(first.compareTo(second) < 0);
             assertTrue(first.toString().compareTo(second.toString()) < 0);
         }

--- a/core/src/test/java/org/bitcoinj/base/SegwitAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/base/SegwitAddressTest.java
@@ -19,39 +19,30 @@ package org.bitcoinj.base;
 import com.google.common.base.MoreObjects;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.bitcoinj.base.AddressParser;
-import org.bitcoinj.base.BitcoinNetwork;
-import org.bitcoinj.base.SegwitAddress;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.core.DefaultAddressParser;
-import org.bitcoinj.core.NetworkParameters;
-import org.bitcoinj.params.MainNetParams;
-import org.bitcoinj.params.RegTestParams;
-import org.bitcoinj.params.SigNetParams;
-import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.script.Script;
-import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptPattern;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
+import static org.bitcoinj.base.BitcoinNetwork.MAINNET;
+import static org.bitcoinj.base.BitcoinNetwork.TESTNET;
+import static org.bitcoinj.base.BitcoinNetwork.SIGNET;
+import static org.bitcoinj.base.BitcoinNetwork.REGTEST;
 
 public class SegwitAddressTest {
-    private static final MainNetParams MAINNET = MainNetParams.get();
-    private static final TestNet3Params TESTNET = TestNet3Params.get();
     private static final AddressParser addressParser = new DefaultAddressParser();
 
     @Test
     public void equalsContract() {
         EqualsVerifier.forClass(SegwitAddress.class)
-                .withPrefabValues(NetworkParameters.class, MAINNET, TESTNET)
+                .withPrefabValues(BitcoinNetwork.class, MAINNET, TESTNET)
                 .suppress(Warning.NULL_FIELDS)
                 .suppress(Warning.TRANSIENT_FIELDS)
                 .usingGetClass()
@@ -62,9 +53,9 @@ public class SegwitAddressTest {
     public void example_p2wpkh_mainnet() {
         String bech32 = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
 
-        SegwitAddress address = SegwitAddress.fromBech32(BitcoinNetwork.MAINNET, bech32);
+        SegwitAddress address = SegwitAddress.fromBech32(MAINNET, bech32);
 
-        assertEquals(MAINNET, address.getParameters());
+        assertEquals(MAINNET, address.network());
         assertEquals("0014751e76e8199196d454941c45d1b3a323f1433bd6",
                 ByteUtils.HEX.encode(ScriptBuilder.createOutputScript(address).getProgram()));
         assertEquals(ScriptType.P2WPKH, address.getOutputScriptType());
@@ -76,9 +67,9 @@ public class SegwitAddressTest {
     public void example_p2wsh_mainnet() {
         String bech32 = "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3";
 
-        SegwitAddress address = SegwitAddress.fromBech32(BitcoinNetwork.MAINNET, bech32);
+        SegwitAddress address = SegwitAddress.fromBech32(MAINNET, bech32);
 
-        assertEquals(MAINNET, address.getParameters());
+        assertEquals(MAINNET, address.network());
         assertEquals("00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
                 ByteUtils.HEX.encode(ScriptBuilder.createOutputScript(address).getProgram()));
         assertEquals(ScriptType.P2WSH, address.getOutputScriptType());
@@ -90,9 +81,9 @@ public class SegwitAddressTest {
     public void example_p2wpkh_testnet() {
         String bech32 = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx";
 
-        SegwitAddress address = SegwitAddress.fromBech32(BitcoinNetwork.TESTNET, bech32);
+        SegwitAddress address = SegwitAddress.fromBech32(TESTNET, bech32);
 
-        assertEquals(TESTNET, address.getParameters());
+        assertEquals(TESTNET, address.network());
         assertEquals("0014751e76e8199196d454941c45d1b3a323f1433bd6",
                 ByteUtils.HEX.encode(ScriptBuilder.createOutputScript(address).getProgram()));
         assertEquals(ScriptType.P2WPKH, address.getOutputScriptType());
@@ -104,8 +95,8 @@ public class SegwitAddressTest {
     public void equalityOfEquivalentNetworks() {
         String bech32 = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx";
 
-        SegwitAddress a = SegwitAddress.fromBech32(BitcoinNetwork.TESTNET, bech32);
-        SegwitAddress b = SegwitAddress.fromBech32(BitcoinNetwork.SIGNET, bech32);
+        SegwitAddress a = SegwitAddress.fromBech32(TESTNET, bech32);
+        SegwitAddress b = SegwitAddress.fromBech32(SIGNET, bech32);
 
         assertEquals(a, b);
         assertEquals(a.toString(), b.toString());
@@ -115,9 +106,9 @@ public class SegwitAddressTest {
     public void example_p2wpkh_regtest() {
         String bcrt1_bech32 = "bcrt1qspfueag7fvty7m8htuzare3xs898zvh30fttu2";
 
-        SegwitAddress address = SegwitAddress.fromBech32(BitcoinNetwork.REGTEST, bcrt1_bech32);
+        SegwitAddress address = SegwitAddress.fromBech32(REGTEST, bcrt1_bech32);
 
-        assertEquals(BitcoinNetwork.REGTEST, address.network());
+        assertEquals(REGTEST, address.network());
         assertEquals("00148053ccf51e4b164f6cf75f05d1e62681ca7132f1",
                 ByteUtils.HEX.encode(ScriptBuilder.createOutputScript(address).getProgram()));
         assertEquals(ScriptType.P2WPKH, address.getOutputScriptType());
@@ -131,7 +122,7 @@ public class SegwitAddressTest {
 
         Address address = addressParser.parseAddressAnyNetwork(bcrt1_bech32);
 
-        assertEquals(BitcoinNetwork.REGTEST, address.network());
+        assertEquals(REGTEST, address.network());
         assertEquals("00148053ccf51e4b164f6cf75f05d1e62681ca7132f1",
                 ByteUtils.HEX.encode(ScriptBuilder.createOutputScript(address).getProgram()));
         assertEquals(ScriptType.P2WPKH, address.getOutputScriptType());
@@ -143,9 +134,9 @@ public class SegwitAddressTest {
     public void example_p2wsh_testnet() {
         String bech32 = "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7";
 
-        SegwitAddress address = SegwitAddress.fromBech32(BitcoinNetwork.TESTNET, bech32);
+        SegwitAddress address = SegwitAddress.fromBech32(TESTNET, bech32);
 
-        assertEquals(TESTNET, address.getParameters());
+        assertEquals(TESTNET, address.network());
         assertEquals("00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
                 ByteUtils.HEX.encode(ScriptBuilder.createOutputScript(address).getProgram()));
         assertEquals(ScriptType.P2WSH, address.getOutputScriptType());
@@ -158,13 +149,13 @@ public class SegwitAddressTest {
         for (AddressData valid : VALID_ADDRESSES) {
             SegwitAddress address = (SegwitAddress) addressParser.parseAddressAnyNetwork(valid.address);
 
-            assertEquals(valid.expectedParams, address.getParameters());
+            assertEquals(valid.expectedNetwork, address.network());
             assertEquals(valid.expectedScriptPubKey,
                     ByteUtils.HEX.encode(ScriptBuilder.createOutputScript(address).getProgram()));
             assertEquals(valid.address.toLowerCase(Locale.ROOT), address.toBech32());
             if (valid.expectedWitnessVersion == 0) {
                 Script expectedScriptPubKey = new Script(ByteUtils.HEX.decode(valid.expectedScriptPubKey));
-                assertEquals(address, SegwitAddress.fromHash(valid.expectedParams.network(),
+                assertEquals(address, SegwitAddress.fromHash(valid.expectedNetwork,
                         ScriptPattern.extractHashFromP2WH(expectedScriptPubKey)));
             }
             assertEquals(valid.expectedWitnessVersion, address.getWitnessVersion());
@@ -173,21 +164,21 @@ public class SegwitAddressTest {
 
     private static class AddressData {
         final String address;
-        final NetworkParameters expectedParams;
+        final BitcoinNetwork expectedNetwork;
         final String expectedScriptPubKey;
         final int expectedWitnessVersion;
 
-        AddressData(String address, NetworkParameters expectedParams, String expectedScriptPubKey,
+        AddressData(String address, BitcoinNetwork expectedNetwork, String expectedScriptPubKey,
                 int expectedWitnessVersion) {
             this.address = address;
-            this.expectedParams = expectedParams;
+            this.expectedNetwork = expectedNetwork;
             this.expectedScriptPubKey = expectedScriptPubKey;
             this.expectedWitnessVersion = expectedWitnessVersion;
         }
 
         @Override
         public String toString() {
-            return MoreObjects.toStringHelper(this).add("address", address).add("params", expectedParams.getId())
+            return MoreObjects.toStringHelper(this).add("address", address).add("params", expectedNetwork.id())
                     .add("scriptPubKey", expectedScriptPubKey).add("witnessVersion", expectedWitnessVersion).toString();
         }
     }
@@ -266,7 +257,7 @@ public class SegwitAddressTest {
         // Taproot, valid bech32m encoding, checksum ok, padding ok, but no valid Segwit v1 program
         // (this program is 20 bytes long, but only 32 bytes program length are valid for Segwit v1/Taproot)
         String taprootAddressWith20BytesWitnessProgram = "bc1pqypqzqspqgqsyqgzqypqzqspqgqsyqgzzezy58";
-        SegwitAddress.fromBech32(BitcoinNetwork.MAINNET, taprootAddressWith20BytesWitnessProgram);
+        SegwitAddress.fromBech32(MAINNET, taprootAddressWith20BytesWitnessProgram);
     }
 
     @Test(expected = AddressFormatException.InvalidDataLength.class)
@@ -274,7 +265,7 @@ public class SegwitAddressTest {
         // Taproot, valid bech32m encoding, checksum ok, padding ok, but no valid Segwit v1 program
         // (this program is 40 bytes long, but only 32 bytes program length are valid for Segwit v1/Taproot)
         String taprootAddressWith40BytesWitnessProgram = "bc1p6t0pcqrq3mvedn884lgj9s2cm52xp9vtnlc89cv5x77f5l725rrdjhqrld6m6rza67j62a";
-        SegwitAddress.fromBech32(BitcoinNetwork.MAINNET, taprootAddressWith40BytesWitnessProgram);
+        SegwitAddress.fromBech32(MAINNET, taprootAddressWith40BytesWitnessProgram);
     }
 
     @Test(expected = AddressFormatException.InvalidPrefix.class)
@@ -284,6 +275,6 @@ public class SegwitAddressTest {
 
     @Test(expected = AddressFormatException.WrongNetwork.class)
     public void fromBech32_wrongNetwork() {
-        SegwitAddress.fromBech32(BitcoinNetwork.TESTNET, "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj");
+        SegwitAddress.fromBech32(TESTNET, "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj");
     }
 }


### PR DESCRIPTION
Finish conversion from NetworkParameters to Network in the tests. This cleans up the code, too.

There are still some references to NetworkParameters in LegacyAddressTest:

1. Tests of deprecated methods that can be removed when those methods are removed
2. Tests that need getP2SHHeader() which hasn't moved to Network yet.