### PR TITLE
MnemonicCode: in `toMnemonic()` throw unchecked rather than checked exception

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/MnemonicCode.java
+++ b/core/src/main/java/org/bitcoinj/crypto/MnemonicCode.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import org.bitcoinj.base.utils.ByteUtils;
 
@@ -201,13 +202,11 @@ public class MnemonicCode {
 
     /**
      * Convert entropy data to mnemonic word list.
+     * @param entropy entropy bits, length must be a multiple of 32 bits
      */
-    public List<String> toMnemonic(byte[] entropy) throws MnemonicException.MnemonicLengthException {
-        if (entropy.length % 4 > 0)
-            throw new MnemonicException.MnemonicLengthException("Entropy length not multiple of 32 bits.");
-
-        if (entropy.length == 0)
-            throw new MnemonicException.MnemonicLengthException("Entropy is empty.");
+    public List<String> toMnemonic(byte[] entropy) {
+        checkArgument(entropy.length % 4 == 0, "entropy length not multiple of 32 bits");
+        checkArgument(entropy.length > 0, "entropy is empty");
 
         // We take initial entropy of ENT bits and compute its
         // checksum by taking first ENT / 32 bits of its SHA256 hash.

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
@@ -100,21 +100,15 @@ public class DeterministicSeed implements EncryptableItem {
     /**
      * Constructs a seed from a BIP 39 mnemonic code. See {@link MnemonicCode} for more
      * details on this scheme.
-     * @param entropy entropy bits, length must be divisible by 32
+     * @param entropy entropy bits, length must be at least 128 bits and a multiple of 32 bits
      * @param passphrase A user supplied passphrase, or an empty string if there is no passphrase
      * @param creationTimeSeconds When the seed was originally created, UNIX time.
      */
     public DeterministicSeed(byte[] entropy, String passphrase, long creationTimeSeconds) {
-        checkArgument(entropy.length % 4 == 0, "entropy size in bits not divisible by 32");
         checkArgument(entropy.length * 8 >= DEFAULT_SEED_ENTROPY_BITS, "entropy size too small");
         checkNotNull(passphrase);
 
-        try {
-            this.mnemonicCode = MnemonicCode.INSTANCE.toMnemonic(entropy);
-        } catch (MnemonicException.MnemonicLengthException e) {
-            // cannot happen
-            throw new RuntimeException(e);
-        }
+        this.mnemonicCode = MnemonicCode.INSTANCE.toMnemonic(entropy);
         this.seed = MnemonicCode.toSeed(mnemonicCode, passphrase);
         this.encryptedMnemonicCode = null;
         this.encryptedSeed = null;

--- a/core/src/test/java/org/bitcoinj/crypto/MnemonicCodeTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/MnemonicCodeTest.java
@@ -58,7 +58,7 @@ public class MnemonicCodeTest {
         wordList.remove(0);
     }
 
-    @Test(expected = MnemonicException.MnemonicLengthException.class)
+    @Test(expected = RuntimeException.class)
     public void testBadEntropyLength() throws Exception {
         byte[] entropy = ByteUtils.parseHex("7f7f7f7f7f7f7f7f7f7f7f7f7f7f");
         mc.toMnemonic(entropy);
@@ -88,7 +88,7 @@ public class MnemonicCodeTest {
         mc.check(words);
     }
 
-    @Test(expected = MnemonicException.MnemonicLengthException.class)
+    @Test(expected = RuntimeException.class)
     public void testEmptyEntropy() throws Exception {
         byte[] entropy = {};
         mc.toMnemonic(entropy);


### PR DESCRIPTION
When converting from entropy to mnemonic with `toMnemonic()`, a `MnemonicLengthException` was thrown for entropies with invalid length. This is bad for two reasons:

- it is a checked exception, and the method will not be called with user input
- misleading exception name, the error is about the entropy length not the mnemonic

We now throw a `RuntimeException` instead. The resulting simplification of calling code can be witnessed in `DeterministicSeed`.