### PR TITLE
TransactionInput: check `sequence` bounds

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/internal/ByteUtils.java
+++ b/core/src/main/java/org/bitcoinj/base/internal/ByteUtils.java
@@ -36,6 +36,9 @@ import static org.bitcoinj.base.internal.Preconditions.checkArgument;
  * from {@code org.bitcoinj.core.Utils}.
  */
 public class ByteUtils {
+    /** Maximum unsigned value that can be expressed by 32 bits. */
+    public static final long MAX_UNSIGNED_INTEGER = (1L << Integer.SIZE) - 1;
+
     /**
      * Hex encoding used throughout the framework. Use with ByteUtils.formatHex(byte[]) or ByteUtils.parseHex(CharSequence).
      * @deprecated Use {@link ByteUtils#hexFormat} or {@link ByteUtils#parseHex(String)} or other available

--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -225,6 +225,8 @@ public class TransactionInput extends ChildMessage {
      * examples of how you can use this feature to build contract protocols.
      */
     public void setSequenceNumber(long sequence) {
+        checkArgument(sequence >= 0 && sequence <= ByteUtils.MAX_UNSIGNED_INTEGER, () ->
+                "sequence out of range: " + sequence);
         unCache();
         this.sequence = sequence;
     }

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -1195,7 +1195,7 @@ public class FullBlockTestGenerator {
         NewBlock b63 = createNextBlock(b60, chainHeadHeight + 19, null, null);
         {
             b63.block.getTransactions().get(0).setLockTime(0xffffffffL);
-            b63.block.getTransactions().get(0).getInputs().get(0).setSequenceNumber(0xDEADBEEF);
+            b63.block.getTransactions().get(0).getInputs().get(0).setSequenceNumber(0xdeadbeefL);
             checkState(!b63.block.getTransactions().get(0).isFinal(chainHeadHeight + 17, b63.block.getTimeSeconds()));
         }
         b63.solve();


### PR DESCRIPTION
It turns out a test is supplying an invalid fake value. This is now fixed.