### PR TITLE
Message: parse the original `ByteBuffer`, rather than a copy of it

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AddressMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressMessage.java
@@ -49,7 +49,6 @@ public abstract class AddressMessage extends Message {
         unCache();
         PeerAddress address = addresses.remove(index);
         address.setParent(null);
-        length = UNKNOWN_LENGTH;
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/AddressV1Message.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressV1Message.java
@@ -55,12 +55,10 @@ public class AddressV1Message extends AddressMessage {
             throw new ProtocolException("Address message too large.");
         addresses = new ArrayList<>(numAddresses);
         MessageSerializer serializer = this.serializer.withProtocolVersion(1);
-        length = numAddressesVarInt.getSizeInBytes();
         for (int i = 0; i < numAddresses; i++) {
             PeerAddress addr = new PeerAddress(params, ByteBuffer.wrap(payload, cursor, payload.length - cursor), this, serializer);
             addresses.add(addr);
             cursor += addr.getMessageSize();
-            length += addr.getMessageSize();
         }
     }
 
@@ -72,7 +70,6 @@ public class AddressV1Message extends AddressMessage {
         unCache();
         address.setParent(this);
         addresses.add(address);
-        length = UNKNOWN_LENGTH;
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/AddressV1Message.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressV1Message.java
@@ -56,9 +56,8 @@ public class AddressV1Message extends AddressMessage {
         addresses = new ArrayList<>(numAddresses);
         MessageSerializer serializer = this.serializer.withProtocolVersion(1);
         for (int i = 0; i < numAddresses; i++) {
-            PeerAddress addr = new PeerAddress(params, ByteBuffer.wrap(payload, cursor, payload.length - cursor), this, serializer);
+            PeerAddress addr = new PeerAddress(params, payload, this, serializer);
             addresses.add(addr);
-            cursor += addr.getMessageSize();
         }
     }
 

--- a/core/src/main/java/org/bitcoinj/core/AddressV2Message.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressV2Message.java
@@ -55,12 +55,10 @@ public class AddressV2Message extends AddressMessage {
             throw new ProtocolException("Address message too large.");
         addresses = new ArrayList<>(numAddresses);
         MessageSerializer serializer = this.serializer.withProtocolVersion(2);
-        length = numAddressesVarInt.getSizeInBytes();
         for (int i = 0; i < numAddresses; i++) {
             PeerAddress addr = new PeerAddress(params, ByteBuffer.wrap(payload, cursor, payload.length - cursor), this, serializer);
             addresses.add(addr);
             cursor += addr.getMessageSize();
-            length += addr.getMessageSize();
         }
     }
 
@@ -72,7 +70,6 @@ public class AddressV2Message extends AddressMessage {
         unCache();
         address.setParent(this);
         addresses.add(address);
-        length = UNKNOWN_LENGTH;
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/AddressV2Message.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressV2Message.java
@@ -56,9 +56,8 @@ public class AddressV2Message extends AddressMessage {
         addresses = new ArrayList<>(numAddresses);
         MessageSerializer serializer = this.serializer.withProtocolVersion(2);
         for (int i = 0; i < numAddresses; i++) {
-            PeerAddress addr = new PeerAddress(params, ByteBuffer.wrap(payload, cursor, payload.length - cursor), this, serializer);
+            PeerAddress addr = new PeerAddress(params, payload, this, serializer);
             addresses.add(addr);
-            cursor += addr.getMessageSize();
         }
     }
 

--- a/core/src/main/java/org/bitcoinj/core/BloomFilter.java
+++ b/core/src/main/java/org/bitcoinj/core/BloomFilter.java
@@ -156,7 +156,6 @@ public class BloomFilter extends Message {
             throw new ProtocolException("Bloom filter hash function count out of range");
         nTweak = readUint32();
         nFlags = readBytes(1)[0];
-        length = cursor - offset;
     }
     
     /**

--- a/core/src/main/java/org/bitcoinj/core/ChildMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/ChildMessage.java
@@ -62,16 +62,4 @@ public abstract class ChildMessage extends Message {
         if (parent != null)
             parent.unCache();
     }
-    
-    protected void adjustLength(int adjustment) {
-        adjustLength(0, adjustment);
-    }
-
-    @Override
-    protected void adjustLength(int newArraySize, int adjustment) {
-        super.adjustLength(newArraySize, adjustment);
-        if (parent != null)
-            parent.adjustLength(newArraySize, adjustment);
-    }
-
 }

--- a/core/src/main/java/org/bitcoinj/core/EmptyMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/EmptyMessage.java
@@ -30,17 +30,19 @@ import java.nio.ByteBuffer;
 public abstract class EmptyMessage extends Message {
 
     public EmptyMessage() {
-        length = 0;
     }
 
     public EmptyMessage(NetworkParameters params) {
         super(params);
-        length = 0;
     }
 
     public EmptyMessage(NetworkParameters params, ByteBuffer payload) throws ProtocolException {
         super(params, payload);
-        length = 0;
+    }
+
+    @Override
+    public final int getMessageSize() {
+        return 0;
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/FilteredBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/FilteredBlock.java
@@ -68,9 +68,7 @@ public class FilteredBlock extends Message {
     protected void parse() throws ProtocolException {
         byte[] headerBytes = readBytes(Block.HEADER_SIZE);
         header = params.getDefaultSerializer().makeBlock(ByteBuffer.wrap(headerBytes));
-        merkleTree = new PartialMerkleTree(params, ByteBuffer.wrap(payload, Block.HEADER_SIZE, length - Block.HEADER_SIZE));
-        
-        length = Block.HEADER_SIZE + merkleTree.getMessageSize();
+        merkleTree = new PartialMerkleTree(params, ByteBuffer.wrap(payload, Block.HEADER_SIZE, payload.length - Block.HEADER_SIZE));
     }
     
     /**

--- a/core/src/main/java/org/bitcoinj/core/FilteredBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/FilteredBlock.java
@@ -68,7 +68,7 @@ public class FilteredBlock extends Message {
     protected void parse() throws ProtocolException {
         byte[] headerBytes = readBytes(Block.HEADER_SIZE);
         header = params.getDefaultSerializer().makeBlock(ByteBuffer.wrap(headerBytes));
-        merkleTree = new PartialMerkleTree(params, ByteBuffer.wrap(payload, Block.HEADER_SIZE, payload.length - Block.HEADER_SIZE));
+        merkleTree = new PartialMerkleTree(params, payload);
     }
     
     /**

--- a/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
@@ -55,7 +55,6 @@ public class GetBlocksMessage extends Message {
         int startCount = readVarInt().intValue();
         if (startCount > 500)
             throw new ProtocolException("Number of locators cannot be > 500, received: " + startCount);
-        length = cursor - offset + ((startCount + 1) * 32);
         locator = new BlockLocator();
         for (int i = 0; i < startCount; i++) {
             locator = locator.add(readHash());

--- a/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
@@ -50,7 +50,6 @@ public class GetBlocksMessage extends Message {
 
     @Override
     protected void parse() throws ProtocolException {
-        cursor = offset;
         version = readUint32();
         int startCount = readVarInt().intValue();
         if (startCount > 500)

--- a/core/src/main/java/org/bitcoinj/core/HeadersMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/HeadersMessage.java
@@ -81,12 +81,8 @@ public class HeadersMessage extends Message {
             if (newBlockHeader.hasTransactions()) {
                 throw new ProtocolException("Block header does not end with a null byte");
             }
-            cursor += newBlockHeader.optimalEncodingMessageSize;
+            cursor += newBlockHeader.getMessageSize();
             blockHeaders.add(newBlockHeader);
-        }
-
-        if (length == UNKNOWN_LENGTH) {
-            length = cursor - offset;
         }
 
         if (log.isDebugEnabled()) {

--- a/core/src/main/java/org/bitcoinj/core/HeadersMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/HeadersMessage.java
@@ -77,11 +77,10 @@ public class HeadersMessage extends Message {
         final BitcoinSerializer serializer = this.params.getSerializer();
 
         for (int i = 0; i < numHeaders; ++i) {
-            final Block newBlockHeader = serializer.makeBlock(ByteBuffer.wrap(payload, cursor, payload.length - cursor));
+            final Block newBlockHeader = serializer.makeBlock(payload);
             if (newBlockHeader.hasTransactions()) {
                 throw new ProtocolException("Block header does not end with a null byte");
             }
-            cursor += newBlockHeader.getMessageSize();
             blockHeaders.add(newBlockHeader);
         }
 

--- a/core/src/main/java/org/bitcoinj/core/ListMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/ListMessage.java
@@ -52,7 +52,6 @@ public abstract class ListMessage extends Message {
     public ListMessage(NetworkParameters params) {
         super(params);
         items = new ArrayList<>();
-        length = 1; //length of 0 varint;
     }
 
     public List<InventoryItem> getItems() {
@@ -61,16 +60,12 @@ public abstract class ListMessage extends Message {
 
     public void addItem(InventoryItem item) {
         unCache();
-        length -= VarInt.sizeOf(items.size());
         items.add(item);
-        length += VarInt.sizeOf(items.size()) + InventoryItem.MESSAGE_LENGTH;
     }
 
     public void removeItem(int index) {
         unCache();
-        length -= VarInt.sizeOf(items.size());
         items.remove(index);
-        length += VarInt.sizeOf(items.size()) - InventoryItem.MESSAGE_LENGTH;
     }
 
     @Override
@@ -78,7 +73,6 @@ public abstract class ListMessage extends Message {
         long arrayLen = readVarInt().longValue();
         if (arrayLen > MAX_INVENTORY_ITEMS)
             throw new ProtocolException("Too many items in INV message: " + arrayLen);
-        length = (int) (cursor - offset + (arrayLen * InventoryItem.MESSAGE_LENGTH));
 
         // An inv is vector<CInv> where CInv is int+hash. The int is either 1 or 2 for tx or block.
         items = new ArrayList<>((int) arrayLen);

--- a/core/src/main/java/org/bitcoinj/core/ListMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/ListMessage.java
@@ -77,7 +77,7 @@ public abstract class ListMessage extends Message {
         // An inv is vector<CInv> where CInv is int+hash. The int is either 1 or 2 for tx or block.
         items = new ArrayList<>((int) arrayLen);
         for (int i = 0; i < arrayLen; i++) {
-            if (cursor + InventoryItem.MESSAGE_LENGTH > payload.length) {
+            if (payload.remaining() < InventoryItem.MESSAGE_LENGTH) {
                 throw new ProtocolException("Ran off the end of the INV");
             }
             int typeCode = (int) readUint32();

--- a/core/src/main/java/org/bitcoinj/core/PartialMerkleTree.java
+++ b/core/src/main/java/org/bitcoinj/core/PartialMerkleTree.java
@@ -131,8 +131,6 @@ public class PartialMerkleTree extends Message {
 
         int nFlagBytes = readVarInt().intValue();
         matchedChildBits = readBytes(nFlagBytes);
-
-        length = cursor - offset;
     }
 
     // Based on CPartialMerkleTree::TraverseAndBuild in Bitcoin Core.

--- a/core/src/main/java/org/bitcoinj/core/PeerAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerAddress.java
@@ -300,8 +300,7 @@ public class PeerAddress extends ChildMessage {
                 hostname = null;
             }
         }
-        port = ByteUtils.readUint16BE(payload, cursor);
-        cursor += 2;
+        port = ByteUtils.readUint16BE(payload);
     }
 
     private static InetAddress getByAddress(byte[] addrBytes) {

--- a/core/src/main/java/org/bitcoinj/core/Ping.java
+++ b/core/src/main/java/org/bitcoinj/core/Ping.java
@@ -65,7 +65,6 @@ public class Ping extends Message {
         } catch(ProtocolException e) {
             hasNonce = false;
         }
-        length = hasNonce ? 8 : 0;
     }
     
     public boolean hasNonce() {

--- a/core/src/main/java/org/bitcoinj/core/Pong.java
+++ b/core/src/main/java/org/bitcoinj/core/Pong.java
@@ -44,7 +44,6 @@ public class Pong extends Message {
     @Override
     protected void parse() throws ProtocolException {
         nonce = readInt64();
-        length = 8;
     }
     
     @Override

--- a/core/src/main/java/org/bitcoinj/core/RejectMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/RejectMessage.java
@@ -100,7 +100,6 @@ public class RejectMessage extends Message {
         reason = readStr();
         if (message.equals("block") || message.equals("tx"))
             messageHash = readHash();
-        length = cursor - offset;
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -645,7 +645,6 @@ public class Transaction extends ChildMessage {
     protected void parse() throws ProtocolException {
         boolean allowWitness = allowWitness();
 
-        cursor = offset;
 
         // version
         version = readUint32();
@@ -690,12 +689,13 @@ public class Transaction extends ChildMessage {
         int numInputs = numInputsVarInt.intValue();
         inputs = new ArrayList<>(Math.min((int) numInputs, Utils.MAX_INITIAL_ARRAY_LENGTH));
         for (long i = 0; i < numInputs; i++) {
-            TransactionInput input = new TransactionInput(params, this, ByteBuffer.wrap(payload, cursor, payload.length - cursor), serializer);
+            TransactionInput input = new TransactionInput(params, this, payload.slice(), serializer);
             inputs.add(input);
-            cursor += TransactionOutPoint.MESSAGE_LENGTH;
+            // intentionally read again, due to the slice above
+            skipBytes(TransactionOutPoint.MESSAGE_LENGTH);
             VarInt scriptLenVarInt = readVarInt();
             int scriptLen = scriptLenVarInt.intValue();
-            cursor += scriptLen + 4;
+            skipBytes(scriptLen + 4);
         }
     }
 
@@ -704,12 +704,13 @@ public class Transaction extends ChildMessage {
         int numOutputs = numOutputsVarInt.intValue();
         outputs = new ArrayList<>(Math.min((int) numOutputs, Utils.MAX_INITIAL_ARRAY_LENGTH));
         for (long i = 0; i < numOutputs; i++) {
-            TransactionOutput output = new TransactionOutput(params, this, ByteBuffer.wrap(payload, cursor, payload.length - cursor), serializer);
+            TransactionOutput output = new TransactionOutput(params, this, payload.slice(), serializer);
             outputs.add(output);
-            cursor += 8; // value
+            // intentionally read again, due to the slice above
+            skipBytes(8); // value
             VarInt scriptLenVarInt = readVarInt();
             int scriptLen = scriptLenVarInt.intValue();
-            cursor += scriptLen;
+            skipBytes(scriptLen);
         }
     }
 

--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -160,8 +160,7 @@ public class TransactionInput extends ChildMessage {
 
     @Override
     protected void parse() throws ProtocolException {
-        outpoint = new TransactionOutPoint(params, ByteBuffer.wrap(payload, cursor, payload.length - cursor), this, serializer);
-        cursor += TransactionOutPoint.MESSAGE_LENGTH;
+        outpoint = new TransactionOutPoint(params, payload, this, serializer);
         int scriptLen = readVarInt().intValue();
         scriptBytes = readBytes(scriptLen);
         sequence = readUint32();

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -66,14 +66,12 @@ public class TransactionOutPoint extends ChildMessage {
             // This happens when constructing the genesis block.
             hash = Sha256Hash.ZERO_HASH;
         }
-        length = MESSAGE_LENGTH;
     }
 
     public TransactionOutPoint(NetworkParameters params, long index, Sha256Hash hash) {
         super(params);
         this.index = index;
         this.hash = hash;
-        length = MESSAGE_LENGTH;
     }
 
     public TransactionOutPoint(NetworkParameters params, TransactionOutput connectedOutput) {
@@ -101,9 +99,13 @@ public class TransactionOutPoint extends ChildMessage {
 
     @Override
     protected void parse() throws ProtocolException {
-        length = MESSAGE_LENGTH;
         hash = readHash();
         index = readUint32();
+    }
+
+    @Override
+    public int getMessageSize() {
+        return MESSAGE_LENGTH;
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -121,7 +121,6 @@ public class TransactionOutput extends ChildMessage {
         this.scriptBytes = scriptBytes;
         setParent(parent);
         availableForSpending = true;
-        length = 8 + VarInt.sizeOf(scriptBytes.length) + scriptBytes.length;
     }
 
     public Script getScriptPubKey() throws ScriptException {
@@ -135,8 +134,14 @@ public class TransactionOutput extends ChildMessage {
     protected void parse() throws ProtocolException {
         value = readInt64();
         int scriptLen = readVarInt().intValue();
-        length = cursor - offset + scriptLen;
         scriptBytes = readBytes(scriptLen);
+    }
+
+    @Override
+    public int getMessageSize() {
+        int size = 8; // value
+        size += VarInt.sizeOf(scriptBytes.length) + scriptBytes.length;
+        return size;
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/TransactionWitness.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionWitness.java
@@ -81,6 +81,13 @@ public class TransactionWitness {
         pushes.set(i, value);
     }
 
+    protected int getMessageSize() {
+        int size = VarInt.sizeOf(pushes.size());
+        for (byte[] push : pushes)
+            size += VarInt.sizeOf(push.length) + push.length;
+        return size;
+    }
+
     protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         stream.write(VarInt.of(pushes.size()).encode());
         for (byte[] push : pushes) {

--- a/core/src/main/java/org/bitcoinj/core/UnknownMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/UnknownMessage.java
@@ -35,6 +35,6 @@ public class UnknownMessage extends EmptyMessage {
 
     @Override
     public String toString() {
-        return "Unknown message [" + name + "]" + (payload == null ? "" : ": " + ByteUtils.formatHex(payload));
+        return "Unknown message [" + name + "]";
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/VersionMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionMessage.java
@@ -131,11 +131,9 @@ public class VersionMessage extends Message {
         clientVersion = (int) readUint32();
         localServices = readUint64().longValue();
         time = Instant.ofEpochSecond(readUint64().longValue());
-        receivingAddr = new PeerAddress(params, ByteBuffer.wrap(payload, cursor, payload.length - cursor), this, serializer.withProtocolVersion(0));
-        cursor += receivingAddr.getMessageSize();
+        receivingAddr = new PeerAddress(params, payload, this, serializer.withProtocolVersion(0));
         if (clientVersion >= 106) {
-            fromAddr = new PeerAddress(params, ByteBuffer.wrap(payload, cursor, payload.length - cursor), this, serializer.withProtocolVersion(0));
-            cursor += fromAddr.getMessageSize();
+            fromAddr = new PeerAddress(params, payload, this, serializer.withProtocolVersion(0));
             // uint64 localHostNonce (random data)
             // We don't care about the localhost nonce. It's used to detect connecting back to yourself in cases where
             // there are NATs and proxies in the way. However we don't listen for inbound connections so it's

--- a/core/src/main/java/org/bitcoinj/core/VersionMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionMessage.java
@@ -157,7 +157,6 @@ public class VersionMessage extends Message {
             bestHeight = 0;
             relayTxesBeforeFilter = true;
         }
-        length = cursor - offset;
     }
 
     @Override

--- a/core/src/test/java/org/bitcoinj/core/BlockTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockTest.java
@@ -156,39 +156,6 @@ public class BlockTest {
         // NB: This tests the bitcoin serialization protocol.
         assertArrayEquals(block700000Bytes, block700000.bitcoinSerialize());
     }
-    
-    @Test
-    public void testUpdateLength() {
-        Context.propagate(new Context(100, Transaction.DEFAULT_TX_FEE, false, true));
-        Block block = TESTNET.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, new ECKey().getPubKey(), Block.BLOCK_HEIGHT_GENESIS);
-        assertEquals(block.bitcoinSerialize().length, block.length);
-        final int origBlockLen = block.length;
-        Transaction tx = new Transaction(TESTNET);
-        // this is broken until the transaction has > 1 input + output (which is required anyway...)
-        //assertTrue(tx.length == tx.bitcoinSerialize().length && tx.length == 8);
-        byte[] outputScript = new byte[10];
-        Arrays.fill(outputScript, (byte) ScriptOpCodes.OP_FALSE);
-        tx.addOutput(new TransactionOutput(TESTNET, null, Coin.SATOSHI, outputScript));
-        tx.addInput(new TransactionInput(TESTNET, null, new byte[] {(byte) ScriptOpCodes.OP_FALSE},
-                new TransactionOutPoint(TESTNET, 0, Sha256Hash.of(new byte[] { 1 }))));
-        int origTxLength = 8 + 2 + 8 + 1 + 10 + 40 + 1 + 1;
-        assertEquals(tx.bitcoinSerialize().length, tx.length);
-        assertEquals(origTxLength, tx.length);
-        block.addTransaction(tx);
-        assertEquals(block.bitcoinSerialize().length, block.length);
-        assertEquals(origBlockLen + tx.length, block.length);
-        block.getTransactions().get(1).getInputs().get(0).setScriptBytes(new byte[] {(byte) ScriptOpCodes.OP_FALSE, (byte) ScriptOpCodes.OP_FALSE});
-        assertEquals(block.length, origBlockLen + tx.length);
-        assertEquals(tx.length, origTxLength + 1);
-        block.getTransactions().get(1).getInputs().get(0).clearScriptBytes();
-        assertEquals(block.length, block.bitcoinSerialize().length);
-        assertEquals(block.length, origBlockLen + tx.length);
-        assertEquals(tx.length, origTxLength - 1);
-        block.getTransactions().get(1).addInput(new TransactionInput(TESTNET, null, new byte[] {(byte) ScriptOpCodes.OP_FALSE},
-                new TransactionOutPoint(TESTNET, 0, Sha256Hash.of(new byte[] { 1 }))));
-        assertEquals(block.length, origBlockLen + tx.length);
-        assertEquals(tx.length, origTxLength + 41); // - 1 + 40 + 1 + 1
-    }
 
     @Test
     public void testCoinbaseHeightTestnet() throws Exception {

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -1234,11 +1234,11 @@ public class FullBlockTestGenerator {
             // The following checks are checking to ensure block serialization functions in the way needed for this test
             // If they fail, it is likely not an indication of error, but an indication that this test needs rewritten
             checkState(stream.size() == b64Original.block.getMessageSize() + 8);
-            checkState(stream.size() == b64.getMessageSize());
             // This check fails because it was created for "retain mode" and the likely encoding is not "optimal".
             // We since removed this capability retain the original encoding, but could not rewrite this test data.
+            // checkState(stream.size() == b64.getMessageSize());
             // checkState(Arrays.equals(stream.toByteArray(), b64.bitcoinSerialize()));
-            checkState(b64.getOptimalEncodingMessageSize() == b64Original.block.getMessageSize());
+            // checkState(b64.getOptimalEncodingMessageSize() == b64Original.block.getMessageSize());
         }
         blocks.add(new BlockAndValidity(b64, true, false, b64.getHash(), chainHeadHeight + 19, "b64"));
         spendableOutputs.offer(b64Original.getCoinbaseOutput());

--- a/core/src/test/java/org/bitcoinj/core/PeerAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerAddressTest.java
@@ -45,7 +45,7 @@ public class PeerAddressTest {
     public void equalsContract() {
         EqualsVerifier.forClass(PeerAddress.class)
                 .suppress(Warning.NONFINAL_FIELDS)
-                .withIgnoredFields("time", "parent", "params", "offset", "cursor", "length", "payload", "serializer")
+                .withIgnoredFields("time", "parent", "params", "offset", "cursor", "payload", "serializer")
                 .usingGetClass()
                 .verify();
     }
@@ -57,7 +57,6 @@ public class PeerAddressTest {
         String hex = "010000000000000000000000000000000000ffff0a000001208d";
         PeerAddress pa = new PeerAddress(MAINNET, ByteBuffer.wrap(ByteUtils.parseHex(hex)), null,
                 serializer);
-        assertEquals(26, pa.length);
         assertEquals(VersionMessage.NODE_NETWORK, pa.getServices().longValue());
         assertEquals("10.0.0.1", pa.getAddr().getHostAddress());
         assertEquals(8333, pa.getPort());
@@ -69,7 +68,6 @@ public class PeerAddressTest {
         PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName(null), 8333, BigInteger.ZERO,
                 serializer);
         assertEquals("000000000000000000000000000000000000ffff7f000001208d", ByteUtils.formatHex(pa.bitcoinSerialize()));
-        assertEquals(26, pa.length);
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/core/PeerAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerAddressTest.java
@@ -45,7 +45,7 @@ public class PeerAddressTest {
     public void equalsContract() {
         EqualsVerifier.forClass(PeerAddress.class)
                 .suppress(Warning.NONFINAL_FIELDS)
-                .withIgnoredFields("time", "parent", "params", "offset", "cursor", "payload", "serializer")
+                .withIgnoredFields("time", "parent", "params", "payload", "serializer")
                 .usingGetClass()
                 .verify();
     }

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -163,27 +163,23 @@ public class TransactionTest {
     }
 
     @Test
-    public void testOptimalEncodingMessageSize() {
+    public void testMessageSize() {
         Transaction tx = new Transaction(TESTNET);
-        int length = tx.length; // at this raw stage, doesn't include numInputs/numOutputs fields
+        int length = tx.getMessageSize();
 
         // add fake transaction input
         TransactionInput input = new TransactionInput(TESTNET, null, ScriptBuilder.createEmpty().getProgram(),
                 new TransactionOutPoint(TESTNET, 0, Sha256Hash.ZERO_HASH));
         tx.addInput(input);
-        length += 1; // numInputs field
-        length += input.length;
+        length += input.getMessageSize();
 
         // add fake transaction output
         TransactionOutput output = new TransactionOutput(TESTNET, null, Coin.COIN, ADDRESS);
         tx.addOutput(output);
-        length += 1; // numOutputs field
-        length += output.length;
+        length += output.getMessageSize();
 
         // message size has now grown
         assertEquals(length, tx.getMessageSize());
-        // optimal encoding size should equal the length we just calculated
-        assertEquals(length, tx.getOptimalEncodingMessageSize());
     }
 
     @Test


### PR DESCRIPTION
This has the advantage of using the read position contained in `ByteBuffer`, so we remove our `offset` and `cursor` fields.