### PR TITLE
BitcoinSerializer: Use Network not NetworkParameters

### DIFF
--- a/core/src/main/java/org/bitcoinj/params/BitcoinNetworkParams.java
+++ b/core/src/main/java/org/bitcoinj/params/BitcoinNetworkParams.java
@@ -248,7 +248,7 @@ public abstract class BitcoinNetworkParams extends NetworkParameters {
 
     @Override
     public BitcoinSerializer getSerializer() {
-        return new BitcoinSerializer(this);
+        return new BitcoinSerializer(network);
     }
 
     @Override

--- a/core/src/test/java/org/bitcoinj/core/SendHeadersMessageTest.java
+++ b/core/src/test/java/org/bitcoinj/core/SendHeadersMessageTest.java
@@ -17,7 +17,7 @@
 package org.bitcoinj.core;
 
 import com.google.common.io.BaseEncoding;
-import org.bitcoinj.params.RegTestParams;
+import org.bitcoinj.base.BitcoinNetwork;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertTrue;
 
 public class SendHeadersMessageTest {
     private static final BaseEncoding HEX = BaseEncoding.base16().lowerCase();
-    private static final NetworkParameters REGTEST = RegTestParams.get();
 
     @Test
     public void decodeAndEncode() throws Exception {
@@ -40,7 +39,7 @@ public class SendHeadersMessageTest {
                         + "c96fe88d4a0f01ed9dedae2b6f9e00da94cad0fecaae66ecf689bf71b50000000000000000000000000000000000000000000000000");
 
         ByteBuffer buffer = ByteBuffer.wrap(message);
-        BitcoinSerializer serializer = new BitcoinSerializer(REGTEST);
+        BitcoinSerializer serializer = new BitcoinSerializer(BitcoinNetwork.REGTEST);
         assertTrue(serializer.deserialize(buffer) instanceof SendHeadersMessage);
     }
 }

--- a/integration-test/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTest.java
@@ -56,7 +56,7 @@ import static org.junit.Assert.fail;
 
 @RunWith(value = Parameterized.class)
 public class FilteredBlockAndPartialMerkleTreeTest extends TestWithPeerGroup {
-    private static final BitcoinSerializer SERIALIZER = new BitcoinSerializer(TESTNET);
+    private static final BitcoinSerializer SERIALIZER = new BitcoinSerializer(BitcoinNetwork.TESTNET);
 
     @Parameterized.Parameters
     public static Collection<ClientType[]> parameters() {


### PR DESCRIPTION
* Use private Network field instead of NetworkParameters
* New constructors that take Network (deprecated old)
* private packetMagic field (requires one-shot use of NetworkParameters to init)
* Deprecate (unused) getParameters() method

After merge TODOs:
1. Maybe figure out how to get packetMagic without using NetworkParameters (add to Network?)
2. equals() and hashCode() can be removed (PR #3062)