### PR TITLE
Replace Guava LongMath.checked{Add,Subtract,Multiply}

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/Coin.java
+++ b/core/src/main/java/org/bitcoinj/base/Coin.java
@@ -217,7 +217,7 @@ public final class Coin implements Monetary, Comparable<Coin> {
     }
 
     public Coin add(final Coin value) {
-        return Coin.valueOf(LongMath.checkedAdd(this.value, value.value));
+        return Coin.valueOf(Math.addExact(this.value, value.value));
     }
 
     /** Alias for add */
@@ -226,7 +226,7 @@ public final class Coin implements Monetary, Comparable<Coin> {
     }
 
     public Coin subtract(final Coin value) {
-        return Coin.valueOf(LongMath.checkedSubtract(this.value, value.value));
+        return Coin.valueOf(Math.subtractExact(this.value, value.value));
     }
 
     /** Alias for subtract */
@@ -235,7 +235,7 @@ public final class Coin implements Monetary, Comparable<Coin> {
     }
 
     public Coin multiply(final long factor) {
-        return Coin.valueOf(LongMath.checkedMultiply(this.value, factor));
+        return Coin.valueOf(Math.multiplyExact(this.value, factor));
     }
 
     /** Alias for multiply */

--- a/core/src/main/java/org/bitcoinj/base/utils/Fiat.java
+++ b/core/src/main/java/org/bitcoinj/base/utils/Fiat.java
@@ -16,7 +16,6 @@
 
 package org.bitcoinj.base.utils;
 
-import com.google.common.math.LongMath;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Monetary;
 
@@ -107,16 +106,16 @@ public final class Fiat implements Monetary, Comparable<Fiat> {
 
     public Fiat add(final Fiat value) {
         checkArgument(value.currencyCode.equals(currencyCode));
-        return new Fiat(currencyCode, LongMath.checkedAdd(this.value, value.value));
+        return new Fiat(currencyCode, Math.addExact(this.value, value.value));
     }
 
     public Fiat subtract(final Fiat value) {
         checkArgument(value.currencyCode.equals(currencyCode));
-        return new Fiat(currencyCode, LongMath.checkedSubtract(this.value, value.value));
+        return new Fiat(currencyCode, Math.subtractExact(this.value, value.value));
     }
 
     public Fiat multiply(final long factor) {
-        return new Fiat(currencyCode, LongMath.checkedMultiply(this.value, factor));
+        return new Fiat(currencyCode, Math.multiplyExact(this.value, factor));
     }
 
     public Fiat divide(final long divisor) {

--- a/core/src/main/java/org/bitcoinj/base/utils/MonetaryFormat.java
+++ b/core/src/main/java/org/bitcoinj/base/utils/MonetaryFormat.java
@@ -29,7 +29,6 @@ import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.math.LongMath.checkedMultiply;
 import static com.google.common.math.LongMath.checkedPow;
 import static com.google.common.math.LongMath.divide;
 
@@ -367,7 +366,7 @@ public final class MonetaryFormat {
         long satoshis = Math.abs(monetary.getValue());
         int potentialDecimals = smallestUnitExponent - shift;
         long precisionDivisor = checkedPow(10, potentialDecimals - maxDecimals);
-        satoshis = checkedMultiply(divide(satoshis, precisionDivisor, roundingMode), precisionDivisor);
+        satoshis = Math.multiplyExact(divide(satoshis, precisionDivisor, roundingMode), precisionDivisor);
 
         // shifting
         long shiftDivisor = checkedPow(10, potentialDecimals);

--- a/core/src/main/java/org/bitcoinj/wallet/DefaultCoinSelector.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DefaultCoinSelector.java
@@ -17,7 +17,6 @@
 package org.bitcoinj.wallet;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.math.LongMath;
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.core.Transaction;
@@ -58,7 +57,7 @@ public class DefaultCoinSelector implements CoinSelector {
             // Only pick chain-included transactions, or transactions that are ours and pending.
             if (!shouldSelect(output.getParentTransaction())) continue;
             selected.add(output);
-            total = LongMath.checkedAdd(total, output.getValue().value);
+            total = Math.addExact(total, output.getValue().value);
         }
         // Total may be lower than target here, if the given candidates were insufficient to create to requested
         // transaction.


### PR DESCRIPTION
**Update: ** This PR has been repurposed to just replace the LongMath.checked{Add,Subtract,Multiply} methods.

Other changes needed to migrate away from Guava Math include:

* Alternative to IntMath.divide and LongMath.divide
* Rebase with pending changes to MonetaryFormat
* Replace Guava math in MonetaryFormat

