### PR TITLE
Message: do away with retaining of original message payload

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
@@ -52,7 +52,6 @@ public class BitcoinSerializer extends MessageSerializer {
 
     private final NetworkParameters params;
     private final int protocolVersion;
-    private final boolean parseRetain;
 
     private static final Map<Class<? extends Message>, String> names = new HashMap<>();
 
@@ -84,30 +83,27 @@ public class BitcoinSerializer extends MessageSerializer {
     /**
      * Constructs a BitcoinSerializer with the given behavior.
      *
-     * @param params           networkParams used to create Messages instances and determining packetMagic
-     * @param parseRetain      retain the backing byte array of a message for fast reserialization.
+     * @param params networkParams used to create Messages instances and determining packetMagic
      */
-    public BitcoinSerializer(NetworkParameters params, boolean parseRetain) {
-        this(params, params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.CURRENT), parseRetain);
+    public BitcoinSerializer(NetworkParameters params) {
+        this(params, params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.CURRENT));
     }
 
     /**
      * Constructs a BitcoinSerializer with the given behavior.
      *
-     * @param params           networkParams used to create Messages instances and determining packetMagic
-     * @param protocolVersion  the protocol version to use
-     * @param parseRetain      retain the backing byte array of a message for fast reserialization.
+     * @param params          networkParams used to create Messages instances and determining packetMagic
+     * @param protocolVersion the protocol version to use
      */
-    public BitcoinSerializer(NetworkParameters params, int protocolVersion, boolean parseRetain) {
+    public BitcoinSerializer(NetworkParameters params, int protocolVersion) {
         this.params = params;
         this.protocolVersion = protocolVersion;
-        this.parseRetain = parseRetain;
     }
 
     @Override
     public BitcoinSerializer withProtocolVersion(int protocolVersion) {
         return protocolVersion == this.protocolVersion ?
-                this : new BitcoinSerializer(params, protocolVersion, parseRetain);
+                this : new BitcoinSerializer(params, protocolVersion);
     }
 
     @Override
@@ -359,15 +355,6 @@ public class BitcoinSerializer extends MessageSerializer {
         }
     }
 
-    /**
-     * Whether the serializer will produce cached mode Messages
-     */
-    @Override
-    public boolean isParseRetainMode() {
-        return parseRetain;
-    }
-
-
     public static class BitcoinPacketHeader {
         /** The largest number of bytes that a header can represent */
         public static final int HEADER_LENGTH = COMMAND_LEN + 4 + 4;
@@ -410,12 +397,11 @@ public class BitcoinSerializer extends MessageSerializer {
         if (o == null || !(o instanceof BitcoinSerializer)) return false;
         BitcoinSerializer other = (BitcoinSerializer) o;
         return Objects.equals(params, other.params) &&
-                protocolVersion == other.protocolVersion &&
-                parseRetain == other.parseRetain;
+                protocolVersion == other.protocolVersion;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(params, protocolVersion, parseRetain);
+        return Objects.hash(params, protocolVersion);
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/DummySerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/DummySerializer.java
@@ -59,11 +59,6 @@ class DummySerializer extends MessageSerializer {
     }
 
     @Override
-    public boolean isParseRetainMode() {
-        return false;
-    }
-
-    @Override
     public AddressV1Message makeAddressV1Message(byte[] payloadBytes) throws UnsupportedOperationException {
         throw new UnsupportedOperationException(DEFAULT_EXCEPTION_MESSAGE);
     }

--- a/core/src/main/java/org/bitcoinj/core/HeadersMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/HeadersMessage.java
@@ -73,7 +73,7 @@ public class HeadersMessage extends Message {
                                          MAX_HEADERS);
 
         blockHeaders = new ArrayList<>();
-        final BitcoinSerializer serializer = this.params.getSerializer(true);
+        final BitcoinSerializer serializer = this.params.getSerializer();
 
         for (int i = 0; i < numHeaders; ++i) {
             final Block newBlockHeader = serializer.makeBlock(payload, cursor);

--- a/core/src/main/java/org/bitcoinj/core/ListMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/ListMessage.java
@@ -92,7 +92,6 @@ public abstract class ListMessage extends Message {
             InventoryItem item = new InventoryItem(type, readHash());
             items.add(item);
         }
-        payload = null;
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
-import java.util.Objects;
 
 import static org.bitcoinj.base.internal.Preconditions.checkState;
 
@@ -57,9 +56,6 @@ public abstract class Message {
     // The raw message payload bytes themselves.
     protected byte[] payload;
 
-    /** @deprecated will be removed after 0.17 */
-    @Deprecated
-    protected boolean recached = false;
     protected MessageSerializer serializer;
 
     protected NetworkParameters params;
@@ -93,10 +89,7 @@ public abstract class Message {
         checkState(this.length != UNKNOWN_LENGTH || this instanceof UnknownMessage, () ->
                 "length field has not been set in constructor for " + getClass().getSimpleName() + " after parse");
 
-        if (serializer.isParseRetainMode())
-            Objects.requireNonNull(this.payload, "payload must be retained");
-        else
-            this.payload = null;
+        this.payload = null;
     }
 
     protected Message(NetworkParameters params, byte[] payload, int offset) throws ProtocolException {
@@ -114,8 +107,6 @@ public abstract class Message {
      * invalidated unless they are also modified internally.</p>
      */
     protected void unCache() {
-        payload = null;
-        recached = false;
     }
 
     protected void adjustLength(int newArraySize, int adjustment) {
@@ -132,19 +123,6 @@ public abstract class Message {
             length++;  // The assumption here is we never call adjustLength with the same arraySize as before.
         else if (newArraySize != 0)
             length += VarInt.sizeOf(newArraySize) - VarInt.sizeOf(newArraySize - 1);
-    }
-
-    /**
-     * used for unit testing
-     */
-    public boolean isCached() {
-        return payload != null;
-    }
-
-    /** @deprecated will be removed after 0.17 */
-    @Deprecated
-    public boolean isRecached() {
-        return recached;
     }
 
     /**
@@ -190,19 +168,6 @@ public abstract class Message {
      * @return a byte array owned by this object, do NOT mutate it.
      */
     public byte[] unsafeBitcoinSerialize() {
-        // 1st attempt to use a cached array.
-        if (payload != null) {
-            if (offset == 0 && length == payload.length) {
-                // Cached byte array is the entire message with no extras so we can return as is and avoid an array
-                // copy.
-                return payload;
-            }
-
-            byte[] buf = new byte[length];
-            System.arraycopy(payload, offset, buf, 0, length);
-            return buf;
-        }
-
         // No cached array available so serialize parts by stream.
         ByteArrayOutputStream stream = new ByteArrayOutputStream(length < 32 ? 32 : length + 32);
         try {
@@ -211,22 +176,6 @@ public abstract class Message {
             // Cannot happen, we are serializing to a memory stream.
         }
 
-        if (serializer.isParseRetainMode()) {
-            // A free set of steak knives!
-            // If there happens to be a call to this method we gain an opportunity to recache
-            // the byte array and in this case it contains no bytes from parent messages.
-            // This give a dual benefit.  Releasing references to the larger byte array so that it
-            // it is more likely to be GC'd.  And preventing double serializations.  E.g. calculating
-            // merkle root calls this method.  It is will frequently happen prior to serializing the block
-            // which means another call to bitcoinSerialize is coming.  If we didn't recache then internal
-            // serialization would occur a 2nd time and every subsequent time the message is serialized.
-            payload = stream.toByteArray();
-            cursor = cursor - offset;
-            offset = 0;
-            recached = true;
-            length = payload.length;
-            return payload;
-        }
         // Record length. If this Message wasn't parsed from a byte stream it won't have length field
         // set (except for static length message types).  Setting it makes future streaming more efficient
         // because we can preallocate the ByteArrayOutputStream buffer and avoid resizing.
@@ -242,12 +191,6 @@ public abstract class Message {
      * @throws IOException
      */
     public final void bitcoinSerialize(OutputStream stream) throws IOException {
-        // 1st check for cached bytes.
-        if (payload != null && length != UNKNOWN_LENGTH) {
-            stream.write(payload, offset, length);
-            return;
-        }
-
         bitcoinSerializeToStream(stream);
     }
 

--- a/core/src/main/java/org/bitcoinj/core/MessageSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/MessageSerializer.java
@@ -57,11 +57,6 @@ public abstract class MessageSerializer {
     public abstract Message deserializePayload(BitcoinSerializer.BitcoinPacketHeader header, ByteBuffer in) throws ProtocolException, BufferUnderflowException, UnsupportedOperationException;
 
     /**
-     * Whether the serializer will produce cached mode Messages
-     */
-    public abstract boolean isParseRetainMode();
-
-    /**
      * Make an address message from the payload. Extension point for alternative
      * serialization format support.
      */

--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -454,7 +454,7 @@ public abstract class NetworkParameters {
                     // As the serializers are intended to be immutable, creating
                     // two due to a race condition should not be a problem, however
                     // to be safe we ensure only one exists for each network.
-                    this.defaultSerializer = getSerializer(false);
+                    this.defaultSerializer = getSerializer();
                 }
             }
         }
@@ -463,10 +463,9 @@ public abstract class NetworkParameters {
 
     /**
      * Construct and return a custom serializer.
-     * @param parseRetain whether the serializer should retain the backing byte array of a message for fast re-serialization.
      * @return the serializer
      */
-    public abstract BitcoinSerializer getSerializer(boolean parseRetain);
+    public abstract BitcoinSerializer getSerializer();
 
     /**
      * The number of blocks in the last {@link #getMajorityWindow()} blocks

--- a/core/src/main/java/org/bitcoinj/params/BitcoinNetworkParams.java
+++ b/core/src/main/java/org/bitcoinj/params/BitcoinNetworkParams.java
@@ -249,8 +249,8 @@ public abstract class BitcoinNetworkParams extends NetworkParameters {
     }
 
     @Override
-    public BitcoinSerializer getSerializer(boolean parseRetain) {
-        return new BitcoinSerializer(this, parseRetain);
+    public BitcoinSerializer getSerializer() {
+        return new BitcoinSerializer(this);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/testing/MockAltNetworkParams.java
+++ b/core/src/main/java/org/bitcoinj/testing/MockAltNetworkParams.java
@@ -74,7 +74,7 @@ public class MockAltNetworkParams extends NetworkParameters {
     }
 
     @Override
-    public BitcoinSerializer getSerializer(boolean parseRetain) {
+    public BitcoinSerializer getSerializer() {
         return null;
     }
 

--- a/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
@@ -92,18 +92,15 @@ public class BitcoinSerializerTest {
 
     @Test
     public void testCachedParsing() throws Exception {
-        MessageSerializer serializer = MAINNET.getSerializer(true);
+        // "retained mode" was removed from Message, so maybe this test doesn't make much sense any more
+
+        MessageSerializer serializer = MAINNET.getSerializer();
         
         // first try writing to a fields to ensure uncaching and children are not affected
         Transaction transaction = (Transaction) serializer.deserialize(ByteBuffer.wrap(TRANSACTION_MESSAGE_BYTES));
         assertNotNull(transaction);
-        assertTrue(transaction.isCached());
 
         transaction.setLockTime(1);
-        // parent should have been uncached
-        assertFalse(transaction.isCached());
-        // child should remain cached.
-        assertTrue(transaction.getInputs().get(0).isCached());
 
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         serializer.serialize(transaction, bos);
@@ -112,13 +109,8 @@ public class BitcoinSerializerTest {
         // now try writing to a child to ensure uncaching is propagated up to parent but not to siblings
         transaction = (Transaction) serializer.deserialize(ByteBuffer.wrap(TRANSACTION_MESSAGE_BYTES));
         assertNotNull(transaction);
-        assertTrue(transaction.isCached());
 
         transaction.getInputs().get(0).setSequenceNumber(1);
-        // parent should have been uncached
-        assertFalse(transaction.isCached());
-        // so should child
-        assertFalse(transaction.getInputs().get(0).isCached());
 
         bos = new ByteArrayOutputStream();
         serializer.serialize(transaction, bos);
@@ -127,7 +119,6 @@ public class BitcoinSerializerTest {
         // deserialize/reserialize to check for equals.
         transaction = (Transaction) serializer.deserialize(ByteBuffer.wrap(TRANSACTION_MESSAGE_BYTES));
         assertNotNull(transaction);
-        assertTrue(transaction.isCached());
         bos = new ByteArrayOutputStream();
         serializer.serialize(transaction, bos);
         assertArrayEquals(TRANSACTION_MESSAGE_BYTES, bos.toByteArray());
@@ -135,7 +126,6 @@ public class BitcoinSerializerTest {
         // deserialize/reserialize to check for equals.  Set a field to it's existing value to trigger uncache
         transaction = (Transaction) serializer.deserialize(ByteBuffer.wrap(TRANSACTION_MESSAGE_BYTES));
         assertNotNull(transaction);
-        assertTrue(transaction.isCached());
 
         transaction.getInputs().get(0).setSequenceNumber(transaction.getInputs().get(0).getSequenceNumber());
 

--- a/core/src/test/java/org/bitcoinj/core/CheckpointManagerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/CheckpointManagerTest.java
@@ -56,8 +56,8 @@ public class CheckpointManagerTest {
     @Test
     public void canReadTextualStream() throws IOException {
         expect(params.getId()).andReturn("org/bitcoinj/core/checkpointmanagertest/validTextualFormat");
-        expect(params.getSerializer(false)).andReturn(
-                new BitcoinSerializer(params, NetworkParameters.ProtocolVersion.CURRENT.getBitcoinProtocolVersion(), false));
+        expect(params.getSerializer()).andReturn(
+                new BitcoinSerializer(params, NetworkParameters.ProtocolVersion.CURRENT.getBitcoinProtocolVersion()));
         expect(params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.CURRENT))
                 .andReturn(NetworkParameters.ProtocolVersion.CURRENT.getBitcoinProtocolVersion());
         replay(params);

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -1228,13 +1228,15 @@ public class FullBlockTestGenerator {
 
             for (Transaction transaction : b64Original.block.getTransactions())
                 transaction.bitcoinSerialize(stream);
-            b64 = params.getSerializer(true).makeBlock(stream.toByteArray());
+            b64 = params.getSerializer().makeBlock(stream.toByteArray());
 
             // The following checks are checking to ensure block serialization functions in the way needed for this test
             // If they fail, it is likely not an indication of error, but an indication that this test needs rewritten
             checkState(stream.size() == b64Original.block.getMessageSize() + 8);
             checkState(stream.size() == b64.getMessageSize());
-            checkState(Arrays.equals(stream.toByteArray(), b64.bitcoinSerialize()));
+            // This check fails because it was created for "retain mode" and the likely encoding is not "optimal".
+            // We since removed this capability retain the original encoding, but could not rewrite this test data.
+            // checkState(Arrays.equals(stream.toByteArray(), b64.bitcoinSerialize()));
             checkState(b64.getOptimalEncodingMessageSize() == b64Original.block.getMessageSize());
         }
         blocks.add(new BlockAndValidity(b64, true, false, b64.getHash(), chainHeadHeight + 19, "b64"));

--- a/core/src/test/java/org/bitcoinj/core/PeerAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerAddressTest.java
@@ -44,7 +44,7 @@ public class PeerAddressTest {
     public void equalsContract() {
         EqualsVerifier.forClass(PeerAddress.class)
                 .suppress(Warning.NONFINAL_FIELDS)
-                .withIgnoredFields("time", "parent", "params", "offset", "cursor", "length", "payload", "recached", "serializer")
+                .withIgnoredFields("time", "parent", "params", "offset", "cursor", "length", "payload", "serializer")
                 .usingGetClass()
                 .verify();
     }

--- a/core/src/test/java/org/bitcoinj/core/SendHeadersMessageTest.java
+++ b/core/src/test/java/org/bitcoinj/core/SendHeadersMessageTest.java
@@ -40,7 +40,7 @@ public class SendHeadersMessageTest {
                         + "c96fe88d4a0f01ed9dedae2b6f9e00da94cad0fecaae66ecf689bf71b50000000000000000000000000000000000000000000000000");
 
         ByteBuffer buffer = ByteBuffer.wrap(message);
-        BitcoinSerializer serializer = new BitcoinSerializer(REGTEST, false);
+        BitcoinSerializer serializer = new BitcoinSerializer(REGTEST);
         assertTrue(serializer.deserialize(buffer) instanceof SendHeadersMessage);
     }
 }

--- a/integration-test/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTest.java
@@ -55,7 +55,7 @@ import static org.junit.Assert.fail;
 
 @RunWith(value = Parameterized.class)
 public class FilteredBlockAndPartialMerkleTreeTest extends TestWithPeerGroup {
-    private static final BitcoinSerializer SERIALIZER = new BitcoinSerializer(TESTNET, true);
+    private static final BitcoinSerializer SERIALIZER = new BitcoinSerializer(TESTNET);
 
     @Parameterized.Parameters
     public static Collection<ClientType[]> parameters() {


### PR DESCRIPTION
This removes all caching of original message payload and "retain mode" in message serializers.

There is some effect on tests. Asserts on the cache status have been removed, rendering some tests almost pointless. Rather than removing them, comments have been added to explain the history of these tests. An assert on a large binary blob of a block was dependent on retain mode, likely due to non-optimal encoding. It had to be disabled.

Note: Some classes still cache individual values, like hashes.