### PR TITLE
NetworkParameters: Change PacketMagic to an `int`

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/internal/ByteUtils.java
+++ b/core/src/main/java/org/bitcoinj/base/internal/ByteUtils.java
@@ -236,6 +236,18 @@ public class ByteUtils {
     }
 
     /**
+     * Write a 32-bit integer to a given buffer in big-endian format.
+     *
+     * @param val value to be written
+     * @param buf buffer to be written into
+     * @return the buffer
+     * @throws BufferOverflowException if the value doesn't fit the remaining buffer
+     */
+    public static ByteBuffer writeInt32BE(int val, ByteBuffer buf) throws BufferOverflowException {
+        return buf.order(ByteOrder.BIG_ENDIAN).putInt((int) val);
+    }
+
+    /**
      * Write a 32-bit integer to a given byte array in big-endian format, starting at a given offset.
      * <p>
      * The value is expected as an unsigned {@code long} as per the Java Unsigned Integer API.
@@ -249,6 +261,19 @@ public class ByteUtils {
     public static void writeInt32BE(long val, byte[] out, int offset) throws ArrayIndexOutOfBoundsException {
         check(offset >= 0 && offset <= out.length - 4, () ->
                 new ArrayIndexOutOfBoundsException(offset));
+        writeInt32BE(val, ByteBuffer.wrap(out, offset, out.length - offset));
+    }
+
+    /**
+     * Write a 32-bit integer to a given byte array in big-endian format, starting at a given offset.
+     *
+     * @param val    value to be written
+     * @param out    buffer to be written into
+     * @param offset offset into the buffer
+     * @throws ArrayIndexOutOfBoundsException if offset points outside of the buffer, or
+     *                                        if the value doesn't fit the remaining buffer
+     */
+    public static void writeInt32BE(int val, byte[] out, int offset) throws ArrayIndexOutOfBoundsException {
         writeInt32BE(val, ByteBuffer.wrap(out, offset, out.length - offset));
     }
 
@@ -354,6 +379,19 @@ public class ByteUtils {
      * @throws IOException if an I/O error occurs
      */
     public static void writeInt32BE(long val, OutputStream stream) throws IOException {
+        byte[] buf = new byte[4];
+        writeInt32BE(val, ByteBuffer.wrap(buf));
+        stream.write(buf);
+    }
+
+    /**
+     * Write a 32-bit integer to a given output stream in big-endian format.
+     *
+     * @param val    value to be written
+     * @param stream strean to be written into
+     * @throws IOException if an I/O error occurs
+     */
+    public static void writeInt32BE(int val, OutputStream stream) throws IOException {
         byte[] buf = new byte[4];
         writeInt32BE(val, ByteBuffer.wrap(buf));
         stream.write(buf);

--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -69,7 +69,7 @@ public abstract class NetworkParameters {
 
     protected BigInteger maxTarget;
     protected int port;
-    protected long packetMagic;  // Indicates message origin network and is used to seek to the next message when stream state is unknown.
+    protected int packetMagic;  // Indicates message origin network and is used to seek to the next message when stream state is unknown.
     protected int addressHeader;
     protected int p2shHeader;
     protected int dumpedPrivateKeyHeader;
@@ -300,7 +300,7 @@ public abstract class NetworkParameters {
      * The header bytes that identify the start of a packet on this network.
      * @return header bytes as a long
      */
-    public long getPacketMagic() {
+    public int getPacketMagic() {
         return packetMagic;
     }
 

--- a/core/src/main/java/org/bitcoinj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/MainNetParams.java
@@ -44,7 +44,7 @@ public class MainNetParams extends BitcoinNetworkParams {
         maxTarget = ByteUtils.decodeCompactBits(Block.STANDARD_MAX_DIFFICULTY_TARGET);
 
         port = 8333;
-        packetMagic = 0xf9beb4d9L;
+        packetMagic = 0xf9beb4d9;
         dumpedPrivateKeyHeader = 128;
         addressHeader = 0;
         p2shHeader = 5;

--- a/core/src/main/java/org/bitcoinj/params/RegTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/RegTestParams.java
@@ -46,7 +46,7 @@ public class RegTestParams extends BitcoinNetworkParams {
         subsidyDecreaseBlockCount = 150;
 
         port = 18444;
-        packetMagic = 0xfabfb5daL;
+        packetMagic = 0xfabfb5da;
         dumpedPrivateKeyHeader = 239;
         addressHeader = 111;
         p2shHeader = 196;


### PR DESCRIPTION
It's just a binary value and does not have signed-edness.

Replace `writeUint32BE` methods in `ByteUtils` with `writeInt32BE` methods