### PR TITLE
AesKey: replace o.bouncycastle.c.p.KeyParameter

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -25,6 +25,7 @@ import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.VarInt;
 import org.bitcoinj.base.internal.TimeUtils;
+import org.bitcoinj.crypto.AesKey;
 import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.core.TransactionConfidence.ConfidenceType;
 import org.bitcoinj.crypto.ECKey;
@@ -40,7 +41,6 @@ import org.bitcoinj.signers.TransactionSigner;
 import org.bitcoinj.utils.ExchangeRate;
 import org.bitcoinj.wallet.Wallet;
 import org.bitcoinj.wallet.WalletTransaction.Pool;
-import org.bouncycastle.crypto.params.KeyParameter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1188,7 +1188,7 @@ public class Transaction extends ChildMessage {
      * @return A newly calculated signature object that wraps the r, s and sighash components.
      */
     public TransactionSignature calculateSignature(int inputIndex, ECKey key,
-                                                   @Nullable KeyParameter aesKey,
+                                                   @Nullable AesKey aesKey,
                                                    byte[] redeemScript,
                                                    SigHash hashType, boolean anyoneCanPay) {
         Sha256Hash hash = hashForSignature(inputIndex, redeemScript, hashType, anyoneCanPay);
@@ -1209,7 +1209,7 @@ public class Transaction extends ChildMessage {
      * @return A newly calculated signature object that wraps the r, s and sighash components.
      */
     public TransactionSignature calculateSignature(int inputIndex, ECKey key,
-                                                   @Nullable KeyParameter aesKey,
+                                                   @Nullable AesKey aesKey,
                                                    Script redeemScript,
                                                    SigHash hashType, boolean anyoneCanPay) {
         Sha256Hash hash = hashForSignature(inputIndex, redeemScript.getProgram(), hashType, anyoneCanPay);
@@ -1372,7 +1372,7 @@ public class Transaction extends ChildMessage {
     public TransactionSignature calculateWitnessSignature(
             int inputIndex,
             ECKey key,
-            @Nullable KeyParameter aesKey,
+            @Nullable AesKey aesKey,
             byte[] scriptCode,
             Coin value,
             SigHash hashType,
@@ -1384,7 +1384,7 @@ public class Transaction extends ChildMessage {
     public TransactionSignature calculateWitnessSignature(
             int inputIndex,
             ECKey key,
-            @Nullable KeyParameter aesKey,
+            @Nullable AesKey aesKey,
             Script scriptCode,
             Coin value,
             SigHash hashType,

--- a/core/src/main/java/org/bitcoinj/crypto/AesKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/AesKey.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.crypto;
+
+import org.bouncycastle.crypto.params.KeyParameter;
+
+/**
+ *  Wrapper for a {@code byte[]}  containing an AES Key. This is a replacement for Bouncy Castle's {@link KeyParameter} which
+ *  was used for this purpose in previous versions of <b>bitcoinj</b>. Unfortunately, this created a Gradle _api_ dependency
+ *  on Bouncy Castle when that wasn't strictly necessary.
+ *  <p>
+ *  We have made this change without deprecation because it affected many method signatures and because updating is a trivial change.
+ *  If for some reason you have code that uses the Bouncy Castle {@link KeyParameter} type and need to convert
+ *  to or from {@code AesKey}, you can temporarily use {@link #ofKeyParameter(KeyParameter)} or {@link #toKeyParameter()}
+ */
+public class AesKey {
+    private final byte[] bytes;
+
+    /**
+     * Wrapper for a {@code byte[]} containing an AES Key
+     * @param keyBytes implementation-dependent AES Key bytes
+     */
+    public AesKey(byte[] keyBytes) {
+        // Make defensive copy, so AesKey is effectively immutable
+        this.bytes = new byte[keyBytes.length];
+        System.arraycopy(keyBytes, 0, this.bytes, 0, keyBytes.length);
+    }
+
+    /**
+     * @return The key bytes
+     */
+    public byte[] bytes() {
+        return bytes;
+    }
+
+    /**
+     * Provided to ease migration from {@link KeyParameter}.
+     * @return The key bytes
+     * @deprecated Use {@link #bytes()}
+     */
+    @Deprecated
+    public byte[] getKey() {
+        return bytes();
+    }
+
+    /**
+     * Provided to ease migration from {@link KeyParameter}.
+     * @param keyParameter instance to convert
+     * @return new, preferred container for AES keys
+     * @deprecated Use {@code new AesKey(keyParameter.bytes())}
+     */
+    @Deprecated
+    public static AesKey ofKeyParameter(KeyParameter keyParameter) {
+        return new AesKey(keyParameter.getKey());
+    }
+
+    /**
+     * Provided to ease migration from {@link KeyParameter}.
+     * @return  if for some reason you still need (temporarily, we hope) a {@link KeyParameter}
+     * @deprecated Use {@code new KeyParameter(key.bytes)}
+     */
+    @Deprecated
+    public KeyParameter toKeyParameter() {
+        return new KeyParameter(this.bytes());
+    }
+}

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -26,7 +26,6 @@ import org.bitcoinj.base.Base58;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.crypto.internal.CryptoUtils;
-import org.bouncycastle.crypto.params.KeyParameter;
 import org.bouncycastle.math.ec.ECPoint;
 
 import javax.annotation.Nullable;
@@ -295,11 +294,11 @@ public class DeterministicKey extends ECKey {
     }
 
     @Override
-    public DeterministicKey encrypt(KeyCrypter keyCrypter, KeyParameter aesKey) throws KeyCrypterException {
+    public DeterministicKey encrypt(KeyCrypter keyCrypter, AesKey aesKey) throws KeyCrypterException {
         throw new UnsupportedOperationException("Must supply a new parent for encryption");
     }
 
-    public DeterministicKey encrypt(KeyCrypter keyCrypter, KeyParameter aesKey, @Nullable DeterministicKey newParent) throws KeyCrypterException {
+    public DeterministicKey encrypt(KeyCrypter keyCrypter, AesKey aesKey, @Nullable DeterministicKey newParent) throws KeyCrypterException {
         // Same as the parent code, except we construct a DeterministicKey instead of an ECKey.
         checkNotNull(keyCrypter);
         if (newParent != null)
@@ -357,7 +356,7 @@ public class DeterministicKey extends ECKey {
     }
 
     @Override
-    public ECDSASignature sign(Sha256Hash input, @Nullable KeyParameter aesKey) throws KeyCrypterException {
+    public ECDSASignature sign(Sha256Hash input, @Nullable AesKey aesKey) throws KeyCrypterException {
         if (isEncrypted()) {
             // If the key is encrypted, ECKey.sign will decrypt it first before rerunning sign. Decryption walks the
             // key hierarchy to find the private key (see below), so, we can just run the inherited method.
@@ -374,7 +373,7 @@ public class DeterministicKey extends ECKey {
     }
 
     @Override
-    public DeterministicKey decrypt(KeyCrypter keyCrypter, KeyParameter aesKey) throws KeyCrypterException {
+    public DeterministicKey decrypt(KeyCrypter keyCrypter, AesKey aesKey) throws KeyCrypterException {
         checkNotNull(keyCrypter);
         // Check that the keyCrypter matches the one used to encrypt the keys, if set.
         if (this.keyCrypter != null && !this.keyCrypter.equals(keyCrypter))
@@ -389,13 +388,13 @@ public class DeterministicKey extends ECKey {
     }
 
     @Override
-    public DeterministicKey decrypt(KeyParameter aesKey) throws KeyCrypterException {
+    public DeterministicKey decrypt(AesKey aesKey) throws KeyCrypterException {
         return (DeterministicKey) super.decrypt(aesKey);
     }
 
     // For when a key is encrypted, either decrypt our encrypted private key bytes, or work up the tree asking parents
     // to decrypt and re-derive.
-    private BigInteger findOrDeriveEncryptedPrivateKey(KeyCrypter keyCrypter, KeyParameter aesKey) {
+    private BigInteger findOrDeriveEncryptedPrivateKey(KeyCrypter keyCrypter, AesKey aesKey) {
         if (encryptedPrivateKey != null) {
             byte[] decryptedKey = keyCrypter.decrypt(encryptedPrivateKey, aesKey);
             if (decryptedKey.length != 32)
@@ -753,7 +752,7 @@ public class DeterministicKey extends ECKey {
     }
 
     @Override
-    public void formatKeyWithAddress(boolean includePrivateKeys, @Nullable KeyParameter aesKey, StringBuilder builder,
+    public void formatKeyWithAddress(boolean includePrivateKeys, @Nullable AesKey aesKey, StringBuilder builder,
                                      Network network, ScriptType outputScriptType, @Nullable String comment) {
         builder.append("  addr:").append(toAddress(outputScriptType, network).toString());
         builder.append("  hash160:").append(ByteUtils.formatHex(getPubKeyHash()));
@@ -767,11 +766,11 @@ public class DeterministicKey extends ECKey {
     }
 
     /**
-     * @deprecated Use {@link #formatKeyWithAddress(boolean, KeyParameter, StringBuilder, Network, ScriptType, String)}
+     * @deprecated Use {@link #formatKeyWithAddress(boolean, AesKey, StringBuilder, Network, ScriptType, String)}
      */
     @Override
     @Deprecated
-    public void formatKeyWithAddress(boolean includePrivateKeys, @Nullable KeyParameter aesKey, StringBuilder builder,
+    public void formatKeyWithAddress(boolean includePrivateKeys, @Nullable AesKey aesKey, StringBuilder builder,
                                      NetworkParameters params, ScriptType outputScriptType, @Nullable String comment) {
         formatKeyWithAddress(includePrivateKeys, aesKey, builder, params.network(), outputScriptType, comment);
     }

--- a/core/src/main/java/org/bitcoinj/crypto/KeyCrypter.java
+++ b/core/src/main/java/org/bitcoinj/crypto/KeyCrypter.java
@@ -17,7 +17,6 @@
 package org.bitcoinj.crypto;
 
 import org.bitcoinj.wallet.Protos.Wallet.EncryptionType;
-import org.bouncycastle.crypto.params.KeyParameter;
 
 /**
  * <p>A KeyCrypter can be used to encrypt and decrypt a message. The sequence of events to encrypt and then decrypt
@@ -41,19 +40,19 @@ public interface KeyCrypter {
     EncryptionType getUnderstoodEncryptionType();
 
     /**
-     * Create a KeyParameter (which typically contains an AES key)
+     * Create an AESKey (which typically contains an AES key)
      * @param password
-     * @return KeyParameter The KeyParameter which typically contains the AES key to use for encrypting and decrypting
+     * @return AESKey which typically contains the AES key to use for encrypting and decrypting
      * @throws KeyCrypterException
      */
-    KeyParameter deriveKey(CharSequence password) throws KeyCrypterException;
+    AesKey deriveKey(CharSequence password) throws KeyCrypterException;
 
     /**
      * Decrypt the provided encrypted bytes, converting them into unencrypted bytes.
      *
      * @throws KeyCrypterException if decryption was unsuccessful.
      */
-    byte[] decrypt(EncryptedData encryptedBytesToDecode, KeyParameter aesKey) throws KeyCrypterException;
+    byte[] decrypt(EncryptedData encryptedBytesToDecode, AesKey aesKey) throws KeyCrypterException;
 
     /**
      * Encrypt the supplied bytes, converting them into ciphertext.
@@ -61,5 +60,5 @@ public interface KeyCrypter {
      * @return encryptedPrivateKey An encryptedPrivateKey containing the encrypted bytes and an initialisation vector.
      * @throws KeyCrypterException if encryption was unsuccessful
      */
-    EncryptedData encrypt(byte[] plainBytes, KeyParameter aesKey) throws KeyCrypterException;
+    EncryptedData encrypt(byte[] plainBytes, AesKey aesKey) throws KeyCrypterException;
 }

--- a/core/src/main/java/org/bitcoinj/wallet/BasicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/BasicKeyChain.java
@@ -18,6 +18,7 @@
 package org.bitcoinj.wallet;
 
 import com.google.protobuf.ByteString;
+import org.bitcoinj.crypto.AesKey;
 import org.bitcoinj.core.BloomFilter;
 import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.core.NetworkParameters;
@@ -29,12 +30,10 @@ import org.bitcoinj.crypto.KeyCrypterScrypt;
 import org.bitcoinj.utils.ListenerRegistration;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.listeners.KeyChainEventListener;
-import org.bouncycastle.crypto.params.KeyParameter;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -462,7 +461,7 @@ public class BasicKeyChain implements EncryptableKeyChain {
 
     /**
      * Convenience wrapper around {@link #toEncrypted(KeyCrypter,
-     * org.bouncycastle.crypto.params.KeyParameter)} which uses the default Scrypt key derivation algorithm and
+     * AesKey)} which uses the default Scrypt key derivation algorithm and
      * parameters, derives a key from the given password and returns the created key.
      */
     @Override
@@ -470,7 +469,7 @@ public class BasicKeyChain implements EncryptableKeyChain {
         checkNotNull(password);
         checkArgument(password.length() > 0);
         KeyCrypter scrypt = new KeyCrypterScrypt();
-        KeyParameter derivedKey = scrypt.deriveKey(password);
+        AesKey derivedKey = scrypt.deriveKey(password);
         return toEncrypted(scrypt, derivedKey);
     }
 
@@ -484,7 +483,7 @@ public class BasicKeyChain implements EncryptableKeyChain {
      * @throws KeyCrypterException Thrown if the wallet encryption fails. If so, the wallet state is unchanged.
      */
     @Override
-    public BasicKeyChain toEncrypted(KeyCrypter keyCrypter, KeyParameter aesKey) {
+    public BasicKeyChain toEncrypted(KeyCrypter keyCrypter, AesKey aesKey) {
         lock.lock();
         try {
             checkNotNull(keyCrypter);
@@ -513,12 +512,12 @@ public class BasicKeyChain implements EncryptableKeyChain {
     @Override
     public BasicKeyChain toDecrypted(CharSequence password) {
         checkNotNull(keyCrypter, "Wallet is already decrypted");
-        KeyParameter aesKey = keyCrypter.deriveKey(password);
+        AesKey aesKey = keyCrypter.deriveKey(password);
         return toDecrypted(aesKey);
     }
 
     @Override
-    public BasicKeyChain toDecrypted(KeyParameter aesKey) {
+    public BasicKeyChain toDecrypted(AesKey aesKey) {
         lock.lock();
         try {
             checkState(keyCrypter != null, "Wallet is already decrypted");
@@ -555,7 +554,7 @@ public class BasicKeyChain implements EncryptableKeyChain {
      * @return true if AES key supplied can decrypt the first encrypted private key in the wallet, false otherwise.
      */
     @Override
-    public boolean checkAESKey(KeyParameter aesKey) {
+    public boolean checkAESKey(AesKey aesKey) {
         lock.lock();
         try {
             // If no keys then cannot decrypt.
@@ -652,7 +651,7 @@ public class BasicKeyChain implements EncryptableKeyChain {
         }
     }
 
-    public String toString(boolean includePrivateKeys, @Nullable KeyParameter aesKey, NetworkParameters params) {
+    public String toString(boolean includePrivateKeys, @Nullable AesKey aesKey, NetworkParameters params) {
         final StringBuilder builder = new StringBuilder();
         List<ECKey> keys = getKeys();
         Collections.sort(keys, ECKey.AGE_COMPARATOR);

--- a/core/src/main/java/org/bitcoinj/wallet/DecryptingKeyBag.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DecryptingKeyBag.java
@@ -17,8 +17,8 @@
 package org.bitcoinj.wallet;
 
 import org.bitcoinj.base.ScriptType;
+import org.bitcoinj.crypto.AesKey;
 import org.bitcoinj.crypto.ECKey;
-import org.bouncycastle.crypto.params.KeyParameter;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -33,9 +33,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class DecryptingKeyBag implements KeyBag {
     protected final KeyBag target;
-    protected final KeyParameter aesKey;
+    protected final AesKey aesKey;
 
-    public DecryptingKeyBag(KeyBag target, @Nullable KeyParameter aesKey) {
+    public DecryptingKeyBag(KeyBag target, @Nullable AesKey aesKey) {
         this.target = checkNotNull(target);
         this.aesKey = aesKey;
     }

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
@@ -20,12 +20,12 @@ package org.bitcoinj.wallet;
 import com.google.common.base.MoreObjects;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.base.internal.InternalUtils;
+import org.bitcoinj.crypto.AesKey;
 import org.bitcoinj.crypto.EncryptableItem;
 import org.bitcoinj.crypto.EncryptedData;
 import org.bitcoinj.crypto.KeyCrypter;
 import org.bitcoinj.crypto.MnemonicCode;
 import org.bitcoinj.crypto.MnemonicException;
-import org.bouncycastle.crypto.params.KeyParameter;
 
 import javax.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
@@ -193,7 +193,7 @@ public class DeterministicSeed implements EncryptableItem {
         this.creationTimeSeconds = creationTimeSeconds;
     }
 
-    public DeterministicSeed encrypt(KeyCrypter keyCrypter, KeyParameter aesKey) {
+    public DeterministicSeed encrypt(KeyCrypter keyCrypter, AesKey aesKey) {
         checkState(encryptedMnemonicCode == null, "Trying to encrypt seed twice");
         checkState(mnemonicCode != null, "Mnemonic missing so cannot encrypt");
         EncryptedData encryptedMnemonic = keyCrypter.encrypt(getMnemonicAsBytes(), aesKey);
@@ -205,7 +205,7 @@ public class DeterministicSeed implements EncryptableItem {
         return getMnemonicString().getBytes(StandardCharsets.UTF_8);
     }
 
-    public DeterministicSeed decrypt(KeyCrypter crypter, String passphrase, KeyParameter aesKey) {
+    public DeterministicSeed decrypt(KeyCrypter crypter, String passphrase, AesKey aesKey) {
         checkState(isEncrypted());
         checkNotNull(encryptedMnemonicCode);
         List<String> mnemonic = decodeMnemonicCode(crypter.decrypt(encryptedMnemonicCode, aesKey));

--- a/core/src/main/java/org/bitcoinj/wallet/EncryptableKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/EncryptableKeyChain.java
@@ -16,10 +16,10 @@
 
 package org.bitcoinj.wallet;
 
+import org.bitcoinj.crypto.AesKey;
 import org.bitcoinj.crypto.KeyCrypter;
 import org.bitcoinj.crypto.KeyCrypterException;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
-import org.bouncycastle.crypto.params.KeyParameter;
 
 import javax.annotation.Nullable;
 
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
 public interface EncryptableKeyChain extends KeyChain {
     /**
      * Takes the given password, which should be strong, derives a key from it and then invokes
-     * {@link #toEncrypted(KeyCrypter, KeyParameter)} with
+     * {@link #toEncrypted(KeyCrypter, AesKey)} with
      * {@link KeyCrypterScrypt} as the crypter.
      *
      * @return The derived key, in case you wish to cache it for future use.
@@ -40,10 +40,10 @@ public interface EncryptableKeyChain extends KeyChain {
      * Returns a new keychain holding identical/cloned keys to this chain, but encrypted under the given key.
      * Old keys and keychains remain valid and so you should ensure you don't accidentally hold references to them.
      */
-    EncryptableKeyChain toEncrypted(KeyCrypter keyCrypter, KeyParameter aesKey);
+    EncryptableKeyChain toEncrypted(KeyCrypter keyCrypter, AesKey aesKey);
 
     /**
-     * Decrypts the key chain with the given password. See {@link #toDecrypted(KeyParameter)}
+     * Decrypts the key chain with the given password. See {@link #toDecrypted(AesKey)}
      * for details.
      */
     EncryptableKeyChain toDecrypted(CharSequence password);
@@ -57,10 +57,10 @@ public interface EncryptableKeyChain extends KeyChain {
      *               create from a password)
      * @throws KeyCrypterException Thrown if the wallet decryption fails. If so, the wallet state is unchanged.
      */
-    EncryptableKeyChain toDecrypted(KeyParameter aesKey);
+    EncryptableKeyChain toDecrypted(AesKey aesKey);
 
     boolean checkPassword(CharSequence password);
-    boolean checkAESKey(KeyParameter aesKey);
+    boolean checkAESKey(AesKey aesKey);
 
     /** Returns the key crypter used by this key chain, or null if it's not encrypted. */
     @Nullable

--- a/core/src/main/java/org/bitcoinj/wallet/MarriedKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/MarriedKeyChain.java
@@ -19,6 +19,7 @@ package org.bitcoinj.wallet;
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
 import org.bitcoinj.base.ScriptType;
+import org.bitcoinj.crypto.AesKey;
 import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.core.BloomFilter;
 import org.bitcoinj.crypto.ECKey;
@@ -28,7 +29,6 @@ import org.bitcoinj.crypto.DeterministicKey;
 import org.bitcoinj.crypto.KeyCrypter;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
-import org.bouncycastle.crypto.params.KeyParameter;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -237,7 +237,7 @@ public class MarriedKeyChain extends DeterministicKeyChain {
     }
 
     @Override
-    protected void formatAddresses(boolean includeLookahead, boolean includePrivateKeys, @Nullable KeyParameter aesKey,
+    protected void formatAddresses(boolean includeLookahead, boolean includePrivateKeys, @Nullable AesKey aesKey,
             NetworkParameters params, StringBuilder builder) {
         for (DeterministicKeyChain followingChain : followingKeyChains)
             builder.append("Following chain:  ").append(followingChain.getWatchingKey().serializePubB58(params.network()))

--- a/core/src/main/java/org/bitcoinj/wallet/SendRequest.java
+++ b/core/src/main/java/org/bitcoinj/wallet/SendRequest.java
@@ -21,6 +21,7 @@ import com.google.common.base.MoreObjects;
 import org.bitcoin.protocols.payments.Protos.PaymentDetails;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.crypto.AesKey;
 import org.bitcoinj.core.Context;
 import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.core.NetworkParameters;
@@ -29,7 +30,6 @@ import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.utils.ExchangeRate;
 import org.bitcoinj.wallet.KeyChain.KeyPurpose;
 import org.bitcoinj.wallet.Wallet.MissingSigsMode;
-import org.bouncycastle.crypto.params.KeyParameter;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -109,7 +109,7 @@ public class SendRequest {
      * If null then no decryption will be performed and if decryption is required an exception will be thrown.
      * You can get this from a password by doing wallet.getKeyCrypter().deriveKey(password).
      */
-    public KeyParameter aesKey = null;
+    public AesKey aesKey = null;
 
     /**
      * If not null, the {@link CoinSelector} to use instead of the wallets default. Coin selectors are

--- a/core/src/test/java/org/bitcoinj/crypto/ChildKeyDerivationTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ChildKeyDerivationTest.java
@@ -22,7 +22,6 @@ import org.bitcoinj.base.Sha256Hash;
 import static org.bitcoinj.base.BitcoinNetwork.MAINNET;
 import static org.bitcoinj.base.BitcoinNetwork.TESTNET;
 
-import org.bouncycastle.crypto.params.KeyParameter;
 import org.junit.Test;
 
 import org.bitcoinj.base.utils.ByteUtils;
@@ -172,7 +171,7 @@ public class ChildKeyDerivationTest {
         // Check that encrypting a parent key in the hierarchy and then deriving from it yields a DeterministicKey
         // with no private key component, and that the private key bytes are derived on demand.
         KeyCrypter scrypter = new KeyCrypterScrypt(SCRYPT_ITERATIONS);
-        KeyParameter aesKey = scrypter.deriveKey("we never went to the moon");
+        AesKey aesKey = scrypter.deriveKey("we never went to the moon");
 
         DeterministicKey key1 = HDKeyDerivation.createMasterPrivateKey("it was all a hoax".getBytes());
         DeterministicKey encryptedKey1 = key1.encrypt(scrypter, aesKey, null);

--- a/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
@@ -30,7 +30,6 @@ import org.bitcoinj.core.Transaction;
 import org.bitcoinj.crypto.ECKey.ECDSASignature;
 import org.bitcoinj.crypto.internal.CryptoUtils;
 import org.bitcoinj.base.internal.FutureUtils;
-import org.bouncycastle.crypto.params.KeyParameter;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -48,7 +47,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import org.bitcoinj.base.utils.ByteUtils;
 import static org.bitcoinj.base.utils.ByteUtils.reverseBytes;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -415,7 +413,7 @@ public class ECKeyTest {
     @Test
     public void keyRecoveryWithEncryptedKey() {
         ECKey unencryptedKey = new ECKey();
-        KeyParameter aesKey =  keyCrypter.deriveKey(PASSWORD1);
+        AesKey aesKey =  keyCrypter.deriveKey(PASSWORD1);
         ECKey encryptedKey = unencryptedKey.encrypt(keyCrypter, aesKey);
 
         String message = "Goodbye Jupiter!";

--- a/core/src/test/java/org/bitcoinj/crypto/HDKeyDerivationTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/HDKeyDerivationTest.java
@@ -19,7 +19,6 @@ package org.bitcoinj.crypto;
 
 import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.crypto.HDKeyDerivation.PublicDeriveMode;
-import org.bouncycastle.crypto.params.KeyParameter;
 import org.junit.Test;
 
 import java.math.BigInteger;
@@ -36,7 +35,7 @@ import static org.junit.Assert.fail;
  */
 public class HDKeyDerivationTest {
     private static final KeyCrypterScrypt KEY_CRYPTER = new KeyCrypterScrypt(2);
-    private static final KeyParameter AES_KEY = KEY_CRYPTER.deriveKey("password");
+    private static final AesKey AES_KEY = KEY_CRYPTER.deriveKey("password");
     private static final ChildNumber CHILD_NUMBER = ChildNumber.ONE;
     private static final String EXPECTED_CHILD_CHAIN_CODE = "c4341fe988a2ae6240788c6b21df268b9286769915bed23c7649f263b3643ee8";
     private static final String EXPECTED_CHILD_PRIVATE_KEY = "48516d403070bc93f5e4d78c984cf2d71fc9799293b4eeb3de4f88e3892f523d";

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -22,6 +22,7 @@ import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.internal.TimeUtils;
+import org.bitcoinj.crypto.AesKey;
 import org.bitcoinj.core.BloomFilter;
 import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.base.LegacyAddress;
@@ -34,7 +35,6 @@ import org.bitcoinj.crypto.HDPath;
 import org.bitcoinj.utils.BriefLogFormatter;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.listeners.AbstractKeyChainEventListener;
-import org.bouncycastle.crypto.params.KeyParameter;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -356,7 +356,7 @@ public class DeterministicKeyChainTest {
         assertFalse(key1.isEncrypted());
         assertTrue(encKey1.isEncrypted());
         assertEquals(encKey1.getPubKeyPoint(), key1.getPubKeyPoint());
-        final KeyParameter aesKey = checkNotNull(encChain.getKeyCrypter()).deriveKey("open secret");
+        final AesKey aesKey = checkNotNull(encChain.getKeyCrypter()).deriveKey("open secret");
         encKey1.sign(Sha256Hash.ZERO_HASH, aesKey);
         encKey2.sign(Sha256Hash.ZERO_HASH, aesKey);
         assertTrue(encChain.checkAESKey(aesKey));

--- a/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
@@ -19,6 +19,7 @@ package org.bitcoinj.wallet;
 
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.internal.TimeUtils;
+import org.bitcoinj.crypto.AesKey;
 import org.bitcoinj.core.BloomFilter;
 import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.core.NetworkParameters;
@@ -33,7 +34,6 @@ import org.bitcoinj.utils.BriefLogFormatter;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.KeyChain.KeyPurpose;
 import org.bitcoinj.wallet.listeners.KeyChainEventListener;
-import org.bouncycastle.crypto.params.KeyParameter;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -59,7 +59,7 @@ public class KeyChainGroupTest {
     private static final String XPUB = "xpub68KFnj3bqUx1s7mHejLDBPywCAKdJEu1b49uniEEn2WSbHmZ7xbLqFTjJbtx1LUcAt1DwhoqWHmo2s5WMJp6wi38CiF2hYD49qVViKVvAoi";
     private static final byte[] ENTROPY = Sha256Hash.hash("don't use a string seed like this in real life".getBytes());
     private static final KeyCrypterScrypt KEY_CRYPTER = new KeyCrypterScrypt(2);
-    private static final KeyParameter AES_KEY = KEY_CRYPTER.deriveKey("password");
+    private static final AesKey AES_KEY = KEY_CRYPTER.deriveKey("password");
     private KeyChainGroup group;
     private DeterministicKey watchingAccountKey;
 

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Lists;
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.internal.TimeUtils;
+import org.bitcoinj.crypto.AesKey;
 import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.core.AbstractBlockChain;
 import org.bitcoinj.base.Address;
@@ -69,7 +70,6 @@ import org.bitcoinj.wallet.KeyChain.KeyPurpose;
 import org.bitcoinj.wallet.Protos.Wallet.EncryptionType;
 import org.bitcoinj.wallet.Wallet.BalanceType;
 import org.bitcoinj.wallet.WalletTransaction.Pool;
-import org.bouncycastle.crypto.params.KeyParameter;
 import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
@@ -86,7 +86,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -105,7 +104,6 @@ import static org.bitcoinj.base.Coin.MILLICOIN;
 import static org.bitcoinj.base.Coin.SATOSHI;
 import static org.bitcoinj.base.Coin.ZERO;
 import static org.bitcoinj.base.Coin.valueOf;
-import org.bitcoinj.base.utils.ByteUtils;
 import static org.bitcoinj.testing.FakeTxBuilder.createFakeBlock;
 import static org.bitcoinj.testing.FakeTxBuilder.createFakeTx;
 import static org.bitcoinj.testing.FakeTxBuilder.createFakeTxWithoutChangeAddress;
@@ -388,8 +386,8 @@ public class WalletTest extends TestWithWallet {
 
         if (encryptedWallet != null) {
             KeyCrypter keyCrypter = encryptedWallet.getKeyCrypter();
-            KeyParameter aesKey = keyCrypter.deriveKey(PASSWORD1);
-            KeyParameter wrongAesKey = keyCrypter.deriveKey(WRONG_PASSWORD);
+            AesKey aesKey = keyCrypter.deriveKey(PASSWORD1);
+            AesKey wrongAesKey = keyCrypter.deriveKey(WRONG_PASSWORD);
 
             // Try to create a send with a fee but no password (this should fail).
             try {
@@ -503,7 +501,7 @@ public class WalletTest extends TestWithWallet {
         assertEquals(1, txns.size());
     }
 
-    private Wallet spendUnconfirmedChange(Wallet wallet, Transaction t2, KeyParameter aesKey) throws Exception {
+    private Wallet spendUnconfirmedChange(Wallet wallet, Transaction t2, AesKey aesKey) throws Exception {
         if (wallet.getTransactionSigners().size() == 1)   // don't bother reconfiguring the p2sh wallet
             wallet = roundTrip(wallet);
         Coin v3 = valueOf(0, 50);
@@ -1923,7 +1921,7 @@ public class WalletTest extends TestWithWallet {
         Wallet encryptedWallet = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH);
         encryptedWallet.encrypt(PASSWORD1);
         KeyCrypter keyCrypter = encryptedWallet.getKeyCrypter();
-        KeyParameter aesKey = keyCrypter.deriveKey(PASSWORD1);
+        AesKey aesKey = keyCrypter.deriveKey(PASSWORD1);
 
         assertEquals(EncryptionType.ENCRYPTED_SCRYPT_AES, encryptedWallet.getEncryptionType());
         assertTrue(encryptedWallet.checkPassword(PASSWORD1));
@@ -1964,7 +1962,7 @@ public class WalletTest extends TestWithWallet {
         Wallet encryptedWallet = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH);
         encryptedWallet.encrypt(PASSWORD1);
         KeyCrypter keyCrypter = encryptedWallet.getKeyCrypter();
-        KeyParameter wrongAesKey = keyCrypter.deriveKey(WRONG_PASSWORD);
+        AesKey wrongAesKey = keyCrypter.deriveKey(WRONG_PASSWORD);
 
         // Check the wallet is currently encrypted
         assertEquals("Wallet is not an encrypted wallet", EncryptionType.ENCRYPTED_SCRYPT_AES, encryptedWallet.getEncryptionType());
@@ -1995,10 +1993,10 @@ public class WalletTest extends TestWithWallet {
         encryptedWallet.encrypt(PASSWORD1);
 
         KeyCrypter keyCrypter = encryptedWallet.getKeyCrypter();
-        KeyParameter aesKey = keyCrypter.deriveKey(PASSWORD1);
+        AesKey aesKey = keyCrypter.deriveKey(PASSWORD1);
 
         CharSequence newPassword = "My name is Tom";
-        KeyParameter newAesKey = keyCrypter.deriveKey(newPassword);
+        AesKey newAesKey = keyCrypter.deriveKey(newPassword);
 
         encryptedWallet.changeEncryptionKey(keyCrypter, aesKey, newAesKey);
 
@@ -2011,7 +2009,7 @@ public class WalletTest extends TestWithWallet {
         Wallet encryptedWallet = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH);
         encryptedWallet.encrypt(PASSWORD1);
         KeyCrypter keyCrypter = encryptedWallet.getKeyCrypter();
-        KeyParameter aesKey = keyCrypter.deriveKey(PASSWORD1);
+        AesKey aesKey = keyCrypter.deriveKey(PASSWORD1);
 
         // Check the wallet is currently encrypted
         assertEquals("Wallet is not an encrypted wallet", EncryptionType.ENCRYPTED_SCRYPT_AES, encryptedWallet.getEncryptionType());
@@ -2070,7 +2068,7 @@ public class WalletTest extends TestWithWallet {
         Wallet encryptedWallet = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH);
         encryptedWallet.encrypt(PASSWORD1);
         KeyCrypter keyCrypter = encryptedWallet.getKeyCrypter();
-        KeyParameter aesKey = keyCrypter.deriveKey(PASSWORD1);
+        AesKey aesKey = keyCrypter.deriveKey(PASSWORD1);
 
         // Try added an ECKey that was encrypted with a differenct ScryptParameters (i.e. a non-homogenous key).
         // This is not allowed as the ScryptParameters is stored at the Wallet level.
@@ -3246,7 +3244,7 @@ public class WalletTest extends TestWithWallet {
         assertFalse(wallet.isDeterministicUpgradeRequired(ScriptType.P2PKH));
         assertTrue(wallet.isDeterministicUpgradeRequired(ScriptType.P2WPKH));
 
-        KeyParameter aesKey = new KeyCrypterScrypt(SCRYPT_ITERATIONS).deriveKey("abc");
+        AesKey aesKey = new KeyCrypterScrypt(SCRYPT_ITERATIONS).deriveKey("abc");
         wallet.encrypt(new KeyCrypterScrypt(), aesKey);
         assertTrue(wallet.isEncrypted());
         assertEquals(ScriptType.P2PKH, wallet.currentReceiveAddress().getOutputScriptType());

--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/utils/KeyDerivationTasks.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/utils/KeyDerivationTasks.java
@@ -16,13 +16,13 @@
 
 package org.bitcoinj.walletfx.utils;
 
+import org.bitcoinj.crypto.AesKey;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
 import com.google.common.util.concurrent.Uninterruptibles;
 import javafx.beans.property.ReadOnlyDoubleProperty;
 import javafx.concurrent.Task;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.crypto.params.KeyParameter;
 
 import javax.annotation.*;
 import java.time.Duration;
@@ -36,7 +36,7 @@ import static org.bitcoinj.walletfx.utils.GuiUtils.checkGuiThread;
 public class KeyDerivationTasks {
     private static final Logger log = LoggerFactory.getLogger(KeyDerivationTasks.class);
 
-    public final Task<KeyParameter> keyDerivationTask;
+    public final Task<AesKey> keyDerivationTask;
     public final ReadOnlyDoubleProperty progress;
 
     private final Task<Void> progressTask;
@@ -46,11 +46,11 @@ public class KeyDerivationTasks {
     public KeyDerivationTasks(KeyCrypterScrypt scrypt, String password, @Nullable Duration targetTime) {
         keyDerivationTask = new Task<>() {
             @Override
-            protected KeyParameter call() throws Exception {
+            protected AesKey call() throws Exception {
                 long start = System.currentTimeMillis();
                 try {
                     log.info("Started key derivation");
-                    KeyParameter result = scrypt.deriveKey(password);
+                    AesKey result = scrypt.deriveKey(password);
                     timeTakenMsec = (int) (System.currentTimeMillis() - start);
                     log.info("Key derivation done in {}ms", timeTakenMsec);
                     return result;
@@ -64,7 +64,7 @@ public class KeyDerivationTasks {
         // And the fake progress meter ... if the vals were calculated correctly progress bar should reach 100%
         // a brief moment after the keys were derived successfully.
         progressTask = new Task<>() {
-            private KeyParameter aesKey;
+            private AesKey aesKey;
 
             @Override
             protected Void call() throws Exception {
@@ -102,6 +102,6 @@ public class KeyDerivationTasks {
         new Thread(progressTask, "Progress ticker").start();
     }
 
-    protected void onFinish(KeyParameter aesKey, int timeTakenMsec) {
+    protected void onFinish(AesKey aesKey, int timeTakenMsec) {
     }
 }

--- a/wallettemplate/src/main/java/wallettemplate/SendMoneyController.java
+++ b/wallettemplate/src/main/java/wallettemplate/SendMoneyController.java
@@ -19,6 +19,7 @@ package wallettemplate;
 import javafx.scene.layout.HBox;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.crypto.AesKey;
 import org.bitcoinj.core.*;
 import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.wallet.SendRequest;
@@ -35,7 +36,6 @@ import javafx.scene.control.TextField;
 import org.bitcoinj.walletfx.application.WalletApplication;
 import org.bitcoinj.walletfx.overlay.OverlayController;
 import org.bitcoinj.walletfx.overlay.OverlayableStackPaneController;
-import org.bouncycastle.crypto.params.KeyParameter;
 import org.bitcoinj.walletfx.controls.BitcoinAddressValidator;
 import org.bitcoinj.walletfx.utils.TextFieldValidator;
 import org.bitcoinj.walletfx.utils.WTUtils;
@@ -58,7 +58,7 @@ public class SendMoneyController implements OverlayController<SendMoneyControlle
     private OverlayableStackPaneController.OverlayUI<? extends OverlayController<SendMoneyController>> overlayUI;
 
     private Wallet.SendResult sendResult;
-    private KeyParameter aesKey;
+    private AesKey aesKey;
 
     @Override
     public void initOverlay(OverlayableStackPaneController overlayableStackPaneController, OverlayableStackPaneController.OverlayUI<? extends OverlayController<SendMoneyController>> ui) {

--- a/wallettemplate/src/main/java/wallettemplate/WalletPasswordController.java
+++ b/wallettemplate/src/main/java/wallettemplate/WalletPasswordController.java
@@ -17,6 +17,7 @@
 package wallettemplate;
 
 import javafx.application.Platform;
+import org.bitcoinj.crypto.AesKey;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
 import com.google.common.primitives.Longs;
 import com.google.protobuf.ByteString;
@@ -35,7 +36,6 @@ import org.bitcoinj.walletfx.overlay.OverlayController;
 import org.bitcoinj.walletfx.overlay.OverlayableStackPaneController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.crypto.params.KeyParameter;
 import org.bitcoinj.walletfx.utils.KeyDerivationTasks;
 
 import java.time.Duration;
@@ -61,7 +61,7 @@ public class WalletPasswordController implements OverlayController<WalletPasswor
     private OverlayableStackPaneController rootController;
     private OverlayableStackPaneController.OverlayUI<? extends OverlayController<WalletPasswordController>> overlayUI;
 
-    private SimpleObjectProperty<KeyParameter> aesKey = new SimpleObjectProperty<>();
+    private SimpleObjectProperty<AesKey> aesKey = new SimpleObjectProperty<>();
 
     @Override
     public void initOverlay(OverlayableStackPaneController overlayableStackPaneController, OverlayableStackPaneController.OverlayUI<? extends OverlayController<WalletPasswordController>> ui) {
@@ -86,7 +86,7 @@ public class WalletPasswordController implements OverlayController<WalletPasswor
         checkNotNull(keyCrypter);   // We should never arrive at this GUI if the wallet isn't actually encrypted.
         KeyDerivationTasks tasks = new KeyDerivationTasks(keyCrypter, password, getTargetTime()) {
             @Override
-            protected final void onFinish(KeyParameter aesKey, int timeTakenMsec) {
+            protected final void onFinish(AesKey aesKey, int timeTakenMsec) {
                 checkGuiThread();
                 if (app.walletAppKit().wallet().checkAESKey(aesKey)) {
                     WalletPasswordController.this.aesKey.set(aesKey);
@@ -114,7 +114,7 @@ public class WalletPasswordController implements OverlayController<WalletPasswor
         overlayUI.done();
     }
 
-    public ReadOnlyObjectProperty<KeyParameter> aesKeyProperty() {
+    public ReadOnlyObjectProperty<AesKey> aesKeyProperty() {
         return aesKey;
     }
 

--- a/wallettemplate/src/main/java/wallettemplate/WalletSetPasswordController.java
+++ b/wallettemplate/src/main/java/wallettemplate/WalletSetPasswordController.java
@@ -16,18 +16,17 @@
 
 package wallettemplate;
 
-import javafx.application.*;
 import javafx.event.*;
 import javafx.fxml.*;
 import javafx.scene.control.*;
 import javafx.scene.layout.*;
+import org.bitcoinj.crypto.AesKey;
 import org.bitcoinj.crypto.*;
 import org.bitcoinj.wallet.*;
 import org.bitcoinj.walletfx.application.WalletApplication;
 import org.bitcoinj.walletfx.overlay.OverlayController;
 import org.bitcoinj.walletfx.overlay.OverlayableStackPaneController;
 import org.slf4j.*;
-import org.bouncycastle.crypto.params.*;
 
 import com.google.protobuf.ByteString;
 
@@ -124,7 +123,7 @@ public class WalletSetPasswordController implements OverlayController<WalletSetP
         // Deriving the actual key runs on a background thread. 500msec is empirical on my laptop (actual val is more like 333 but we give padding time).
         KeyDerivationTasks tasks = new KeyDerivationTasks(scrypt, password, estimatedKeyDerivationTime) {
             @Override
-            protected final void onFinish(KeyParameter aesKey, int timeTakenMsec) {
+            protected final void onFinish(AesKey aesKey, int timeTakenMsec) {
                 // Write the target time to the wallet so we can make the progress bar work when entering the password.
                 WalletPasswordController.setTargetTime(Duration.ofMillis(timeTakenMsec));
                 // The actual encryption part doesn't take very long as most private keys are derived on demand.

--- a/wallettemplate/src/main/java/wallettemplate/WalletSettingsController.java
+++ b/wallettemplate/src/main/java/wallettemplate/WalletSettingsController.java
@@ -17,6 +17,7 @@
 package wallettemplate;
 
 import org.bitcoinj.base.internal.InternalUtils;
+import org.bitcoinj.crypto.AesKey;
 import org.bitcoinj.crypto.MnemonicCode;
 import org.bitcoinj.wallet.DeterministicSeed;
 import com.google.common.util.concurrent.Service;
@@ -32,7 +33,6 @@ import org.bitcoinj.walletfx.overlay.OverlayController;
 import org.bitcoinj.walletfx.overlay.OverlayableStackPaneController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.crypto.params.KeyParameter;
 import org.bitcoinj.walletfx.utils.TextFieldValidator;
 
 import javax.annotation.Nullable;
@@ -61,7 +61,7 @@ public class WalletSettingsController implements OverlayController<WalletSetting
     private OverlayableStackPaneController rootController;
     private OverlayableStackPaneController.OverlayUI<? extends OverlayController<WalletSettingsController>> overlayUI;
 
-    private KeyParameter aesKey;
+    private AesKey aesKey;
 
     @Override
     public void initOverlay(OverlayableStackPaneController overlayableStackPaneController, OverlayableStackPaneController.OverlayUI<? extends OverlayController<WalletSettingsController>> ui) {
@@ -70,7 +70,7 @@ public class WalletSettingsController implements OverlayController<WalletSetting
     }
 
     // Note: NOT called by FXMLLoader!
-    public void initialize(@Nullable KeyParameter aesKey) {
+    public void initialize(@Nullable AesKey aesKey) {
         app = WalletApplication.instance();
         DeterministicSeed seed = app.walletAppKit().wallet().getKeyChainSeed();
         if (aesKey == null) {

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -20,6 +20,7 @@ package org.bitcoinj.wallettool;
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.internal.TimeUtils;
+import org.bitcoinj.crypto.AesKey;
 import org.bitcoinj.base.utils.ByteUtils;
 import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.crypto.*;
@@ -38,7 +39,6 @@ import org.bitcoinj.wallet.CoinSelector;
 import org.bitcoinj.wallet.DeterministicKeyChain;
 import org.bitcoinj.wallet.DeterministicSeed;
 
-import com.google.common.io.BaseEncoding;
 import com.google.common.io.Resources;
 import com.google.protobuf.ByteString;
 
@@ -78,7 +78,6 @@ import org.bitcoinj.wallet.listeners.WalletCoinsSentEventListener;
 import org.bitcoinj.wallet.listeners.WalletReorganizeEventListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.bouncycastle.crypto.params.KeyParameter;
 import picocli.CommandLine;
 
 import javax.annotation.Nullable;
@@ -574,7 +573,7 @@ public class WalletTool implements Callable<Integer> {
                             + " to " + outputScriptType);
             return;
         }
-        KeyParameter aesKey = null;
+        AesKey aesKey = null;
         if (wallet.isEncrypted()) {
             aesKey = passwordToKey(true);
             if (aesKey == null)
@@ -597,7 +596,7 @@ public class WalletTool implements Callable<Integer> {
         }
         log.info("Setting wallet key rotation time to {}", rotationTimeSecs);
         wallet.setKeyRotationTime(rotationTimeSecs);
-        KeyParameter aesKey = null;
+        AesKey aesKey = null;
         if (wallet.isEncrypted()) {
             aesKey = passwordToKey(true);
             if (aesKey == null)
@@ -1157,7 +1156,7 @@ public class WalletTool implements Callable<Integer> {
         }
         try {
             if (wallet.isEncrypted()) {
-                KeyParameter aesKey = passwordToKey(true);
+                AesKey aesKey = passwordToKey(true);
                 if (aesKey == null)
                     return;   // Error message already printed.
                 key = key.encrypt(checkNotNull(wallet.getKeyCrypter()), aesKey);
@@ -1177,7 +1176,7 @@ public class WalletTool implements Callable<Integer> {
     }
 
     @Nullable
-    private KeyParameter passwordToKey(boolean printError) {
+    private AesKey passwordToKey(boolean printError) {
         if (password == null) {
             if (printError)
                 System.err.println("You must provide a password.");
@@ -1258,7 +1257,7 @@ public class WalletTool implements Callable<Integer> {
 
         if (dumpPrivKeys && wallet.isEncrypted()) {
             if (password != null) {
-                final KeyParameter aesKey = passwordToKey(true);
+                final AesKey aesKey = passwordToKey(true);
                 if (aesKey == null)
                     return; // Error message already printed.
                 printWallet( aesKey);
@@ -1271,7 +1270,7 @@ public class WalletTool implements Callable<Integer> {
         }
     }
 
-    private void printWallet(@Nullable KeyParameter aesKey) {
+    private void printWallet(@Nullable AesKey aesKey) {
         System.out.println(wallet.toString(dumpLookAhead, dumpPrivKeys, aesKey, true, true, chain));
     }
 


### PR DESCRIPTION
We were using KeyParameter as a wrapper for a byte array containing an AES Key and passing it around our API. This introduced an unnecessary API dependency on Bouncy Castle. This PR adds an AesKey class for the same purpose to replace it.

This is a breaking change, but one that should be easy to accommodate.