### PR TITLE
Message: remove method `unCache()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AddressMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressMessage.java
@@ -46,7 +46,6 @@ public abstract class AddressMessage extends Message {
     public abstract void addAddress(PeerAddress address);
 
     public void removeAddress(int index) {
-        unCache();
         PeerAddress address = addresses.remove(index);
     }
 

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -326,7 +326,6 @@ public class Block extends Message {
         writeTransactions(stream);
     }
 
-    @Override
     protected void unCache() {
         // Since we have alternate uncache methods to use internally this will only ever be called by a child
         // transaction so we only need to invalidate that part of the cache.

--- a/core/src/main/java/org/bitcoinj/core/ListMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/ListMessage.java
@@ -56,12 +56,10 @@ public abstract class ListMessage extends Message {
     }
 
     public void addItem(InventoryItem item) {
-        unCache();
         items.add(item);
     }
 
     public void removeItem(int index) {
-        unCache();
         items.remove(index);
     }
 

--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -97,15 +97,6 @@ public abstract class Message {
     protected abstract void parse() throws BufferUnderflowException, ProtocolException;
 
     /**
-     * <p>To be called before any change of internal values including any setters. This ensures any cached byte array is
-     * removed.</p>
-     * <p>Child messages of this object(e.g. Transactions belonging to a Block) will not have their internal byte caches
-     * invalidated unless they are also modified internally.</p>
-     */
-    protected void unCache() {
-    }
-
-    /**
      * <p>Serialize this message to a byte array that conforms to the bitcoin wire protocol.</p>
      *
      * @return a byte array

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -599,7 +599,6 @@ public class Transaction extends Message {
      */
     public static final byte SIGHASH_ANYONECANPAY_VALUE = (byte) 0x80;
 
-    @Override
     protected void unCache() {
         cachedTxId = null;
         cachedWTxId = null;

--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -538,9 +538,7 @@ public class TransactionInput extends Message {
     /* (non-Javadoc)
      * @see Message#unCache()
      */
-    @Override
     protected void unCache() {
-        super.unCache();
         if (parent != null)
             parent.unCache();
     }

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -433,9 +433,7 @@ public class TransactionOutput extends Message {
     /* (non-Javadoc)
      * @see Message#unCache()
      */
-    @Override
     protected void unCache() {
-        super.unCache();
         if (parent != null)
             parent.unCache();
     }


### PR DESCRIPTION
It's still implemented in `Block`, `Transaction`, `TransactionInput` and `TransactionOutput`. But there is no need to have it in the superclass.