### PR TITLE
StreamUtils: move to `o.b.b.internal` from `o.b.b.utils`

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/DefaultAddressParser.java
+++ b/core/src/main/java/org/bitcoinj/base/DefaultAddressParser.java
@@ -17,7 +17,7 @@
 package org.bitcoinj.base;
 
 import org.bitcoinj.base.exceptions.AddressFormatException;
-import org.bitcoinj.base.utils.StreamUtils;
+import org.bitcoinj.base.internal.StreamUtils;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.params.Networks;
 

--- a/core/src/main/java/org/bitcoinj/base/internal/StreamUtils.java
+++ b/core/src/main/java/org/bitcoinj/base/internal/StreamUtils.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.base.utils;
+package org.bitcoinj.base.internal;
 
 import java.util.Collections;
 import java.util.List;

--- a/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
@@ -19,7 +19,7 @@ package org.bitcoinj.core;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.bitcoinj.base.internal.FutureUtils;
-import org.bitcoinj.base.utils.StreamUtils;
+import org.bitcoinj.base.internal.StreamUtils;
 import org.bitcoinj.base.internal.InternalUtils;
 import org.bitcoinj.core.listeners.PreMessageReceivedEventListener;
 import org.bitcoinj.utils.ListenableCompletableFuture;

--- a/core/src/main/java/org/bitcoinj/crypto/HDPath.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDPath.java
@@ -16,7 +16,7 @@
 
 package org.bitcoinj.crypto;
 
-import org.bitcoinj.base.utils.StreamUtils;
+import org.bitcoinj.base.internal.StreamUtils;
 import org.bitcoinj.base.internal.InternalUtils;
 
 import javax.annotation.Nonnull;

--- a/core/src/main/java/org/bitcoinj/crypto/MnemonicCode.java
+++ b/core/src/main/java/org/bitcoinj/crypto/MnemonicCode.java
@@ -20,7 +20,7 @@ package org.bitcoinj.crypto;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.internal.PlatformUtils;
 import org.bitcoinj.base.internal.TimeUtils;
-import org.bitcoinj.base.utils.StreamUtils;
+import org.bitcoinj.base.internal.StreamUtils;
 import org.bitcoinj.base.internal.InternalUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -22,7 +22,7 @@ import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.base.utils.ByteUtils;
-import org.bitcoinj.base.utils.StreamUtils;
+import org.bitcoinj.base.internal.StreamUtils;
 import org.bitcoinj.core.BloomFilter;
 import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.core.NetworkParameters;

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -29,7 +29,7 @@ import org.bitcoinj.base.Network;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.internal.PlatformUtils;
 import org.bitcoinj.base.internal.TimeUtils;
-import org.bitcoinj.base.utils.StreamUtils;
+import org.bitcoinj.base.internal.StreamUtils;
 import org.bitcoinj.core.AbstractBlockChain;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.Base58;

--- a/core/src/test/java/org/bitcoinj/base/AddressComparatorSortTest.java
+++ b/core/src/test/java/org/bitcoinj/base/AddressComparatorSortTest.java
@@ -16,7 +16,7 @@
 
 package org.bitcoinj.base;
 
-import org.bitcoinj.base.utils.StreamUtils;
+import org.bitcoinj.base.internal.StreamUtils;
 import org.junit.Test;
 
 import java.util.ArrayList;

--- a/core/src/test/java/org/bitcoinj/base/internal/StreamUtilsTest.java
+++ b/core/src/test/java/org/bitcoinj/base/internal/StreamUtilsTest.java
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.base.utils;
+package org.bitcoinj.base.internal;
 
+import org.bitcoinj.base.internal.StreamUtils;
 import org.junit.Test;
 
 import java.util.Arrays;


### PR DESCRIPTION
This was previously part of PR #2740, but we decided to create a separate PR to just move `StreamUtils`.
