### PR TITLE
ListenableCompletionStage: deprecate addListener

### DIFF
--- a/core/src/main/java/org/bitcoinj/utils/ListenableCompletionStage.java
+++ b/core/src/main/java/org/bitcoinj/utils/ListenableCompletionStage.java
@@ -28,7 +28,11 @@ import java.util.concurrent.Executor;
  * to implement {@code CompletionStage}.
  */
 public interface ListenableCompletionStage<V> extends CompletionStage<V>, ListenableFuture<V> {
+    /**
+     * @deprecated Use {@link java.util.concurrent.CompletableFuture} and {@link java.util.concurrent.CompletableFuture#thenRunAsync(Runnable, Executor)}
+     */
     @Override
+    @Deprecated
     default void addListener(Runnable listener, Executor executor) {
         this.thenRunAsync(listener, executor);
     }


### PR DESCRIPTION
When people upgrade to 0.17 this deprecation will make it more clear that they need to switch from this method to `thenRunAsync`

Reminder: we did not deprecate ListenableCompletionStage or ListenableCompletableFuture because they are still used in many places in the bitcoinj API, but this method is not used anywhere in bitcoinj.