### PR TITLE
Message: remove `length` arguments from constructors of the hierarchy

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AddressMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressMessage.java
@@ -28,8 +28,8 @@ public abstract class AddressMessage extends Message {
     protected static final long MAX_ADDRESSES = 1000;
     protected List<PeerAddress> addresses;
 
-    AddressMessage(NetworkParameters params, byte[] payload, int offset, MessageSerializer serializer, int length) throws ProtocolException {
-        super(params, payload, offset, serializer, length);
+    AddressMessage(NetworkParameters params, byte[] payload, int offset, MessageSerializer serializer) throws ProtocolException {
+        super(params, payload, offset, serializer);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/AddressV1Message.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressV1Message.java
@@ -36,32 +36,28 @@ public class AddressV1Message extends AddressMessage {
      * @param params NetworkParameters object.
      * @param offset The location of the first payload byte within the array.
      * @param serializer the serializer to use for this block.
-     * @param length The length of message if known.  Usually this is provided when deserializing of the wire
-     * as the length will be provided as part of the header.  If unknown then set to Message.UNKNOWN_LENGTH
      * @throws ProtocolException
      */
-    AddressV1Message(NetworkParameters params, byte[] payload, int offset, MessageSerializer serializer, int length) throws ProtocolException {
-        super(params, payload, offset, serializer, length);
+    AddressV1Message(NetworkParameters params, byte[] payload, int offset, MessageSerializer serializer) throws ProtocolException {
+        super(params, payload, offset, serializer);
     }
 
     /**
      * Construct a new 'addr' message.
      * @param params NetworkParameters object.
      * @param serializer the serializer to use for this block.
-     * @param length The length of message if known.  Usually this is provided when deserializing of the wire
-     * as the length will be provided as part of the header.  If unknown then set to Message.UNKNOWN_LENGTH
      * @throws ProtocolException
      */
-    AddressV1Message(NetworkParameters params, byte[] payload, MessageSerializer serializer, int length) throws ProtocolException {
-        super(params, payload, 0, serializer, length);
+    AddressV1Message(NetworkParameters params, byte[] payload, MessageSerializer serializer) throws ProtocolException {
+        super(params, payload, 0, serializer);
     }
 
     AddressV1Message(NetworkParameters params, byte[] payload, int offset) throws ProtocolException {
-        super(params, payload, offset, params.getDefaultSerializer(), UNKNOWN_LENGTH);
+        super(params, payload, offset, params.getDefaultSerializer());
     }
 
     AddressV1Message(NetworkParameters params, byte[] payload) throws ProtocolException {
-        super(params, payload, 0, params.getDefaultSerializer(), UNKNOWN_LENGTH);
+        super(params, payload, 0, params.getDefaultSerializer());
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/AddressV2Message.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressV2Message.java
@@ -37,28 +37,24 @@ public class AddressV2Message extends AddressMessage {
      * @param params NetworkParameters object.
      * @param offset The location of the first payload byte within the array.
      * @param serializer the serializer to use for this block.
-     * @param length The length of message if known.  Usually this is provided when deserializing of the wire
-     * as the length will be provided as part of the header.  If unknown then set to Message.UNKNOWN_LENGTH
      * @throws ProtocolException
      */
-    AddressV2Message(NetworkParameters params, byte[] payload, int offset, MessageSerializer serializer, int length) throws ProtocolException {
-        super(params, payload, offset, serializer, length);
+    AddressV2Message(NetworkParameters params, byte[] payload, int offset, MessageSerializer serializer) throws ProtocolException {
+        super(params, payload, offset, serializer);
     }
 
     /**
      * Construct a new 'addrv2' message.
      * @param params NetworkParameters object.
      * @param serializer the serializer to use for this block.
-     * @param length The length of message if known.  Usually this is provided when deserializing of the wire
-     * as the length will be provided as part of the header.  If unknown then set to Message.UNKNOWN_LENGTH
      * @throws ProtocolException
      */
-    AddressV2Message(NetworkParameters params, byte[] payload, MessageSerializer serializer, int length) throws ProtocolException {
-        super(params, payload, 0, serializer, length);
+    AddressV2Message(NetworkParameters params, byte[] payload, MessageSerializer serializer) throws ProtocolException {
+        super(params, payload, 0, serializer);
     }
 
     AddressV2Message(NetworkParameters params, byte[] payload) throws ProtocolException {
-        super(params, payload, 0, params.getDefaultSerializer(), UNKNOWN_LENGTH);
+        super(params, payload, 0, params.getDefaultSerializer());
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
@@ -211,36 +211,36 @@ public class BitcoinSerializer extends MessageSerializer {
         }
 
         try {
-            return makeMessage(header.command, header.size, payloadBytes, hash);
+            return makeMessage(header.command, payloadBytes, hash);
         } catch (Exception e) {
             throw new ProtocolException("Error deserializing message " + ByteUtils.formatHex(payloadBytes) + "\n", e);
         }
     }
 
-    private Message makeMessage(String command, int length, byte[] payloadBytes, byte[] hash) throws ProtocolException {
+    private Message makeMessage(String command, byte[] payloadBytes, byte[] hash) throws ProtocolException {
         // We use an if ladder rather than reflection because reflection is very slow on Android.
         if (command.equals("version")) {
             return new VersionMessage(params, payloadBytes);
         } else if (command.equals("inv")) { 
-            return makeInventoryMessage(payloadBytes, length);
+            return makeInventoryMessage(payloadBytes);
         } else if (command.equals("block")) {
-            return makeBlock(payloadBytes, length);
+            return makeBlock(payloadBytes);
         } else if (command.equals("merkleblock")) {
             return makeFilteredBlock(payloadBytes);
         } else if (command.equals("getdata")) {
-            return new GetDataMessage(params, payloadBytes, this, length);
+            return new GetDataMessage(params, payloadBytes, this);
         } else if (command.equals("getblocks")) {
             return new GetBlocksMessage(params, payloadBytes);
         } else if (command.equals("getheaders")) {
             return new GetHeadersMessage(params, payloadBytes);
         } else if (command.equals("tx")) {
-            return makeTransaction(payloadBytes, 0, length, hash);
+            return makeTransaction(payloadBytes, 0, hash);
         } else if (command.equals("sendaddrv2")) {
             return new SendAddrV2Message(params);
         } else if (command.equals("addr")) {
-            return makeAddressV1Message(payloadBytes, length);
+            return makeAddressV1Message(payloadBytes);
         } else if (command.equals("addrv2")) {
-            return makeAddressV2Message(payloadBytes, length);
+            return makeAddressV2Message(payloadBytes);
         } else if (command.equals("ping")) {
             return new Ping(params, payloadBytes);
         } else if (command.equals("pong")) {
@@ -260,7 +260,7 @@ public class BitcoinSerializer extends MessageSerializer {
         } else if (command.equals("sendheaders")) {
             return new SendHeadersMessage(params, payloadBytes);
         } else if (command.equals("feefilter")) {
-            return new FeeFilterMessage(params, payloadBytes, this, length);
+            return new FeeFilterMessage(params, payloadBytes, this);
         } else {
             return new UnknownMessage(params, command, payloadBytes);
         }
@@ -278,8 +278,8 @@ public class BitcoinSerializer extends MessageSerializer {
      * serialization format support.
      */
     @Override
-    public AddressV1Message makeAddressV1Message(byte[] payloadBytes, int length) throws ProtocolException {
-        return new AddressV1Message(params, payloadBytes, this, length);
+    public AddressV1Message makeAddressV1Message(byte[] payloadBytes) throws ProtocolException {
+        return new AddressV1Message(params, payloadBytes, this);
     }
 
     /**
@@ -287,8 +287,8 @@ public class BitcoinSerializer extends MessageSerializer {
      * serialization format support.
      */
     @Override
-    public AddressV2Message makeAddressV2Message(byte[] payloadBytes, int length) throws ProtocolException {
-        return new AddressV2Message(params, payloadBytes, this, length);
+    public AddressV2Message makeAddressV2Message(byte[] payloadBytes) throws ProtocolException {
+        return new AddressV2Message(params, payloadBytes, this);
     }
 
     /**
@@ -296,8 +296,8 @@ public class BitcoinSerializer extends MessageSerializer {
      * serialization format support.
      */
     @Override
-    public Block makeBlock(final byte[] payloadBytes, final int offset, final int length) throws ProtocolException {
-        return new Block(params, payloadBytes, offset, this, length);
+    public Block makeBlock(byte[] payloadBytes, int offset) throws ProtocolException {
+        return new Block(params, payloadBytes, offset, this);
     }
 
     /**
@@ -323,8 +323,8 @@ public class BitcoinSerializer extends MessageSerializer {
      * serialization format support.
      */
     @Override
-    public InventoryMessage makeInventoryMessage(byte[] payloadBytes, int length) throws ProtocolException {
-        return new InventoryMessage(params, payloadBytes, this, length);
+    public InventoryMessage makeInventoryMessage(byte[] payloadBytes) throws ProtocolException {
+        return new InventoryMessage(params, payloadBytes, this);
     }
 
     /**
@@ -332,9 +332,9 @@ public class BitcoinSerializer extends MessageSerializer {
      * serialization format support.
      */
     @Override
-    public Transaction makeTransaction(byte[] payloadBytes, int offset, int length, byte[] hashFromHeader)
+    public Transaction makeTransaction(byte[] payloadBytes, int offset, byte[] hashFromHeader)
             throws ProtocolException {
-        return new Transaction(params, payloadBytes, offset, null, this, length, hashFromHeader);
+        return new Transaction(params, payloadBytes, offset, null, this, hashFromHeader);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -155,13 +155,11 @@ public class Block extends Message {
      * @param params NetworkParameters object.
      * @param payloadBytes the payload to extract the block from.
      * @param serializer the serializer to use for this message.
-     * @param length The length of message if known.  Usually this is provided when deserializing of the wire
-     * as the length will be provided as part of the header.  If unknown then set to Message.UNKNOWN_LENGTH
      * @throws ProtocolException
      */
-    public Block(NetworkParameters params, byte[] payloadBytes, MessageSerializer serializer, int length)
+    public Block(NetworkParameters params, byte[] payloadBytes, MessageSerializer serializer)
             throws ProtocolException {
-        super(params, payloadBytes, 0, serializer, length);
+        super(params, payloadBytes, 0, serializer);
     }
 
     /**
@@ -170,13 +168,11 @@ public class Block extends Message {
      * @param payloadBytes the payload to extract the block from.
      * @param offset The location of the first payload byte within the array.
      * @param serializer the serializer to use for this message.
-     * @param length The length of message if known.  Usually this is provided when deserializing of the wire
-     * as the length will be provided as part of the header.  If unknown then set to Message.UNKNOWN_LENGTH
      * @throws ProtocolException
      */
-    public Block(NetworkParameters params, byte[] payloadBytes, int offset, MessageSerializer serializer, int length)
+    public Block(NetworkParameters params, byte[] payloadBytes, int offset, MessageSerializer serializer)
             throws ProtocolException {
-        super(params, payloadBytes, offset, serializer, length);
+        super(params, payloadBytes, offset, serializer);
     }
 
     /**
@@ -188,14 +184,12 @@ public class Block extends Message {
      * @param offset The location of the first payload byte within the array.
      * @param parent The message element which contains this block, maybe null for no parent.
      * @param serializer the serializer to use for this block.
-     * @param length The length of message if known.  Usually this is provided when deserializing of the wire
-     * as the length will be provided as part of the header.  If unknown then set to Message.UNKNOWN_LENGTH
      * @throws ProtocolException
      */
-    public Block(NetworkParameters params, byte[] payloadBytes, int offset, @Nullable Message parent, MessageSerializer serializer, int length)
+    public Block(NetworkParameters params, byte[] payloadBytes, int offset, @Nullable Message parent, MessageSerializer serializer)
             throws ProtocolException {
         // TODO: Keep the parent
-        super(params, payloadBytes, offset, serializer, length);
+        super(params, payloadBytes, offset, serializer);
     }
 
     /**
@@ -268,7 +262,7 @@ public class Block extends Message {
         int numTransactions = numTransactionsVarInt.intValue();
         transactions = new ArrayList<>(Math.min(numTransactions, Utils.MAX_INITIAL_ARRAY_LENGTH));
         for (int i = 0; i < numTransactions; i++) {
-            Transaction tx = new Transaction(params, payload, cursor, this, serializer, UNKNOWN_LENGTH, null);
+            Transaction tx = new Transaction(params, payload, cursor, this, serializer, null);
             // Label the transaction as coming from the P2P network, so code that cares where we first saw it knows.
             tx.getConfidence().setSource(TransactionConfidence.Source.NETWORK);
             transactions.add(tx);

--- a/core/src/main/java/org/bitcoinj/core/ChildMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/ChildMessage.java
@@ -37,8 +37,8 @@ public abstract class ChildMessage extends Message {
     }
 
     public ChildMessage(NetworkParameters params, byte[] payload, int offset, @Nullable Message parent,
-                        MessageSerializer serializer, int length) throws ProtocolException {
-        super(params, payload, offset, serializer, length);
+                        MessageSerializer serializer) throws ProtocolException {
+        super(params, payload, offset, serializer);
         this.parent = parent;
     }
 

--- a/core/src/main/java/org/bitcoinj/core/DummySerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/DummySerializer.java
@@ -64,17 +64,17 @@ class DummySerializer extends MessageSerializer {
     }
 
     @Override
-    public AddressV1Message makeAddressV1Message(byte[] payloadBytes, int length) throws UnsupportedOperationException {
+    public AddressV1Message makeAddressV1Message(byte[] payloadBytes) throws UnsupportedOperationException {
         throw new UnsupportedOperationException(DEFAULT_EXCEPTION_MESSAGE);
     }
 
     @Override
-    public AddressV2Message makeAddressV2Message(byte[] payloadBytes, int length) throws UnsupportedOperationException {
+    public AddressV2Message makeAddressV2Message(byte[] payloadBytes) throws UnsupportedOperationException {
         throw new UnsupportedOperationException(DEFAULT_EXCEPTION_MESSAGE);
     }
 
     @Override
-    public Block makeBlock(byte[] payloadBytes, int offset, int length) throws UnsupportedOperationException {
+    public Block makeBlock(byte[] payloadBytes, int offset) throws UnsupportedOperationException {
         throw new UnsupportedOperationException(DEFAULT_EXCEPTION_MESSAGE);
     }
 
@@ -89,12 +89,12 @@ class DummySerializer extends MessageSerializer {
     }
 
     @Override
-    public InventoryMessage makeInventoryMessage(byte[] payloadBytes, int length) throws UnsupportedOperationException {
+    public InventoryMessage makeInventoryMessage(byte[] payloadBytes) throws UnsupportedOperationException {
         throw new UnsupportedOperationException(DEFAULT_EXCEPTION_MESSAGE);
     }
 
     @Override
-    public Transaction makeTransaction(byte[] payloadBytes, int offset, int length, byte[] hash) throws UnsupportedOperationException {
+    public Transaction makeTransaction(byte[] payloadBytes, int offset, byte[] hash) throws UnsupportedOperationException {
         throw new UnsupportedOperationException(DEFAULT_EXCEPTION_MESSAGE);
     }
 

--- a/core/src/main/java/org/bitcoinj/core/FeeFilterMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/FeeFilterMessage.java
@@ -34,8 +34,8 @@ import java.math.BigInteger;
 public class FeeFilterMessage extends Message {
     private Coin feeRate;
 
-    public FeeFilterMessage(NetworkParameters params, byte[] payloadBytes, BitcoinSerializer serializer, int length) {
-        super(params, payloadBytes, 0, serializer, length);
+    public FeeFilterMessage(NetworkParameters params, byte[] payloadBytes, BitcoinSerializer serializer) {
+        super(params, payloadBytes, 0, serializer);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/GetDataMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetDataMessage.java
@@ -36,13 +36,11 @@ public class GetDataMessage extends ListMessage {
      * @param params NetworkParameters object.
      * @param payload Bitcoin protocol formatted byte array containing message content.
      * @param serializer the serializer to use for this message.
-     * @param length The length of message if known.  Usually this is provided when deserializing of the wire
-     * as the length will be provided as part of the header.  If unknown then set to Message.UNKNOWN_LENGTH
      * @throws ProtocolException
      */
-    public GetDataMessage(NetworkParameters params, byte[] payload, MessageSerializer serializer, int length)
+    public GetDataMessage(NetworkParameters params, byte[] payload, MessageSerializer serializer)
             throws ProtocolException {
-        super(params, payload, serializer, length);
+        super(params, payload, serializer);
     }
 
     public GetDataMessage(NetworkParameters params) {

--- a/core/src/main/java/org/bitcoinj/core/HeadersMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/HeadersMessage.java
@@ -76,7 +76,7 @@ public class HeadersMessage extends Message {
         final BitcoinSerializer serializer = this.params.getSerializer(true);
 
         for (int i = 0; i < numHeaders; ++i) {
-            final Block newBlockHeader = serializer.makeBlock(payload, cursor, UNKNOWN_LENGTH);
+            final Block newBlockHeader = serializer.makeBlock(payload, cursor);
             if (newBlockHeader.hasTransactions()) {
                 throw new ProtocolException("Block header does not end with a null byte");
             }

--- a/core/src/main/java/org/bitcoinj/core/InventoryMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/InventoryMessage.java
@@ -40,13 +40,11 @@ public class InventoryMessage extends ListMessage {
      * @param params NetworkParameters object.
      * @param payload Bitcoin protocol formatted byte array containing message content.
      * @param serializer the serializer to use for this message.
-     * @param length The length of message if known.  Usually this is provided when deserializing of the wire
-     * as the length will be provided as part of the header.  If unknown then set to Message.UNKNOWN_LENGTH
      * @throws ProtocolException
      */
-    public InventoryMessage(NetworkParameters params, byte[] payload, MessageSerializer serializer, int length)
+    public InventoryMessage(NetworkParameters params, byte[] payload, MessageSerializer serializer)
             throws ProtocolException {
-        super(params, payload, serializer, length);
+        super(params, payload, serializer);
     }
 
     public InventoryMessage(NetworkParameters params) {

--- a/core/src/main/java/org/bitcoinj/core/ListMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/ListMessage.java
@@ -43,9 +43,9 @@ public abstract class ListMessage extends Message {
         super(params, bytes, 0);
     }
 
-    public ListMessage(NetworkParameters params, byte[] payload, MessageSerializer serializer, int length)
+    public ListMessage(NetworkParameters params, byte[] payload, MessageSerializer serializer)
             throws ProtocolException {
-        super(params, payload, 0, serializer, length);
+        super(params, payload, 0, serializer);
     }
 
     public ListMessage(NetworkParameters params) {

--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -79,16 +79,14 @@ public abstract class Message {
      * @param payload Bitcoin protocol formatted byte array containing message content.
      * @param offset The location of the first payload byte within the array.
      * @param serializer the serializer to use for this message.
-     * @param length The length of message payload if known.  Usually this is provided when deserializing of the wire
-     * as the length will be provided as part of the header.  If unknown then set to Message.UNKNOWN_LENGTH
      * @throws ProtocolException
      */
-    protected Message(NetworkParameters params, byte[] payload, int offset, MessageSerializer serializer, int length) throws ProtocolException {
+    protected Message(NetworkParameters params, byte[] payload, int offset, MessageSerializer serializer) throws ProtocolException {
         this.serializer = serializer;
         this.params = params;
         this.payload = payload;
         this.cursor = this.offset = offset;
-        this.length = length;
+        this.length = payload.length;
 
         parse();
 
@@ -102,7 +100,7 @@ public abstract class Message {
     }
 
     protected Message(NetworkParameters params, byte[] payload, int offset) throws ProtocolException {
-        this(params, payload, offset, params.getDefaultSerializer(), UNKNOWN_LENGTH);
+        this(params, payload, offset, params.getDefaultSerializer());
     }
 
     // These methods handle the serialization/deserialization using the custom Bitcoin protocol.

--- a/core/src/main/java/org/bitcoinj/core/MessageSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/MessageSerializer.java
@@ -81,11 +81,10 @@ public abstract class MessageSerializer {
     }
 
     /**
-     * Make a block from the payload, using an offset of zero and the provided
-     * length as block length. Extension point for alternative
+     * Make a block from the payload, using an offset of zero. Extension point for alternative
      * serialization format support.
      */
-    public abstract Block makeBlock(byte[] payloadBytes, final int offset) throws ProtocolException, UnsupportedOperationException;
+    public abstract Block makeBlock(byte[] payloadBytes, int offset) throws ProtocolException, UnsupportedOperationException;
 
     /**
      * Make an filter message from the payload. Extension point for alternative

--- a/core/src/main/java/org/bitcoinj/core/MessageSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/MessageSerializer.java
@@ -65,28 +65,19 @@ public abstract class MessageSerializer {
      * Make an address message from the payload. Extension point for alternative
      * serialization format support.
      */
-    public abstract AddressV1Message makeAddressV1Message(byte[] payloadBytes, int length) throws ProtocolException, UnsupportedOperationException;
+    public abstract AddressV1Message makeAddressV1Message(byte[] payloadBytes) throws ProtocolException, UnsupportedOperationException;
 
     /**
      * Make an address message from the payload. Extension point for alternative
      * serialization format support.
      */
-    public abstract AddressV2Message makeAddressV2Message(byte[] payloadBytes, int length) throws ProtocolException, UnsupportedOperationException;
+    public abstract AddressV2Message makeAddressV2Message(byte[] payloadBytes) throws ProtocolException, UnsupportedOperationException;
 
     /**
-     * Make a block from the payload, using an offset of zero and the payload
-     * length as block length.
+     * Make a block from the payload, using an offset of zero.
      */
     public final Block makeBlock(byte[] payloadBytes) throws ProtocolException {
-        return makeBlock(payloadBytes, 0, payloadBytes.length);
-    }
-
-    /**
-     * Make a block from the payload, using an offset of zero and the provided
-     * length as block length.
-     */
-    public final Block makeBlock(byte[] payloadBytes, int length) throws ProtocolException {
-        return makeBlock(payloadBytes, 0, length);
+        return makeBlock(payloadBytes, 0);
     }
 
     /**
@@ -94,7 +85,7 @@ public abstract class MessageSerializer {
      * length as block length. Extension point for alternative
      * serialization format support.
      */
-    public abstract Block makeBlock(final byte[] payloadBytes, final int offset, final int length) throws ProtocolException, UnsupportedOperationException;
+    public abstract Block makeBlock(byte[] payloadBytes, final int offset) throws ProtocolException, UnsupportedOperationException;
 
     /**
      * Make an filter message from the payload. Extension point for alternative
@@ -112,7 +103,7 @@ public abstract class MessageSerializer {
      * Make an inventory message from the payload. Extension point for alternative
      * serialization format support.
      */
-    public abstract InventoryMessage makeInventoryMessage(byte[] payloadBytes, int length) throws ProtocolException, UnsupportedOperationException;
+    public abstract InventoryMessage makeInventoryMessage(byte[] payloadBytes) throws ProtocolException, UnsupportedOperationException;
 
     /**
      * Make a transaction from the payload. Extension point for alternative
@@ -123,7 +114,7 @@ public abstract class MessageSerializer {
      * serializer (i.e. for messages with no network parameters), or because
      * it does not support deserializing transactions.
      */
-    public abstract Transaction makeTransaction(byte[] payloadBytes, int offset, int length, byte[] hash) throws ProtocolException, UnsupportedOperationException;
+    public abstract Transaction makeTransaction(byte[] payloadBytes, int offset, byte[] hash) throws ProtocolException, UnsupportedOperationException;
 
     /**
      * Make a transaction from the payload. Extension point for alternative
@@ -148,7 +139,7 @@ public abstract class MessageSerializer {
      * it does not support deserializing transactions.
      */
     public final Transaction makeTransaction(byte[] payloadBytes, int offset) throws ProtocolException {
-        return makeTransaction(payloadBytes, offset, payloadBytes.length, null);
+        return makeTransaction(payloadBytes, offset, null);
     }
 
     public abstract void seekPastMagicBytes(ByteBuffer in) throws BufferUnderflowException;

--- a/core/src/main/java/org/bitcoinj/core/PeerAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerAddress.java
@@ -89,7 +89,7 @@ public class PeerAddress extends ChildMessage {
      * @throws ProtocolException
      */
     public PeerAddress(NetworkParameters params, byte[] payload, int offset, Message parent, MessageSerializer serializer) throws ProtocolException {
-        super(params, payload, offset, parent, serializer, UNKNOWN_LENGTH);
+        super(params, payload, offset, parent, serializer);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -259,16 +259,14 @@ public class Transaction extends ChildMessage {
      * @param offset The location of the first payload byte within the array.
      * @param parent The parent of the transaction.
      * @param setSerializer The serializer to use for this transaction.
-     * @param length The length of message if known.  Usually this is provided when deserializing of the wire
-     * as the length will be provided as part of the header.  If unknown then set to Message.UNKNOWN_LENGTH
      * @param hashFromHeader Used by BitcoinSerializer. The serializer has to calculate a hash for checksumming so to
      * avoid wasting the considerable effort a set method is provided so the serializer can set it. No verification
      * is performed on this hash.
      * @throws ProtocolException
      */
     public Transaction(NetworkParameters params, byte[] payload, int offset, @Nullable Message parent,
-            MessageSerializer setSerializer, int length, @Nullable byte[] hashFromHeader) throws ProtocolException {
-        super(params, payload, offset, parent, setSerializer, length);
+            MessageSerializer setSerializer, @Nullable byte[] hashFromHeader) throws ProtocolException {
+        super(params, payload, offset, parent, setSerializer);
         if (hashFromHeader != null) {
             cachedWTxId = Sha256Hash.wrapReversed(hashFromHeader);
             if (!hasWitnesses())
@@ -279,9 +277,9 @@ public class Transaction extends ChildMessage {
     /**
      * Creates a transaction by reading payload. Length of a transaction is fixed.
      */
-    public Transaction(NetworkParameters params, byte[] payload, @Nullable Message parent, MessageSerializer setSerializer, int length)
+    public Transaction(NetworkParameters params, byte[] payload, @Nullable Message parent, MessageSerializer setSerializer)
             throws ProtocolException {
-        super(params, payload, 0, parent, setSerializer, length);
+        super(params, payload, 0, parent, setSerializer);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -145,7 +145,7 @@ public class TransactionInput extends ChildMessage {
      */
     public TransactionInput(NetworkParameters params, Transaction parentTransaction, byte[] payload, int offset, MessageSerializer serializer)
             throws ProtocolException {
-        super(params, payload, offset, parentTransaction, serializer, UNKNOWN_LENGTH);
+        super(params, payload, offset, parentTransaction, serializer);
         this.value = null;
     }
 

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -96,7 +96,7 @@ public class TransactionOutPoint extends ChildMessage {
      * @throws ProtocolException
      */
     public TransactionOutPoint(NetworkParameters params, byte[] payload, int offset, Message parent, MessageSerializer serializer) throws ProtocolException {
-        super(params, payload, offset, parent, serializer, MESSAGE_LENGTH);
+        super(params, payload, offset, parent, serializer);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -88,7 +88,7 @@ public class TransactionOutput extends ChildMessage {
      * @throws ProtocolException
      */
     public TransactionOutput(NetworkParameters params, @Nullable Transaction parent, byte[] payload, int offset, MessageSerializer serializer) throws ProtocolException {
-        super(params, payload, offset, parent, serializer, UNKNOWN_LENGTH);
+        super(params, payload, offset, parent, serializer);
         availableForSpending = true;
     }
 

--- a/core/src/test/java/org/bitcoinj/core/BlockTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockTest.java
@@ -367,7 +367,7 @@ public class BlockTest {
         };
         byte[] serializedBlock = block.bitcoinSerialize();
         try {
-            TESTNET.getDefaultSerializer().makeBlock(serializedBlock, serializedBlock.length);
+            TESTNET.getDefaultSerializer().makeBlock(serializedBlock);
             fail("We expect ProtocolException with the fixed code and OutOfMemoryError with the buggy code, so this is weird");
         } catch (ProtocolException e) {
             //Expected, do nothing

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -1228,7 +1228,7 @@ public class FullBlockTestGenerator {
 
             for (Transaction transaction : b64Original.block.getTransactions())
                 transaction.bitcoinSerialize(stream);
-            b64 = params.getSerializer(true).makeBlock(stream.toByteArray(), stream.size());
+            b64 = params.getSerializer(true).makeBlock(stream.toByteArray());
 
             // The following checks are checking to ensure block serialization functions in the way needed for this test
             // If they fail, it is likely not an indication of error, but an indication that this test needs rewritten


### PR DESCRIPTION
There was never a case where `length` wasn't equal to `payload.length`, which is supplied by the same constructors. This also does away with a couple of constructor variants.

Finally a small achievement in the quest to get rid of cruft in the Message hierarchy!