### PR TITLE
Wallet.SendResult: deprecate public fields, replace with accessors

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4012,11 +4012,23 @@ public class Wallet extends BaseTaggableObject
 
     /** A SendResult is returned to you as part of sending coins to a recipient. */
     public static class SendResult {
-        /** The Bitcoin transaction message that moves the money. */
+        /**
+         * The Bitcoin transaction message that moves the money.
+         * @deprecated Use {@link #transaction()}
+         */
+        @Deprecated
         public final Transaction tx;
-        /** A future that will complete once the tx message has been successfully broadcast to the network. This is just the result of calling broadcast.future() */
+        /**
+         * A future that will complete once the tx message has been successfully broadcast to the network. This is just the result of calling broadcast.future()
+         * @deprecated Use {@link #awaitRelayed()}
+         */
+        @Deprecated
         public final ListenableCompletableFuture<Transaction> broadcastComplete;
-        /** The broadcast object returned by the linked TransactionBroadcaster */
+        /**
+         * The broadcast object returned by the linked TransactionBroadcaster
+         * @deprecated Use {@link #getBroadcast()}
+         */
+        @Deprecated
         public final TransactionBroadcast broadcast;
 
         /**
@@ -4031,6 +4043,18 @@ public class Wallet extends BaseTaggableObject
             this.tx = broadcast.transaction();
             this.broadcast = broadcast;
             this.broadcastComplete = ListenableCompletableFuture.of(broadcast.awaitRelayed().thenApply(TransactionBroadcast::transaction));
+        }
+
+        public Transaction transaction() {
+            return broadcast.transaction();
+        }
+
+        public TransactionBroadcast getBroadcast() {
+            return broadcast;
+        }
+
+        public CompletableFuture<TransactionBroadcast> awaitRelayed() {
+            return broadcast.awaitRelayed();
         }
     }
 

--- a/examples/src/main/java/org/bitcoinj/examples/SendRequest.java
+++ b/examples/src/main/java/org/bitcoinj/examples/SendRequest.java
@@ -60,7 +60,7 @@ public class SendRequest {
         // In this example we catch the InsufficientMoneyException and register a BalanceFuture callback that runs once the wallet has enough balance.
         try {
             Wallet.SendResult result = kit.wallet().sendCoins(kit.peerGroup(), to, value);
-            System.out.println("coins sent. transaction hash: " + result.tx.getTxId());
+            System.out.println("coins sent. transaction hash: " + result.transaction().getTxId());
             // you can use a block explorer like https://www.biteasy.com/ to inspect the transaction with the printed transaction hash. 
         } catch (InsufficientMoneyException e) {
             System.out.println("Not enough coins in your wallet. Missing " + e.missing.getValue() + " satoshis are missing (including fees)");

--- a/integration-test/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
@@ -171,14 +171,14 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
         // Now create a spend, and expect the announcement on p1.
         Address dest = new ECKey().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
         Wallet.SendResult sendResult = wallet.sendCoins(peerGroup, dest, COIN);
-        assertFalse(sendResult.broadcastComplete.isDone());
+        assertFalse(sendResult.awaitRelayed().isDone());
         Transaction t1;
         {
             Message m;
             while (!((m = outbound(p1)) instanceof Transaction));
             t1 = (Transaction) m;
         }
-        assertFalse(sendResult.broadcastComplete.isDone());
+        assertFalse(sendResult.awaitRelayed().isDone());
 
         // p1 eats it :( A bit later the PeerGroup is taken down.
         peerGroup.removeWallet(wallet);
@@ -215,10 +215,10 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
         // Now create a spend, and expect the announcement on p1.
         Address dest = new ECKey().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
         Wallet.SendResult sendResult = wallet.sendCoins(peerGroup, dest, COIN);
-        assertNotNull(sendResult.tx);
+        assertNotNull(sendResult.transaction());
         Threading.waitForUserCode();
-        assertFalse(sendResult.broadcastComplete.isDone());
-        assertEquals(transactions[0], sendResult.tx);
+        assertFalse(sendResult.awaitRelayed().isDone());
+        assertEquals(transactions[0], sendResult.transaction());
         assertEquals(0, transactions[0].getConfidence().numBroadcastPeers());
         transactions[0] = null;
         Transaction t1;
@@ -239,8 +239,8 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
         inbound(p2, inv);
         pingAndWait(p2);
         Threading.waitForUserCode();
-        assertTrue(sendResult.broadcastComplete.isDone());
-        assertEquals(transactions[0], sendResult.tx);
+        assertTrue(sendResult.awaitRelayed().isDone());
+        assertEquals(transactions[0], sendResult.transaction());
         assertEquals(1, transactions[0].getConfidence().numBroadcastPeers());
         // Confirm it.
         Block b2 = FakeTxBuilder.createFakeBlock(blockStore, Block.BLOCK_HEIGHT_GENESIS, t1).block;

--- a/wallettemplate/src/main/java/wallettemplate/SendMoneyController.java
+++ b/wallettemplate/src/main/java/wallettemplate/SendMoneyController.java
@@ -92,7 +92,7 @@ public class SendMoneyController implements OverlayController<SendMoneyControlle
             // their own money!
             req.allowUnconfirmed();
             sendResult = app.walletAppKit().wallet().sendCoins(req);
-            sendResult.broadcastComplete.whenComplete((result, t) -> {
+            sendResult.awaitRelayed().whenComplete((result, t) -> {
                 if (t == null) {
                     Platform.runLater(() -> overlayUI.done());
                 } else {
@@ -100,7 +100,7 @@ public class SendMoneyController implements OverlayController<SendMoneyControlle
                     crashAlert(t);
                 }
             });
-            sendResult.tx.getConfidence().addEventListener((tx, reason) -> {
+            sendResult.transaction().getConfidence().addEventListener((tx, reason) -> {
                 if (reason == TransactionConfidence.Listener.ChangeReason.SEEN_PEERS)
                     updateTitleForBroadcast();
             });
@@ -135,7 +135,7 @@ public class SendMoneyController implements OverlayController<SendMoneyControlle
     }
 
     private void updateTitleForBroadcast() {
-        final int peers = sendResult.tx.getConfidence().numBroadcastPeers();
+        final int peers = sendResult.transaction().getConfidence().numBroadcastPeers();
         titleLabel.setText(String.format("Broadcasting ... seen by %d peers", peers));
     }
 }


### PR DESCRIPTION
* Deprecate public fields in `SendResult`
* Make available equivalent accessors
* Update all usages

This prepares the way for replacing `SendResult` with `TransactionBroadcast` in the future.