### PR TITLE
Address,SegwitAddress: Deprecate getHash()

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/Address.java
+++ b/core/src/main/java/org/bitcoinj/base/Address.java
@@ -127,7 +127,9 @@ public abstract class Address implements Comparable<Address> {
      * Get either the public key hash or script hash that is encoded in the address.
      * 
      * @return hash that is encoded in the address
+     * @deprecated Use {@link LegacyAddress#getHash()} or {@link SegwitAddress#getWitnessProgram()} as appropriate
      */
+    @Deprecated
     public abstract byte[] getHash();
 
     /**

--- a/core/src/main/java/org/bitcoinj/base/LegacyAddress.java
+++ b/core/src/main/java/org/bitcoinj/base/LegacyAddress.java
@@ -214,7 +214,6 @@ public class LegacyAddress extends Address {
     }
 
     /** The (big endian) 20 byte hash that is the core of a Bitcoin address. */
-    @Override
     public byte[] getHash() {
         return bytes;
     }

--- a/core/src/main/java/org/bitcoinj/base/SegwitAddress.java
+++ b/core/src/main/java/org/bitcoinj/base/SegwitAddress.java
@@ -221,7 +221,11 @@ public class SegwitAddress extends Address {
         return convertBits(bytes, 1, bytes.length - 1, 5, 8, false);
     }
 
+    /**
+     * @deprecated Use {@link #getWitnessProgram()} (if you're sure that's what you need)
+     */
     @Override
+    @Deprecated
     public byte[] getHash() {
         return getWitnessProgram();
     }

--- a/core/src/main/java/org/bitcoinj/utils/MessageVerifyUtils.java
+++ b/core/src/main/java/org/bitcoinj/utils/MessageVerifyUtils.java
@@ -1,6 +1,7 @@
 package org.bitcoinj.utils;
 
 import com.google.common.primitives.Bytes;
+import org.bitcoinj.base.LegacyAddress;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.crypto.ECKey;
@@ -78,7 +79,9 @@ public class MessageVerifyUtils {
         }
 
         final byte[] pubKeyHashFromSignature = ECKey.signedMessageToKey(message, signatureBase64).getPubKeyHash();
-        final byte[] pubKeyHashFromAddress = address.getHash();
+        final byte[] pubKeyHashFromAddress = (address instanceof SegwitAddress)
+                            ? ((SegwitAddress) address).getWitnessProgram()
+                            : ((LegacyAddress) address).getHash();
 
         if (!Arrays.equals(pubKeyHashFromAddress, pubKeyHashFromSignature)) {
             throw new SignatureException(SIGNATURE_FAILED_ERROR_MESSAGE);


### PR DESCRIPTION
* Deprecate Address.getHash() and SegwitAddress.getHash()
* Use SegwitAddress.getWitnessProgram() in the cases where SegwitAddress.getHash() was previously used.

It seems that both cases where a segwit address "hash" is being used are special-cases and we should not be providing "hash" has a general property of address.  Especially, given that hash does not currently include `witnessVersion`.