### PR TITLE
Github graalvm and gradle workflows: use Gradle 7.6.1

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -10,7 +10,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
         java: [ '17' ]
         graalvm: [ '22.3.1' ]
-        gradle: ['7.6']
+        gradle: ['7.6.1']
       fail-fast: false
     name: ${{ matrix.os }} JDK ${{ matrix.graalvm }}.${{ matrix.java }}
     steps:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,7 +10,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         java: ['11', '17', '19']
         distribution: ['temurin']
-        gradle: ['7.6']
+        gradle: ['7.6.1']
         include:
           # Special case to test something close to Debian config with the oldest supported (standard) Gradle on Ubuntu
           - os: ubuntu-latest


### PR DESCRIPTION
Minor version bump 7.6 -> 7.6.1