### PR TITLE
DetermnisticHierarchy/MnemonicCode: BIPXX_STANDARDISATION_TIME as `Duration`

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicHierarchy.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicHierarchy.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.crypto;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -44,7 +45,13 @@ public class DeterministicHierarchy {
     // Keep track of how many child keys each node has. This is kind of weak.
     private final Map<HDPath, ChildNumber> lastChildNumbers = new HashMap<>();
 
-    public static final int BIP32_STANDARDISATION_TIME_SECS = 1369267200;
+    public static final Instant BIP32_STANDARDISATION_TIME = Instant.ofEpochSecond(1369267200);
+
+    /**
+     * @deprecated Use {@link #BIP32_STANDARDISATION_TIME}
+     */
+    @Deprecated
+    public static final int BIP32_STANDARDISATION_TIME_SECS = Math.toIntExact(BIP32_STANDARDISATION_TIME.getEpochSecond());
 
     /**
      * Constructs a new hierarchy rooted at the given key. Note that this does not have to be the top of the tree.

--- a/core/src/main/java/org/bitcoinj/crypto/MnemonicCode.java
+++ b/core/src/main/java/org/bitcoinj/crypto/MnemonicCode.java
@@ -55,7 +55,13 @@ public class MnemonicCode {
     private static final String BIP39_ENGLISH_SHA256 = "ad90bf3beb7b0eb7e5acd74727dc0da96e0a280a258354e7293fb7e211ac03db";
 
     /** UNIX time for when the BIP39 standard was finalised. This can be used as a default seed birthday. */
-    public static long BIP39_STANDARDISATION_TIME_SECS = 1381276800;
+    public static final Instant BIP39_STANDARDISATION_TIME = Instant.ofEpochSecond(1369267200);
+
+    /**
+     * @deprecated Use {@link #BIP39_STANDARDISATION_TIME}
+     */
+    @Deprecated
+    public static final int BIP39_STANDARDISATION_TIME_SECS = Math.toIntExact(BIP39_STANDARDISATION_TIME.getEpochSecond());
 
     private static final int PBKDF2_ROUNDS = 2048;
 


### PR DESCRIPTION
Deprecate BIPXX_STANDARDISATION_TIME_SECS int constants. Replace with BIPXX_STANDARDISATION_TIME Duration constants.

I did not update all usages of the deprecated constants because we have pending (and competing) PRs that would have conflicts. Once those PRs are finalized/merged we can update the deprecated usages.