### PR TITLE
DeterministicSeed: introduce static constructors meant for external consumers

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -308,10 +308,10 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
 
             if (random != null)
                 // Default passphrase to "" if not specified
-                return new DeterministicKeyChain(new DeterministicSeed(random, bits, getPassphrase()), null,
+                return new DeterministicKeyChain(DeterministicSeed.fromRandom(random, bits, getPassphrase()), null,
                         outputScriptType, accountPath);
             else if (entropy != null)
-                return new DeterministicKeyChain(new DeterministicSeed(entropy, getPassphrase(), creationTimeSecs),
+                return new DeterministicKeyChain(DeterministicSeed.fromEntropy(entropy, getPassphrase(), creationTimeSecs),
                         null, outputScriptType, accountPath);
             else if (seed != null)
                 return new DeterministicKeyChain(seed, null, outputScriptType, accountPath);

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -308,10 +308,10 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
 
             if (random != null)
                 // Default passphrase to "" if not specified
-                return new DeterministicKeyChain(DeterministicSeed.fromRandom(random, bits, getPassphrase()), null,
+                return new DeterministicKeyChain(DeterministicSeed.ofRandom(random, bits, getPassphrase()), null,
                         outputScriptType, accountPath);
             else if (entropy != null)
-                return new DeterministicKeyChain(DeterministicSeed.fromEntropy(entropy, getPassphrase(), creationTimeSecs),
+                return new DeterministicKeyChain(DeterministicSeed.ofEntropy(entropy, getPassphrase(), creationTimeSecs),
                         null, outputScriptType, accountPath);
             else if (seed != null)
                 return new DeterministicKeyChain(seed, null, outputScriptType, accountPath);

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
@@ -61,7 +61,7 @@ public class DeterministicSeed implements EncryptableItem {
      * @param passphrase user supplied passphrase, or empty string if there is no passphrase
      * @param creationTimeSecs when the seed was originally created, UNIX time in seconds
      */
-    public static DeterministicSeed fromMnemonic(String mnemonicCode, String passphrase, long creationTimeSecs) {
+    public static DeterministicSeed ofMnemonic(String mnemonicCode, String passphrase, long creationTimeSecs) {
         return new DeterministicSeed(mnemonicCode, null, passphrase, creationTimeSecs);
     }
 
@@ -72,7 +72,7 @@ public class DeterministicSeed implements EncryptableItem {
      * @param passphrase user supplied passphrase, or empty string if there is no passphrase
      * @param creationTimeSecs when the seed was originally created, UNIX time in seconds
      */
-    public static DeterministicSeed fromMnemonic(List<String> mnemonicCode, String passphrase, long creationTimeSecs) {
+    public static DeterministicSeed ofMnemonic(List<String> mnemonicCode, String passphrase, long creationTimeSecs) {
         return new DeterministicSeed(mnemonicCode, null, passphrase, creationTimeSecs);
     }
 
@@ -83,7 +83,7 @@ public class DeterministicSeed implements EncryptableItem {
      * @param passphrase user supplied passphrase, or empty string if there is no passphrase
      * @param creationTimeSecs when the seed was originally created, UNIX time in seconds
      */
-    public static DeterministicSeed fromEntropy(byte[] entropy, String passphrase, long creationTimeSecs) {
+    public static DeterministicSeed ofEntropy(byte[] entropy, String passphrase, long creationTimeSecs) {
         return new DeterministicSeed(entropy, passphrase, creationTimeSecs);
     }
 
@@ -94,13 +94,13 @@ public class DeterministicSeed implements EncryptableItem {
      * @param bits number of bits of entropy, must be at least 128 bits and a multiple of 32 bits
      * @param passphrase user supplied passphrase, or empty string if there is no passphrase
      */
-    public static DeterministicSeed fromRandom(SecureRandom random, int bits, String passphrase) {
+    public static DeterministicSeed ofRandom(SecureRandom random, int bits, String passphrase) {
         return new DeterministicSeed(random, bits, passphrase);
     }
 
     /**
      * Internal use only – will be restricted to private in a future release.
-     * Use {@link #fromMnemonic(String, String, long)}  instead.
+     * Use {@link #ofMnemonic(String, String, long)}  instead.
      */
     public DeterministicSeed(String mnemonicString, byte[] seed, String passphrase, long creationTimeSeconds) {
         this(decodeMnemonicCode(mnemonicString), seed, passphrase, creationTimeSeconds);
@@ -126,7 +126,7 @@ public class DeterministicSeed implements EncryptableItem {
 
     /**
      * Internal use only – will be restricted to private in a future release.
-     * Use {@link #fromMnemonic(List, String, long)}  instead.
+     * Use {@link #ofMnemonic(List, String, long)}  instead.
      */
     public DeterministicSeed(List<String> mnemonicCode, @Nullable byte[] seed, String passphrase, long creationTimeSeconds) {
         this((seed != null ? seed : MnemonicCode.toSeed(mnemonicCode, checkNotNull(passphrase))), mnemonicCode, creationTimeSeconds);
@@ -134,7 +134,7 @@ public class DeterministicSeed implements EncryptableItem {
 
     /**
      * Internal use only – will be restricted to private in a future release.
-     * Use {@link #fromRandom(SecureRandom, int, String)} instead.
+     * Use {@link #ofRandom(SecureRandom, int, String)} instead.
      */
     public DeterministicSeed(SecureRandom random, int bits, String passphrase) {
         this(getEntropy(random, bits), checkNotNull(passphrase), TimeUtils.currentTimeSeconds());
@@ -142,7 +142,7 @@ public class DeterministicSeed implements EncryptableItem {
 
     /**
      * Internal use only – will be restricted to private in a future release.
-     * Use {@link #fromEntropy(byte[], String, long)}  instead.
+     * Use {@link #ofEntropy(byte[], String, long)}  instead.
      */
     public DeterministicSeed(byte[] entropy, String passphrase, long creationTimeSeconds) {
         checkArgument(entropy.length * 8 >= DEFAULT_SEED_ENTROPY_BITS, "entropy size too small");

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
@@ -54,11 +54,60 @@ public class DeterministicSeed implements EncryptableItem {
     @Nullable private final EncryptedData encryptedSeed;
     private long creationTimeSeconds;
 
-    public DeterministicSeed(String mnemonicString, byte[] seed, String passphrase, long creationTimeSeconds) throws UnreadableWalletException {
+    /**
+     * Constructs a seed from a BIP 39 mnemonic code. See {@link MnemonicCode} for more
+     * details on this scheme.
+     * @param mnemonicCode list of words, space separated
+     * @param passphrase user supplied passphrase, or empty string if there is no passphrase
+     * @param creationTimeSecs when the seed was originally created, UNIX time in seconds
+     */
+    public static DeterministicSeed fromMnemonic(String mnemonicCode, String passphrase, long creationTimeSecs) {
+        return new DeterministicSeed(mnemonicCode, null, passphrase, creationTimeSecs);
+    }
+
+    /**
+     * Constructs a seed from a BIP 39 mnemonic code. See {@link MnemonicCode} for more
+     * details on this scheme.
+     * @param mnemonicCode list of words
+     * @param passphrase user supplied passphrase, or empty string if there is no passphrase
+     * @param creationTimeSecs when the seed was originally created, UNIX time in seconds
+     */
+    public static DeterministicSeed fromMnemonic(List<String> mnemonicCode, String passphrase, long creationTimeSecs) {
+        return new DeterministicSeed(mnemonicCode, null, passphrase, creationTimeSecs);
+    }
+
+    /**
+     * Constructs a BIP 39 mnemonic code and a seed from a given entropy. See {@link MnemonicCode} for more
+     * details on this scheme.
+     * @param entropy entropy bits, length must be at least 128 bits and a multiple of 32 bits
+     * @param passphrase user supplied passphrase, or empty string if there is no passphrase
+     * @param creationTimeSecs when the seed was originally created, UNIX time in seconds
+     */
+    public static DeterministicSeed fromEntropy(byte[] entropy, String passphrase, long creationTimeSecs) {
+        return new DeterministicSeed(entropy, passphrase, creationTimeSecs);
+    }
+
+    /**
+     * Constructs a BIP 39 mnemonic code and a seed randomly. See {@link MnemonicCode} for more
+     * details on this scheme.
+     * @param random random source for the entropy
+     * @param bits number of bits of entropy, must be at least 128 bits and a multiple of 32 bits
+     * @param passphrase user supplied passphrase, or empty string if there is no passphrase
+     */
+    public static DeterministicSeed fromRandom(SecureRandom random, int bits, String passphrase) {
+        return new DeterministicSeed(random, bits, passphrase);
+    }
+
+    /**
+     * Internal use only – will be restricted to private in a future release.
+     * Use {@link #fromMnemonic(String, String, long)}  instead.
+     */
+    public DeterministicSeed(String mnemonicString, byte[] seed, String passphrase, long creationTimeSeconds) {
         this(decodeMnemonicCode(mnemonicString), seed, passphrase, creationTimeSeconds);
     }
 
-    public DeterministicSeed(byte[] seed, List<String> mnemonic, long creationTimeSeconds) {
+    /** Internal use only. */
+    private DeterministicSeed(byte[] seed, List<String> mnemonic, long creationTimeSeconds) {
         this.seed = checkNotNull(seed);
         this.mnemonicCode = checkNotNull(mnemonic);
         this.encryptedMnemonicCode = null;
@@ -66,6 +115,7 @@ public class DeterministicSeed implements EncryptableItem {
         this.creationTimeSeconds = creationTimeSeconds;
     }
 
+    /** Internal use only – will be restricted to private in a future release. */
     public DeterministicSeed(EncryptedData encryptedMnemonic, @Nullable EncryptedData encryptedSeed, long creationTimeSeconds) {
         this.seed = null;
         this.mnemonicCode = null;
@@ -75,34 +125,24 @@ public class DeterministicSeed implements EncryptableItem {
     }
 
     /**
-     * Constructs a seed from a BIP 39 mnemonic code. See {@link MnemonicCode} for more
-     * details on this scheme.
-     * @param mnemonicCode A list of words.
-     * @param seed The derived seed, or pass null to derive it from mnemonicCode (slow)
-     * @param passphrase A user supplied passphrase, or an empty string if there is no passphrase
-     * @param creationTimeSeconds When the seed was originally created, UNIX time.
+     * Internal use only – will be restricted to private in a future release.
+     * Use {@link #fromMnemonic(List, String, long)}  instead.
      */
     public DeterministicSeed(List<String> mnemonicCode, @Nullable byte[] seed, String passphrase, long creationTimeSeconds) {
         this((seed != null ? seed : MnemonicCode.toSeed(mnemonicCode, checkNotNull(passphrase))), mnemonicCode, creationTimeSeconds);
     }
 
     /**
-     * Constructs a seed from a BIP 39 mnemonic code. See {@link MnemonicCode} for more
-     * details on this scheme.
-     * @param random Entropy source
-     * @param bits number of bits, must be divisible by 32
-     * @param passphrase A user supplied passphrase, or an empty string if there is no passphrase
+     * Internal use only – will be restricted to private in a future release.
+     * Use {@link #fromRandom(SecureRandom, int, String)} instead.
      */
     public DeterministicSeed(SecureRandom random, int bits, String passphrase) {
         this(getEntropy(random, bits), checkNotNull(passphrase), TimeUtils.currentTimeSeconds());
     }
 
     /**
-     * Constructs a seed from a BIP 39 mnemonic code. See {@link MnemonicCode} for more
-     * details on this scheme.
-     * @param entropy entropy bits, length must be at least 128 bits and a multiple of 32 bits
-     * @param passphrase A user supplied passphrase, or an empty string if there is no passphrase
-     * @param creationTimeSeconds When the seed was originally created, UNIX time.
+     * Internal use only – will be restricted to private in a future release.
+     * Use {@link #fromEntropy(byte[], String, long)}  instead.
      */
     public DeterministicSeed(byte[] entropy, String passphrase, long creationTimeSeconds) {
         checkArgument(entropy.length * 8 >= DEFAULT_SEED_ENTROPY_BITS, "entropy size too small");

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
@@ -113,7 +113,7 @@ public class KeyChainGroup implements KeyBag {
          * @param outputScriptType type of addresses (aka output scripts) to generate for receiving
          */
         public Builder fromRandom(ScriptType outputScriptType) {
-            DeterministicSeed seed = new DeterministicSeed(new SecureRandom(),
+            DeterministicSeed seed = DeterministicSeed.fromRandom(new SecureRandom(),
                     DeterministicSeed.DEFAULT_SEED_ENTROPY_BITS, "");
             fromSeed(seed, outputScriptType);
             return this;

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
@@ -113,7 +113,7 @@ public class KeyChainGroup implements KeyBag {
          * @param outputScriptType type of addresses (aka output scripts) to generate for receiving
          */
         public Builder fromRandom(ScriptType outputScriptType) {
-            DeterministicSeed seed = DeterministicSeed.fromRandom(new SecureRandom(),
+            DeterministicSeed seed = DeterministicSeed.ofRandom(new SecureRandom(),
                     DeterministicSeed.DEFAULT_SEED_ENTROPY_BITS, "");
             fromSeed(seed, outputScriptType);
             return this;

--- a/core/src/main/java/org/bitcoinj/wallet/MarriedKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/MarriedKeyChain.java
@@ -103,9 +103,9 @@ public class MarriedKeyChain extends DeterministicKeyChain {
 
             MarriedKeyChain chain;
             if (random != null)
-                chain = new MarriedKeyChain(new DeterministicSeed(random, bits, getPassphrase()), null, outputScriptType, accountPath);
+                chain = new MarriedKeyChain(DeterministicSeed.fromRandom(random, bits, getPassphrase()), null, outputScriptType, accountPath);
             else if (entropy != null)
-                chain = new MarriedKeyChain(new DeterministicSeed(entropy, getPassphrase(), creationTimeSecs), null,
+                chain = new MarriedKeyChain(DeterministicSeed.fromEntropy(entropy, getPassphrase(), creationTimeSecs), null,
                         outputScriptType, accountPath);
             else if (seed != null)
                 chain = new MarriedKeyChain(seed, null, outputScriptType, accountPath);

--- a/core/src/main/java/org/bitcoinj/wallet/MarriedKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/MarriedKeyChain.java
@@ -103,9 +103,9 @@ public class MarriedKeyChain extends DeterministicKeyChain {
 
             MarriedKeyChain chain;
             if (random != null)
-                chain = new MarriedKeyChain(DeterministicSeed.fromRandom(random, bits, getPassphrase()), null, outputScriptType, accountPath);
+                chain = new MarriedKeyChain(DeterministicSeed.ofRandom(random, bits, getPassphrase()), null, outputScriptType, accountPath);
             else if (entropy != null)
-                chain = new MarriedKeyChain(DeterministicSeed.fromEntropy(entropy, getPassphrase(), creationTimeSecs), null,
+                chain = new MarriedKeyChain(DeterministicSeed.ofEntropy(entropy, getPassphrase(), creationTimeSecs), null,
                         outputScriptType, accountPath);
             else if (seed != null)
                 chain = new MarriedKeyChain(seed, null, outputScriptType, accountPath);

--- a/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
@@ -105,7 +105,7 @@ public class KeyChainGroupTest {
 
     private MarriedKeyChain createMarriedKeyChain() {
         byte[] entropy = Sha256Hash.hash("don't use a seed like this in real life".getBytes());
-        DeterministicSeed seed = DeterministicSeed.fromEntropy(entropy, "", MnemonicCode.BIP39_STANDARDISATION_TIME_SECS);
+        DeterministicSeed seed = DeterministicSeed.ofEntropy(entropy, "", MnemonicCode.BIP39_STANDARDISATION_TIME_SECS);
         MarriedKeyChain chain = MarriedKeyChain.builder()
                 .seed(seed)
                 .followingKeys(watchingAccountKey)
@@ -520,7 +520,7 @@ public class KeyChainGroupTest {
 
     @Test
     public void addAndActivateHDChain_freshCurrentAddress() {
-        DeterministicSeed seed = DeterministicSeed.fromEntropy(ENTROPY, "", 0);
+        DeterministicSeed seed = DeterministicSeed.ofEntropy(ENTROPY, "", 0);
         DeterministicKeyChain chain1 = DeterministicKeyChain.builder().seed(seed)
                 .accountPath(DeterministicKeyChain.ACCOUNT_ZERO_PATH).outputScriptType(ScriptType.P2PKH).build();
         group = KeyChainGroup.builder(MAINNET).addChain(chain1).build();

--- a/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
@@ -105,7 +105,7 @@ public class KeyChainGroupTest {
 
     private MarriedKeyChain createMarriedKeyChain() {
         byte[] entropy = Sha256Hash.hash("don't use a seed like this in real life".getBytes());
-        DeterministicSeed seed = new DeterministicSeed(entropy, "", MnemonicCode.BIP39_STANDARDISATION_TIME_SECS);
+        DeterministicSeed seed = DeterministicSeed.fromEntropy(entropy, "", MnemonicCode.BIP39_STANDARDISATION_TIME_SECS);
         MarriedKeyChain chain = MarriedKeyChain.builder()
                 .seed(seed)
                 .followingKeys(watchingAccountKey)
@@ -520,7 +520,7 @@ public class KeyChainGroupTest {
 
     @Test
     public void addAndActivateHDChain_freshCurrentAddress() {
-        DeterministicSeed seed = new DeterministicSeed(ENTROPY, "", 0);
+        DeterministicSeed seed = DeterministicSeed.fromEntropy(ENTROPY, "", 0);
         DeterministicKeyChain chain1 = DeterministicKeyChain.builder().seed(seed)
                 .accountPath(DeterministicKeyChain.ACCOUNT_ZERO_PATH).outputScriptType(ScriptType.P2PKH).build();
         group = KeyChainGroup.builder(MAINNET).addChain(chain1).build();

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -219,7 +219,7 @@ public class WalletTest extends TestWithWallet {
     public void encryptDecryptWalletWithArbitraryPathAndScriptType() throws Exception {
         final byte[] ENTROPY = Sha256Hash.hash("don't use a string seed like this in real life".getBytes());
         KeyChainGroup keyChainGroup = KeyChainGroup.builder(TESTNET)
-                .addChain(DeterministicKeyChain.builder().seed(DeterministicSeed.fromEntropy(ENTROPY, "", 1389353062L))
+                .addChain(DeterministicKeyChain.builder().seed(DeterministicSeed.ofEntropy(ENTROPY, "", 1389353062L))
                         .outputScriptType(ScriptType.P2WPKH)
                         .accountPath(DeterministicKeyChain.BIP44_ACCOUNT_ZERO_PATH).build())
                 .build();
@@ -3530,7 +3530,7 @@ public class WalletTest extends TestWithWallet {
     public void roundtripViaMnemonicCode() {
         Wallet wallet = Wallet.createDeterministic(TESTNET, ScriptType.P2WPKH);
         List<String> mnemonicCode = wallet.getKeyChainSeed().getMnemonicCode();
-        final DeterministicSeed clonedSeed = DeterministicSeed.fromMnemonic(mnemonicCode, "",
+        final DeterministicSeed clonedSeed = DeterministicSeed.ofMnemonic(mnemonicCode, "",
                 wallet.getEarliestKeyCreationTimeInstant().getEpochSecond());
         Wallet clone = Wallet.fromSeed(TESTNET, clonedSeed, ScriptType.P2WPKH);
         assertEquals(wallet.currentReceiveKey(), clone.currentReceiveKey());

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -219,7 +219,7 @@ public class WalletTest extends TestWithWallet {
     public void encryptDecryptWalletWithArbitraryPathAndScriptType() throws Exception {
         final byte[] ENTROPY = Sha256Hash.hash("don't use a string seed like this in real life".getBytes());
         KeyChainGroup keyChainGroup = KeyChainGroup.builder(TESTNET)
-                .addChain(DeterministicKeyChain.builder().seed(new DeterministicSeed(ENTROPY, "", 1389353062L))
+                .addChain(DeterministicKeyChain.builder().seed(DeterministicSeed.fromEntropy(ENTROPY, "", 1389353062L))
                         .outputScriptType(ScriptType.P2WPKH)
                         .accountPath(DeterministicKeyChain.BIP44_ACCOUNT_ZERO_PATH).build())
                 .build();
@@ -3530,7 +3530,7 @@ public class WalletTest extends TestWithWallet {
     public void roundtripViaMnemonicCode() {
         Wallet wallet = Wallet.createDeterministic(TESTNET, ScriptType.P2WPKH);
         List<String> mnemonicCode = wallet.getKeyChainSeed().getMnemonicCode();
-        final DeterministicSeed clonedSeed = new DeterministicSeed(mnemonicCode, null, "",
+        final DeterministicSeed clonedSeed = DeterministicSeed.fromMnemonic(mnemonicCode, "",
                 wallet.getEarliestKeyCreationTimeInstant().getEpochSecond());
         Wallet clone = Wallet.fromSeed(TESTNET, clonedSeed, ScriptType.P2WPKH);
         assertEquals(wallet.currentReceiveKey(), clone.currentReceiveKey());

--- a/examples/src/main/java/org/bitcoinj/examples/RestoreFromSeed.java
+++ b/examples/src/main/java/org/bitcoinj/examples/RestoreFromSeed.java
@@ -47,7 +47,7 @@ public class RestoreFromSeed {
         String passphrase = "";
         Long creationtime = 1409478661L;
 
-        DeterministicSeed seed = DeterministicSeed.fromMnemonic(seedCode, passphrase, creationtime);
+        DeterministicSeed seed = DeterministicSeed.ofMnemonic(seedCode, passphrase, creationtime);
 
         // The wallet class provides a easy fromSeed() function that loads a new wallet from a given seed.
         Wallet wallet = Wallet.fromSeed(params, seed, ScriptType.P2PKH);

--- a/examples/src/main/java/org/bitcoinj/examples/RestoreFromSeed.java
+++ b/examples/src/main/java/org/bitcoinj/examples/RestoreFromSeed.java
@@ -47,7 +47,7 @@ public class RestoreFromSeed {
         String passphrase = "";
         Long creationtime = 1409478661L;
 
-        DeterministicSeed seed = new DeterministicSeed(seedCode, null, passphrase, creationtime);
+        DeterministicSeed seed = DeterministicSeed.fromMnemonic(seedCode, passphrase, creationtime);
 
         // The wallet class provides a easy fromSeed() function that loads a new wallet from a given seed.
         Wallet wallet = Wallet.fromSeed(params, seed, ScriptType.P2PKH);

--- a/integration-test/src/test/java/org/bitcoinj/wallet/WalletAccountPathTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/wallet/WalletAccountPathTest.java
@@ -82,7 +82,7 @@ public class WalletAccountPathTest {
     // Create a wallet, save it to a file, then reload from a file
     private static Wallet createWallet(File walletFile, NetworkParameters params, KeyChainGroupStructure structure, ScriptType outputScriptType) throws IOException, UnreadableWalletException {
         Context.propagate(new Context());
-        DeterministicSeed seed = DeterministicSeed.fromMnemonic(testWalletMnemonic,"", Instant.now().getEpochSecond());
+        DeterministicSeed seed = DeterministicSeed.ofMnemonic(testWalletMnemonic,"", Instant.now().getEpochSecond());
         Wallet wallet = Wallet.fromSeed(params, seed, outputScriptType, structure);
         wallet.saveToFile(walletFile);
         return Wallet.loadFromFile(walletFile);

--- a/integration-test/src/test/java/org/bitcoinj/wallet/WalletAccountPathTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/wallet/WalletAccountPathTest.java
@@ -82,7 +82,7 @@ public class WalletAccountPathTest {
     // Create a wallet, save it to a file, then reload from a file
     private static Wallet createWallet(File walletFile, NetworkParameters params, KeyChainGroupStructure structure, ScriptType outputScriptType) throws IOException, UnreadableWalletException {
         Context.propagate(new Context());
-        DeterministicSeed seed = new DeterministicSeed(testWalletMnemonic, null, "", Instant.now().getEpochSecond());
+        DeterministicSeed seed = DeterministicSeed.fromMnemonic(testWalletMnemonic,"", Instant.now().getEpochSecond());
         Wallet wallet = Wallet.fromSeed(params, seed, outputScriptType, structure);
         wallet.saveToFile(walletFile);
         return Wallet.loadFromFile(walletFile);

--- a/wallettemplate/src/main/java/wallettemplate/WalletSettingsController.java
+++ b/wallettemplate/src/main/java/wallettemplate/WalletSettingsController.java
@@ -180,7 +180,7 @@ public class WalletSettingsController implements OverlayController<WalletSetting
         app.mainWindowController().restoreFromSeedAnimation();
 
         long birthday = datePicker.getValue().atStartOfDay().toEpochSecond(ZoneOffset.UTC);
-        DeterministicSeed seed = DeterministicSeed.fromMnemonic(InternalUtils.splitter(" ").splitToList(wordsArea.getText()),"", birthday);
+        DeterministicSeed seed = DeterministicSeed.ofMnemonic(InternalUtils.splitter(" ").splitToList(wordsArea.getText()),"", birthday);
         // Shut down bitcoinj and restart it with the new seed.
         app.walletAppKit().addListener(new Service.Listener() {
             @Override

--- a/wallettemplate/src/main/java/wallettemplate/WalletSettingsController.java
+++ b/wallettemplate/src/main/java/wallettemplate/WalletSettingsController.java
@@ -180,7 +180,7 @@ public class WalletSettingsController implements OverlayController<WalletSetting
         app.mainWindowController().restoreFromSeedAnimation();
 
         long birthday = datePicker.getValue().atStartOfDay().toEpochSecond(ZoneOffset.UTC);
-        DeterministicSeed seed = new DeterministicSeed(InternalUtils.splitter(" ").splitToList(wordsArea.getText()), null, "", birthday);
+        DeterministicSeed seed = DeterministicSeed.fromMnemonic(InternalUtils.splitter(" ").splitToList(wordsArea.getText()),"", birthday);
         // Shut down bitcoinj and restart it with the new seed.
         app.walletAppKit().addListener(new Service.Listener() {
             @Override

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -1078,7 +1078,7 @@ public class WalletTool implements Callable<Integer> {
             // Parse as mnemonic code.
             final List<String> split = splitMnemonic(seedStr);
             String passphrase = ""; // TODO allow user to specify a passphrase
-            seed = DeterministicSeed.fromMnemonic(split, passphrase, creationTimeSecs);
+            seed = DeterministicSeed.ofMnemonic(split, passphrase, creationTimeSecs);
             try {
                 seed.check();
             } catch (MnemonicException.MnemonicLengthException e) {

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -1078,7 +1078,7 @@ public class WalletTool implements Callable<Integer> {
             // Parse as mnemonic code.
             final List<String> split = splitMnemonic(seedStr);
             String passphrase = ""; // TODO allow user to specify a passphrase
-            seed = new DeterministicSeed(split, null, passphrase, creationTimeSecs);
+            seed = DeterministicSeed.fromMnemonic(split, passphrase, creationTimeSecs);
             try {
                 seed.check();
             } catch (MnemonicException.MnemonicLengthException e) {


### PR DESCRIPTION
* native constructors that were meant to be called by consumers now have static equivalents
* all native constructors are discouraged from being used by a JavaDoc comment
* one constructor that wasn't meant to be used by consumers is switched to private access
* tests and tools that resemble consumers are updated to use the new API

Note: although most native constructors are now deprecated, we're not using annotations because we're still calling them.