### PR TITLE
Ping: require a nonce value

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -1601,8 +1601,7 @@ public class Peer extends PeerSocketHandler {
     }
 
     private void processPing(Ping m) {
-        if (m.hasNonce())
-            sendMessage(new Pong(m.getNonce()));
+        sendMessage(new Pong(m.getNonce()));
     }
 
     protected void processPong(Pong m) {

--- a/core/src/main/java/org/bitcoinj/core/Ping.java
+++ b/core/src/main/java/org/bitcoinj/core/Ping.java
@@ -22,55 +22,50 @@ import org.bitcoinj.base.internal.ByteUtils;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.util.Random;
 
 /**
+ * <p>See <a href="https://github.com/bitcoin/bips/blob/master/bip-0031.mediawiki">BIP31</a> for details.</p>
+ *
  * <p>Instances of this class are not safe for use by multiple threads.</p>
  */
 public class Ping extends Message {
     private long nonce;
-    private boolean hasNonce;
-    
+
     public Ping(NetworkParameters params, ByteBuffer payload) throws ProtocolException {
         super(params, payload);
     }
-    
+
     /**
-     * Create a Ping with a nonce value.
-     * Only use this if the remote node has a protocol version greater than 60000
+     * Create a Ping with a given nonce value.
      */
     public Ping(long nonce) {
         this.nonce = nonce;
-        this.hasNonce = true;
     }
-    
+
     /**
-     * Create a Ping without a nonce value.
-     * Only use this if the remote node has a protocol version lower than or equal 60000
+     * Create a Ping with a random nonce value.
      */
     public Ping() {
-        this.hasNonce = false;
+        this.nonce = new Random().nextLong();
     }
-    
+
     @Override
     public void bitcoinSerializeToStream(OutputStream stream) throws IOException {
-        if (hasNonce)
-            ByteUtils.writeInt64LE(nonce, stream);
+        ByteUtils.writeInt64LE(nonce, stream);
     }
 
     @Override
     protected void parse() throws ProtocolException {
-        try {
-            nonce = readInt64();
-            hasNonce = true;
-        } catch(ProtocolException e) {
-            hasNonce = false;
-        }
+        nonce = readInt64();
     }
-    
+
+    /** @deprecated returns true */
+    @Deprecated
     public boolean hasNonce() {
-        return hasNonce;
+        return true;
     }
-    
+
     public long getNonce() {
         return nonce;
     }

--- a/core/src/main/java/org/bitcoinj/core/Pong.java
+++ b/core/src/main/java/org/bitcoinj/core/Pong.java
@@ -24,6 +24,8 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
 /**
+ * <p>See <a href="https://github.com/bitcoin/bips/blob/master/bip-0031.mediawiki">BIP31</a> for details.</p>
+ *
  * <p>Instances of this class are not safe for use by multiple threads.</p>
  */
 public class Pong extends Message {


### PR DESCRIPTION
Pings without nonce are not protocol compliant since version 60001. Our minimum version is at 70000.