### PR TITLE
FutureUtils: add failedFuture method

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/internal/FutureUtils.java
+++ b/core/src/main/java/org/bitcoinj/base/internal/FutureUtils.java
@@ -55,6 +55,18 @@ public class FutureUtils {
     }
 
     /**
+     * Can be replaced with {@code CompletableFuture.failedFuture(Throwable)} in Java 9+.
+     * @param t Exception that is causing the failure
+     * @return a failed future containing the specified exception
+     * @param <T> the future's return type
+     */
+    public static <T> CompletableFuture<T> failedFuture(Throwable t) {
+        CompletableFuture<T> future = new CompletableFuture<>();
+        future.completeExceptionally(t);
+        return future;
+    }
+
+    /**
      * Subinterface of {@link Supplier} for Lambdas which throw exceptions.
      * Can be used for two purposes:
      * 1. To cast a lambda that throws an exception to a {@link Supplier} and

--- a/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
@@ -18,6 +18,7 @@ package org.bitcoinj.core;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.Uninterruptibles;
+import org.bitcoinj.base.internal.FutureUtils;
 import org.bitcoinj.base.utils.StreamUtils;
 import org.bitcoinj.base.internal.InternalUtils;
 import org.bitcoinj.core.listeners.PreMessageReceivedEventListener;
@@ -246,7 +247,7 @@ public class TransactionBroadcast {
             return future;
         } catch (Exception e) {
             log.error("Caught exception sending to {}", peer, e);
-            return ListenableCompletableFuture.failedFuture(e);
+            return FutureUtils.failedFuture(e);
         }
     }
 

--- a/core/src/main/java/org/bitcoinj/utils/ListenableCompletableFuture.java
+++ b/core/src/main/java/org/bitcoinj/utils/ListenableCompletableFuture.java
@@ -15,6 +15,8 @@
  */
 package org.bitcoinj.utils;
 
+import org.bitcoinj.base.internal.FutureUtils;
+
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -41,20 +43,18 @@ public class ListenableCompletableFuture<V> extends CompletableFuture<V> impleme
     }
 
     /**
-     * Returns a new {@link CompletableFuture} that is already completed exceptionally
-     * the given throwable.
+     * Returns a new {@link ListenableCompletableFuture} that is already completed exceptionally
+     * with the given throwable.
      * <p>
-     * When the migration to {@link CompletableFuture} is finished we'll probably move this
-     * method to FutureUtils as the {@code failedFuture()} is not available until Java 9.
+     * When the migration to {@link CompletableFuture} is finished this can be deprecated
+     * and {@link FutureUtils#failedFuture(Throwable)} can be used instead.
      *
      * @param throwable the exceptions
      * @param <T> the type of the expected value
      * @return the completed CompletableFuture
      */
     public static <T> ListenableCompletableFuture<T> failedFuture(Throwable throwable) {
-        ListenableCompletableFuture<T> future = new ListenableCompletableFuture<>();
-        future.completeExceptionally(throwable);
-        return future;
+        return ListenableCompletableFuture.of(FutureUtils.failedFuture(throwable));
     }
 
     /**


### PR DESCRIPTION
As we're migrating from ListenableCompletableFuture to standard CompletableFuture, we need a failedFuture() method that returns the standard CompletableFuture object.

TransactionBroadcast already needed this method as it was returning a ListenableCompletableFuture in one case where a standard CompletableFuture would be preferred.

This method can be deprecated when we require Java 9.