### PR TITLE
Create CryptoUtils, move sha256hash160 from Utils

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Utils.java
+++ b/core/src/main/java/org/bitcoinj/core/Utils.java
@@ -19,10 +19,8 @@ package org.bitcoinj.core;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
-import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.base.internal.InternalUtils;
-import org.bouncycastle.crypto.digests.RIPEMD160Digest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,18 +61,6 @@ public class Utils {
     public static final int MAX_INITIAL_ARRAY_LENGTH = 20;
 
     private static final Logger log = LoggerFactory.getLogger(Utils.class);
-
-    /**
-     * Calculates RIPEMD160(SHA256(input)). This is used in Address calculations.
-     */
-    public static byte[] sha256hash160(byte[] input) {
-        byte[] sha256 = Sha256Hash.hash(input);
-        RIPEMD160Digest digest = new RIPEMD160Digest();
-        digest.update(sha256, 0, sha256.length);
-        byte[] out = new byte[20];
-        digest.doFinal(out, 0);
-        return out;
-    }
 
     /**
      * If non-null, overrides the return value of now().

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -24,7 +24,7 @@ import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.base.Base58;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.base.Sha256Hash;
-import org.bitcoinj.core.Utils;
+import org.bitcoinj.crypto.internal.CryptoUtils;
 import org.bouncycastle.crypto.params.KeyParameter;
 import org.bouncycastle.math.ec.ECPoint;
 
@@ -223,7 +223,7 @@ public class DeterministicKey extends ECKey {
      * Returns RIPE-MD160(SHA256(pub key bytes)).
      */
     public byte[] getIdentifier() {
-        return Utils.sha256hash160(getPubKey());
+        return CryptoUtils.sha256hash160(getPubKey());
     }
 
     /** Returns the first 32 bits of the result of {@link #getIdentifier()}. */

--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -34,6 +34,7 @@ import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Utils;
 import org.bitcoinj.base.VarInt;
+import org.bitcoinj.crypto.internal.CryptoUtils;
 import org.bitcoinj.utils.MessageVerifyUtils;
 import org.bitcoinj.wallet.Protos;
 import org.bitcoinj.wallet.Wallet;
@@ -384,7 +385,7 @@ public class ECKey implements EncryptableItem {
     /** Gets the hash160 form of the public key (as seen in addresses). */
     public byte[] getPubKeyHash() {
         if (pubKeyHash == null)
-            pubKeyHash = Utils.sha256hash160(this.pub.getEncoded());
+            pubKeyHash = CryptoUtils.sha256hash160(this.pub.getEncoded());
         return pubKeyHash;
     }
 

--- a/core/src/main/java/org/bitcoinj/crypto/internal/CryptoUtils.java
+++ b/core/src/main/java/org/bitcoinj/crypto/internal/CryptoUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.crypto.internal;
+
+import org.bitcoinj.base.Sha256Hash;
+import org.bouncycastle.crypto.digests.RIPEMD160Digest;
+
+/**
+ * Utilities for the crypto module (e.g. using Bouncy Castle)
+ */
+public class CryptoUtils {
+    /**
+     * Calculates RIPEMD160(SHA256(input)). This is used in Address calculations.
+     */
+    public static byte[] sha256hash160(byte[] input) {
+        byte[] sha256 = Sha256Hash.hash(input);
+        RIPEMD160Digest digest = new RIPEMD160Digest();
+        digest.update(sha256, 0, sha256.length);
+        byte[] out = new byte[20];
+        digest.doFinal(out, 0);
+        return out;
+    }
+}

--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -41,6 +41,7 @@ import org.bitcoinj.base.VarInt;
 import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.base.internal.InternalUtils;
 import org.bitcoinj.crypto.TransactionSignature;
+import org.bitcoinj.crypto.internal.CryptoUtils;
 import org.bouncycastle.crypto.digests.RIPEMD160Digest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1283,7 +1284,7 @@ public class Script {
                 case OP_HASH160:
                     if (stack.size() < 1)
                         throw new ScriptException(ScriptError.SCRIPT_ERR_INVALID_STACK_OPERATION, "Attempted OP_HASH160 on an empty stack");
-                    stack.add(Utils.sha256hash160(stack.pollLast()));
+                    stack.add(CryptoUtils.sha256hash160(stack.pollLast()));
                     break;
                 case OP_HASH256:
                     if (stack.size() < 1)

--- a/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
@@ -24,9 +24,9 @@ import org.bitcoinj.base.LegacyAddress;
 import org.bitcoinj.base.SegwitAddress;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.core.Transaction;
-import org.bitcoinj.core.Utils;
 import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.base.ScriptType;
+import org.bitcoinj.crypto.internal.CryptoUtils;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -508,7 +508,7 @@ public class ScriptBuilder {
      * @return an output script that sends to the redeem script
      */
     public static Script createP2SHOutputScript(Script redeemScript) {
-        byte[] hash = Utils.sha256hash160(redeemScript.getProgram());
+        byte[] hash = CryptoUtils.sha256hash160(redeemScript.getProgram());
         return ScriptBuilder.createP2SHOutputScript(hash);
     }
 

--- a/core/src/main/java/org/bitcoinj/utils/MessageVerifyUtils.java
+++ b/core/src/main/java/org/bitcoinj/utils/MessageVerifyUtils.java
@@ -5,7 +5,7 @@ import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.base.SegwitAddress;
-import org.bitcoinj.core.Utils;
+import org.bitcoinj.crypto.internal.CryptoUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,7 +106,7 @@ public class MessageVerifyUtils {
         final byte[] segwitScriptFromSignaturePubKey = wrapPubKeyHashInSegwitScript(pubKeyHashFromSignature);
 
         // and as in a P2SH address only the hash of the script is contained, we also hash this script before comparing:
-        final byte[] scriptHashDerivedFromSig = Utils.sha256hash160(segwitScriptFromSignaturePubKey);
+        final byte[] scriptHashDerivedFromSig = CryptoUtils.sha256hash160(segwitScriptFromSignaturePubKey);
 
         if (!Arrays.equals(scriptHashFromAddress, scriptHashDerivedFromSig)) {
             throw new SignatureException(SIGNATURE_FAILED_ERROR_MESSAGE);

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -24,6 +24,7 @@ import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.core.Transaction.SigHash;
 import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.crypto.TransactionSignature;
+import org.bitcoinj.crypto.internal.CryptoUtils;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptException;
@@ -691,7 +692,7 @@ public class FullBlockTestGenerator {
             }
             b39p2shScriptPubKey = p2shScriptPubKey.toByteArray();
 
-            byte[] scriptHash = Utils.sha256hash160(b39p2shScriptPubKey);
+            byte[] scriptHash = CryptoUtils.sha256hash160(b39p2shScriptPubKey);
             UnsafeByteArrayOutputStream scriptPubKey = new UnsafeByteArrayOutputStream(scriptHash.length + 3);
             scriptPubKey.write(OP_HASH160);
             try {

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -26,6 +26,7 @@ import org.bitcoinj.base.VarInt;
 import org.bitcoinj.core.TransactionConfidence.ConfidenceType;
 import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.crypto.TransactionSignature;
+import org.bitcoinj.crypto.internal.CryptoUtils;
 import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
@@ -383,7 +384,7 @@ public class TransactionTest {
         assertEquals("001479091972186c449eb1ded22b78e40d009bdf0089",
                 HEX.encode(redeemScript.getProgram()));
 
-        byte[] p2wpkhHash = Utils.sha256hash160(redeemScript.getProgram());
+        byte[] p2wpkhHash = CryptoUtils.sha256hash160(redeemScript.getProgram());
         Script scriptPubKey = ScriptBuilder.createP2SHOutputScript(p2wpkhHash);
         assertEquals("a9144733f37cf4db86fbc2efed2500b4f4e49f31202387",
                 HEX.encode(scriptPubKey.getProgram()));

--- a/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
@@ -30,6 +30,7 @@ import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.Utils;
 import org.bitcoinj.crypto.ECKey.ECDSASignature;
+import org.bitcoinj.crypto.internal.CryptoUtils;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.utils.FutureUtils;
@@ -268,7 +269,7 @@ public class ECKeyTest {
         ECKey key = ECKey.signedMessageToKey(message, sigBase64);
         final byte[] segwitV0_OpPush20 = {0x00, 0x14};
         byte[] segwitV0ScriptPubKey = Bytes.concat(segwitV0_OpPush20, key.getPubKeyHash()); // as defined in BIP 141
-        byte[] scriptHashOfSegwitScript = Utils.sha256hash160(segwitV0ScriptPubKey);
+        byte[] scriptHashOfSegwitScript = CryptoUtils.sha256hash160(segwitV0ScriptPubKey);
         Address gotAddress = LegacyAddress.fromScriptHash(BitcoinNetwork.MAINNET, scriptHashOfSegwitScript);
         assertEquals(expectedAddress, gotAddress);
     }

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -49,6 +49,7 @@ import org.bitcoinj.crypto.KeyCrypterException;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
 import org.bitcoinj.crypto.MnemonicException;
 import org.bitcoinj.crypto.TransactionSignature;
+import org.bitcoinj.crypto.internal.CryptoUtils;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptChunk;
@@ -546,7 +547,7 @@ public class WalletTest extends TestWithWallet {
         List<ScriptChunk> scriptSigChunks = t2.getInput(0).getScriptSig().getChunks();
         // check 'from address' -- in a unit test this is fine
         assertEquals(2, scriptSigChunks.size());
-        assertEquals(myAddress, LegacyAddress.fromPubKeyHash(BitcoinNetwork.TESTNET, Utils.sha256hash160(scriptSigChunks.get(1).data)));
+        assertEquals(myAddress, LegacyAddress.fromPubKeyHash(BitcoinNetwork.TESTNET, CryptoUtils.sha256hash160(scriptSigChunks.get(1).data)));
         assertEquals(TransactionConfidence.ConfidenceType.UNKNOWN, t2.getConfidence().getConfidenceType());
 
         // We have NOT proven that the signature is correct!


### PR DESCRIPTION
`Utils. sha256hash160()` is currently used by the `crypto` package (to be module) and requires Bouncy Castle.

Move it to a new class `CryptoUtils` in a new `internal` sub package.