### PR TITLE
WIP: Move depth to wallet

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -784,19 +784,6 @@ public class Transaction extends ChildMessage {
         return inputs.size() == 1 && inputs.get(0).isCoinBase();
     }
 
-    /**
-     * A transaction is mature if it is either a building coinbase tx that is as deep or deeper than the required coinbase depth, or a non-coinbase tx.
-     */
-    public boolean isMature() {
-        if (!isCoinBase())
-            return true;
-
-        if (getConfidence().getConfidenceType() != ConfidenceType.BUILDING)
-            return false;
-
-        return getConfidence().getDepthInBlocks() >= params.getSpendableCoinbaseDepth();
-    }
-
     @Override
     public String toString() {
         MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this);

--- a/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
@@ -143,7 +143,6 @@ public class TransactionConfidence {
     }
 
     private ConfidenceType confidenceType = ConfidenceType.UNKNOWN;
-    private int appearedAtChainHeight = -1;
     // The transaction that double spent this one, if any.
     private Transaction overridingTransaction;
 
@@ -252,23 +251,12 @@ public class TransactionConfidence {
     }
 
     /**
-     * Returns the chain height at which the transaction appeared if confidence type is BUILDING.
-     * @throws IllegalStateException if the confidence type is not BUILDING.
-     */
-    public synchronized int getAppearedAtChainHeight() {
-        if (getConfidenceType() != ConfidenceType.BUILDING)
-            throw new IllegalStateException("Confidence type is " + getConfidenceType() + ", not BUILDING");
-        return appearedAtChainHeight;
-    }
-
-    /**
      * The chain height at which the transaction appeared, if it has been seen in the best chain. Automatically sets
      * the current type to {@link ConfidenceType#BUILDING} and depth to one.
      */
     public synchronized void setAppearedAtChainHeight(int appearedAtChainHeight) {
         if (appearedAtChainHeight < 0)
             throw new IllegalArgumentException("appearedAtChainHeight out of range");
-        this.appearedAtChainHeight = appearedAtChainHeight;
         this.depth = 1;
         setConfidenceType(ConfidenceType.BUILDING);
     }
@@ -293,7 +281,6 @@ public class TransactionConfidence {
         }
         if (confidenceType == ConfidenceType.PENDING || confidenceType == ConfidenceType.IN_CONFLICT) {
             depth = 0;
-            appearedAtChainHeight = -1;
         }
     }
 
@@ -392,8 +379,7 @@ public class TransactionConfidence {
                 builder.append("In conflict.");
                 break;
             case BUILDING:
-                builder.append(String.format(Locale.US, "Appeared in best chain at height %d, depth %d.",
-                        getAppearedAtChainHeight(), getDepthInBlocks()));
+                builder.append("Is included in a block and depth is increasing");
                 break;
         }
         if (source != Source.UNKNOWN)
@@ -476,7 +462,6 @@ public class TransactionConfidence {
         synchronized (this) {
             c.confidenceType = confidenceType;
             c.overridingTransaction = overridingTransaction;
-            c.appearedAtChainHeight = appearedAtChainHeight;
         }
         return c;
     }

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -374,23 +374,6 @@ public class TransactionOutput extends ChildMessage {
     }
 
     /**
-     * Returns the depth in blocks of the parent tx.
-     *
-     * <p>If the transaction appears in the top block, the depth is one. If it's anything else (pending, dead, unknown)
-     * then -1.</p>
-     * @return The tx depth or -1.
-     */
-    public int getParentTransactionDepthInBlocks() {
-        if (getParentTransaction() != null) {
-            TransactionConfidence confidence = getParentTransaction().getConfidence();
-            if (confidence.getConfidenceType() == TransactionConfidence.ConfidenceType.BUILDING) {
-                return confidence.getDepthInBlocks();
-            }
-        }
-        return -1;
-    }
-
-    /**
      * Returns a new {@link TransactionOutPoint}, which is essentially a structure pointing to this output.
      * Requires that this output is not detached.
      */

--- a/core/src/main/java/org/bitcoinj/wallet/CoinSelector.java
+++ b/core/src/main/java/org/bitcoinj/wallet/CoinSelector.java
@@ -33,5 +33,5 @@ public interface CoinSelector {
      * this call and can be edited freely. See the docs for CoinSelection to learn more, or look a the implementation
      * of {@link DefaultCoinSelector}.
      */
-    CoinSelection select(Coin target, List<TransactionOutput> candidates);
+    CoinSelection select(Coin target, List<TransactionOutput> candidates, DepthProvider depthProvider);
 }

--- a/core/src/main/java/org/bitcoinj/wallet/DepthProvider.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DepthProvider.java
@@ -1,0 +1,8 @@
+package org.bitcoinj.wallet;
+
+import org.bitcoinj.base.Sha256Hash;
+
+import java.util.function.Function;
+
+public interface DepthProvider extends Function<Sha256Hash, Integer> {
+}

--- a/core/src/main/java/org/bitcoinj/wallet/FilteringCoinSelector.java
+++ b/core/src/main/java/org/bitcoinj/wallet/FilteringCoinSelector.java
@@ -44,12 +44,12 @@ public class FilteringCoinSelector implements CoinSelector {
     }
 
     @Override
-    public CoinSelection select(Coin target, List<TransactionOutput> candidates) {
+    public CoinSelection select(Coin target, List<TransactionOutput> candidates, DepthProvider depthProvider) {
         Iterator<TransactionOutput> iter = candidates.iterator();
         while (iter.hasNext()) {
             TransactionOutput output = iter.next();
             if (spent.contains(output.getOutPointFor())) iter.remove();
         }
-        return delegate.select(target, candidates);
+        return delegate.select(target, candidates, depthProvider);
     }
 }

--- a/core/src/main/java/org/bitcoinj/wallet/KeyTimeCoinSelector.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyTimeCoinSelector.java
@@ -61,7 +61,7 @@ public class KeyTimeCoinSelector implements CoinSelector {
     }
 
     @Override
-    public CoinSelection select(Coin target, List<TransactionOutput> candidates) {
+    public CoinSelection select(Coin target, List<TransactionOutput> candidates, DepthProvider depthProvider) {
         try {
             LinkedList<TransactionOutput> gathered = new LinkedList<>();
             for (TransactionOutput output : candidates) {

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -361,8 +361,8 @@ public class WalletProtobufSerializer {
         synchronized (confidence) {
             confidenceBuilder.setType(Protos.TransactionConfidence.Type.forNumber(confidence.getConfidenceType().getValue()));
             if (confidence.getConfidenceType() == ConfidenceType.BUILDING) {
-                confidenceBuilder.setAppearedAtHeight(confidence.getAppearedAtChainHeight());
-                confidenceBuilder.setDepth(confidence.getDepthInBlocks());
+                //confidenceBuilder.setAppearedAtHeight(confidence.getAppearedAtChainHeight());
+                //confidenceBuilder.setDepth(confidence.getDepthInBlocks());
             }
             if (confidence.getConfidenceType() == ConfidenceType.DEAD) {
                 // Copy in the overriding transaction, if available.
@@ -783,14 +783,7 @@ public class WalletProtobufSerializer {
                 log.warn("Have appearedAtHeight but not BUILDING for tx {}", tx.getTxId());
                 return;
             }
-            confidence.setAppearedAtChainHeight(confidenceProto.getAppearedAtHeight());
-        }
-        if (confidenceProto.hasDepth()) {
-            if (confidence.getConfidenceType() != ConfidenceType.BUILDING) {
-                log.warn("Have depth but not BUILDING for tx {}", tx.getTxId());
-                return;
-            }
-            confidence.setDepthInBlocks(confidenceProto.getDepth());
+            //confidence.setAppearedAtChainHeight(confidenceProto.getAppearedAtHeight());
         }
         if (confidenceProto.hasOverridingTransaction()) {
             if (confidence.getConfidenceType() != ConfidenceType.DEAD) {

--- a/core/src/main/java/org/bitcoinj/wallet/WalletTxHelper.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletTxHelper.java
@@ -1,0 +1,40 @@
+package org.bitcoinj.wallet;
+
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.Transaction;
+
+import javax.annotation.Nullable;
+
+public class WalletTxHelper {
+
+    /**
+     * <p>Depth in the chain is an approximation of how much time has elapsed since the transaction has been confirmed.
+     * On average there is supposed to be a new block every 10 minutes, but the actual rate may vary. Bitcoin Core
+     * considers a transaction impractical to reverse after 6 blocks, but as of EOY 2011 network
+     * security is high enough that often only one block is considered enough even for high value transactions. For low
+     * value transactions like songs, or other cheap items, no blocks at all may be necessary.</p>
+     *
+     * <p>If the transaction appears in the top block, the depth is one. If it's anything else (pending, dead, unknown)
+     * the depth is zero.</p>
+     */
+    public static int calcDepth(@Nullable Integer appearedAtChainHeight, int lastBlockSeenHeight) {
+        if (appearedAtChainHeight == null){
+            return 0;
+        }
+        return lastBlockSeenHeight - appearedAtChainHeight + 1;
+    }
+
+    /**
+     * A transaction is mature if it is either a building coinbase tx that is as deep or deeper than the required coinbase depth, or a non-coinbase tx.
+     */
+    public static boolean isMature(NetworkParameters params,
+                                   Transaction tx,
+                                   @Nullable Integer appearedAtChainHeight,
+                                   int lastBlockSeenHeight) {
+        if (!tx.isCoinBase())
+            return true;
+
+        return calcDepth(appearedAtChainHeight, lastBlockSeenHeight) >= params.getSpendableCoinbaseDepth();
+    }
+
+}

--- a/core/src/test/java/org/bitcoinj/wallet/DefaultCoinSelectorTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DefaultCoinSelectorTest.java
@@ -89,7 +89,7 @@ public class DefaultCoinSelectorTest extends TestWithWallet {
 
         // Check we selected just the oldest one.
         DefaultCoinSelector selector = DefaultCoinSelector.get();
-        CoinSelection selection = selector.select(COIN, wallet.calculateAllSpendCandidates());
+        CoinSelection selection = selector.select(COIN, wallet.calculateAllSpendCandidates(), wallet::calcDepth);
         assertTrue(selection.outputs().contains(t1.getOutputs().get(0)));
         assertEquals(COIN, selection.totalValue());
 
@@ -97,7 +97,7 @@ public class DefaultCoinSelectorTest extends TestWithWallet {
         ArrayList<TransactionOutput> candidates = new ArrayList<>();
         candidates.add(t2.getOutput(0));
         candidates.add(t1.getOutput(0));
-        DefaultCoinSelector.sortOutputs(candidates);
+        DefaultCoinSelector.sortOutputs(candidates, depthProvider);
         assertEquals(t1.getOutput(0), candidates.get(0));
         assertEquals(t2.getOutput(0), candidates.get(1));
     }
@@ -118,7 +118,7 @@ public class DefaultCoinSelectorTest extends TestWithWallet {
         candidates.add(t3.getOutput(0));
         candidates.add(t2.getOutput(0));
         candidates.add(t1.getOutput(0));
-        DefaultCoinSelector.sortOutputs(candidates);
+        DefaultCoinSelector.sortOutputs(candidates, depthProvider);
         assertEquals(t2.getOutput(0), candidates.get(0));
         assertEquals(t1.getOutput(0), candidates.get(1));
         assertEquals(t3.getOutput(0), candidates.get(2));
@@ -137,7 +137,7 @@ public class DefaultCoinSelectorTest extends TestWithWallet {
         t.getConfidence().setConfidenceType(TransactionConfidence.ConfidenceType.BUILDING);
 
         DefaultCoinSelector selector = DefaultCoinSelector.get();
-        CoinSelection selection = selector.select(COIN.multiply(2), outputs);
+        CoinSelection selection = selector.select(COIN.multiply(2), outputs); //??
 
         assertTrue(selection.outputs().size() == 4);
     }


### PR DESCRIPTION
Another way is to move `depth` and `appearedAtChainHeight` up to `Wallet`. It kind of makes the `TransactionConfidence` object redundant once a tx is past the `EventHorizon`. Obviously this introduces a dependency on a `Wallet` whenever `depth` is needed which might be fine for now.. or not. 