### PR TITLE
Message: make `serializer` field immutable

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/ChildMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/ChildMessage.java
@@ -33,6 +33,10 @@ public abstract class ChildMessage extends Message {
         super(params);
     }
 
+    public ChildMessage(NetworkParameters params, MessageSerializer serializer) {
+        super(params, serializer);
+    }
+
     public ChildMessage(NetworkParameters params, ByteBuffer payload) throws ProtocolException {
         super(params, payload);
     }

--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -50,7 +50,7 @@ public abstract class Message {
     // The raw message payload bytes themselves.
     protected ByteBuffer payload;
 
-    protected MessageSerializer serializer;
+    protected final MessageSerializer serializer;
 
     @Nullable
     protected final NetworkParameters params;
@@ -63,6 +63,11 @@ public abstract class Message {
     protected Message(NetworkParameters params) {
         this.params = params;
         this.serializer = params.getDefaultSerializer();
+    }
+
+    protected Message(NetworkParameters params, MessageSerializer serializer) {
+        this.params = params;
+        this.serializer = serializer;
     }
 
     /**
@@ -97,17 +102,6 @@ public abstract class Message {
      * invalidated unless they are also modified internally.</p>
      */
     protected void unCache() {
-    }
-
-    /**
-     * Overrides the message serializer.
-     * @param serializer the new serializer
-     */
-    public void setSerializer(MessageSerializer serializer) {
-        if (!this.serializer.equals(serializer)) {
-            this.serializer = serializer;
-            unCache();
-        }
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/PeerAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerAddress.java
@@ -96,10 +96,9 @@ public class PeerAddress extends ChildMessage {
      * Construct a peer address from a memorized or hardcoded address.
      */
     public PeerAddress(NetworkParameters params, InetAddress addr, int port, BigInteger services, MessageSerializer serializer) {
-        super(params);
+        super(params, serializer);
         this.addr = Objects.requireNonNull(addr);
         this.port = port;
-        setSerializer(serializer);
         this.services = services;
         this.time = Optional.of(TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS));
     }


### PR DESCRIPTION
This requires two new pass-through constructors, but in return we get rid of the setter.