### PR TITLE
wallettemplate: require JDK 17+

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,7 +12,7 @@ The bitcoinj library is a Java implementation of the Bitcoin protocol, which all
 
 * Java 8+ (needs Java 8 API or Android 8.0 API, compiles to Java 8 bytecode) and Gradle 4.4+ for the `core` module
 * Java 11+ and Gradle 4.4+ for `tools`, `wallettool` and `examples`
-* Java 11+ and Gradle 4.10+ for the JavaFX-based `wallettemplate`
+* Java 17+ and Gradle 7.3+ for the JavaFX-based `wallettemplate`
 * https://gradle.org/[Gradle] - for building the project
 * https://github.com/google/protobuf[Google Protocol Buffers] - for use with serialization and hardware communications
 
@@ -24,12 +24,12 @@ To get started, it is best to have the latest JDK and Gradle installed. The HEAD
 
 Official builds are currently using JDK 11. Our GitHub Actions build and test with JDK 11 and JDK 17.
 
-To perform a full build (_including_ JavaDocs and unit/integration _tests_) use JDK 11+.
+To perform a full build (_including_ JavaDocs, unit/integration _tests_, and `wallettemplate`) use JDK 17+.
 
 ```
 gradle clean build
 ```
-If you are using Gradle 4.10 or later, the build will automatically include the JavaFX-based `wallettemplate` module. The outputs are under the `build` directory.
+If you are using JDK 17+ and Gradle 7.3+, the build will automatically include the JavaFX-based `wallettemplate` module. The outputs are under the `build` directory.
 
 To perform a full build _without_ unit/integration _tests_ use:
 ```

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,8 +5,8 @@ import org.gradle.api.GradleScriptException
 def minGradleVersion = GradleVersion.version("4.4")
 // Minimum Gradle version for JUnit5
 def minJunit5GradleVersion = GradleVersion.version("4.6")
-// Minimum Gradle version for builds of JavaFX 11 module
-def minFxGradleVersion = GradleVersion.version("4.10")
+// Minimum Gradle version for builds of JavaFX 17 module using JDK 17
+def minFxGradleVersion = GradleVersion.version("7.3")
 
 rootProject.name = 'bitcoinj-parent'
 
@@ -30,12 +30,12 @@ project(':wallettool').name = 'bitcoinj-wallettool'
 include 'examples'
 project(':examples').name = 'bitcoinj-examples'
 
-if (GradleVersion.current().compareTo(minFxGradleVersion) > 0) {
+if (GradleVersion.current().compareTo(minFxGradleVersion) > 0 && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
     System.err.println "Including wallettemplate because ${GradleVersion.current()}"
     include 'wallettemplate'
     project(':wallettemplate').name = 'bitcoinj-wallettemplate'
 } else {
-    System.err.println "Skipping wallettemplate, requires Gradle ${minFxGradleVersion}+, currently running: ${GradleVersion.current()}"
+    System.err.println "Skipping wallettemplate, requires Gradle ${minFxGradleVersion}+ and Java 17+, currently running Gradle: ${GradleVersion.current()}, Java ${JavaVersion.current()}"
 }
 
 if (GradleVersion.current().compareTo(minJunit5GradleVersion) >= 0) {

--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -17,13 +17,13 @@ javafx {
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 
-sourceCompatibility = 11
+sourceCompatibility = 17
 compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
 javadoc.options.encoding = 'UTF-8'
 
 compileJava {
-    options.compilerArgs.addAll(['--release', '11'])
+    options.compilerArgs.addAll(['--release', '17'])
     options.compilerArgs << '-Xlint:deprecation'
 }
 


### PR DESCRIPTION
I think it's time to upgrade `walletfx` to JDK 17 for the following reasons:

1. JavaFX applications are increasingly shipping with bundled, recent JDKs
2. In the past this module required later versions of JDK than `core`, `examples`, etc. and that worked well.
3. Our build now requires JDK 11 (use one LTS version behind) 
4. JDK 17 is now widely available (e.g. Debian distros, CI servers, etc.)
5. The forthcoming JavaFX 20 (due March 2023) will _require_ JDK 17.
6. A JDK17-based `wallettemplate` will give us opportunities to see how our `core` API works under JDK 17+.
