### PR TITLE
Peer: Deprecate ping() and replace with sendPing()

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -1672,7 +1672,7 @@ public class PeerGroup implements TransactionBroadcaster {
                 for (Peer peer : getConnectedPeers()) {
                     if (peer.getPeerVersionMessage().clientVersion < params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.PONG))
                         continue;
-                    peer.ping();
+                    peer.sendPing();
                 }
             } catch (Throwable e) {
                 log.error("Exception in ping loop", e);  // The executor swallows exceptions :(
@@ -2231,7 +2231,7 @@ public class PeerGroup implements TransactionBroadcaster {
      * times are available via {@link Peer#getLastPingTime()} but it increases load on the
      * remote node. It defaults to {@link PeerGroup#DEFAULT_PING_INTERVAL_MSEC}.
      * Setting the value to be smaller or equals 0 disables pinging entirely, although you can still request one yourself
-     * using {@link Peer#ping()}.
+     * using {@link Peer#sendPing()}.
      */
     public void setPingIntervalMsec(long pingIntervalMsec) {
         lock.lock();

--- a/core/src/main/java/org/bitcoinj/core/VersionMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionMessage.java
@@ -270,7 +270,7 @@ public class VersionMessage extends Message {
 
     /**
      * Returns true if the clientVersion field is {@link NetworkParameters.ProtocolVersion#PONG} or higher.
-     * If it is then {@link Peer#ping()} is usable.
+     * If it is then {@link Peer#sendPing()} is usable.
      */
     public boolean isPingPongSupported() {
         return clientVersion >= params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.PONG);

--- a/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
@@ -302,7 +302,7 @@ public class BitcoindComparisonTool {
                 locator = new BlockLocator();
                 locator = locator.add(bitcoindChainHead);
                 bitcoind.sendMessage(new GetHeadersMessage(PARAMS, locator, hashTo));
-                bitcoind.ping().get();
+                bitcoind.sendPing().get();
                 if (!chain.getChainHead().getHeader().getHash().equals(bitcoindChainHead)) {
                     rulesSinceFirstFail++;
                     log.error("ERROR: bitcoind and bitcoinj acceptance differs on block \"" + block.ruleName + "\"");
@@ -313,7 +313,7 @@ public class BitcoindComparisonTool {
             } else if (rule instanceof MemoryPoolState) {
                 MemoryPoolMessage message = new MemoryPoolMessage();
                 bitcoind.sendMessage(message);
-                bitcoind.ping().get();
+                bitcoind.sendPing().get();
                 if (mostRecentInv == null && !((MemoryPoolState) rule).mempool.isEmpty()) {
                     log.error("ERROR: bitcoind had an empty mempool, but we expected some transactions on rule " + rule.ruleName);
                     rulesSinceFirstFail++;

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -729,7 +729,7 @@ public class WalletTool implements Callable<Integer> {
             // Hack for regtest/single peer mode, as we're about to shut down and won't get an ACK from the remote end.
             List<Peer> peerList = peerGroup.getConnectedPeers();
             if (peerList.size() == 1)
-                peerList.get(0).ping().get();
+                peerList.get(0).sendPing().get();
         } catch (BlockStoreException | ExecutionException | InterruptedException | KeyCrypterException e) {
             throw new RuntimeException(e);
         } catch (InsufficientMoneyException e) {


### PR DESCRIPTION
sendPing:

1. Returns Duration rather than Long
2. Uses CompletableFuture rather than ListenableCompletableFuture

I've also changed the error-handling a little. Instead of throwing a ProtocolException (RuntimeException) if PingPong isn't supported the exception is set in the CompletableFuture. We don't currently have anything catching this exception, so wrapping it in the CompletableFuture seems like a safe move.
