### PR TITLE
WalletTool: rename `t` to `tx` in send and don't unnecessarily re-initialize it.

### DIFF
--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -715,7 +715,6 @@ public class WalletTool implements Callable<Integer> {
             } catch (ScriptException e) {
                 throw new RuntimeException(e);
             }
-            t = req.tx;   // Not strictly required today.
             System.out.println(t.getTxId());
             if (offline) {
                 wallet.commitTx(t);


### PR DESCRIPTION
Two commits:

1. Make `t` effectively final by not unnecessarily reinitializing it.
2. Rename `t` to `tx`.