### PR TITLE
ParseByteCacheTest: rewrite `arrayContains()` helper

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/ParseByteCacheTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ParseByteCacheTest.java
@@ -453,12 +453,13 @@ public class ParseByteCacheTest {
 
     // Determine if sub is contained in sup.
     public static boolean arrayContains(byte[] sup, byte[] sub) {
+        ByteBuffer subBuf = ByteBuffer.wrap(sub);
         int subLength = sub.length;
         int lengthDiff = sup.length - subLength;
         if (lengthDiff < 0)
             return false;
         for (int i = 0; i <= lengthDiff; i++)
-            if (Arrays.equals(sup, i, i + subLength, sub, 0, subLength))
+            if (ByteBuffer.wrap(sup, i, subLength).equals(subBuf))
                 return true;
         return false;
     }

--- a/core/src/test/java/org/bitcoinj/core/ParseByteCacheTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ParseByteCacheTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 import static org.bitcoinj.base.Coin.COIN;
 import static org.bitcoinj.base.Coin.valueOf;
@@ -449,23 +450,30 @@ public class ParseByteCacheTest {
             assertTrue(arrayContains(containingBytes, b1));
         }
     }
-    
+
+    // Determine if sub is contained in sup.
     public static boolean arrayContains(byte[] sup, byte[] sub) {
-        if (sup.length < sub.length)
-            return false;       
-        
-        String superstring = ByteUtils.formatHex(sup);
-        String substring = ByteUtils.formatHex(sub);
-        
-        int ind = superstring.indexOf(substring);
-        
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < superstring.indexOf(substring); i++)
-            sb.append(" ");
-        
-        //System.out.println(superstring);
-        //System.out.println(sb.append(substring).toString());
-        //System.out.println();
-        return ind > -1;
+        int subLength = sub.length;
+        int lengthDiff = sup.length - subLength;
+        if (lengthDiff < 0)
+            return false;
+        for (int i = 0; i <= lengthDiff; i++)
+            if (Arrays.equals(sup, i, i + subLength, sub, 0, subLength))
+                return true;
+        return false;
+    }
+
+    @Test
+    public void testArrayContains() {
+        byte[] oneToNine = ByteUtils.parseHex("010203040506070809");
+        assertTrue(arrayContains(oneToNine, oneToNine));
+        assertTrue(arrayContains(oneToNine, ByteUtils.parseHex("010203")));
+        assertTrue(arrayContains(oneToNine, ByteUtils.parseHex("040506")));
+        assertTrue(arrayContains(oneToNine, ByteUtils.parseHex("070809")));
+        assertTrue(arrayContains(oneToNine, new byte[0]));
+
+        assertFalse(arrayContains(oneToNine, ByteUtils.parseHex("123456")));
+        assertFalse(arrayContains(oneToNine, ByteUtils.parseHex("080910")));
+        assertFalse(arrayContains(oneToNine, ByteUtils.parseHex("01020304050607080910")));
     }
 }


### PR DESCRIPTION
The previous implementation was based on hex strings and was prone to raising a false positive when matching at an uneven hex position.

This also adds a test.