### PR TITLE
WIP: Decouple TxConfidenceTable & Context

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
@@ -18,6 +18,7 @@
 package org.bitcoinj.core;
 
 import com.google.common.base.Preconditions;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.core.listeners.NewBestBlockListener;
 import org.bitcoinj.core.listeners.ReorganizeListener;
@@ -47,6 +48,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -101,6 +103,16 @@ import static com.google.common.base.Preconditions.checkState;
  */
 public abstract class AbstractBlockChain {
     private static final Logger log = LoggerFactory.getLogger(AbstractBlockChain.class);
+
+    // TODO: 2023-03-16 remove values with only one value on the heap
+    private static final Map<Network, Set<AbstractBlockChain>> _instances = new HashMap<>();
+
+    private static void addInstance(Network network, AbstractBlockChain instance){
+
+        Set<AbstractBlockChain> networkInstances = _instances.getOrDefault(network, new HashSet<>());
+        networkInstances.add(instance);
+        _instances.put(network, networkInstances);
+    }
     /** synchronization lock */
     protected final ReentrantLock lock = Threading.lock(AbstractBlockChain.class);
 
@@ -182,6 +194,7 @@ public abstract class AbstractBlockChain {
 
         this.versionTally = new VersionTally(params);
         this.versionTally.initialize(blockStore, chainHead);
+        addInstance(params.network(), this);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
@@ -113,6 +113,13 @@ public abstract class AbstractBlockChain {
         networkInstances.add(instance);
         _instances.put(network, networkInstances);
     }
+
+    //intended only as a migration method
+    @Deprecated
+    @Nullable
+    public static Set<AbstractBlockChain> instances(Network network){
+        return _instances.get(network);
+    }
     /** synchronization lock */
     protected final ReentrantLock lock = Threading.lock(AbstractBlockChain.class);
 

--- a/core/src/main/java/org/bitcoinj/core/Context.java
+++ b/core/src/main/java/org/bitcoinj/core/Context.java
@@ -81,7 +81,9 @@ public class Context {
      */
     public Context(int eventHorizon, Coin feePerKb, boolean ensureMinRequiredFee, boolean relaxProofOfWork) {
         log.info("Creating bitcoinj {} context.", VersionMessage.BITCOINJ_VERSION);
-        this.confidenceTable = new TxConfidenceTable();
+        TxConfidenceTable txConfidenceTable = new TxConfidenceTable();
+        TxConfidenceTable.setInstance(txConfidenceTable);
+        this.confidenceTable = txConfidenceTable;
         this.eventHorizon = eventHorizon;
         this.ensureMinRequiredFee = ensureMinRequiredFee;
         this.feePerKb = feePerKb;

--- a/core/src/main/java/org/bitcoinj/core/Context.java
+++ b/core/src/main/java/org/bitcoinj/core/Context.java
@@ -47,8 +47,6 @@ public class Context {
     private static final Logger log = LoggerFactory.getLogger(Context.class);
 
     public static final int DEFAULT_EVENT_HORIZON = 100;
-
-    final private TxConfidenceTable confidenceTable;
     final private int eventHorizon;
     final private boolean ensureMinRequiredFee;
     final private Coin feePerKb;
@@ -81,9 +79,6 @@ public class Context {
      */
     public Context(int eventHorizon, Coin feePerKb, boolean ensureMinRequiredFee, boolean relaxProofOfWork) {
         log.info("Creating bitcoinj {} context.", VersionMessage.BITCOINJ_VERSION);
-        TxConfidenceTable txConfidenceTable = new TxConfidenceTable();
-        TxConfidenceTable.setInstance(txConfidenceTable);
-        this.confidenceTable = txConfidenceTable;
         this.eventHorizon = eventHorizon;
         this.ensureMinRequiredFee = ensureMinRequiredFee;
         this.feePerKb = feePerKb;

--- a/core/src/main/java/org/bitcoinj/core/Context.java
+++ b/core/src/main/java/org/bitcoinj/core/Context.java
@@ -186,7 +186,7 @@ public class Context {
      * have that it's really valid.
      */
     public TxConfidenceTable getConfidenceTable() {
-        return confidenceTable;
+        return TxConfidenceTable.getSingleInstance();
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/Context.java
+++ b/core/src/main/java/org/bitcoinj/core/Context.java
@@ -178,6 +178,7 @@ public class Context {
         slot.set(Objects.requireNonNull(context));
     }
 
+    @Deprecated
     /**
      * Returns the {@link TxConfidenceTable} created by this context. The pool tracks advertised
      * and downloaded transactions so their confidence can be measured as a proportion of how many peers announced it.

--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -1169,7 +1169,7 @@ public class Peer extends PeerSocketHandler {
             // sending us the transaction: currently we'll never try to re-fetch after a timeout.
             //
             // The line below can trigger confidence listeners.
-            TransactionConfidence conf = TxConfidenceTable.instance(params.network()).seen(item.hash, this.getAddress());
+            TransactionConfidence conf = TxConfidenceTable.getOrCreateInstance(params.network()).seen(item.hash, this.getAddress());
             if (conf.numBroadcastPeers() > 1) {
                 // Some other peer already announced this so don't download.
                 it.remove();

--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -1169,7 +1169,7 @@ public class Peer extends PeerSocketHandler {
             // sending us the transaction: currently we'll never try to re-fetch after a timeout.
             //
             // The line below can trigger confidence listeners.
-            TransactionConfidence conf = context.getConfidenceTable().seen(item.hash, this.getAddress());
+            TransactionConfidence conf = TxConfidenceTable.instance(params.network()).seen(item.hash, this.getAddress());
             if (conf.numBroadcastPeers() > 1) {
                 // Some other peer already announced this so don't download.
                 it.remove();

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -1730,7 +1730,7 @@ public class PeerGroup implements TransactionBroadcaster {
     /** Use "Context.get().getConfidenceTable()" instead */
     @Deprecated @Nullable
     public TxConfidenceTable getMemoryPool() {
-        return Context.get().getConfidenceTable();
+        return TxConfidenceTable.instance(params.network());
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -1730,7 +1730,7 @@ public class PeerGroup implements TransactionBroadcaster {
     /** Use "Context.get().getConfidenceTable()" instead */
     @Deprecated @Nullable
     public TxConfidenceTable getMemoryPool() {
-        return TxConfidenceTable.instance(params.network());
+        return TxConfidenceTable.getOrCreateInstance(params.network());
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -1678,7 +1678,7 @@ public class Transaction extends ChildMessage {
      * referenced by the given {@link Context}.
      */
     public TransactionConfidence getConfidence(Context context) {
-        return getConfidence(context.getConfidenceTable());
+        return getConfidence(TxConfidenceTable.instance(params.network()));
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -1678,7 +1678,7 @@ public class Transaction extends ChildMessage {
      * referenced by the given {@link Context}.
      */
     public TransactionConfidence getConfidence(Context context) {
-        return getConfidence(TxConfidenceTable.instance(params.network()));
+        return getConfidence(TxConfidenceTable.getOrCreateInstance(params.network()));
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/TxConfidenceTable.java
+++ b/core/src/main/java/org/bitcoinj/core/TxConfidenceTable.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.core;
 
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.utils.Threading;
 
@@ -41,6 +42,21 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public class TxConfidenceTable {
     protected final ReentrantLock lock = Threading.lock(TxConfidenceTable.class);
+
+    //simply to help with migration.
+    @Deprecated
+    private static TxConfidenceTable _instance;
+
+    @Deprecated
+    public static void setInstance(TxConfidenceTable txConfidenceTable) {
+        if (_instance != null){
+            throw new RuntimeException("confidence table already set");
+        }
+        _instance = txConfidenceTable;
+    }
+    public static TxConfidenceTable instance(Network network) {
+        return _instance;
+    }
 
     private static class WeakConfidenceReference extends WeakReference<TransactionConfidence> {
         public Sha256Hash hash;


### PR DESCRIPTION
Work in progress...

Having a look at https://github.com/bitcoinj/bitcoinj/pull/1553 and https://github.com/bitcoinj/bitcoinj/issues/2531. Originally my aim was to find a non breaking way to remove `depth` but realised that this can't really be done without addressing where `TxConfidenceTable` should be located. This P.R assumes that there is going to be one `TxConfidenceTable` per `Network`. Also rather than attaching it to an existing object like `Network` or `NetworkParameters` it's just attached as a static member in `TxConfidenceTable`. The intention is that in the future a  `TxConfidenceTable` is created once there is an `AbstractBlockChain` and is set as a Singleton for a `Network` on `TxConfidenceTable`. 

The reason why `TxConfidenceTable` has an indirect dependency on `AbstractBlockChain` is to be able to calculate `depth` by using `AbstractBlockChain.getBestChainHeight()`.