### PR TITLE
ByteUtils: add `readUint64()` helper to read unsigned 64-bit values

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/internal/Buffers.java
+++ b/core/src/main/java/org/bitcoinj/base/internal/Buffers.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.base.internal;
+
+import org.bitcoinj.base.VarInt;
+
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import static org.bitcoinj.base.internal.Preconditions.check;
+import static org.bitcoinj.base.internal.Preconditions.checkArgument;
+import static org.bitcoinj.base.internal.Preconditions.checkState;
+
+public class Buffers {
+    /**
+     * Read given number of bytes from the buffer.
+     *
+     * @param buf    buffer to read from
+     * @param length number of bytes to read
+     * @return bytes read
+     * @throws BufferUnderflowException if the read value extends beyond the remaining bytes of the buffer
+     */
+    public static byte[] readBytes(ByteBuffer buf, int length) throws BufferUnderflowException {
+        // defensive check against cheap memory exhaustion attack
+        check(length <= buf.remaining(), BufferUnderflowException::new);
+        byte[] b = new byte[length];
+        buf.get(b);
+        return b;
+    }
+
+    /**
+     * First read a {@link VarInt} to determine the number of bytes to read. Then read that number of bytes from the
+     * buffer. This construct is frequently used by the Bitcoin protocol.
+     *
+     * @param buf buffer to read from
+     * @return read bytes
+     * @throws BufferUnderflowException if the read value extends beyond the remaining bytes of the buffer
+     */
+    public static byte[] readByteArray(ByteBuffer buf) throws BufferUnderflowException {
+        int length = VarInt.read(buf).intValue();
+        return readBytes(buf, length);
+    }
+
+    /**
+     * First read a {@link VarInt} to determine the number of bytes to read. Then read that number of bytes from the
+     * buffer and interpret it as an UTF-8 encoded string. This construct is frequently used by the Bitcoin protocol.
+     *
+     * @param buf buffer to read from
+     * @return read string
+     * @throws BufferUnderflowException if the read value extends beyond the remaining bytes of the buffer
+     */
+    public static String readString(ByteBuffer buf) throws BufferUnderflowException {
+        return new String(readByteArray(buf), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Advance buffer position by a given number of bytes.
+     *
+     * @param buf      buffer to skip bytes on
+     * @param numBytes number of bytes to skip
+     * @return the buffer
+     * @throws BufferUnderflowException if the read value extends beyond the remaining bytes of the buffer
+     */
+    public static ByteBuffer skipBytes(ByteBuffer buf, int numBytes) throws BufferUnderflowException {
+        checkArgument(numBytes >= 0);
+        check(numBytes <= buf.remaining(), BufferUnderflowException::new);
+        buf.position(buf.position() + numBytes);
+        return buf;
+    }
+}

--- a/core/src/main/java/org/bitcoinj/base/internal/ByteUtils.java
+++ b/core/src/main/java/org/bitcoinj/base/internal/ByteUtils.java
@@ -421,6 +421,16 @@ public class ByteUtils {
     }
 
     /**
+     * Read 8 bytes from the buffer as unsigned 64-bit integer in little endian format.
+     * @param buf buffer to be read from
+     * @throws BufferUnderflowException if the read value extends beyond the remaining bytes of the buffer
+     */
+    public static BigInteger readUint64(ByteBuffer buf) throws BufferUnderflowException {
+        // Java does not have an unsigned 64 bit type. So scrape it off the wire then flip
+        return new BigInteger(ByteUtils.reverseBytes(Buffers.readBytes(buf, 8)));
+    }
+
+    /**
      * Read 8 bytes from the buffer as signed 64-bit integer in little endian format.
      * @param buf buffer to be read from
      * @throws BufferUnderflowException if the read value extends beyond the remaining bytes of the buffer

--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -158,8 +158,11 @@ public abstract class Message {
     }
 
     protected BigInteger readUint64() throws ProtocolException {
-        // Java does not have an unsigned 64 bit type. So scrape it off the wire then flip.
-        return new BigInteger(ByteUtils.reverseBytes(readBytes(8)));
+        try {
+            return ByteUtils.readUint64(payload);
+        } catch (BufferUnderflowException e) {
+            throw new ProtocolException(e);
+        }
     }
 
     protected VarInt readVarInt() throws ProtocolException {


### PR DESCRIPTION
This is a followup PR to #2866.