### PR TITLE
SegwitAddress: store witnessProgram as 8-bits/byte

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/Address.java
+++ b/core/src/main/java/org/bitcoinj/base/Address.java
@@ -21,46 +21,15 @@ import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.core.NetworkParameters;
 
 import javax.annotation.Nullable;
-import java.util.Arrays;
 import java.util.Comparator;
-import java.util.Objects;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Base class for addresses, e.g. native segwit addresses ({@link SegwitAddress}) or legacy addresses ({@link LegacyAddress}).
+ * Interface for addresses, e.g. native segwit addresses ({@link SegwitAddress}) or legacy addresses ({@link LegacyAddress}).
  * <p>
  * Use an implementation of {@link AddressParser#parseAddress(String, Network)} to conveniently construct any kind of address from its textual
  * form.
  */
-public abstract class Address implements Comparable<Address> {
-    protected final Network network;
-    protected final byte[] bytes;
-
-    /**
-     * Construct an address from its binary form.
-     *
-     * @param params the network this address is valid for
-     * @param bytes the binary address data
-     * @deprecated Use {@link Address#Address(Network, byte[])}
-     */
-    @Deprecated
-    protected Address(NetworkParameters params, byte[] bytes) {
-        this.network = checkNotNull(params).network();
-        this.bytes = checkNotNull(bytes);
-    }
-
-    /**
-     * Construct an address from its binary form.
-     *
-     * @param network the network this address is valid for
-     * @param bytes the binary address data
-     */
-    protected Address(Network network, byte[] bytes) {
-        this.network = checkNotNull(network);
-        this.bytes = checkNotNull(bytes);
-    }
-
+public interface Address extends Comparable<Address> {
     /**
      * Construct an address from its textual form.
      * 
@@ -76,7 +45,7 @@ public abstract class Address implements Comparable<Address> {
      * @deprecated Use {@link org.bitcoinj.wallet.Wallet#parseAddress(String)} or {@link AddressParser#parseAddress(String, Network)}
      */
     @Deprecated
-    public static Address fromString(@Nullable NetworkParameters params, String str)
+    static Address fromString(@Nullable NetworkParameters params, String str)
             throws AddressFormatException {
         AddressParser addressParser = DefaultAddressParser.fromNetworks();
         return (params != null)
@@ -97,7 +66,7 @@ public abstract class Address implements Comparable<Address> {
      * @deprecated Use {@link ECKey#toAddress(ScriptType, Network)}
      */
     @Deprecated
-    public static Address fromKey(final NetworkParameters params, final ECKey key, final ScriptType outputScriptType) {
+    static Address fromKey(final NetworkParameters params, final ECKey key, final ScriptType outputScriptType) {
         return key.toAddress(outputScriptType, params.network());
     }
 
@@ -106,21 +75,8 @@ public abstract class Address implements Comparable<Address> {
      * @deprecated Use {@link #network()}
      */
     @Deprecated
-    public final NetworkParameters getParameters() {
-        return NetworkParameters.of(network);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(network, Arrays.hashCode(bytes));
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Address other = (Address) o;
-        return this.network == other.network && Arrays.equals(this.bytes, other.bytes);
+    default NetworkParameters getParameters() {
+        return NetworkParameters.of(network());
     }
 
     /**
@@ -128,14 +84,14 @@ public abstract class Address implements Comparable<Address> {
      * 
      * @return hash that is encoded in the address
      */
-    public abstract byte[] getHash();
+    byte[] getHash();
 
     /**
      * Get the type of output script that will be used for sending to the address.
      * 
      * @return type of output script
      */
-    public abstract ScriptType getOutputScriptType();
+    ScriptType getOutputScriptType();
 
     /**
      * Comparison field order for addresses is:
@@ -152,26 +108,26 @@ public abstract class Address implements Comparable<Address> {
      * @return comparison result
      */
     @Override
-    abstract public int compareTo(Address o);
+    int compareTo(Address o);
 
     /**
      * Get the network this address works on. Use of {@link BitcoinNetwork} is preferred to use of {@link NetworkParameters}
      * when you need to know what network an address is for.
      * @return the Network.
      */
-    public Network network() {
-        return network;
-    }
+    Network network();
 
     /**
      * Comparator for the first two comparison fields in {@code Address} comparisons, see {@link Address#compareTo(Address)}.
      * Used by {@link LegacyAddress#compareTo(Address)} and {@link SegwitAddress#compareTo(Address)}.
+     * For use by implementing classes only.
      */
-    protected static final Comparator<Address> PARTIAL_ADDRESS_COMPARATOR = Comparator
-        .comparing((Address a) -> a.network.id())   // First compare network
+     Comparator<Address> PARTIAL_ADDRESS_COMPARATOR = Comparator
+        .comparing((Address a) -> a.network().id())   // First compare network
         .thenComparing(Address::compareTypes);      // Then compare address type (subclass)
 
-    private static int compareTypes(Address a, Address b) {
+    /* private */
+    static int compareTypes(Address a, Address b) {
         if (a instanceof LegacyAddress && b instanceof SegwitAddress) {
             return -1;  // Legacy addresses (starting with 1 or 3) come before Segwit addresses.
         } else if (a instanceof SegwitAddress && b instanceof LegacyAddress) {

--- a/core/src/main/java/org/bitcoinj/base/SegwitAddress.java
+++ b/core/src/main/java/org/bitcoinj/base/SegwitAddress.java
@@ -123,7 +123,7 @@ public class SegwitAddress implements Address {
 
     protected final Network network;
     protected final short witnessVersion;
-    protected final byte[] witnessProgram;          // Currently this is in 5-bit Bech32 form
+    protected final byte[] witnessProgram;          // In 8-bits per byte format
 
     private static Network normalizeNetwork(Network network) {
         // SegwitAddress does not distinguish between the SIGNET and TESTNET, normalize to TESTNET
@@ -186,7 +186,7 @@ public class SegwitAddress implements Address {
                     "Invalid length for address version 1: " + witnessProgram.length);
         this.network = normalizeNetwork(checkNotNull(network));
         this.witnessVersion = (short) witnessVersion;
-        this.witnessProgram = encode8to5(checkNotNull(witnessProgram));
+        this.witnessProgram = checkNotNull(witnessProgram);
     }
 
     /**
@@ -205,7 +205,7 @@ public class SegwitAddress implements Address {
      */
     public byte[] getWitnessProgram() {
         // no version byte
-        return decode5to8(witnessProgram);
+        return witnessProgram;
     }
 
     @Override
@@ -401,9 +401,9 @@ public class SegwitAddress implements Address {
      */
     public String toBech32() {
         if (getWitnessVersion() == 0)
-            return Bech32.encode(Bech32.Encoding.BECH32, network.segwitAddressHrp(), appendVersion(witnessVersion, witnessProgram));
+            return Bech32.encode(Bech32.Encoding.BECH32, network.segwitAddressHrp(), appendVersion(witnessVersion, encode8to5(witnessProgram)));
         else
-            return Bech32.encode(Bech32.Encoding.BECH32M, network.segwitAddressHrp(), appendVersion(witnessVersion, witnessProgram));
+            return Bech32.encode(Bech32.Encoding.BECH32M, network.segwitAddressHrp(), appendVersion(witnessVersion, encode8to5(witnessProgram)));
     }
 
     // Trim the version byte and return the witness program only

--- a/core/src/main/java/org/bitcoinj/base/SegwitAddress.java
+++ b/core/src/main/java/org/bitcoinj/base/SegwitAddress.java
@@ -24,12 +24,14 @@ import org.bitcoinj.core.NetworkParameters;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumSet;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static org.bitcoinj.base.BitcoinNetwork.*;
 
 /**
@@ -49,7 +51,7 @@ import static org.bitcoinj.base.BitcoinNetwork.*;
  * {@link #fromHash(org.bitcoinj.base.Network, byte[])} or {@link ECKey#toAddress(ScriptType, Network)}
  * to construct a native segwit address.</p>
  */
-public class SegwitAddress extends Address {
+public class SegwitAddress implements Address {
     public static final int WITNESS_PROGRAM_LENGTH_PKH = 20;
     public static final int WITNESS_PROGRAM_LENGTH_SH = 32;
     public static final int WITNESS_PROGRAM_LENGTH_TR = 32;
@@ -119,6 +121,9 @@ public class SegwitAddress extends Address {
         }
     }
 
+    protected final Network network;
+    protected final byte[] bytes;
+
     /**
      * Private constructor. Use {@link #fromBech32(Network, String)},
      * {@link #fromHash(Network, byte[])} or {@link ECKey#toAddress(ScriptType, Network)}.
@@ -169,7 +174,8 @@ public class SegwitAddress extends Address {
      *             if any of the sanity checks fail
      */
     private SegwitAddress(Network network, byte[] data) throws AddressFormatException {
-        super(normalizeNetwork(network), data);
+        this.network = normalizeNetwork(checkNotNull(network));
+        this.bytes = checkNotNull(data);
         if (data.length < 1)
             throw new AddressFormatException.InvalidDataLength("Zero data found");
         final int witnessVersion = getWitnessVersion();
@@ -381,6 +387,29 @@ public class SegwitAddress extends Address {
     }
 
     /**
+     * Get the network this address works on. Use of {@link BitcoinNetwork} is preferred to use of {@link NetworkParameters}
+     * when you need to know what network an address is for.
+     * @return the Network.
+     */
+    @Override
+    public Network network() {
+        return network;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(network, Arrays.hashCode(bytes));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SegwitAddress other = (SegwitAddress) o;
+        return this.network == other.network && Arrays.equals(this.bytes, other.bytes);
+    }
+
+    /**
      * Returns the textual form of the address.
      * 
      * @return textual form encoded in bech32
@@ -426,7 +455,7 @@ public class SegwitAddress extends Address {
 
     // Comparator for SegwitAddress, left argument must be SegwitAddress, right argument can be any Address
     private static final Comparator<Address> SEGWIT_ADDRESS_COMPARATOR = Address.PARTIAL_ADDRESS_COMPARATOR
-            .thenComparing(a -> a.bytes, ByteUtils.arrayUnsignedComparator());  // Then compare Segwit bytes
+            .thenComparing(a -> ((SegwitAddress) a).bytes, ByteUtils.arrayUnsignedComparator());  // Then compare Segwit bytes
 
     /**
      * {@inheritDoc}

--- a/core/src/test/java/org/bitcoinj/base/AddressTest.java
+++ b/core/src/test/java/org/bitcoinj/base/AddressTest.java
@@ -16,22 +16,6 @@
 
 package org.bitcoinj.base;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
-import org.bitcoinj.base.Address;
-import org.bitcoinj.core.NetworkParameters;
-import org.bitcoinj.params.MainNetParams;
-import org.bitcoinj.params.TestNet3Params;
-import org.junit.Test;
-
+// TODO: Maybe add some tests here. Address has minimal functionality now, however -- see LegacyAddress and SegwitAddress
 public class AddressTest {
-    @Test
-    public void equalsContract() {
-        EqualsVerifier.forClass(Address.class)
-                .withPrefabValues(NetworkParameters.class, MainNetParams.get(), TestNet3Params.get())
-                .suppress(Warning.NULL_FIELDS)
-                .suppress(Warning.TRANSIENT_FIELDS)
-                .usingGetClass()
-                .verify();
-    }
 }


### PR DESCRIPTION
Change the internal storage format from 5-bits/byte (Bech32 intermediate format)
to standard 8-bits/byte. 

Remove now unneeded conversions and add conversion in toBech32().
