### PR TITLE
TransactionOutPoint: check `index` bounds

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/internal/ByteUtils.java
+++ b/core/src/main/java/org/bitcoinj/base/internal/ByteUtils.java
@@ -36,6 +36,9 @@ import static org.bitcoinj.base.internal.Preconditions.checkArgument;
  * from {@code org.bitcoinj.core.Utils}.
  */
 public class ByteUtils {
+    /** Maximum unsigned value that can be expressed by 32 bits. */
+    public static final long MAX_UNSIGNED_INTEGER = (1L << Integer.SIZE) - 1;
+
     /**
      * Hex encoding used throughout the framework. Use with ByteUtils.formatHex(byte[]) or ByteUtils.parseHex(CharSequence).
      * @deprecated Use {@link ByteUtils#hexFormat} or {@link ByteUtils#parseHex(String)} or other available

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -34,6 +34,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 
+import static org.bitcoinj.base.internal.Preconditions.checkArgument;
 import static org.bitcoinj.base.internal.Preconditions.checkState;
 
 /**
@@ -58,6 +59,8 @@ public class TransactionOutPoint extends ChildMessage {
 
     public TransactionOutPoint(NetworkParameters params, long index, @Nullable Transaction fromTx) {
         super(params);
+        checkArgument(index >= 0 && index <= ByteUtils.MAX_UNSIGNED_INTEGER, () ->
+                "index out of range: " + index);
         this.index = index;
         if (fromTx != null) {
             this.hash = fromTx.getTxId();
@@ -71,6 +74,8 @@ public class TransactionOutPoint extends ChildMessage {
 
     public TransactionOutPoint(NetworkParameters params, long index, Sha256Hash hash) {
         super(params);
+        checkArgument(index >= 0 && index <= ByteUtils.MAX_UNSIGNED_INTEGER, () ->
+                "index out of range: " + index);
         this.index = index;
         this.hash = hash;
         length = MESSAGE_LENGTH;
@@ -224,6 +229,8 @@ public class TransactionOutPoint extends ChildMessage {
      */
     @Deprecated
     public void setIndex(long index) {
+        checkArgument(index >= 0 && index <= ByteUtils.MAX_UNSIGNED_INTEGER, () ->
+                "index out of range: " + index);
         this.index = index;
     }
 

--- a/core/src/main/java/org/bitcoinj/testing/FakeTxBuilder.java
+++ b/core/src/main/java/org/bitcoinj/testing/FakeTxBuilder.java
@@ -20,6 +20,7 @@ package org.bitcoinj.testing;
 import com.google.common.annotations.VisibleForTesting;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.Address;
+import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.base.Coin;
@@ -73,7 +74,7 @@ public class FakeTxBuilder {
 
     /** Create a fake coinbase transaction. */
     public static Transaction createFakeCoinbaseTx(final NetworkParameters params) {
-        TransactionOutPoint outpoint = new TransactionOutPoint(params, -1, Sha256Hash.ZERO_HASH);
+        TransactionOutPoint outpoint = new TransactionOutPoint(params, ByteUtils.MAX_UNSIGNED_INTEGER, Sha256Hash.ZERO_HASH);
         TransactionInput input = new TransactionInput(params, null, new byte[0], outpoint);
         Transaction tx = new Transaction(params);
         tx.addInput(input);

--- a/core/src/test/java/org/bitcoinj/script/ScriptTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptTest.java
@@ -338,7 +338,9 @@ public class ScriptTest {
         Map<TransactionOutPoint, Script> scriptPubKeys = new HashMap<>();
         for (JsonNode input : inputs) {
             String hash = input.get(0).asText();
-            int index = input.get(1).asInt();
+            long index = input.get(1).asLong();
+            if (index == -1)
+                index = ByteUtils.MAX_UNSIGNED_INTEGER;
             String script = input.get(2).asText();
             Sha256Hash sha256Hash = Sha256Hash.wrap(ByteUtils.parseHex(hash));
             scriptPubKeys.put(new TransactionOutPoint(TESTNET, index, sha256Hash), parseScriptString(script));
@@ -394,8 +396,6 @@ public class ScriptTest {
 
                 for (int i = 0; i < transaction.getInputs().size(); i++) {
                     TransactionInput input = transaction.getInputs().get(i);
-                    if (input.getOutpoint().getIndex() == 0xffffffffL)
-                        input.getOutpoint().setIndex(-1);
                     assertTrue(scriptPubKeys.containsKey(input.getOutpoint()));
                     input.getScriptSig().correctlySpends(transaction, i, null, null,
                             scriptPubKeys.get(input.getOutpoint()), verifyFlags);


### PR DESCRIPTION
It turns out some tests are supplying an invalid fake value for coinbase transaction. This is now fixed.