### PR TITLE
GetBlocksMessage, GetHeadersMessage: remove `params` from constructors

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
@@ -227,9 +227,9 @@ public class BitcoinSerializer extends MessageSerializer {
         } else if (command.equals("getdata")) {
             return new GetDataMessage(payload);
         } else if (command.equals("getblocks")) {
-            return new GetBlocksMessage(params, payload);
+            return new GetBlocksMessage(payload);
         } else if (command.equals("getheaders")) {
-            return new GetHeadersMessage(params, payload);
+            return new GetHeadersMessage(payload);
         } else if (command.equals("tx")) {
             return makeTransaction(payload, hash);
         } else if (command.equals("sendaddrv2")) {

--- a/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
@@ -38,15 +38,14 @@ public class GetBlocksMessage extends Message {
     protected BlockLocator locator;
     protected Sha256Hash stopHash;
 
-    public GetBlocksMessage(NetworkParameters params, BlockLocator locator, Sha256Hash stopHash) {
-        super(params);
-        this.version = serializer.getProtocolVersion();
+    public GetBlocksMessage(long protocolVersion, BlockLocator locator, Sha256Hash stopHash) {
+        this.version = protocolVersion;
         this.locator = locator;
         this.stopHash = stopHash;
     }
 
-    public GetBlocksMessage(NetworkParameters params, ByteBuffer payload) throws ProtocolException {
-        super(params, payload);
+    public GetBlocksMessage(ByteBuffer payload) throws ProtocolException {
+        super(payload);
     }
 
     @Override
@@ -78,7 +77,7 @@ public class GetBlocksMessage extends Message {
     @Override
     protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         // Version, for some reason.
-        ByteUtils.writeInt32LE(serializer.getProtocolVersion(), stream);
+        ByteUtils.writeInt32LE(version, stream);
         // Then a vector of block hashes. This is actually a "block locator", a set of block
         // identifiers that spans the entire chain with exponentially increasing gaps between
         // them, until we end up at the genesis block. See CBlockLocator::Set()

--- a/core/src/main/java/org/bitcoinj/core/GetHeadersMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetHeadersMessage.java
@@ -29,12 +29,12 @@ import java.nio.ByteBuffer;
  * <p>Instances of this class are not safe for use by multiple threads.</p>
  */
 public class GetHeadersMessage extends GetBlocksMessage {
-    public GetHeadersMessage(NetworkParameters params, BlockLocator locator, Sha256Hash stopHash) {
-        super(params, locator, stopHash);
+    public GetHeadersMessage(long protocolVersion, BlockLocator locator, Sha256Hash stopHash) {
+        super(protocolVersion, locator, stopHash);
     }
 
-    public GetHeadersMessage(NetworkParameters params, ByteBuffer payload) throws ProtocolException {
-        super(params, payload);
+    public GetHeadersMessage(ByteBuffer payload) throws ProtocolException {
+        super(payload);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -1452,12 +1452,13 @@ public class Peer extends PeerSocketHandler {
         lastGetBlocksBegin = chainHeadHash;
         lastGetBlocksEnd = toHash;
 
+        long protocolVersion = params.getSerializer().getProtocolVersion();
         if (downloadBlockBodies) {
-            GetBlocksMessage message = new GetBlocksMessage(params, blockLocator, toHash);
+            GetBlocksMessage message = new GetBlocksMessage(protocolVersion, blockLocator, toHash);
             sendMessage(message);
         } else {
             // Downloading headers for a while instead of full blocks.
-            GetHeadersMessage message = new GetHeadersMessage(params, blockLocator, toHash);
+            GetHeadersMessage message = new GetHeadersMessage(protocolVersion, blockLocator, toHash);
             sendMessage(message);
         }
     }

--- a/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
@@ -304,7 +304,7 @@ public class BitcoindComparisonTool {
                 //bitcoind.sendMessage(nextBlock);
                 locator = new BlockLocator();
                 locator = locator.add(bitcoindChainHead);
-                bitcoind.sendMessage(new GetHeadersMessage(PARAMS, locator, hashTo));
+                bitcoind.sendMessage(new GetHeadersMessage(PARAMS.getSerializer().getProtocolVersion(), locator, hashTo));
                 bitcoind.sendPing().get();
                 if (!chain.getChainHead().getHeader().getHash().equals(bitcoindChainHead)) {
                     rulesSinceFirstFail++;


### PR DESCRIPTION
Because the serialized messages contain the protocol version – for whatever reason, possibly unused – that value is now passed instead.