### PR TITLE
MarriedKeyChain.Builder: simplify followingKeys

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/MarriedKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/MarriedKeyChain.java
@@ -16,7 +16,6 @@
 
 package org.bitcoinj.wallet;
 
-import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.crypto.AesKey;
@@ -32,6 +31,7 @@ import org.bitcoinj.script.ScriptBuilder;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -71,13 +71,25 @@ public class MarriedKeyChain extends DeterministicKeyChain {
         protected Builder() {
         }
 
+        public T followingKey(DeterministicKey followingKey) {
+            this.followingKeys = Collections.singletonList(followingKey);
+            return self();
+        }
+
         public T followingKeys(List<DeterministicKey> followingKeys) {
             this.followingKeys = followingKeys;
             return self();
         }
 
+        /**
+         * @deprecated Merge the elements and call {@link #followingKeys(List)}
+         */
+        @Deprecated
         public T followingKeys(DeterministicKey followingKey, DeterministicKey ...followingKeys) {
-            this.followingKeys = Lists.asList(followingKey, followingKeys);
+            List<DeterministicKey> tempList = new ArrayList<>();
+            tempList.add(followingKey);
+            tempList.addAll(Arrays.asList(followingKeys));
+            this.followingKeys = tempList;
             return self();
         }
 

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -370,7 +370,7 @@ public class WalletProtobufSerializerTest {
         DeterministicKey partnerKey = DeterministicKey.deserializeB58(null, partnerChain.getWatchingKey().serializePubB58(TESTNET.network()), TESTNET.network());
         MarriedKeyChain chain = MarriedKeyChain.builder()
                 .random(new SecureRandom())
-                .followingKeys(partnerKey)
+                .followingKey(partnerKey)
                 .threshold(2).build();
         myWallet.addAndActivateHDChain(chain);
 

--- a/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
@@ -110,7 +110,7 @@ public class KeyChainGroupTest {
         DeterministicSeed seed = DeterministicSeed.ofEntropy(entropy, "", Instant.ofEpochSecond(MnemonicCode.BIP39_STANDARDISATION_TIME_SECS));
         MarriedKeyChain chain = MarriedKeyChain.builder()
                 .seed(seed)
-                .followingKeys(watchingAccountKey)
+                .followingKey(watchingAccountKey)
                 .threshold(2).build();
         return chain;
     }

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -3325,7 +3325,7 @@ public class WalletTest extends TestWithWallet {
         wallet.addTransactionSigner(signer);
         MarriedKeyChain chain = MarriedKeyChain.builder()
                 .random(new SecureRandom())
-                .followingKeys(partnerKey)
+                .followingKey(partnerKey)
                 .build();
         wallet.addAndActivateHDChain(chain);
 


### PR DESCRIPTION
* Deprecate unused `followingKeys(DeterministicKey, DeterministicKey...)`
* Replace usage of Guava's `Lists.asList()`