### PR TITLE
Message: get rid of `payload` field

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AddressV1Message.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressV1Message.java
@@ -48,7 +48,7 @@ public class AddressV1Message extends AddressMessage {
     }
 
     @Override
-    protected void parse() throws BufferUnderflowException, ProtocolException {
+    protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         final VarInt numAddressesVarInt = VarInt.read(payload);
         int numAddresses = numAddressesVarInt.intValue();
         // Guard against ultra large messages that will crash us.

--- a/core/src/main/java/org/bitcoinj/core/AddressV2Message.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressV2Message.java
@@ -48,7 +48,7 @@ public class AddressV2Message extends AddressMessage {
     }
 
     @Override
-    protected void parse() throws BufferUnderflowException, ProtocolException {
+    protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         final VarInt numAddressesVarInt = VarInt.read(payload);
         int numAddresses = numAddressesVarInt.intValue();
         // Guard against ultra large messages that will crash us.

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -221,7 +221,7 @@ public class Block extends Message {
     /**
      * Parse transactions from the block.
      */
-    protected void parseTransactions() throws ProtocolException {
+    protected void parseTransactions(ByteBuffer payload) throws ProtocolException {
         VarInt numTransactionsVarInt = VarInt.read(payload);
         int numTransactions = numTransactionsVarInt.intValue();
         transactions = new ArrayList<>(Math.min(numTransactions, Utils.MAX_INITIAL_ARRAY_LENGTH));
@@ -234,7 +234,7 @@ public class Block extends Message {
     }
 
     @Override
-    protected void parse() throws BufferUnderflowException, ProtocolException {
+    protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         // header
         payload.mark();
         version = ByteUtils.readUint32(payload);
@@ -248,7 +248,7 @@ public class Block extends Message {
 
         // transactions
         if (payload.hasRemaining()) // otherwise this message is just a header
-            parseTransactions();
+            parseTransactions(payload);
     }
 
     public static Block createGenesis(NetworkParameters n) {

--- a/core/src/main/java/org/bitcoinj/core/BloomFilter.java
+++ b/core/src/main/java/org/bitcoinj/core/BloomFilter.java
@@ -149,7 +149,7 @@ public class BloomFilter extends Message {
     }
 
     @Override
-    protected void parse() throws BufferUnderflowException, ProtocolException {
+    protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         data = Buffers.readLengthPrefixedBytes(payload);
         if (data.length > MAX_FILTER_SIZE)
             throw new ProtocolException ("Bloom filter out of size range.");

--- a/core/src/main/java/org/bitcoinj/core/EmptyMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/EmptyMessage.java
@@ -20,6 +20,7 @@ package org.bitcoinj.core;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
 
 /**
  * <p>Parent class for header only messages that don't have a payload.
@@ -43,6 +44,6 @@ public abstract class EmptyMessage extends Message {
     }
 
     @Override
-    protected void parse() throws BufferUnderflowException, ProtocolException {
+    protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/FeeFilterMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/FeeFilterMessage.java
@@ -48,7 +48,7 @@ public class FeeFilterMessage extends Message {
     }
 
     @Override
-    protected void parse() throws BufferUnderflowException, ProtocolException {
+    protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         feeRate = Coin.ofSat(ByteUtils.readInt64(payload));
         check(feeRate.signum() >= 0, () -> new ProtocolException("fee rate out of range: " + feeRate));
     }

--- a/core/src/main/java/org/bitcoinj/core/FilteredBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/FilteredBlock.java
@@ -67,7 +67,7 @@ public class FilteredBlock extends Message {
     }
 
     @Override
-    protected void parse() throws BufferUnderflowException, ProtocolException {
+    protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         byte[] headerBytes = Buffers.readBytes(payload, Block.HEADER_SIZE);
         header = new Block(params, ByteBuffer.wrap(headerBytes));
         merkleTree = new PartialMerkleTree(params, payload);

--- a/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
@@ -49,7 +49,7 @@ public class GetBlocksMessage extends Message {
     }
 
     @Override
-    protected void parse() throws BufferUnderflowException, ProtocolException {
+    protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         version = ByteUtils.readUint32(payload);
         int startCount = VarInt.read(payload).intValue();
         if (startCount > 500)

--- a/core/src/main/java/org/bitcoinj/core/HeadersMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/HeadersMessage.java
@@ -68,7 +68,7 @@ public class HeadersMessage extends Message {
     }
 
     @Override
-    protected void parse() throws BufferUnderflowException, ProtocolException {
+    protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         int numHeaders = VarInt.read(payload).intValue();
         if (numHeaders > MAX_HEADERS)
             throw new ProtocolException("Too many headers: got " + numHeaders + " which is larger than " +

--- a/core/src/main/java/org/bitcoinj/core/ListMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/ListMessage.java
@@ -66,7 +66,7 @@ public abstract class ListMessage extends Message {
     }
 
     @Override
-    protected void parse() throws BufferUnderflowException, ProtocolException {
+    protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         long arrayLen = VarInt.read(payload).longValue();
         if (arrayLen > MAX_INVENTORY_ITEMS)
             throw new ProtocolException("Too many items in INV message: " + arrayLen);

--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -40,9 +40,6 @@ public abstract class Message {
 
     public static final int MAX_SIZE = 0x02000000; // 32MB
 
-    // The raw message payload bytes themselves.
-    protected ByteBuffer payload;
-
     protected final MessageSerializer serializer;
 
     @Nullable
@@ -73,15 +70,12 @@ public abstract class Message {
     protected Message(NetworkParameters params, ByteBuffer payload, MessageSerializer serializer) throws ProtocolException {
         this.serializer = serializer;
         this.params = params;
-        this.payload = payload;
 
         try {
-            parse();
+            parse(payload);
         } catch(BufferUnderflowException e) {
             throw new ProtocolException(e);
         }
-
-        this.payload = null;
     }
 
     protected Message(ByteBuffer payload) throws ProtocolException {
@@ -94,7 +88,7 @@ public abstract class Message {
 
     // These methods handle the serialization/deserialization using the custom Bitcoin protocol.
 
-    protected abstract void parse() throws BufferUnderflowException, ProtocolException;
+    protected abstract void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException;
 
     /**
      * <p>To be called before any change of internal values including any setters. This ensures any cached byte array is

--- a/core/src/main/java/org/bitcoinj/core/PartialMerkleTree.java
+++ b/core/src/main/java/org/bitcoinj/core/PartialMerkleTree.java
@@ -123,7 +123,7 @@ public class PartialMerkleTree extends Message {
     }
 
     @Override
-    protected void parse() throws BufferUnderflowException, ProtocolException {
+    protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         transactionCount = (int) ByteUtils.readUint32(payload);
 
         int nHashes = VarInt.read(payload).intValue();

--- a/core/src/main/java/org/bitcoinj/core/PeerAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerAddress.java
@@ -229,7 +229,7 @@ public class PeerAddress extends Message {
     }
 
     @Override
-    protected void parse() throws BufferUnderflowException, ProtocolException {
+    protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         int protocolVersion = serializer.getProtocolVersion();
         if (protocolVersion < 0 || protocolVersion > 2)
             throw new IllegalStateException("invalid protocolVersion: " + protocolVersion);

--- a/core/src/main/java/org/bitcoinj/core/Ping.java
+++ b/core/src/main/java/org/bitcoinj/core/Ping.java
@@ -57,7 +57,7 @@ public class Ping extends Message {
     }
 
     @Override
-    protected void parse() throws BufferUnderflowException, ProtocolException {
+    protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         nonce = ByteUtils.readInt64(payload);
     }
 

--- a/core/src/main/java/org/bitcoinj/core/Pong.java
+++ b/core/src/main/java/org/bitcoinj/core/Pong.java
@@ -45,7 +45,7 @@ public class Pong extends Message {
     }
     
     @Override
-    protected void parse() throws BufferUnderflowException, ProtocolException {
+    protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         nonce = ByteUtils.readInt64(payload);
     }
     

--- a/core/src/main/java/org/bitcoinj/core/RejectMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/RejectMessage.java
@@ -95,7 +95,7 @@ public class RejectMessage extends Message {
     }
 
     @Override
-    protected void parse() throws BufferUnderflowException, ProtocolException {
+    protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         message = Buffers.readLengthPrefixedString(payload);
         code = RejectCode.fromCode(payload.get());
         reason = Buffers.readLengthPrefixedString(payload);

--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -161,7 +161,7 @@ public class TransactionInput extends ChildMessage {
     }
 
     @Override
-    protected void parse() throws BufferUnderflowException, ProtocolException {
+    protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         outpoint = new TransactionOutPoint(payload);
         int scriptLen = VarInt.read(payload).intValue();
         scriptBytes = Buffers.readBytes(payload, scriptLen);

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -94,7 +94,7 @@ public class TransactionOutPoint extends Message {
     }
 
     @Override
-    protected void parse() throws BufferUnderflowException, ProtocolException {
+    protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         hash = Sha256Hash.read(payload);
         index = ByteUtils.readUint32(payload);
     }

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -134,7 +134,7 @@ public class TransactionOutput extends ChildMessage {
     }
 
     @Override
-    protected void parse() throws BufferUnderflowException, ProtocolException {
+    protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         value = ByteUtils.readInt64(payload);
         // Negative values obviously make no sense, except for -1 which is used as a sentinel value when calculating
         // SIGHASH_SINGLE signatures, so unfortunately we have to allow that here.

--- a/core/src/main/java/org/bitcoinj/core/VersionMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionMessage.java
@@ -112,7 +112,7 @@ public class VersionMessage extends Message {
     }
 
     @Override
-    protected void parse() throws BufferUnderflowException, ProtocolException {
+    protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         clientVersion = (int) ByteUtils.readUint32(payload);
         localServices = Services.read(payload);
         time = Instant.ofEpochSecond(ByteUtils.readInt64(payload));

--- a/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
@@ -233,7 +233,7 @@ public class BitcoinSerializerTest {
 
         Message unknownMessage = new Message() {
             @Override
-            protected void parse() throws BufferUnderflowException, ProtocolException {
+            protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
             }
         };
         ByteArrayOutputStream bos = new ByteArrayOutputStream(ADDRESS_MESSAGE_BYTES.length);

--- a/core/src/test/java/org/bitcoinj/core/MessageTest.java
+++ b/core/src/test/java/org/bitcoinj/core/MessageTest.java
@@ -42,7 +42,7 @@ public class MessageTest {
         }
 
         @Override
-        protected void parse() throws BufferUnderflowException, ProtocolException {
+        protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
             Buffers.readLengthPrefixedString(payload);
         }
     }
@@ -61,7 +61,7 @@ public class MessageTest {
         }
 
         @Override
-        protected void parse() throws BufferUnderflowException, ProtocolException {
+        protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
             Buffers.readLengthPrefixedBytes(payload);
         }
     }

--- a/core/src/test/java/org/bitcoinj/core/PeerAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerAddressTest.java
@@ -45,7 +45,7 @@ public class PeerAddressTest {
     public void equalsContract() {
         EqualsVerifier.forClass(PeerAddress.class)
                 .suppress(Warning.NONFINAL_FIELDS)
-                .withIgnoredFields("time", "params", "payload", "serializer")
+                .withIgnoredFields("time", "params", "serializer")
                 .usingGetClass()
                 .verify();
     }


### PR DESCRIPTION
It's now passed into the `parse()` method, and passed along from there.