### PR TITLE
DummySerializer: make capable of pretending specific protocol version

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AddressV1Message.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressV1Message.java
@@ -55,7 +55,7 @@ public class AddressV1Message extends AddressMessage {
         if (numAddresses > MAX_ADDRESSES)
             throw new ProtocolException("Address message too large.");
         addresses = new ArrayList<>(numAddresses);
-        MessageSerializer serializer = this.serializer.withProtocolVersion(1);
+        MessageSerializer serializer = new DummySerializer(1);
         for (int i = 0; i < numAddresses; i++) {
             PeerAddress addr = new PeerAddress(params, payload, serializer);
             addresses.add(addr);

--- a/core/src/main/java/org/bitcoinj/core/AddressV2Message.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressV2Message.java
@@ -55,7 +55,7 @@ public class AddressV2Message extends AddressMessage {
         if (numAddresses > MAX_ADDRESSES)
             throw new ProtocolException("Address message too large.");
         addresses = new ArrayList<>(numAddresses);
-        MessageSerializer serializer = this.serializer.withProtocolVersion(2);
+        MessageSerializer serializer = new DummySerializer(2);
         for (int i = 0; i < numAddresses; i++) {
             PeerAddress addr = new PeerAddress(params, payload, serializer);
             addresses.add(addr);

--- a/core/src/main/java/org/bitcoinj/core/DummySerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/DummySerializer.java
@@ -30,17 +30,24 @@ class DummySerializer extends MessageSerializer {
 
     private static final String DEFAULT_EXCEPTION_MESSAGE = "Dummy serializer cannot serialize/deserialize objects as it does not know which network they belong to.";
 
+    private final int protocolVersion;
+
     public DummySerializer() {
+        this.protocolVersion = 0;
+    }
+
+    public DummySerializer(int protocolVersion) {
+        this.protocolVersion = protocolVersion;
     }
 
     @Override
     public DummySerializer withProtocolVersion(int protocolVersion) {
-        return this;
+        return new DummySerializer(protocolVersion);
     }
 
     @Override
     public int getProtocolVersion() {
-        return 0;
+        return protocolVersion;
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/PeerAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerAddress.java
@@ -108,7 +108,7 @@ public class PeerAddress extends Message {
      * Constructs a peer address from the given IP address, port and services. Version number is default for the given parameters.
      */
     public PeerAddress(NetworkParameters params, InetAddress addr, int port, Services services) {
-        this(params, addr, port, services, params.getDefaultSerializer().withProtocolVersion(0));
+        this(params, addr, port, services, new DummySerializer(0));
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/VersionMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionMessage.java
@@ -103,7 +103,7 @@ public class VersionMessage extends Message {
         // Note that the Bitcoin Core doesn't do anything with these, and finding out your own external IP address
         // is kind of tricky anyway, so we just put nonsense here for now.
         InetAddress localhost = InetAddresses.forString("127.0.0.1");
-        MessageSerializer serializer = this.serializer.withProtocolVersion(0);
+        MessageSerializer serializer = new DummySerializer(0);
         receivingAddr = new PeerAddress(params, localhost, params.getPort(), Services.none(), serializer);
         fromAddr = new PeerAddress(params, localhost, params.getPort(), Services.none(), serializer);
         subVer = LIBRARY_SUBVER;
@@ -116,9 +116,9 @@ public class VersionMessage extends Message {
         clientVersion = (int) ByteUtils.readUint32(payload);
         localServices = Services.read(payload);
         time = Instant.ofEpochSecond(ByteUtils.readInt64(payload));
-        receivingAddr = new PeerAddress(params, payload, serializer.withProtocolVersion(0));
+        receivingAddr = new PeerAddress(params, payload, new DummySerializer(0));
         if (clientVersion >= 106) {
-            fromAddr = new PeerAddress(params, payload, serializer.withProtocolVersion(0));
+            fromAddr = new PeerAddress(params, payload, new DummySerializer(0));
             // uint64 localHostNonce (random data)
             // We don't care about the localhost nonce. It's used to detect connecting back to yourself in cases where
             // there are NATs and proxies in the way. However we don't listen for inbound connections so it's

--- a/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
@@ -76,7 +76,7 @@ public class BitcoinSerializerTest {
         assertEquals(31, addressMessage.getMessageSize());
 
         addressMessage.addAddress(new PeerAddress(MAINNET, InetAddress.getLocalHost(), MAINNET.getPort(),
-                Services.none(), serializer.withProtocolVersion(1)));
+                Services.none(), new DummySerializer(1)));
         bos = new ByteArrayOutputStream(61);
         serializer.serialize(addressMessage, bos);
         assertEquals(61, addressMessage.getMessageSize());

--- a/core/src/test/java/org/bitcoinj/core/PeerAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerAddressTest.java
@@ -52,9 +52,9 @@ public class PeerAddressTest {
 
     @Test
     public void parse_versionVariant() {
-        MessageSerializer serializer = MAINNET.getDefaultSerializer().withProtocolVersion(0);
         // copied from https://en.bitcoin.it/wiki/Protocol_documentation#Network_address
         String hex = "010000000000000000000000000000000000ffff0a000001208d";
+        MessageSerializer serializer = new DummySerializer(0);
         PeerAddress pa = new PeerAddress(MAINNET, ByteBuffer.wrap(ByteUtils.parseHex(hex)),
                 serializer);
         assertEquals(Services.NODE_NETWORK, pa.getServices().bits());
@@ -64,7 +64,7 @@ public class PeerAddressTest {
 
     @Test
     public void bitcoinSerialize_versionVariant() throws Exception {
-        MessageSerializer serializer = MAINNET.getDefaultSerializer().withProtocolVersion(0);
+        MessageSerializer serializer = new DummySerializer(0);
         PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName(null), 8333, Services.none(),
                 serializer);
         assertEquals("000000000000000000000000000000000000ffff7f000001208d", ByteUtils.formatHex(pa.bitcoinSerialize()));
@@ -73,7 +73,7 @@ public class PeerAddressTest {
     @Test
     public void roundtrip_ipv4_addressV2Variant() throws Exception {
         Instant time = TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS);
-        MessageSerializer serializer = MAINNET.getDefaultSerializer().withProtocolVersion(2);
+        MessageSerializer serializer = new DummySerializer(2);
         PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName("1.2.3.4"), 1234, Services.none(),
                 serializer);
         byte[] serialized = pa.bitcoinSerialize();
@@ -87,7 +87,7 @@ public class PeerAddressTest {
     @Test
     public void roundtrip_ipv4_addressVariant() throws Exception {
         Instant time = TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS);
-        MessageSerializer serializer = MAINNET.getDefaultSerializer().withProtocolVersion(1);
+        MessageSerializer serializer = new DummySerializer(1);
         PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName("1.2.3.4"), 1234, Services.none(),
                 serializer);
         byte[] serialized = pa.bitcoinSerialize();
@@ -100,7 +100,7 @@ public class PeerAddressTest {
 
     @Test
     public void roundtrip_ipv4_versionVariant() throws Exception {
-        MessageSerializer serializer = MAINNET.getDefaultSerializer().withProtocolVersion(0);
+        MessageSerializer serializer = new DummySerializer(0);
         PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName("1.2.3.4"), 1234, Services.none(),
                 serializer);
         byte[] serialized = pa.bitcoinSerialize();
@@ -114,7 +114,7 @@ public class PeerAddressTest {
     @Test
     public void roundtrip_ipv6_addressV2Variant() throws Exception {
         Instant time = TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS);
-        MessageSerializer serializer = MAINNET.getDefaultSerializer().withProtocolVersion(2);
+        MessageSerializer serializer = new DummySerializer(2);
         PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334"), 1234,
                 Services.none(), serializer);
         byte[] serialized = pa.bitcoinSerialize();
@@ -128,7 +128,7 @@ public class PeerAddressTest {
     @Test
     public void roundtrip_ipv6_addressVariant() throws Exception {
         Instant time = TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS);
-        MessageSerializer serializer = MAINNET.getDefaultSerializer().withProtocolVersion(1);
+        MessageSerializer serializer = new DummySerializer(1);
         PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334"), 1234,
                 Services.none(), serializer);
         byte[] serialized = pa.bitcoinSerialize();
@@ -141,7 +141,7 @@ public class PeerAddressTest {
 
     @Test
     public void roundtrip_ipv6_versionVariant() throws Exception {
-        MessageSerializer serializer = MAINNET.getDefaultSerializer().withProtocolVersion(0);
+        MessageSerializer serializer = new DummySerializer(0);
         PeerAddress pa = new PeerAddress(MAINNET, InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334"), 1234,
                 Services.none(), serializer);
         byte[] serialized = pa.bitcoinSerialize();
@@ -155,7 +155,7 @@ public class PeerAddressTest {
     @Test
     @Parameters(method = "deserializeToStringValues")
     public void deserializeToString(int version, String expectedToString, String hex) {
-        MessageSerializer serializer = MAINNET.getDefaultSerializer().withProtocolVersion(version);
+        MessageSerializer serializer = new DummySerializer(version);
         PeerAddress pa = new PeerAddress(MAINNET, ByteBuffer.wrap(ByteUtils.parseHex(hex)), serializer);
 
         assertEquals(expectedToString, pa.toString());


### PR DESCRIPTION
This is put to use for the "misuse of protocol version" for `PeerAddress`.