### PR TITLE
ChildMessage: Store typed parent in subclass

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/ChildMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/ChildMessage.java
@@ -27,8 +27,6 @@ import java.nio.ByteBuffer;
  */
 public abstract class ChildMessage extends Message {
 
-    @Nullable protected Message parent;
-
     public ChildMessage(NetworkParameters params) {
         super(params);
     }
@@ -43,24 +41,13 @@ public abstract class ChildMessage extends Message {
 
     public ChildMessage(NetworkParameters params, ByteBuffer payload, @Nullable Message parent) throws ProtocolException {
         super(params, payload);
-        this.parent = parent;
     }
 
-    public ChildMessage(NetworkParameters params, ByteBuffer payload, @Nullable Message parent,
-                        MessageSerializer serializer) throws ProtocolException {
+    public ChildMessage(NetworkParameters params, ByteBuffer payload, MessageSerializer serializer) throws ProtocolException {
         super(params, payload, serializer);
-        this.parent = parent;
     }
 
-    public final void setParent(@Nullable Message parent) {
-        if (this.parent != null && this.parent != parent && parent != null) {
-            // After old parent is unlinked it won't be able to receive notice if this ChildMessage
-            // changes internally.  To be safe we invalidate the parent cache to ensure it rebuilds
-            // manually on serialization.
-            this.parent.unCache();
-        }
-        this.parent = parent;
-    }
+    protected abstract Message getParent();
 
     /* (non-Javadoc)
       * @see Message#unCache()
@@ -68,7 +55,7 @@ public abstract class ChildMessage extends Message {
     @Override
     protected void unCache() {
         super.unCache();
-        if (parent != null)
-            parent.unCache();
+        if (getParent() != null)
+            getParent().unCache();
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -47,6 +47,8 @@ public class TransactionOutPoint extends ChildMessage {
 
     static final int MESSAGE_LENGTH = 36;
 
+    private TransactionInput parent;
+
     /** Hash of the transaction to which we refer. */
     private Sha256Hash hash;
     /** Which output of that transaction we are talking about. */
@@ -98,8 +100,15 @@ public class TransactionOutPoint extends ChildMessage {
      * @param params NetworkParameters object.
      * @throws ProtocolException
      */
-    public TransactionOutPoint(NetworkParameters params, ByteBuffer payload, Message parent) throws ProtocolException {
-        super(params, payload, parent);
+    public TransactionOutPoint(NetworkParameters params, ByteBuffer payload, TransactionInput parent) throws ProtocolException {
+        super(params, payload);
+        this.parent = parent;
+    }
+
+    @Nullable
+    @Override
+    public TransactionInput getParent() {
+        return parent;
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/wallet/DefaultCoinSelector.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DefaultCoinSelector.java
@@ -55,7 +55,7 @@ public class DefaultCoinSelector implements CoinSelector {
         for (TransactionOutput output : sortedOutputs) {
             if (total >= target.value) break;
             // Only pick chain-included transactions, or transactions that are ours and pending.
-            if (!shouldSelect(output.getParentTransaction())) continue;
+            if (!shouldSelect(output.getParent())) continue;
             selected.add(output);
             total = Math.addExact(total, output.getValue().value);
         }

--- a/core/src/main/java/org/bitcoinj/wallet/KeyTimeCoinSelector.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyTimeCoinSelector.java
@@ -97,6 +97,6 @@ public class KeyTimeCoinSelector implements CoinSelector {
     }
 
     private boolean isConfirmed(TransactionOutput output) {
-        return output.getParentTransaction().getConfidence().getConfidenceType().equals(TransactionConfidence.ConfidenceType.BUILDING);
+        return output.getParent().getConfidence().getConfidenceType().equals(TransactionConfidence.ConfidenceType.BUILDING);
     }
 }

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -2626,7 +2626,7 @@ public class Wallet extends BaseTaggableObject
                     log.warn("Saw two pending transactions double spend each other");
                     log.warn("  offending input is input {}", tx.getInputs().indexOf(input));
                     log.warn("{}: {}", tx.getTxId(), tx.toHexString());
-                    Transaction other = output.getSpentBy().getParentTransaction();
+                    Transaction other = output.getSpentBy().getParent();
                     log.warn("{}: {}", other.getTxId(), other.toHexString());
                 }
             } else if (result == TransactionInput.ConnectionResult.SUCCESS) {
@@ -2692,7 +2692,7 @@ public class Wallet extends BaseTaggableObject
                 if (connected == null) continue;
                 if (connected.getConfidence().getConfidenceType() != ConfidenceType.DEAD && deadInput.getConnectedOutput().getSpentBy() != null && deadInput.getConnectedOutput().getSpentBy().equals(deadInput)) {
                     checkState(myUnspents.add(deadInput.getConnectedOutput()));
-                    log.info("Added to UNSPENTS: {} in {}", deadInput.getConnectedOutput(), deadInput.getConnectedOutput().getParentTransaction().getTxId());
+                    log.info("Added to UNSPENTS: {} in {}", deadInput.getConnectedOutput(), deadInput.getConnectedOutput().getParent().getTxId());
                 }
                 deadInput.disconnect();
                 maybeMovePool(connected, "kill");
@@ -2705,7 +2705,7 @@ public class Wallet extends BaseTaggableObject
                     log.info("XX Removed from UNSPENTS: {}", deadOutput);
                 TransactionInput connected = deadOutput.getSpentBy();
                 if (connected == null) continue;
-                final Transaction parentTransaction = connected.getParentTransaction();
+                final Transaction parentTransaction = connected.getParent();
                 log.info("This death invalidated dependent tx {}", parentTransaction.getTxId());
                 work.push(parentTransaction);
             }
@@ -4613,7 +4613,7 @@ public class Wallet extends BaseTaggableObject
             if (vUTXOProvider == null) {
                 candidates = myUnspents.stream()
                     .filter(output ->   (!excludeUnsignable || canSignFor(output.getScriptPubKey())) &&
-                                        (!excludeImmatureCoinbases || Objects.requireNonNull(output.getParentTransaction()).isMature()))
+                                        (!excludeImmatureCoinbases || Objects.requireNonNull(output.getParent()).isMature()))
                     .collect(StreamUtils.toUnmodifiableList());
             } else {
                 candidates = calculateAllSpendCandidatesFromUTXOProvider(excludeImmatureCoinbases);

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -52,12 +52,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -295,7 +293,7 @@ public class WalletProtobufSerializer {
                 .setValue(output.getValue().value);
             final TransactionInput spentBy = output.getSpentBy();
             if (spentBy != null) {
-                Sha256Hash spendingHash = spentBy.getParentTransaction().getTxId();
+                Sha256Hash spendingHash = spentBy.getParent().getTxId();
                 outputBuilder.setSpentByTransactionHash(hashToByteString(spendingHash))
                              .setSpentByTransactionIndex(spentBy.getIndex());
             }

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -45,9 +45,7 @@ import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.Iterator;
-import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
@@ -454,7 +452,7 @@ public class TransactionTest {
 
     private boolean correctlySpends(TransactionInput txIn, Script scriptPubKey, int inputIndex) {
         try {
-            txIn.getScriptSig().correctlySpends(txIn.getParentTransaction(), inputIndex, txIn.getWitness(),
+            txIn.getScriptSig().correctlySpends(txIn.getParent(), inputIndex, txIn.getWitness(),
                     txIn.getValue(), scriptPubKey, Script.ALL_VERIFY_FLAGS);
             return true;
         } catch (ScriptException x) {

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -921,7 +921,7 @@ public class WalletTest extends TestWithWallet {
         send2 = TESTNET.getDefaultSerializer().makeTransaction(ByteBuffer.wrap(send2.bitcoinSerialize()));
         // Broadcast send1.
         wallet.commitTx(send1);
-        assertEquals(send1, received.getOutput(0).getSpentBy().getParentTransaction());
+        assertEquals(send1, received.getOutput(0).getSpentBy().getParent());
         // Receive a block that overrides it.
         sendMoneyToWallet(AbstractBlockChain.NewBlockType.BEST_CHAIN, send2);
         Threading.waitForUserCode();
@@ -929,7 +929,7 @@ public class WalletTest extends TestWithWallet {
         assertEquals(send2, eventReplacement[0]);
         assertEquals(TransactionConfidence.ConfidenceType.DEAD,
                 send1.getConfidence().getConfidenceType());
-        assertEquals(send2, received.getOutput(0).getSpentBy().getParentTransaction());
+        assertEquals(send2, received.getOutput(0).getSpentBy().getParent());
 
         FakeTxBuilder.DoubleSpends doubleSpends = FakeTxBuilder.createFakeDoubleSpendTxns(TESTNET, myAddress);
         // t1 spends to our wallet. t2 double spends somewhere else.
@@ -3153,11 +3153,11 @@ public class WalletTest extends TestWithWallet {
         // Selected inputs can be in any order.
         for (int i = 0; i < req.tx.getInputs().size(); i++) {
             TransactionInput input = req.tx.getInput(i);
-            if (input.getConnectedOutput().getParentTransaction().equals(t1)) {
+            if (input.getConnectedOutput().getParent().equals(t1)) {
                 assertArrayEquals(expectedSig, input.getScriptSig().getChunks().get(0).data);
-            } else if (input.getConnectedOutput().getParentTransaction().equals(t2)) {
+            } else if (input.getConnectedOutput().getParent().equals(t2)) {
                 assertArrayEquals(expectedSig, input.getScriptSig().getChunks().get(0).data);
-            } else if (input.getConnectedOutput().getParentTransaction().equals(t3)) {
+            } else if (input.getConnectedOutput().getParent().equals(t3)) {
                 input.getScriptSig().correctlySpends(
                         req.tx, i, null, null, t3.getOutput(0).getScriptPubKey(), Script.ALL_VERIFY_FLAGS);
             }


### PR DESCRIPTION
* Replace parent field in ChildMessage with protected, abstract getParent()
* Remove parent parameter from ChildMessage constructor
* Use correct Message subtype in subclass constructors
* Override getParent() in subtypes and narrow return type
* Replace getParentTransaction with getParent

TODO:
1. Eliminate redundancy in setParent
2. Consider removing unCache and perhaps ChildMessage itself is no longer needed.