### PR TITLE
SeedPeers: use ByteBuffer directly for address conversion

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/internal/ByteUtils.java
+++ b/core/src/main/java/org/bitcoinj/base/internal/ByteUtils.java
@@ -204,31 +204,6 @@ public class ByteUtils {
     }
 
     /**
-     * Write 4 bytes to the buffer as signed 32-bit integer in big endian format.
-     * @param val value to be written
-     * @param buf buffer to be written into
-     * @return the buffer
-     * @throws BufferOverflowException if the value doesn't fit the remaining buffer
-     */
-    public static ByteBuffer writeInt32BE(int val, ByteBuffer buf) throws BufferOverflowException {
-        return buf.order(ByteOrder.BIG_ENDIAN).putInt((int) val);
-    }
-
-    /**
-     * Write 4 bytes to the byte array (starting at the offset) as signed 32-bit integer in big endian format.
-     * @param val value to be written
-     * @param out buffer to be written into
-     * @param offset offset into the buffer
-     * @throws ArrayIndexOutOfBoundsException if offset points outside of the buffer, or
-     *                                        if the value doesn't fit the remaining buffer
-     */
-    public static void writeInt32BE(int val, byte[] out, int offset) throws ArrayIndexOutOfBoundsException {
-        check(offset >= 0 && offset <= out.length - 4, () ->
-                new ArrayIndexOutOfBoundsException(offset));
-        writeInt32BE(val, ByteBuffer.wrap(out, offset, out.length - offset));
-    }
-
-    /**
      * Write 8 bytes to the buffer as signed 64-bit integer in little endian format.
      * @param val value to be written
      * @param buf buffer to be written into

--- a/core/src/main/java/org/bitcoinj/net/discovery/SeedPeers.java
+++ b/core/src/main/java/org/bitcoinj/net/discovery/SeedPeers.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
@@ -121,8 +122,7 @@ public class SeedPeers implements PeerDiscovery {
     }
 
     private static InetAddress convertAddress(int seed) throws UnknownHostException {
-        byte[] v4addr = new byte[4];
-        ByteUtils.writeInt32BE(seed, v4addr, 0);
+        byte[] v4addr = ByteBuffer.allocate(4).putInt(seed).array(); // Big-Endian
         return InetAddress.getByAddress(v4addr);
     }
 }


### PR DESCRIPTION
This removes the added `ByteUtils` methods of b8f77abe62947deb41847bb1458bf46aa9f466ab and uses `ByteBuffer` directly.