### PR TITLE
TransactionOutPoint: define parent as TransactionInput in constructor

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -99,7 +99,7 @@ public class TransactionOutPoint extends ChildMessage {
      * @param serializer the serializer to use for this message.
      * @throws ProtocolException
      */
-    public TransactionOutPoint(NetworkParameters params, ByteBuffer payload, Message parent, MessageSerializer serializer) throws ProtocolException {
+    public TransactionOutPoint(NetworkParameters params, ByteBuffer payload, TransactionInput parent, MessageSerializer serializer) throws ProtocolException {
         super(params, payload, parent, serializer);
     }
 


### PR DESCRIPTION
It might be possible to do this for more of the messages with parents and removing the Message.parent field and replacing with:

abstract @Nullable Message getParent()

may allow us to narrow the return type in subclasses.