### PR TITLE
wallettemplate: Upgrade to JavaFX 17.0.6

### DIFF
--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 }
 
 javafx {
-    version = '17.0.2'
+    version = '17.0.6'
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 


### PR DESCRIPTION
17.0.6 is currently the latest version of the current LTS version of JavaFX:

https://gluonhq.com/products/javafx/

Note that Gluon has recently announced that ongoing maintenance builds of JavaFX 17 will be free and publicly available. They have also announced that JavaFX 20 and later will require JDK 17 and later. (So it's time to start thinking about upgrading this project to require JDK 17.)
