### PR TITLE
Preconditions: add generic `check()` that allows to supply a custom exception

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/internal/Preconditions.java
+++ b/core/src/main/java/org/bitcoinj/base/internal/Preconditions.java
@@ -25,8 +25,7 @@ public class Preconditions {
      * @throws IllegalArgumentException if {@code expression} is false
      */
     public static void checkArgument(boolean expression) {
-        if (!expression)
-            throw new IllegalArgumentException();
+        check(expression, () -> new IllegalArgumentException());
     }
 
     /**
@@ -36,8 +35,7 @@ public class Preconditions {
      * @throws IllegalArgumentException if {@code expression} is false
      */
     public static void checkArgument(boolean expression, Supplier<String> messageSupplier) {
-        if (!expression)
-            throw new IllegalArgumentException(messageSupplier.get());
+        check(expression, () -> new IllegalArgumentException(messageSupplier.get()));
     }
 
     /**
@@ -47,8 +45,7 @@ public class Preconditions {
      * @throws IllegalStateException if {@code expression} is false
      */
     public static void checkState(boolean expression) {
-        if (!expression)
-            throw new IllegalStateException();
+        check(expression, () -> new IllegalStateException());
     }
 
     /**
@@ -59,7 +56,17 @@ public class Preconditions {
      * @throws IllegalStateException if {@code expression} is false
      */
     public static void checkState(boolean expression, Supplier<String> messageSupplier) {
+        check(expression, () -> new IllegalStateException(messageSupplier.get()));
+    }
+
+    /**
+     * Ensures the truth of an expression, throwing a custom exception if not.
+     * @param expression a boolean expression
+     * @param exceptionSupplier supplier of the exception to be thrown
+     * @throws X if {@code expression} is false
+     */
+    public static <X extends Throwable> void check(boolean expression, Supplier<? extends X> exceptionSupplier) throws X {
         if (!expression)
-            throw new IllegalStateException(messageSupplier.get());
+            throw exceptionSupplier.get();
     }
 }

--- a/core/src/test/java/org/bitcoinj/base/internal/PreconditionsTest.java
+++ b/core/src/test/java/org/bitcoinj/base/internal/PreconditionsTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.base.internal;
+
+import org.junit.Test;
+
+public class PreconditionsTest {
+    @Test
+    public void check_true() {
+        Preconditions.check(true, ArithmeticException::new);
+    }
+
+    @Test(expected = ArithmeticException.class)
+    public void check_false() {
+        Preconditions.check(false, ArithmeticException::new);
+    }
+}


### PR DESCRIPTION
The idea is to use this in #2821 to throw an `ArithmeticException` rather than a `IllegalArgumentException`.