### PR TITLE
Move MessageVerifyUtils to o.b.crypto.utils

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -35,7 +35,7 @@ import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.base.VarInt;
 import org.bitcoinj.crypto.internal.CryptoUtils;
-import org.bitcoinj.utils.MessageVerifyUtils;
+import org.bitcoinj.crypto.utils.MessageVerifyUtils;
 import org.bitcoinj.wallet.Protos;
 import org.bitcoinj.wallet.Wallet;
 import org.bouncycastle.asn1.ASN1InputStream;

--- a/core/src/main/java/org/bitcoinj/crypto/utils/MessageVerifyUtils.java
+++ b/core/src/main/java/org/bitcoinj/crypto/utils/MessageVerifyUtils.java
@@ -1,4 +1,4 @@
-package org.bitcoinj.utils;
+package org.bitcoinj.crypto.utils;
 
 import com.google.common.primitives.Bytes;
 import org.bitcoinj.base.LegacyAddress;

--- a/core/src/test/java/org/bitcoinj/crypto/utils/MessageVerifyUtilsTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/utils/MessageVerifyUtilsTest.java
@@ -1,4 +1,4 @@
-package org.bitcoinj.utils;
+package org.bitcoinj.crypto.utils;
 
 import org.bitcoinj.base.AddressParser;
 import org.bitcoinj.base.DefaultAddressParser;


### PR DESCRIPTION
This class belongs in the crypto module.

PR #2738 should be merged first.