### PR TITLE
EmptyMessage: remove `params` and `payload` from constructors in hierarchy

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static org.bitcoinj.base.internal.ByteUtils.readUint32;
+import static org.bitcoinj.base.internal.Preconditions.check;
 
 /**
  * <p>Methods to serialize and de-serialize messages to the Bitcoin network format as defined in
@@ -232,7 +233,8 @@ public class BitcoinSerializer extends MessageSerializer {
         } else if (command.equals("tx")) {
             return makeTransaction(payload, hash);
         } else if (command.equals("sendaddrv2")) {
-            return new SendAddrV2Message(params);
+            check(!payload.hasRemaining(), ProtocolException::new);
+            return new SendAddrV2Message();
         } else if (command.equals("addr")) {
             return makeAddressV1Message(payload);
         } else if (command.equals("addrv2")) {
@@ -242,7 +244,8 @@ public class BitcoinSerializer extends MessageSerializer {
         } else if (command.equals("pong")) {
             return new Pong(params, payload);
         } else if (command.equals("verack")) {
-            return new VersionAck(params, payload);
+            check(!payload.hasRemaining(), ProtocolException::new);
+            return new VersionAck();
         } else if (command.equals("headers")) {
             return new HeadersMessage(params, payload);
         } else if (command.equals("filterload")) {
@@ -254,11 +257,13 @@ public class BitcoinSerializer extends MessageSerializer {
         } else if (command.equals("reject")) {
             return new RejectMessage(params, payload);
         } else if (command.equals("sendheaders")) {
-            return new SendHeadersMessage(params, payload);
+            check(!payload.hasRemaining(), ProtocolException::new);
+            return new SendHeadersMessage();
         } else if (command.equals("feefilter")) {
             return new FeeFilterMessage(params, payload, this);
         } else {
-            return new UnknownMessage(params, command, payload);
+            check(!payload.hasRemaining(), ProtocolException::new);
+            return new UnknownMessage(command);
         }
     }
 

--- a/core/src/main/java/org/bitcoinj/core/EmptyMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/EmptyMessage.java
@@ -20,7 +20,6 @@ package org.bitcoinj.core;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.BufferUnderflowException;
-import java.nio.ByteBuffer;
 
 /**
  * <p>Parent class for header only messages that don't have a payload.
@@ -31,14 +30,7 @@ import java.nio.ByteBuffer;
 public abstract class EmptyMessage extends Message {
 
     public EmptyMessage() {
-    }
-
-    public EmptyMessage(NetworkParameters params) {
-        super(params);
-    }
-
-    public EmptyMessage(NetworkParameters params, ByteBuffer payload) throws ProtocolException {
-        super(params, payload);
+        super();
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/GetAddrMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetAddrMessage.java
@@ -26,7 +26,7 @@ import org.bitcoinj.base.Address;
  */
 public class GetAddrMessage extends EmptyMessage {
 
-    public GetAddrMessage(NetworkParameters params) {
-        super(params);
+    public GetAddrMessage() {
+        super();
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -547,7 +547,7 @@ public class Peer extends PeerSocketHandler {
             throw new ProtocolException("Peer reports invalid best height: " + peerVersionMessage.bestHeight);
         // Now it's our turn ...
         // Send a sendaddrv2 message, indicating that we prefer to receive addrv2 messages.
-        sendMessage(new SendAddrV2Message(params));
+        sendMessage(new SendAddrV2Message());
         // Send an ACK message stating we accept the peers protocol version.
         sendMessage(new VersionAck());
         if (log.isDebugEnabled())
@@ -1304,7 +1304,7 @@ public class Peer extends PeerSocketHandler {
         synchronized (getAddrFutures) {
             getAddrFutures.add(future);
         }
-        sendMessage(new GetAddrMessage(params));
+        sendMessage(new GetAddrMessage());
         return future;
     }
 

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -1670,7 +1670,7 @@ public class PeerGroup implements TransactionBroadcaster {
 
         // Discovery more peers.
         if (vDiscoverPeersViaP2P)
-            peer.sendMessage(new GetAddrMessage(params));
+            peer.sendMessage(new GetAddrMessage());
     }
 
     @Nullable private volatile ScheduledFuture<?> vPingTask;

--- a/core/src/main/java/org/bitcoinj/core/ProtocolException.java
+++ b/core/src/main/java/org/bitcoinj/core/ProtocolException.java
@@ -18,6 +18,9 @@ package org.bitcoinj.core;
 
 @SuppressWarnings("serial")
 public class ProtocolException extends VerificationException {
+    public ProtocolException() {
+        super();
+    }
 
     public ProtocolException(String msg) {
         super(msg);

--- a/core/src/main/java/org/bitcoinj/core/SendAddrV2Message.java
+++ b/core/src/main/java/org/bitcoinj/core/SendAddrV2Message.java
@@ -25,7 +25,7 @@ package org.bitcoinj.core;
  * <p>Instances of this class are not safe for use by multiple threads.</p>
  */
 public class SendAddrV2Message extends EmptyMessage {
-    public SendAddrV2Message(NetworkParameters params) {
-        super(params);
+    public SendAddrV2Message() {
+        super();
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/SendHeadersMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/SendHeadersMessage.java
@@ -16,8 +16,6 @@
 
 package org.bitcoinj.core;
 
-import java.nio.ByteBuffer;
-
 /**
  * <p>
  * A new message, "sendheaders", which indicates that a node prefers to receive new block announcements via a "headers"
@@ -30,9 +28,5 @@ import java.nio.ByteBuffer;
  */
 public class SendHeadersMessage extends EmptyMessage {
     public SendHeadersMessage() {
-    }
-
-    // this is needed by the BitcoinSerializer
-    public SendHeadersMessage(NetworkParameters params, ByteBuffer payload) {
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/UnknownMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/UnknownMessage.java
@@ -17,10 +17,6 @@
 
 package org.bitcoinj.core;
 
-import org.bitcoinj.base.internal.ByteUtils;
-
-import java.nio.ByteBuffer;
-
 /**
  * <p>Instances of this class are not safe for use by multiple threads.</p>
  */
@@ -28,8 +24,8 @@ public class UnknownMessage extends EmptyMessage {
 
     private String name;
 
-    public UnknownMessage(NetworkParameters params, String name, ByteBuffer payload) throws ProtocolException {
-        super(params, payload);
+    public UnknownMessage(String name) throws ProtocolException {
+        super();
         this.name = name;
     }
 

--- a/core/src/main/java/org/bitcoinj/core/VerificationException.java
+++ b/core/src/main/java/org/bitcoinj/core/VerificationException.java
@@ -18,6 +18,10 @@ package org.bitcoinj.core;
 
 @SuppressWarnings("serial")
 public class VerificationException extends RuntimeException {
+    public VerificationException() {
+        super();
+    }
+
     public VerificationException(String msg) {
         super(msg);
     }

--- a/core/src/main/java/org/bitcoinj/core/VersionAck.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionAck.java
@@ -16,8 +16,6 @@
 
 package org.bitcoinj.core;
 
-import java.nio.ByteBuffer;
-
 /**
  * <p>The verack message, sent by a client accepting the version message they
  * received from their peer.</p>
@@ -26,9 +24,5 @@ import java.nio.ByteBuffer;
  */
 public class VersionAck extends EmptyMessage {
     public VersionAck() {
-    }
-
-    // this is needed by the BitcoinSerializer
-    public VersionAck(NetworkParameters params, ByteBuffer payload) {
     }
 }


### PR DESCRIPTION
Empty messages don't need any of these.

There is a commit prefixed:
ProtocolException, VerificationException: allow construction without message