### PR TITLE
WIP: TimeLock: refactor to subtypes

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/LockTime.java
+++ b/core/src/main/java/org/bitcoinj/core/LockTime.java
@@ -32,7 +32,6 @@ import java.util.Objects;
 public abstract /* sealed */ class LockTime {
 
     public static final class HeightLock extends LockTime {
-
         public HeightLock(long value) {
             super(value);
         }
@@ -119,8 +118,8 @@ public abstract /* sealed */ class LockTime {
     }
 
     /**
-     * This is equivalent to {@code lockTime instanceof HeightLock && rawValue() > 0 || lockTime instanceof TimeLock}.
-     * (The lock time is considered to be set only if its raw value is greater than zero.)
+     * The lock time is considered to be set only if its raw value is greater than zero.
+     * In other words, it is set if it is either a non-zero block height or a timestamp.
      * @return true if lock time is set
      */
     public boolean isSet() {

--- a/core/src/main/java/org/bitcoinj/core/LockTime.java
+++ b/core/src/main/java/org/bitcoinj/core/LockTime.java
@@ -22,30 +22,44 @@ import java.time.Instant;
 import java.util.Objects;
 
 /**
- * Wrapper for transaction lock time, specified either as a block height or as a timestamp (in seconds
- * since epoch). Both are encoded into the same long "raw value", as used in the Bitcoin protocol.
- * The lock time is said to be "not set" if its raw value is zero.
+ * Wrapper for transaction lock time, specified either as a block height {@link HeightLock} or as a timestamp
+ * {@link TimeLock}(in seconds since epoch). Both are encoded into the same long "raw value", as used in the Bitcoin protocol.
+ * The lock time is said to be "not set" if its raw value is zero (and the zero value will be represented by a {@link HeightLock}
+ * with value zero.)
  * <p>
  * Instances of this class are immutable and should be treated as Java
  * <a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/doc-files/ValueBased.html#Value-basedClasses">value-based</a>.
  */
 public abstract /* sealed */ class LockTime {
 
+    /**
+     * A {@code LockTime} instance that contains a block height.
+     * Can also be zero to represent no-lock.
+     */
     public static final class HeightLock extends LockTime {
         public HeightLock(long value) {
             super(value);
         }
 
+        /**
+         * @return block height as an int
+         */
         public int blockHeight() {
             return Math.toIntExact(value);
         }
     }
 
+    /**
+     * A {@code LockTime} instance that contains a timestamp.
+     */
     public static final class TimeLock extends LockTime {
         public TimeLock(long value) {
             super(value);
         }
 
+        /**
+         * @return timestamp in java.time format
+         */
         public Instant timestamp() {
             return Instant.ofEpochSecond(value);
         }

--- a/core/src/main/java/org/bitcoinj/core/LockTime.java
+++ b/core/src/main/java/org/bitcoinj/core/LockTime.java
@@ -119,7 +119,7 @@ public abstract /* sealed */ class LockTime {
     }
 
     /**
-     * This is equivalent to {@code lockTime instanceof HeightLock || lockTime instanceof TimeLock}.
+     * This is equivalent to {@code lockTime instanceof HeightLock && rawValue() > 0 || lockTime instanceof TimeLock}.
      * (The lock time is considered to be set only if its raw value is greater than zero.)
      * @return true if lock time is set
      */

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -131,9 +131,8 @@ public class Transaction extends ChildMessage {
     public static final int SERIALIZE_TRANSACTION_NO_WITNESS = 0x40000000;
 
     /**
-     * @deprecated use {@link LockTime#THRESHOLD},
-     *                 {@link LockTime#isBlockHeight()} or
-     *                 {@link LockTime#isTimestamp()}
+     * @deprecated use {@code lockTime instanceof HeightLock} or
+     *                 {@code lockTime instanceof TimeLock}
      **/
     @Deprecated
     public static final int LOCKTIME_THRESHOLD = (int) LockTime.THRESHOLD;
@@ -845,7 +844,7 @@ public class Transaction extends ChildMessage {
             s.append(indent).append("time locked until ");
             LockTime locktime = lockTime();
             s.append(locktime);
-            if (locktime.isBlockHeight()) {
+            if (locktime instanceof HeightLock) {
                 if (chain != null) {
                     s.append(" (estimated to be reached at ")
                             .append(TimeUtils.dateTimeFormat(chain.estimateBlockTimeInstant(((HeightLock)locktime).blockHeight())))
@@ -1860,7 +1859,7 @@ public class Transaction extends ChildMessage {
      */
     public boolean isFinal(int height, long blockTimeSeconds) {
         LockTime locktime = lockTime();
-        return locktime.rawValue() < (locktime.isBlockHeight() ? height : blockTimeSeconds) ||
+        return locktime.rawValue() < (locktime instanceof HeightLock ? height : blockTimeSeconds) ||
                 !isTimeLocked();
     }
 
@@ -1870,7 +1869,7 @@ public class Transaction extends ChildMessage {
      */
     public Instant estimateLockTimeInstant(AbstractBlockChain chain) {
         LockTime locktime = lockTime();
-        return locktime.isBlockHeight() ?
+        return locktime instanceof HeightLock ?
                 chain.estimateBlockTimeInstant(((HeightLock) locktime).blockHeight()) :
                 ((TimeLock)locktime).timestamp();
     }

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -848,7 +848,7 @@ public class Transaction extends ChildMessage {
             if (locktime instanceof HeightLock) {
                 if (chain != null) {
                     s.append(" (estimated to be reached at ")
-                            .append(TimeUtils.dateTimeFormat(chain.estimateBlockTimeInstant(((HeightLock)locktime).blockHeight())))
+                            .append(TimeUtils.dateTimeFormat(chain.estimateBlockTimeInstant(((HeightLock) locktime).blockHeight())))
                             .append(')');
                 }
             }
@@ -1872,7 +1872,7 @@ public class Transaction extends ChildMessage {
         LockTime locktime = lockTime();
         return locktime instanceof HeightLock ?
                 chain.estimateBlockTimeInstant(((HeightLock) locktime).blockHeight()) :
-                ((TimeLock)locktime).timestamp();
+                ((TimeLock) locktime).timestamp();
     }
 
     /** @deprecated use {@link #estimateLockTimeInstant(AbstractBlockChain)} */

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -25,6 +25,8 @@ import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.VarInt;
 import org.bitcoinj.base.internal.TimeUtils;
+import org.bitcoinj.core.LockTime.HeightLock;
+import org.bitcoinj.core.LockTime.TimeLock;
 import org.bitcoinj.crypto.AesKey;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.core.TransactionConfidence.ConfidenceType;
@@ -846,7 +848,7 @@ public class Transaction extends ChildMessage {
             if (locktime.isBlockHeight()) {
                 if (chain != null) {
                     s.append(" (estimated to be reached at ")
-                            .append(TimeUtils.dateTimeFormat(chain.estimateBlockTimeInstant(locktime.blockHeight())))
+                            .append(TimeUtils.dateTimeFormat(chain.estimateBlockTimeInstant(((HeightLock)locktime).blockHeight())))
                             .append(')');
                 }
             }
@@ -1869,8 +1871,8 @@ public class Transaction extends ChildMessage {
     public Instant estimateLockTimeInstant(AbstractBlockChain chain) {
         LockTime locktime = lockTime();
         return locktime.isBlockHeight() ?
-                chain.estimateBlockTimeInstant(locktime.blockHeight()) :
-                locktime.timestamp();
+                chain.estimateBlockTimeInstant(((HeightLock) locktime).blockHeight()) :
+                ((TimeLock)locktime).timestamp();
     }
 
     /** @deprecated use {@link #estimateLockTimeInstant(AbstractBlockChain)} */

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -131,7 +131,8 @@ public class Transaction extends ChildMessage {
     public static final int SERIALIZE_TRANSACTION_NO_WITNESS = 0x40000000;
 
     /**
-     * @deprecated use {@code lockTime instanceof HeightLock} or
+     * @deprecated use {@link LockTime#THRESHOLD} or
+     *                 {@code lockTime instanceof HeightLock} or
      *                 {@code lockTime instanceof TimeLock}
      **/
     @Deprecated

--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -1407,8 +1407,8 @@ public class Script {
         // There are two kinds of nLockTime, need to ensure we're comparing apples-to-apples
         LockTime txContainingThisLockTime = txContainingThis.lockTime();
         if (!(
-            ((txContainingThisLockTime.isBlockHeight()) && (nLockTime.compareTo(LOCKTIME_THRESHOLD_BIG)) < 0) ||
-            ((txContainingThisLockTime.isTimestamp()) && (nLockTime.compareTo(LOCKTIME_THRESHOLD_BIG)) >= 0))
+            ((txContainingThisLockTime instanceof LockTime.HeightLock) && (nLockTime.compareTo(LOCKTIME_THRESHOLD_BIG)) < 0) ||
+            ((txContainingThisLockTime instanceof LockTime.TimeLock) && (nLockTime.compareTo(LOCKTIME_THRESHOLD_BIG)) >= 0))
         )
             throw new ScriptException(ScriptError.SCRIPT_ERR_UNSATISFIED_LOCKTIME, "Lock time requirement type mismatch");
 

--- a/core/src/test/java/org/bitcoinj/core/LockTimeTest.java
+++ b/core/src/test/java/org/bitcoinj/core/LockTimeTest.java
@@ -16,38 +16,24 @@
 
 package org.bitcoinj.core;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.bitcoinj.core.LockTime.HeightLock;
 import org.bitcoinj.core.LockTime.TimeLock;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
 import static org.junit.Assert.*;
 
+@RunWith(JUnitParamsRunner.class)
 public class LockTimeTest {
-    @Test
-    public void of() {
-        assertEquals(0, LockTime.of(0).rawValue());
-        assertEquals(499_999_999, LockTime.of(LockTime.THRESHOLD - 1).rawValue());
-        assertEquals(500_000_000, LockTime.of(LockTime.THRESHOLD).rawValue());
-        assertEquals(Long.MAX_VALUE, LockTime.of(Long.MAX_VALUE).rawValue());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void of_negative() {
-        LockTime.of(-1);
-    }
-
     @Test
     public void ofBlockHeight() {
         assertEquals(1, LockTime.ofBlockHeight(1).blockHeight());
         assertEquals(499_999_999, LockTime.ofBlockHeight((int) LockTime.THRESHOLD - 1).blockHeight());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void ofBlockHeight_negative() {
-        LockTime.ofBlockHeight(-1);
     }
 
     @Test
@@ -92,5 +78,36 @@ public class LockTimeTest {
         if (unset instanceof HeightLock && unset.rawValue() == 0) {
             assertTrue(unset.rawValue() == 0);
         }
+    }
+
+    @Test
+    @Parameters(method = "validValueVectors")
+    public void testValues(long value, Class<?> clazz) {
+        LockTime lockTime = LockTime.of(value);
+
+        assertTrue(clazz.isInstance(lockTime));
+        assertEquals(value, lockTime.rawValue());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    @Parameters(method = "invalidValues")
+    public void testValues(long value) {
+        LockTime lockTime = LockTime.of(value);
+    }
+
+    private Object[] validValueVectors() {
+        return new Object[]{
+                new Object[]{0, HeightLock.class},
+                new Object[]{1, HeightLock.class},
+                new Object[]{499_999_999, HeightLock.class},
+                new Object[]{500_000_000, TimeLock.class},
+                new Object[]{Long.MAX_VALUE, TimeLock.class},
+                new Object[]{Instant.now().getEpochSecond(), TimeLock.class},
+                new Object[]{Instant.MAX.getEpochSecond(), TimeLock.class}
+        };
+    }
+
+    private Long[] invalidValues() {
+        return new Long[]{Long.MIN_VALUE, -1L};
     }
 }

--- a/core/src/test/java/org/bitcoinj/core/LockTimeTest.java
+++ b/core/src/test/java/org/bitcoinj/core/LockTimeTest.java
@@ -16,6 +16,9 @@
 
 package org.bitcoinj.core;
 
+import org.bitcoinj.core.LockTime.HeightLock;
+import org.bitcoinj.core.LockTime.NoLock;
+import org.bitcoinj.core.LockTime.TimeLock;
 import org.junit.Test;
 
 import java.time.Instant;
@@ -73,11 +76,32 @@ public class LockTimeTest {
 
     @Test(expected = IllegalStateException.class)
     public void blockHeight_mismatch() {
-        LockTime.ofTimestamp(Instant.MAX).blockHeight();
+        LockTime.ofTimestamp(Instant.MAX).getBlockHeight().orElseThrow(IllegalStateException::new);
     }
 
     @Test(expected = IllegalStateException.class)
     public void timestamp_mismatch() {
-        LockTime.ofBlockHeight(1).timestamp();
+        LockTime.ofBlockHeight(1).getTimestamp().orElseThrow(IllegalStateException::new);
+    }
+
+    @Test
+    public void testSubtypes() {
+        LockTime timestamp = LockTime.ofTimestamp(Instant.now());
+        LockTime height = LockTime.ofBlockHeight(100);
+        LockTime unset = LockTime.unset();
+
+        assertTrue(timestamp instanceof TimeLock);
+        assertTrue(height instanceof HeightLock);
+        assertTrue(unset instanceof NoLock);
+
+        if (timestamp instanceof TimeLock) {
+            assertTrue(((TimeLock) timestamp).timestamp().isAfter(Instant.EPOCH));
+        }
+        if (height instanceof HeightLock) {
+            assertTrue(((HeightLock) height).blockHeight() > 0);
+        }
+        if (unset instanceof NoLock) {
+            assertTrue(unset.rawValue() == 0);
+        }
     }
 }

--- a/core/src/test/java/org/bitcoinj/core/LockTimeTest.java
+++ b/core/src/test/java/org/bitcoinj/core/LockTimeTest.java
@@ -17,7 +17,6 @@
 package org.bitcoinj.core;
 
 import org.bitcoinj.core.LockTime.HeightLock;
-import org.bitcoinj.core.LockTime.NoLock;
 import org.bitcoinj.core.LockTime.TimeLock;
 import org.junit.Test;
 
@@ -74,16 +73,6 @@ public class LockTimeTest {
         assertEquals(0, LockTime.unset().rawValue());
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void blockHeight_mismatch() {
-        LockTime.ofTimestamp(Instant.MAX).getBlockHeight().orElseThrow(IllegalStateException::new);
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void timestamp_mismatch() {
-        LockTime.ofBlockHeight(1).getTimestamp().orElseThrow(IllegalStateException::new);
-    }
-
     @Test
     public void testSubtypes() {
         LockTime timestamp = LockTime.ofTimestamp(Instant.now());
@@ -92,7 +81,7 @@ public class LockTimeTest {
 
         assertTrue(timestamp instanceof TimeLock);
         assertTrue(height instanceof HeightLock);
-        assertTrue(unset instanceof NoLock);
+        assertTrue(unset instanceof HeightLock);
 
         if (timestamp instanceof TimeLock) {
             assertTrue(((TimeLock) timestamp).timestamp().isAfter(Instant.EPOCH));
@@ -100,7 +89,7 @@ public class LockTimeTest {
         if (height instanceof HeightLock) {
             assertTrue(((HeightLock) height).blockHeight() > 0);
         }
-        if (unset instanceof NoLock) {
+        if (unset instanceof HeightLock && unset.rawValue() == 0) {
             assertTrue(unset.rawValue() == 0);
         }
     }


### PR DESCRIPTION
This is to support pattern-matching in JDK 16 and later and supports testing with `instanceof` on all JDKs (but may require casting after the tests on pre-16 JDKs)
