### PR TITLE
base: extinguish unwanted references from main classpath

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/Address.java
+++ b/core/src/main/java/org/bitcoinj/base/Address.java
@@ -16,9 +16,6 @@
 
 package org.bitcoinj.base;
 
-import org.bitcoinj.crypto.ECKey;
-import org.bitcoinj.core.NetworkParameters;
-
 import java.util.Comparator;
 
 /**
@@ -27,32 +24,6 @@ import java.util.Comparator;
  * Use {@link AddressParser} to construct any kind of address from its textual form.
  */
 public interface Address extends Comparable<Address> {
-    /**
-     * Construct an {@link Address} that represents the public part of the given {@code ECKey}.
-     * 
-     * @param params
-     *            network this address is valid for
-     * @param key
-     *            only the public part is used
-     * @param outputScriptType
-     *            script type the address should use
-     * @return constructed address
-     * @deprecated Use {@link ECKey#toAddress(ScriptType, Network)}
-     */
-    @Deprecated
-    static Address fromKey(final NetworkParameters params, final ECKey key, final ScriptType outputScriptType) {
-        return key.toAddress(outputScriptType, params.network());
-    }
-
-    /**
-     * @return network this data is valid for
-     * @deprecated Use {@link #network()}
-     */
-    @Deprecated
-    default NetworkParameters getParameters() {
-        return NetworkParameters.of(network());
-    }
-
     /**
      * Get either the public key hash or script hash that is encoded in the address.
      * 

--- a/core/src/main/java/org/bitcoinj/base/LegacyAddress.java
+++ b/core/src/main/java/org/bitcoinj/base/LegacyAddress.java
@@ -20,8 +20,6 @@ package org.bitcoinj.base;
 
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.internal.ByteUtils;
-import org.bitcoinj.core.NetworkParameters;
-import org.bitcoinj.crypto.ECKey;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -87,22 +85,6 @@ public class LegacyAddress implements Address {
     /**
      * Construct a {@link LegacyAddress} that represents the given pubkey hash. The resulting address will be a P2PKH type of
      * address.
-     * 
-     * @param params
-     *            network this address is valid for
-     * @param hash160
-     *            20-byte pubkey hash
-     * @return constructed address
-     * @deprecated Use {@link #fromPubKeyHash(Network, byte[])}
-     */
-    @Deprecated
-    public static LegacyAddress fromPubKeyHash(NetworkParameters params, byte[] hash160) throws AddressFormatException {
-        return fromPubKeyHash(params.network(), hash160);
-    }
-
-    /**
-     * Construct a {@link LegacyAddress} that represents the given pubkey hash. The resulting address will be a P2PKH type of
-     * address.
      *
      * @param network network this address is valid for
      * @param hash160 20-byte pubkey hash
@@ -110,37 +92,6 @@ public class LegacyAddress implements Address {
      */
     public static LegacyAddress fromPubKeyHash(Network network, byte[] hash160) throws AddressFormatException {
         return new LegacyAddress(network, false, hash160);
-    }
-
-    /**
-     * Construct a {@link LegacyAddress} that represents the public part of the given {@code ECKey}. Note that an address is
-     * derived from a hash of the public key and is not the public key itself.
-     * 
-     * @param params
-     *            network this address is valid for
-     * @param key
-     *            only the public part is used
-     * @return constructed address
-     * @deprecated Use {@code ECKey#toAddress(ScriptType, Network)}
-     */
-    @Deprecated
-    public static LegacyAddress fromKey(NetworkParameters params, ECKey key) {
-        return (LegacyAddress) key.toAddress(ScriptType.P2PKH, params.network());
-    }
-
-    /**
-     * Construct a {@link LegacyAddress} that represents the given P2SH script hash.
-     * 
-     * @param params
-     *            network this address is valid for
-     * @param hash160
-     *            P2SH script hash
-     * @return constructed address
-     * @deprecated Use {@link #fromScriptHash(Network, byte[])}
-     */
-    @Deprecated
-    public static LegacyAddress fromScriptHash(NetworkParameters params, byte[] hash160) throws AddressFormatException {
-        return fromScriptHash(params.network(), hash160);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/base/SegwitAddress.java
+++ b/core/src/main/java/org/bitcoinj/base/SegwitAddress.java
@@ -18,8 +18,6 @@ package org.bitcoinj.base;
 
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.internal.ByteUtils;
-import org.bitcoinj.core.NetworkParameters;
-import org.bitcoinj.crypto.ECKey;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -261,22 +259,6 @@ public class SegwitAddress implements Address {
     /**
      * Construct a {@link SegwitAddress} that represents the given hash, which is either a pubkey hash or a script hash.
      * The resulting address will be either a P2WPKH or a P2WSH type of address.
-     * 
-     * @param params
-     *            network this address is valid for
-     * @param hash
-     *            20-byte pubkey hash or 32-byte script hash
-     * @return constructed address
-     * @deprecated Use {@link #fromHash(Network, byte[])}
-     */
-    @Deprecated
-    public static SegwitAddress fromHash(NetworkParameters params, byte[] hash) {
-        return fromHash(params.network(), hash);
-    }
-
-    /**
-     * Construct a {@link SegwitAddress} that represents the given hash, which is either a pubkey hash or a script hash.
-     * The resulting address will be either a P2WPKH or a P2WSH type of address.
      *
      * @param network network this address is valid for
      * @param hash 20-byte pubkey hash or 32-byte script hash
@@ -291,25 +273,6 @@ public class SegwitAddress implements Address {
      * or a script hash – depending on the script version. The resulting address will be either a P2WPKH, a P2WSH or
      * a P2TR type of address.
      *
-     * @param params
-     *            network this address is valid for
-     * @param witnessVersion
-     *            version number between 0 and 16
-     * @param witnessProgram
-     *            version dependent witness program
-     * @return constructed address
-     * @deprecated Use {@link #fromProgram(Network, int, byte[])}
-     */
-    @Deprecated
-    public static SegwitAddress fromProgram(NetworkParameters params, int witnessVersion, byte[] witnessProgram) {
-        return fromProgram(params.network(), witnessVersion, witnessProgram);
-    }
-
-    /**
-     * Construct a {@link SegwitAddress} that represents the given program, which is either a pubkey, a pubkey hash
-     * or a script hash – depending on the script version. The resulting address will be either a P2WPKH, a P2WSH or
-     * a P2TR type of address.
-     *
      * @param network network this address is valid for
      * @param witnessVersion version number between 0 and 16
      * @param witnessProgram version dependent witness program
@@ -317,22 +280,6 @@ public class SegwitAddress implements Address {
      */
     public static SegwitAddress fromProgram(Network network, int witnessVersion, byte[] witnessProgram) {
         return new SegwitAddress(network, witnessVersion, witnessProgram);
-    }
-
-    /**
-     * Construct a {@link SegwitAddress} that represents the public part of the given {@code ECKey}. Note that an
-     * address is derived from a hash of the public key and is not the public key itself.
-     * 
-     * @param params
-     *            network this address is valid for
-     * @param key
-     *            only the public part is used
-     * @return constructed address
-     * @deprecated Use {@code ECKey#toAddress(ScriptType, org.bitcoinj.base.Network)}
-     */
-    @Deprecated
-    public static SegwitAddress fromKey(NetworkParameters params, ECKey key) {
-        return (SegwitAddress) key.toAddress(ScriptType.P2WPKH, params.network());
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/base/internal/ByteUtils.java
+++ b/core/src/main/java/org/bitcoinj/base/internal/ByteUtils.java
@@ -16,8 +16,6 @@
 
 package org.bitcoinj.base.internal;
 
-import com.google.common.io.BaseEncoding;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -41,13 +39,6 @@ public class ByteUtils {
     /** Maximum unsigned value that can be expressed by 32 bits. */
     public static final long MAX_UNSIGNED_INTEGER = Integer.toUnsignedLong(-1);
 
-    /**
-     * Hex encoding used throughout the framework. Use with ByteUtils.formatHex(byte[]) or ByteUtils.parseHex(CharSequence).
-     * @deprecated Use {@link ByteUtils#hexFormat} or {@link ByteUtils#parseHex(String)} or other available
-     * options.
-     */
-    @Deprecated
-    public static final BaseEncoding HEX = BaseEncoding.base16().lowerCase();
     // 00000001, 00000010, 00000100, 00001000, ...
     private static final int[] bitMask = {0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80};
 

--- a/core/src/main/java/org/bitcoinj/base/package-info.java
+++ b/core/src/main/java/org/bitcoinj/base/package-info.java
@@ -22,12 +22,6 @@
  *     <li>No API dependencies on external libraries other than the core JDK and {@code slf4j-api}</li>
  * </ul>
  * <p>
- * <b>Temporary exception:</b> In the 0.17 release, we are allowing some dependencies on other packages, e.g. to
- * {@code org.bitcoinj.core.NetworkParameters} or to Guava <i>provided</i> that those references are in <b>deprecated</b> methods.
- * This smooths migration by allowing users to, for example, replace {@code import org.bitcoinj.core.Address} with
- * {@code import org.bitcoinj.base.Address} as first step of conversion and then remove usages of the deprecated methods
- * of {@code Address} in a second step.
- * <p>
  * The base package makes bitcoinj more modular as it breaks circular dependencies between existing packages and provides
  * a "zero-dependency" foundation for the other packages. In a future release {@code base} will be
  * split into a separate JAR/module (tentatively {@code bitcoinj-base}.)

--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -205,19 +205,6 @@ public abstract class NetworkParameters {
         return PaymentProtocol.paramsFromPmtProtocolID(pmtProtocolId);
     }
 
-    /**
-     * Get a NetworkParameters from an Address.
-     * Addresses should not be used for storing NetworkParameters. In the future Address will
-     * be an {@code interface} that only makes a {@link Network} available.
-     * @param address An address
-     * @return network parameters
-     * @deprecated You should be using {@link Address#network()} instead
-     */
-    @Deprecated
-    public static NetworkParameters fromAddress(Address address) {
-        return address.getParameters();
-    }
-
     public int getSpendableCoinbaseDepth() {
         return spendableCoinbaseDepth;
     }


### PR DESCRIPTION
The idea of this patchset is to check if base has no unwanted dependencies to libraries or bitcoinj modules.

It was created this way:

- Remove all references of non-base packages (imports, fully qualified names)
- Try fix "cannot resolve symbol" compiler errors only by removing deprecated methods or variables

Optional: After the next release, we could merge this.