### PR TITLE
NetworkParameters: fix protocol version for BIP37 bloom filters

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -555,7 +555,7 @@ public abstract class NetworkParameters {
     public static enum ProtocolVersion {
         MINIMUM(70000),
         PONG(60001),
-        BLOOM_FILTER(70000), // BIP37
+        BLOOM_FILTER(70001), // BIP37
         BLOOM_FILTER_BIP111(70011), // BIP111
         WITNESS_VERSION(70012),
         FEEFILTER(70013), // BIP133

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -732,10 +732,10 @@ public class PeerGroupTest extends TestWithPeerGroup {
         CompletableFuture<List<Peer>> future = peerGroup.waitForPeersWithServiceMask(2, 3);
 
         VersionMessage ver1 = new VersionMessage(UNITTEST, 10);
-        ver1.clientVersion = 70000;
+        ver1.clientVersion = 70001;
         ver1.localServices = Services.of(Services.NODE_NETWORK);
         VersionMessage ver2 = new VersionMessage(UNITTEST, 10);
-        ver2.clientVersion = 70000;
+        ver2.clientVersion = 70001;
         ver2.localServices = Services.of(Services.NODE_NETWORK | 2);
         peerGroup.start();
         assertFalse(future.isDone());


### PR DESCRIPTION
According to BIP111, the protocol version must be greater than 70000. Since we use "greater or equals", 70001 is the correct number.