### PR TITLE
BriefLogFormatter: migrate timestamp formatting to `java.time` API

### DIFF
--- a/core/src/main/java/org/bitcoinj/utils/BriefLogFormatter.java
+++ b/core/src/main/java/org/bitcoinj/utils/BriefLogFormatter.java
@@ -20,6 +20,10 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.text.MessageFormat;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
@@ -31,7 +35,7 @@ import java.util.logging.Logger;
  * A Java logging formatter that writes more compact output than the default.
  */
 public class BriefLogFormatter extends Formatter {
-    private static final MessageFormat messageFormat = new MessageFormat("{3,date,HH:mm:ss} {0} {1}.{2}: {4}\n{5}");
+    private static final MessageFormat messageFormat = new MessageFormat("{3} {0} {1}.{2}: {4}\n{5}");
 
     // OpenJDK made a questionable, backwards incompatible change to the Logger implementation. It internally uses
     // weak references now which means simply fetching the logger and changing its configuration won't work. We must
@@ -66,7 +70,8 @@ public class BriefLogFormatter extends Formatter {
         String className = fullClassName.substring(lastDot + 1);
         arguments[1] = className;
         arguments[2] = logRecord.getSourceMethodName();
-        arguments[3] = new Date(logRecord.getMillis());
+        arguments[3] = DateTimeFormatter.ISO_LOCAL_TIME.format(
+                LocalDateTime.ofInstant(Instant.ofEpochMilli(logRecord.getMillis()), ZoneOffset.UTC));
         arguments[4] = logRecord.getMessage();
         if (logRecord.getThrown() != null) {
             Writer result = new StringWriter();

--- a/core/src/test/java/org/bitcoinj/utils/BriefLogFormatterTest.java
+++ b/core/src/test/java/org/bitcoinj/utils/BriefLogFormatterTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.utils;
+
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import static org.junit.Assert.assertEquals;
+
+public class BriefLogFormatterTest {
+    @Test
+    public void format() {
+        BriefLogFormatter formatter = new BriefLogFormatter();
+        LogRecord record = new LogRecord(Level.INFO, "message");
+        record.setSourceClassName("org.example.Class");
+        record.setSourceMethodName("method");
+        record.setMillis(Instant.EPOCH.toEpochMilli());
+        record.setThreadID(123);
+        assertEquals("00:00:00 123 Class.method: message\n", formatter.format(record));
+    }
+}


### PR DESCRIPTION
This also changes the time zone of timestamps to UTC and adds a test.