### PR TITLE
TransactionConfidence: migrate `lastBroadcastedAt` field to `java.time` API

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -389,9 +389,9 @@ public class WalletProtobufSerializer {
                     .build();
             confidenceBuilder.addBroadcastBy(proto);
         }
-        Instant lastBroadcastedAt = confidence.getLastBroadcastedAtInstant();
-        if (lastBroadcastedAt != null)
-            confidenceBuilder.setLastBroadcastedAt(lastBroadcastedAt.toEpochMilli());
+        confidence.getLastBroadcastTime().ifPresent(
+                lastBroadcastTime -> confidenceBuilder.setLastBroadcastedAt(lastBroadcastTime.toEpochMilli())
+        );
         txBuilder.setConfidence(confidenceBuilder);
     }
 
@@ -808,7 +808,7 @@ public class WalletProtobufSerializer {
             confidence.markBroadcastBy(address);
         }
         if (confidenceProto.hasLastBroadcastedAt())
-            confidence.setLastBroadcastedAt(Instant.ofEpochMilli(confidenceProto.getLastBroadcastedAt()));
+            confidence.setLastBroadcastTime(Instant.ofEpochMilli(confidenceProto.getLastBroadcastedAt()));
         switch (confidenceProto.getSource()) {
             case SOURCE_SELF: confidence.setSource(TransactionConfidence.Source.SELF); break;
             case SOURCE_NETWORK: confidence.setSource(TransactionConfidence.Source.NETWORK); break;

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -148,7 +148,7 @@ public class WalletProtobufSerializerTest {
         Transaction t1copy = wallet1.getTransaction(t1.getTxId());
         assertArrayEquals(t1.unsafeBitcoinSerialize(), t1copy.unsafeBitcoinSerialize());
         assertEquals(2, t1copy.getConfidence().numBroadcastPeers());
-        assertNotNull(t1copy.getConfidence().getLastBroadcastedAtInstant());
+        assertNotNull(t1copy.getConfidence().getLastBroadcastTime());
         assertEquals(TransactionConfidence.Source.NETWORK, t1copy.getConfidence().getSource());
         
         Protos.Wallet walletProto = new WalletProtobufSerializer().walletToProto(myWallet);

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -390,7 +390,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         inv.addTransaction(tx);
 
         assertEquals(0, tx.getConfidence().numBroadcastPeers());
-        assertNull(tx.getConfidence().getLastBroadcastedAtInstant());
+        assertFalse(tx.getConfidence().getLastBroadcastTime().isPresent());
 
         // Peer 2 advertises the tx but does not receive it yet.
         inbound(p2, inv);
@@ -414,7 +414,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         assertEquals(2, tx.getConfidence().numBroadcastPeers());
         assertTrue(tx.getConfidence().wasBroadcastBy(peerOf(p1).getAddress()));
         assertTrue(tx.getConfidence().wasBroadcastBy(peerOf(p2).getAddress()));
-        assertNotNull(tx.getConfidence().getLastBroadcastedAtInstant());
+        assertTrue(tx.getConfidence().getLastBroadcastTime().isPresent());
 
         tx.getConfidence().addEventListener((confidence, reason) -> confEvent[0] = confidence);
         // A straggler reports in.


### PR DESCRIPTION
Note this also adds a couple of nullable declarations, as that's how the current code works – and I didn't change that.