### PR TITLE
tools/wallettool `build.gradle`: use `mainClass` not `main` in `JavaExec` task

### DIFF
--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -21,7 +21,7 @@ compileJava {
 
 task build_checkpoints(type: JavaExec) {
     description = 'Create checkpoint files to use with CheckpointManager.'
-    main = 'org.bitcoinj.tools.BuildCheckpoints'
+    mainClass = 'org.bitcoinj.tools.BuildCheckpoints'
     if (project.hasProperty('appArgs') && appArgs.length() > 0)
         args = Arrays.asList(appArgs.split("\\s+"))
     classpath = sourceSets.main.runtimeClasspath

--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -61,7 +61,7 @@ task generateManpageAsciiDoc(type: JavaExec) {
     } else {
         classpath(sourceSets.main.compileClasspath, sourceSets.main.runtimeClasspath)
     }
-    main 'picocli.codegen.docgen.manpage.ManPageGenerator'
+    mainClass = 'picocli.codegen.docgen.manpage.ManPageGenerator'
     args mainClassName, "--outdir=${project.buildDir}/generated-picocli-docs", "-v" //, "--template-dir=src/docs/mantemplates"
 }
 


### PR DESCRIPTION
Fix Gradle 8.0 deprecation warning by changing `main` to `mainClass` in the `JavaExec` tasks.

**Note**: this change **breaks Gradle prior to 6.4.x**, so to support both ancient Gradle (currently 4.4) and Gradle 8, we're going to need to add some kind of conditional code to handle `main` vs `mainClass`.

So this will be a **DRAFT** PR for now.

You can see the failure on Github Actions because Ubuntu/JDK 11/Gradle 4.10.3 is in our test matrix: https://github.com/bitcoinj/bitcoinj/actions/runs/4370061279