### PR TITLE
PeerAddress: remove `params` from constructor

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AddressV1Message.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressV1Message.java
@@ -57,7 +57,7 @@ public class AddressV1Message extends AddressMessage {
         addresses = new ArrayList<>(numAddresses);
         MessageSerializer serializer = this.serializer.withProtocolVersion(1);
         for (int i = 0; i < numAddresses; i++) {
-            PeerAddress addr = new PeerAddress(params, payload, serializer);
+            PeerAddress addr = new PeerAddress(payload, serializer);
             addresses.add(addr);
         }
     }

--- a/core/src/main/java/org/bitcoinj/core/AddressV2Message.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressV2Message.java
@@ -57,7 +57,7 @@ public class AddressV2Message extends AddressMessage {
         addresses = new ArrayList<>(numAddresses);
         MessageSerializer serializer = this.serializer.withProtocolVersion(2);
         for (int i = 0; i < numAddresses; i++) {
-            PeerAddress addr = new PeerAddress(params, payload, serializer);
+            PeerAddress addr = new PeerAddress(payload, serializer);
             addresses.add(addr);
         }
     }

--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -59,6 +59,11 @@ public abstract class Message {
         this.serializer = params.getDefaultSerializer();
     }
 
+    protected Message(MessageSerializer serializer) {
+        this.params = null;
+        this.serializer = serializer;
+    }
+
     protected Message(NetworkParameters params, MessageSerializer serializer) {
         this.params = params;
         this.serializer = serializer;
@@ -87,6 +92,10 @@ public abstract class Message {
 
     protected Message(ByteBuffer payload) throws ProtocolException {
         this(null, payload, DummySerializer.DEFAULT);
+    }
+
+    protected Message(ByteBuffer payload, MessageSerializer serializer) throws ProtocolException {
+        this(null, payload, serializer);
     }
 
     protected Message(NetworkParameters params, ByteBuffer payload) throws ProtocolException {

--- a/core/src/main/java/org/bitcoinj/core/PeerAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerAddress.java
@@ -84,20 +84,19 @@ public class PeerAddress extends Message {
 
     /**
      * Construct a peer address from a serialized payload.
-     * @param params NetworkParameters object.
      * @param payload Bitcoin protocol formatted byte array containing message content.
      * @param serializer the serializer to use for this message.
      * @throws ProtocolException
      */
-    public PeerAddress(NetworkParameters params, ByteBuffer payload, MessageSerializer serializer) throws ProtocolException {
-        super(params, payload, serializer);
+    public PeerAddress(ByteBuffer payload, MessageSerializer serializer) throws ProtocolException {
+        super(payload, serializer);
     }
 
     /**
      * Construct a peer address from a memorized or hardcoded address.
      */
-    public PeerAddress(NetworkParameters params, InetAddress addr, int port, Services services, MessageSerializer serializer) {
-        super(params, serializer);
+    public PeerAddress(InetAddress addr, int port, Services services, MessageSerializer serializer) {
+        super(serializer);
         this.addr = Objects.requireNonNull(addr);
         this.port = port;
         this.services = services;
@@ -107,38 +106,30 @@ public class PeerAddress extends Message {
     /**
      * Constructs a peer address from the given IP address, port and services. Version number is default for the given parameters.
      */
-    public PeerAddress(NetworkParameters params, InetAddress addr, int port, Services services) {
-        this(params, addr, port, services, params.getDefaultSerializer().withProtocolVersion(0));
+    public PeerAddress(InetAddress addr, int port, Services services) {
+        this(addr, port, services, DummySerializer.DEFAULT);
     }
 
     /**
      * Constructs a peer address from the given IP address and port. Version number is default for the given parameters.
      */
-    public PeerAddress(NetworkParameters params, InetAddress addr, int port) {
-        this(params, addr, port, Services.none());
-    }
-
-    /**
-     * Constructs a peer address from the given IP address. Port and version number are default for the given
-     * parameters.
-     */
-    public PeerAddress(NetworkParameters params, InetAddress addr) {
-        this(params, addr, params.getPort());
+    public PeerAddress(InetAddress addr, int port) {
+        this(addr, port, Services.none());
     }
 
     /**
      * Constructs a peer address from an {@link InetSocketAddress}. An InetSocketAddress can take in as parameters an
      * InetAddress or a String hostname. If you want to connect to a .onion, set the hostname to the .onion address.
      */
-    public PeerAddress(NetworkParameters params, InetSocketAddress addr) {
-        this(params, addr.getAddress(), addr.getPort());
+    public PeerAddress(InetSocketAddress addr) {
+        this(addr.getAddress(), addr.getPort());
     }
 
     /**
      * Constructs a peer address from a stringified hostname+port. Use this if you want to connect to a Tor .onion address.
      */
-    public PeerAddress(NetworkParameters params, String hostname, int port) {
-        super(params);
+    public PeerAddress(String hostname, int port) {
+        super();
         this.hostname = hostname;
         this.port = port;
         this.services = Services.none();
@@ -146,7 +137,7 @@ public class PeerAddress extends Message {
     }
 
     public static PeerAddress localhost(NetworkParameters params) {
-        return new PeerAddress(params, InetAddress.getLoopbackAddress(), params.getPort());
+        return new PeerAddress(InetAddress.getLoopbackAddress(), params.getPort());
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -1033,12 +1033,12 @@ public class PeerGroup implements TransactionBroadcaster {
 
     /** Convenience method for {@link #addAddress(PeerAddress)}. */
     public void addAddress(InetAddress address) {
-        addAddress(new PeerAddress(params, address, params.getPort()));
+        addAddress(new PeerAddress(address, params.getPort()));
     }
 
     /** Convenience method for {@link #addAddress(PeerAddress, int)}. */
     public void addAddress(InetAddress address, int priority) {
-        addAddress(new PeerAddress(params, address, params.getPort()), priority);
+        addAddress(new PeerAddress(address, params.getPort()), priority);
     }
 
     /**
@@ -1084,7 +1084,7 @@ public class PeerGroup implements TransactionBroadcaster {
                 log.warn(e.getMessage());
                 continue;
             }
-            for (InetSocketAddress address : addresses) addressList.add(new PeerAddress(params, address));
+            for (InetSocketAddress address : addresses) addressList.add(new PeerAddress(address));
             if (addressList.size() >= maxPeersToDiscoverCount) break;
         }
         if (!addressList.isEmpty()) {
@@ -1454,7 +1454,7 @@ public class PeerGroup implements TransactionBroadcaster {
     public Peer connectTo(InetSocketAddress address) {
         lock.lock();
         try {
-            PeerAddress peerAddress = new PeerAddress(params, address);
+            PeerAddress peerAddress = new PeerAddress(address);
             backoffMap.put(peerAddress, new ExponentialBackoff(peerBackoffParams));
             return connectTo(peerAddress, true, vConnectTimeout);
         } finally {

--- a/core/src/main/java/org/bitcoinj/core/PeerSocketHandler.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerSocketHandler.java
@@ -67,7 +67,7 @@ public abstract class PeerSocketHandler implements TimeoutHandler, StreamConnect
     private BitcoinSerializer.BitcoinPacketHeader header;
 
     public PeerSocketHandler(NetworkParameters params, InetSocketAddress remoteIp) {
-        this(params, new PeerAddress(params, remoteIp));
+        this(params, new PeerAddress(remoteIp));
     }
 
     public PeerSocketHandler(NetworkParameters params, PeerAddress peerAddress) {

--- a/core/src/main/java/org/bitcoinj/core/VersionMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionMessage.java
@@ -104,8 +104,8 @@ public class VersionMessage extends Message {
         // is kind of tricky anyway, so we just put nonsense here for now.
         InetAddress localhost = InetAddresses.forString("127.0.0.1");
         MessageSerializer serializer = this.serializer.withProtocolVersion(0);
-        receivingAddr = new PeerAddress(params, localhost, params.getPort(), Services.none(), serializer);
-        fromAddr = new PeerAddress(params, localhost, params.getPort(), Services.none(), serializer);
+        receivingAddr = new PeerAddress(localhost, params.getPort(), Services.none(), serializer);
+        fromAddr = new PeerAddress(localhost, params.getPort(), Services.none(), serializer);
         subVer = LIBRARY_SUBVER;
         bestHeight = newBestHeight;
         relayTxesBeforeFilter = true;
@@ -116,9 +116,9 @@ public class VersionMessage extends Message {
         clientVersion = (int) ByteUtils.readUint32(payload);
         localServices = Services.read(payload);
         time = Instant.ofEpochSecond(ByteUtils.readInt64(payload));
-        receivingAddr = new PeerAddress(params, payload, serializer.withProtocolVersion(0));
+        receivingAddr = new PeerAddress(payload, serializer.withProtocolVersion(0));
         if (clientVersion >= 106) {
-            fromAddr = new PeerAddress(params, payload, serializer.withProtocolVersion(0));
+            fromAddr = new PeerAddress(payload, serializer.withProtocolVersion(0));
             // uint64 localHostNonce (random data)
             // We don't care about the localhost nonce. It's used to detect connecting back to yourself in cases where
             // there are NATs and proxies in the way. However we don't listen for inbound connections so it's

--- a/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
+++ b/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
@@ -233,13 +233,7 @@ public class WalletAppKit extends AbstractIdleService implements Closeable {
 
     /** Will only connect to localhost. Cannot be called after startup. */
     public WalletAppKit connectToLocalHost() {
-        try {
-            final InetAddress localHost = InetAddress.getLocalHost();
-            return setPeerNodes(new PeerAddress(params, localHost, params.getPort()));
-        } catch (UnknownHostException e) {
-            // Borked machine with no loopback adapter configured properly.
-            throw new RuntimeException(e);
-        }
+        return setPeerNodes(PeerAddress.localhost(params));
     }
 
     /** If true, the wallet will save itself to disk automatically whenever it changes. */

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -815,7 +815,7 @@ public class WalletProtobufSerializer {
             }
             int port = proto.getPort();
             Services services = Services.of(proto.getServices());
-            PeerAddress address = new PeerAddress(params, ip, port, services);
+            PeerAddress address = new PeerAddress(ip, port, services);
             confidence.markBroadcastBy(address);
         }
         if (confidenceProto.hasLastBroadcastedAt())

--- a/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
@@ -75,7 +75,7 @@ public class BitcoinSerializerTest {
         serializer.serialize(addressMessage, bos);
         assertEquals(31, addressMessage.getMessageSize());
 
-        addressMessage.addAddress(new PeerAddress(MAINNET, InetAddress.getLocalHost(), MAINNET.getPort(),
+        addressMessage.addAddress(new PeerAddress(InetAddress.getLocalHost(), MAINNET.getPort(),
                 Services.none(), serializer.withProtocolVersion(1)));
         bos = new ByteArrayOutputStream(61);
         serializer.serialize(addressMessage, bos);

--- a/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
@@ -92,7 +92,7 @@ public class BitcoindComparisonTool {
         VersionMessage ver = new VersionMessage(PARAMS, 42);
         ver.appendToSubVer("BlockAcceptanceComparisonTool", "1.1", null);
         ver.localServices = Services.of(Services.NODE_NETWORK);
-        final Peer bitcoind = new Peer(PARAMS, ver, new PeerAddress(PARAMS, InetAddress.getLocalHost()),
+        final Peer bitcoind = new Peer(PARAMS, ver, PeerAddress.localhost(PARAMS),
                 new BlockChain(PARAMS, new MemoryBlockStore(PARAMS)));
         checkState(bitcoind.getVersionMessage().hasBlockChain());
 

--- a/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
@@ -191,8 +191,8 @@ public class ChainSplitTest {
         wallet.commitTx(spend);
         // Waiting for confirmation ... make it eligible for selection.
         assertEquals(Coin.ZERO, wallet.getBalance());
-        spend.getConfidence().markBroadcastBy(new PeerAddress(TESTNET, InetAddress.getByAddress(new byte[]{1, 2, 3, 4})));
-        spend.getConfidence().markBroadcastBy(new PeerAddress(TESTNET, InetAddress.getByAddress(new byte[]{5,6,7,8})));
+        spend.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByAddress(new byte[]{1, 2, 3, 4}), TESTNET.getPort()));
+        spend.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByAddress(new byte[]{5,6,7,8}), TESTNET.getPort()));
         assertEquals(ConfidenceType.PENDING, spend.getConfidence().getConfidenceType());
         assertEquals(valueOf(40, 0), wallet.getBalance());
         Block b2 = b1.createNextBlock(someOtherGuy);

--- a/core/src/test/java/org/bitcoinj/core/PeerAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerAddressTest.java
@@ -55,8 +55,7 @@ public class PeerAddressTest {
         MessageSerializer serializer = MAINNET.getDefaultSerializer().withProtocolVersion(0);
         // copied from https://en.bitcoin.it/wiki/Protocol_documentation#Network_address
         String hex = "010000000000000000000000000000000000ffff0a000001208d";
-        PeerAddress pa = new PeerAddress(MAINNET, ByteBuffer.wrap(ByteUtils.parseHex(hex)),
-                serializer);
+        PeerAddress pa = new PeerAddress(ByteBuffer.wrap(ByteUtils.parseHex(hex)), serializer);
         assertEquals(Services.NODE_NETWORK, pa.getServices().bits());
         assertEquals("10.0.0.1", pa.getAddr().getHostAddress());
         assertEquals(8333, pa.getPort());
@@ -65,8 +64,7 @@ public class PeerAddressTest {
     @Test
     public void bitcoinSerialize_versionVariant() throws Exception {
         MessageSerializer serializer = MAINNET.getDefaultSerializer().withProtocolVersion(0);
-        PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName(null), 8333, Services.none(),
-                serializer);
+        PeerAddress pa = new PeerAddress(InetAddress.getByName(null), 8333, Services.none(), serializer);
         assertEquals("000000000000000000000000000000000000ffff7f000001208d", ByteUtils.formatHex(pa.bitcoinSerialize()));
     }
 
@@ -74,10 +72,9 @@ public class PeerAddressTest {
     public void roundtrip_ipv4_addressV2Variant() throws Exception {
         Instant time = TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS);
         MessageSerializer serializer = MAINNET.getDefaultSerializer().withProtocolVersion(2);
-        PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName("1.2.3.4"), 1234, Services.none(),
-                serializer);
+        PeerAddress pa = new PeerAddress(InetAddress.getByName("1.2.3.4"), 1234, Services.none(), serializer);
         byte[] serialized = pa.bitcoinSerialize();
-        PeerAddress pa2 = new PeerAddress(MAINNET, ByteBuffer.wrap(serialized), serializer);
+        PeerAddress pa2 = new PeerAddress(ByteBuffer.wrap(serialized), serializer);
         assertEquals("1.2.3.4", pa2.getAddr().getHostAddress());
         assertEquals(1234, pa2.getPort());
         assertEquals(Services.none(), pa2.getServices());
@@ -88,10 +85,9 @@ public class PeerAddressTest {
     public void roundtrip_ipv4_addressVariant() throws Exception {
         Instant time = TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS);
         MessageSerializer serializer = MAINNET.getDefaultSerializer().withProtocolVersion(1);
-        PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName("1.2.3.4"), 1234, Services.none(),
-                serializer);
+        PeerAddress pa = new PeerAddress(InetAddress.getByName("1.2.3.4"), 1234, Services.none(), serializer);
         byte[] serialized = pa.bitcoinSerialize();
-        PeerAddress pa2 = new PeerAddress(MAINNET, ByteBuffer.wrap(serialized), serializer);
+        PeerAddress pa2 = new PeerAddress(ByteBuffer.wrap(serialized), serializer);
         assertEquals("1.2.3.4", pa2.getAddr().getHostAddress());
         assertEquals(1234, pa2.getPort());
         assertEquals(Services.none(), pa2.getServices());
@@ -101,10 +97,9 @@ public class PeerAddressTest {
     @Test
     public void roundtrip_ipv4_versionVariant() throws Exception {
         MessageSerializer serializer = MAINNET.getDefaultSerializer().withProtocolVersion(0);
-        PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName("1.2.3.4"), 1234, Services.none(),
-                serializer);
+        PeerAddress pa = new PeerAddress(InetAddress.getByName("1.2.3.4"), 1234, Services.none(), serializer);
         byte[] serialized = pa.bitcoinSerialize();
-        PeerAddress pa2 = new PeerAddress(MAINNET, ByteBuffer.wrap(serialized), serializer);
+        PeerAddress pa2 = new PeerAddress(ByteBuffer.wrap(serialized), serializer);
         assertEquals("1.2.3.4", pa2.getAddr().getHostAddress());
         assertEquals(1234, pa2.getPort());
         assertEquals(Services.none(), pa2.getServices());
@@ -115,10 +110,10 @@ public class PeerAddressTest {
     public void roundtrip_ipv6_addressV2Variant() throws Exception {
         Instant time = TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS);
         MessageSerializer serializer = MAINNET.getDefaultSerializer().withProtocolVersion(2);
-        PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334"), 1234,
+        PeerAddress pa = new PeerAddress(InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334"), 1234,
                 Services.none(), serializer);
         byte[] serialized = pa.bitcoinSerialize();
-        PeerAddress pa2 = new PeerAddress(MAINNET, ByteBuffer.wrap(serialized), serializer);
+        PeerAddress pa2 = new PeerAddress(ByteBuffer.wrap(serialized), serializer);
         assertEquals("2001:db8:85a3:0:0:8a2e:370:7334", pa2.getAddr().getHostAddress());
         assertEquals(1234, pa2.getPort());
         assertEquals(Services.none(), pa2.getServices());
@@ -129,10 +124,10 @@ public class PeerAddressTest {
     public void roundtrip_ipv6_addressVariant() throws Exception {
         Instant time = TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS);
         MessageSerializer serializer = MAINNET.getDefaultSerializer().withProtocolVersion(1);
-        PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334"), 1234,
+        PeerAddress pa = new PeerAddress(InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334"), 1234,
                 Services.none(), serializer);
         byte[] serialized = pa.bitcoinSerialize();
-        PeerAddress pa2 = new PeerAddress(MAINNET, ByteBuffer.wrap(serialized), serializer);
+        PeerAddress pa2 = new PeerAddress(ByteBuffer.wrap(serialized), serializer);
         assertEquals("2001:db8:85a3:0:0:8a2e:370:7334", pa2.getAddr().getHostAddress());
         assertEquals(1234, pa2.getPort());
         assertEquals(Services.none(), pa2.getServices());
@@ -142,10 +137,10 @@ public class PeerAddressTest {
     @Test
     public void roundtrip_ipv6_versionVariant() throws Exception {
         MessageSerializer serializer = MAINNET.getDefaultSerializer().withProtocolVersion(0);
-        PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334"), 1234,
+        PeerAddress pa = new PeerAddress(InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334"), 1234,
                 Services.none(), serializer);
         byte[] serialized = pa.bitcoinSerialize();
-        PeerAddress pa2 = new PeerAddress(MAINNET, ByteBuffer.wrap(serialized), serializer);
+        PeerAddress pa2 = new PeerAddress(ByteBuffer.wrap(serialized), serializer);
         assertEquals("2001:db8:85a3:0:0:8a2e:370:7334", pa2.getAddr().getHostAddress());
         assertEquals(1234, pa2.getPort());
         assertEquals(Services.none(), pa2.getServices());
@@ -156,7 +151,7 @@ public class PeerAddressTest {
     @Parameters(method = "deserializeToStringValues")
     public void deserializeToString(int version, String expectedToString, String hex) {
         MessageSerializer serializer = MAINNET.getDefaultSerializer().withProtocolVersion(version);
-        PeerAddress pa = new PeerAddress(MAINNET, ByteBuffer.wrap(ByteUtils.parseHex(hex)), serializer);
+        PeerAddress pa = new PeerAddress(ByteBuffer.wrap(ByteUtils.parseHex(hex)), serializer);
 
         assertEquals(expectedToString, pa.toString());
     }

--- a/core/src/test/java/org/bitcoinj/core/TxConfidenceTableTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TxConfidenceTableTest.java
@@ -61,9 +61,9 @@ public class TxConfidenceTableTest {
         tx2 = FakeTxBuilder.createFakeTxWithChangeAddress(TESTNET, COIN, to, change);
         assertEquals(tx1.getTxId(), tx2.getTxId());
 
-        address1 = new PeerAddress(TESTNET, InetAddress.getByAddress(new byte[] { 127, 0, 0, 1 }));
-        address2 = new PeerAddress(TESTNET, InetAddress.getByAddress(new byte[] { 127, 0, 0, 2 }));
-        address3 = new PeerAddress(TESTNET, InetAddress.getByAddress(new byte[] { 127, 0, 0, 3 }));
+        address1 = new PeerAddress(InetAddress.getByAddress(new byte[] { 127, 0, 0, 1 }), TESTNET.getPort());
+        address2 = new PeerAddress(InetAddress.getByAddress(new byte[] { 127, 0, 0, 2 }), TESTNET.getPort());
+        address3 = new PeerAddress(InetAddress.getByAddress(new byte[] { 127, 0, 0, 3 }), TESTNET.getPort());
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/core/VersionMessageTest.java
+++ b/core/src/test/java/org/bitcoinj/core/VersionMessageTest.java
@@ -76,8 +76,8 @@ public class VersionMessageTest {
         ver.subVer = "/bitcoinj/";
         ver.clientVersion = NetworkParameters.ProtocolVersion.CURRENT.getBitcoinProtocolVersion();
         ver.localServices = Services.of(1);
-        ver.fromAddr = new PeerAddress(TESTNET, InetAddress.getByName("1.2.3.4"), 3888);
-        ver.receivingAddr = new PeerAddress(TESTNET, InetAddress.getByName("4.3.2.1"), 8333);
+        ver.fromAddr = new PeerAddress(InetAddress.getByName("1.2.3.4"), 3888);
+        ver.receivingAddr = new PeerAddress(InetAddress.getByName("4.3.2.1"), 8333);
         byte[] serialized = ver.bitcoinSerialize();
         VersionMessage ver2 = new VersionMessage(TESTNET, ByteBuffer.wrap(serialized));
         assertEquals(1234, ver2.bestHeight);
@@ -98,8 +98,8 @@ public class VersionMessageTest {
         ver.subVer = "/bitcoinj/";
         ver.clientVersion = NetworkParameters.ProtocolVersion.CURRENT.getBitcoinProtocolVersion();
         ver.localServices = Services.of(1);
-        ver.fromAddr = new PeerAddress(TESTNET, InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334"), 3888);
-        ver.receivingAddr = new PeerAddress(TESTNET, InetAddress.getByName("2002:db8:85a3:0:0:8a2e:370:7335"), 8333);
+        ver.fromAddr = new PeerAddress(InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334"), 3888);
+        ver.receivingAddr = new PeerAddress(InetAddress.getByName("2002:db8:85a3:0:0:8a2e:370:7335"), 8333);
         byte[] serialized = ver.bitcoinSerialize();
         VersionMessage ver2 = new VersionMessage(TESTNET, ByteBuffer.wrap(serialized));
         assertEquals(1234, ver2.bestHeight);

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -139,8 +139,8 @@ public class WalletProtobufSerializerTest {
         // Check basic tx serialization.
         Coin v1 = COIN;
         Transaction t1 = createFakeTx(TESTNET, v1, myAddress);
-        t1.getConfidence().markBroadcastBy(new PeerAddress(TESTNET, InetAddress.getByName("1.2.3.4")));
-        t1.getConfidence().markBroadcastBy(new PeerAddress(TESTNET, InetAddress.getByName("5.6.7.8")));
+        t1.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByName("1.2.3.4"), TESTNET.getPort()));
+        t1.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByName("5.6.7.8"), TESTNET.getPort()));
         t1.getConfidence().setSource(TransactionConfidence.Source.NETWORK);
         myWallet.receivePending(t1, null);
         Wallet wallet1 = roundTrip(myWallet);

--- a/core/src/test/java/org/bitcoinj/wallet/DefaultCoinSelectorTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DefaultCoinSelectorTest.java
@@ -68,9 +68,9 @@ public class DefaultCoinSelectorTest extends TestWithWallet {
         assertFalse(DefaultCoinSelector.isSelectable(t));
         t.getConfidence().setSource(TransactionConfidence.Source.SELF);
         assertFalse(DefaultCoinSelector.isSelectable(t));
-        t.getConfidence().markBroadcastBy(new PeerAddress(TESTNET, InetAddress.getByName("1.2.3.4")));
+        t.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByName("1.2.3.4"), TESTNET.getPort()));
         assertTrue(DefaultCoinSelector.isSelectable(t));
-        t.getConfidence().markBroadcastBy(new PeerAddress(TESTNET, InetAddress.getByName("5.6.7.8")));
+        t.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByName("5.6.7.8"), TESTNET.getPort()));
         assertTrue(DefaultCoinSelector.isSelectable(t));
         t = new Transaction(TESTNET);
         t.getConfidence().setConfidenceType(TransactionConfidence.ConfidenceType.BUILDING);

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -492,8 +492,8 @@ public class WalletTest extends TestWithWallet {
         final LinkedList<Transaction> txns = new LinkedList<>();
         wallet.addCoinsSentEventListener((wallet1, tx, prevBalance, newBalance) -> txns.add(tx));
 
-        t.getConfidence().markBroadcastBy(new PeerAddress(TESTNET, InetAddress.getByAddress(new byte[]{1,2,3,4})));
-        t.getConfidence().markBroadcastBy(new PeerAddress(TESTNET, InetAddress.getByAddress(new byte[]{10,2,3,4})));
+        t.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByAddress(new byte[]{1,2,3,4}), TESTNET.getPort()));
+        t.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByAddress(new byte[]{10,2,3,4}), TESTNET.getPort()));
         wallet.commitTx(t);
         Threading.waitForUserCode();
         assertEquals(1, wallet.getPoolSize(WalletTransaction.Pool.PENDING));

--- a/examples/src/main/java/org/bitcoinj/examples/FetchBlock.java
+++ b/examples/src/main/java/org/bitcoinj/examples/FetchBlock.java
@@ -64,7 +64,7 @@ public class FetchBlock implements Callable<Integer> {
         if (localhost) {
             peerGroup.addPeerDiscovery(new DnsDiscovery(params));
         } else {
-            PeerAddress addr = new PeerAddress(params, InetAddress.getLocalHost());
+            PeerAddress addr = PeerAddress.localhost(params);
             peerGroup.addAddress(addr);
         }
         peerGroup.start();

--- a/examples/src/main/java/org/bitcoinj/examples/FetchTransactions.java
+++ b/examples/src/main/java/org/bitcoinj/examples/FetchTransactions.java
@@ -43,7 +43,7 @@ public class FetchTransactions {
         BlockChain chain = new BlockChain(params, blockStore);
         PeerGroup peerGroup = new PeerGroup(network, chain);
         peerGroup.start();
-        peerGroup.addAddress(new PeerAddress(params, InetAddress.getLocalHost()));
+        peerGroup.addAddress(PeerAddress.localhost(params));
         peerGroup.waitForPeers(1).get();
         Peer peer = peerGroup.getConnectedPeers().get(0);
 

--- a/examples/src/main/java/org/bitcoinj/examples/PrintPeers.java
+++ b/examples/src/main/java/org/bitcoinj/examples/PrintPeers.java
@@ -83,7 +83,7 @@ public class PrintPeers {
         for (final InetAddress addr : addrs) {
             InetSocketAddress address = new InetSocketAddress(addr, params.getPort());
             final Peer peer = new Peer(params, new VersionMessage(params, 0),
-                    new PeerAddress(params, address), null);
+                    new PeerAddress(address), null);
             final CompletableFuture<Void> future = new CompletableFuture<>();
             // Once the connection has completed version handshaking ...
             peer.addConnectedEventListener((p, peerCount) -> {

--- a/examples/src/main/java/org/bitcoinj/examples/PrivateKeys.java
+++ b/examples/src/main/java/org/bitcoinj/examples/PrivateKeys.java
@@ -74,7 +74,7 @@ public class PrivateKeys {
             BlockChain chain = new BlockChain(params, wallet, blockStore);
 
             final PeerGroup peerGroup = new PeerGroup(network, chain);
-            peerGroup.addAddress(new PeerAddress(params, InetAddress.getLocalHost()));
+            peerGroup.addAddress(PeerAddress.localhost(params));
             peerGroup.startAsync();
             peerGroup.downloadBlockChain();
 

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -94,7 +94,7 @@ public class PeerTest extends TestWithNetworkConnections {
         super.setUp();
         VersionMessage ver = new VersionMessage(TESTNET, 100);
         InetSocketAddress address = new InetSocketAddress(InetAddress.getLoopbackAddress(), 4000);
-        peer = new Peer(TESTNET, ver, new PeerAddress(TESTNET, address), blockChain);
+        peer = new Peer(TESTNET, ver, new PeerAddress(address), blockChain);
         peer.addWallet(wallet);
     }
 
@@ -275,7 +275,7 @@ public class PeerTest extends TestWithNetworkConnections {
         // Check co-ordination of which peer to download via the memory pool.
         VersionMessage ver = new VersionMessage(TESTNET, 100);
         InetSocketAddress address = new InetSocketAddress(InetAddress.getLoopbackAddress(), 4242);
-        Peer peer2 = new Peer(TESTNET, ver, new PeerAddress(TESTNET, address), blockChain);
+        Peer peer2 = new Peer(TESTNET, ver, new PeerAddress(address), blockChain);
         peer2.addWallet(wallet);
         VersionMessage peerVersion = new VersionMessage(TESTNET, OTHER_PEER_CHAIN_HEIGHT);
         peerVersion.clientVersion = 70001;

--- a/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
@@ -244,7 +244,7 @@ public class BuildCheckpoints implements Callable<Integer> {
     }
 
     private static void startPeerGroup(PeerGroup peerGroup, InetAddress ipAddress) {
-        final PeerAddress peerAddress = new PeerAddress(params, ipAddress);
+        final PeerAddress peerAddress = new PeerAddress(ipAddress, params.getPort());
         System.out.println("Connecting to " + peerAddress + "...");
         peerGroup.addAddress(peerAddress);
         peerGroup.start();

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -1016,7 +1016,7 @@ public class WalletTool implements Callable<Integer> {
             String[] peerAddrs = peersStr.split(",");
             for (String peer : peerAddrs) {
                 try {
-                    peerGroup.addAddress(new PeerAddress(params, InetAddress.getByName(peer)));
+                    peerGroup.addAddress(new PeerAddress(InetAddress.getByName(peer), params.getPort()));
                 } catch (UnknownHostException e) {
                     System.err.println("Could not understand peer domain name/IP address: " + peer + ": " + e.getMessage());
                     System.exit(1);


### PR DESCRIPTION
To make this possible, a port has to be specified in all cases.