### PR TITLE
Coin.COIN_VALUE: replace use of LongMath.pow with long literal

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/Coin.java
+++ b/core/src/main/java/org/bitcoinj/base/Coin.java
@@ -16,7 +16,6 @@
 
 package org.bitcoinj.base;
 
-import com.google.common.math.LongMath;
 import org.bitcoinj.base.utils.MonetaryFormat;
 
 import java.math.BigDecimal;
@@ -50,7 +49,7 @@ public final class Coin implements Monetary, Comparable<Coin> {
     /**
      * The number of satoshis equal to one bitcoin.
      */
-    private static final long COIN_VALUE = LongMath.pow(10, SMALLEST_UNIT_EXPONENT);
+    private static final long COIN_VALUE = 100_000_000;
 
     /**
      * Zero Bitcoins.


### PR DESCRIPTION
There's no convenient Java built-in for exponentiation of `long`. And this constant is unlikely to ever change. So we're just going to define it with a `long` literal. 

Fortunately Java 7 added the ability to use `_` to group digits.