### PR TITLE
FullBlockTestGenerator: Write the size as a single Int64, rather than two Int32s.

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -1222,8 +1222,8 @@ public class FullBlockTestGenerator {
 
             byte[] varIntBytes = new byte[9];
             varIntBytes[0] = (byte) 255;
-            ByteUtils.writeInt32LE((long)b64Original.block.getTransactions().size(), varIntBytes, 1);
-            ByteUtils.writeInt32LE(((long)b64Original.block.getTransactions().size()) >>> 32, varIntBytes, 5);
+            ByteUtils.writeInt32LE(b64Original.block.getTransactions().size(), varIntBytes, 1);
+            ByteUtils.writeInt32LE(0, varIntBytes, 5);
             stream.write(varIntBytes);
             checkState(VarInt.ofBytes(varIntBytes, 0).intValue() == b64Original.block.getTransactions().size());
 

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -1222,8 +1222,7 @@ public class FullBlockTestGenerator {
 
             byte[] varIntBytes = new byte[9];
             varIntBytes[0] = (byte) 255;
-            ByteUtils.writeInt32LE(b64Original.block.getTransactions().size(), varIntBytes, 1);
-            ByteUtils.writeInt32LE(0, varIntBytes, 5);
+            ByteUtils.writeInt64LE(b64Original.block.getTransactions().size(), varIntBytes, 1);
             stream.write(varIntBytes);
             checkState(VarInt.ofBytes(varIntBytes, 0).intValue() == b64Original.block.getTransactions().size());
 


### PR DESCRIPTION
Write the size as a single Int64, rather than two Int32s.