### PR TITLE
WIP: Refactoring key rotation to use Instant

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/internal/TimeUtils.java
+++ b/core/src/main/java/org/bitcoinj/base/internal/TimeUtils.java
@@ -126,4 +126,8 @@ public class TimeUtils {
         iso8601.setTimeZone(UTC);
         return iso8601.format(dateTime);
     }
+
+    public static Instant minInstant(Instant a, Instant b) {
+        return a.isBefore(b) ? a : b;
+    }
 }

--- a/core/src/main/java/org/bitcoinj/core/PeerFilterProvider.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerFilterProvider.java
@@ -17,6 +17,8 @@
 
 package org.bitcoinj.core;
 
+import java.time.Instant;
+
 /**
  * An interface which provides the information required to properly filter data downloaded from Peers. Note that an
  * implementer is responsible for calling
@@ -25,11 +27,25 @@ package org.bitcoinj.core;
  */
 public interface PeerFilterProvider {
     /**
+     * Returns the earliest timestamp for which full/bloom-filtered blocks must be downloaded.
+     * Blocks with timestamps before this time will only have headers downloaded. {@code 0} requires that all
+     * blocks be downloaded, and thus this should default to {@link System#currentTimeMillis()}/1000.
+     * @return Earliest key creation timestamp or ?? or ?? TODO: fix this comment
+     */
+    Instant getEarliestKeyCreationInstant();
+
+
+    /**
      * Returns the earliest timestamp (seconds since epoch) for which full/bloom-filtered blocks must be downloaded.
      * Blocks with timestamps before this time will only have headers downloaded. {@code 0} requires that all
      * blocks be downloaded, and thus this should default to {@link System#currentTimeMillis()}/1000.
+     * @deprecated Use {@link #getEarliestKeyCreationInstant()}
      */
-    long getEarliestKeyCreationTime();
+    @Deprecated
+    default long getEarliestKeyCreationTime() {
+        return getEarliestKeyCreationInstant().getEpochSecond();
+    }
+
 
     /**
      * Called on all registered filter providers before {@link #getBloomFilterElementCount()} and

--- a/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
+++ b/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
@@ -351,7 +351,7 @@ public class WalletAppKit extends AbstractIdleService {
                 }
                 else
                 {
-                    time = vWallet.getEarliestKeyCreationTime();
+                    time = vWallet.getEarliestKeyCreationInstant().getEpochSecond();
                 }
                 if (time > 0)
                     CheckpointManager.checkpoint(params, checkpoints, vStore, time);

--- a/core/src/main/java/org/bitcoinj/net/FilterMerger.java
+++ b/core/src/main/java/org/bitcoinj/net/FilterMerger.java
@@ -72,7 +72,7 @@ public class FilterMerger {
             result.earliestKeyTimeSecs = Long.MAX_VALUE;
             int elements = 0;
             for (PeerFilterProvider p : providers) {
-                result.earliestKeyTimeSecs = Math.min(result.earliestKeyTimeSecs, p.getEarliestKeyCreationTime());
+                result.earliestKeyTimeSecs = Math.min(result.earliestKeyTimeSecs, p.getEarliestKeyCreationInstant().getEpochSecond());
                 elements += p.getBloomFilterElementCount();
             }
 

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -356,9 +356,9 @@ public class WalletProtobufSerializerTest {
         assertEquals(creationTime.getEpochSecond(), wallet.getWatchingKey().getCreationTimeSeconds());
         assertEquals(creationTime.getEpochSecond(), wallet2.getWatchingKey().getCreationTimeSeconds());
         assertEquals(creationTime.getEpochSecond(), wallet3.getWatchingKey().getCreationTimeSeconds());
-        assertEquals(creationTime.getEpochSecond(), wallet.getEarliestKeyCreationTime());
-        assertEquals(creationTime.getEpochSecond(), wallet2.getEarliestKeyCreationTime());
-        assertEquals(creationTime.getEpochSecond(), wallet3.getEarliestKeyCreationTime());
+        assertEquals(creationTime, wallet.getEarliestKeyCreationInstant());
+        assertEquals(creationTime, wallet2.getEarliestKeyCreationInstant());
+        assertEquals(creationTime, wallet3.getEarliestKeyCreationInstant());
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -1479,24 +1479,24 @@ public class WalletTest extends TestWithWallet {
     @Test
     public void keyCreationTime() {
         TimeUtils.setMockClock();
-        long now = TimeUtils.currentTimeSeconds();
+        Instant now = TimeUtils.currentTime();
         wallet = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH);
-        assertEquals(now, wallet.getEarliestKeyCreationTime());
+        assertEquals(now, wallet.getEarliestKeyCreationInstant());
         TimeUtils.rollMockClock(60);
         wallet.freshReceiveKey();
-        assertEquals(now, wallet.getEarliestKeyCreationTime());
+        assertEquals(now, wallet.getEarliestKeyCreationInstant());
     }
 
     @Test
     public void scriptCreationTime() {
         TimeUtils.setMockClock();
-        long now = TimeUtils.currentTimeSeconds();
+        Instant now = TimeUtils.currentTime();
         wallet = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH);
-        assertEquals(now, wallet.getEarliestKeyCreationTime());
+        assertEquals(now, wallet.getEarliestKeyCreationInstant());
         TimeUtils.rollMockClock(-120);
         wallet.addWatchedAddress(OTHER_ADDRESS);
         wallet.freshReceiveKey();
-        assertEquals(now - 120, wallet.getEarliestKeyCreationTime());
+        assertEquals(now.minusSeconds(120), wallet.getEarliestKeyCreationInstant());
     }
 
     @Test
@@ -3531,7 +3531,7 @@ public class WalletTest extends TestWithWallet {
         Wallet wallet = Wallet.createDeterministic(TESTNET, ScriptType.P2WPKH);
         List<String> mnemonicCode = wallet.getKeyChainSeed().getMnemonicCode();
         final DeterministicSeed clonedSeed = new DeterministicSeed(mnemonicCode, null, "",
-                wallet.getEarliestKeyCreationTime());
+                wallet.getEarliestKeyCreationInstant().getEpochSecond());
         Wallet clone = Wallet.fromSeed(TESTNET, clonedSeed, ScriptType.P2WPKH);
         assertEquals(wallet.currentReceiveKey(), clone.currentReceiveKey());
         assertEquals(wallet.freshReceiveAddress(ScriptType.P2PKH),

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -991,7 +991,7 @@ public class WalletTool implements Callable<Integer> {
             if (reset) {
                 try {
                     CheckpointManager.checkpoint(params, CheckpointManager.openStream(params), store,
-                            wallet.getEarliestKeyCreationTime());
+                            wallet.getEarliestKeyCreationInstant().getEpochSecond());
                     StoredBlock head = store.getChainHead();
                     System.out.println("Skipped to checkpoint " + head.getHeight() + " at "
                             + TimeUtils.dateTimeFormat(head.getHeader().getTimeSeconds() * 1000));


### PR DESCRIPTION
This is W.I.P.

* The first commit is an internal change inside `Wallet` to use `Instant` internally for `vKeyRotationTimestamp`.
* The second creates ``getEarliestKeyCreationInstant` and deprecates `getEarliestKeyCreationTime` in  `PeerFilterProvider` and `Wallet`.

The second commit exposes issues that I believe are resolved by (WIP) PR #2765.

I decided to explore the continuing to use special values on the (`Instant`) timeline in an analogous manner to how the current code uses special values on the `long` seconds timeline. Whether these special values are considered "magic numbers" or not is something we can discuss. I also went down the path of refactoring the routines that return key timestamps before refactoring the routines like `freshAddress()` where we were discussion whether or not to use an `Optional`.

I'll keep exploring this and have more to share/discuss later.