### PR TITLE
modular-architecture.md: `base` with zero dependencies, `crypto` without Guava dependencies.

### DIFF
--- a/designdocs/modular-architecture.md
+++ b/designdocs/modular-architecture.md
@@ -5,12 +5,13 @@ Other packages that are not significant or are not changing are not shown (and a
 
 ````mermaid
 graph TD
-    B[base] --> G[guava]
-    B --> S[slf4j]
-    B --> A[jcip-annotations]
+    B[base]
     CR[crypto] --> BC[Bouncy Castle]
+    CR --> S[slf4j]
+    CR --> A[jcip-annotations]
     CR --> B
     CO[core] --> CR
+    CO --> G[guava]
     W --> P[ProtoBuf]
     W[wallet] --> CO
     I[integration-test] --> W


### PR DESCRIPTION
Also, move Guava dependency to `core`

`crypto` still depends on `slf4j` and `jcip-annotations` but hopefully at some point that can be eliminated, too.