### PR TITLE
Peer: fix default of the minimum protocol version of remote peers

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -245,7 +245,7 @@ public class Peer extends PeerSocketHandler {
         this.getAddrFutures = new LinkedList<>();
         this.fastCatchupTime = params.getGenesisBlock().time();
         this.pendingPings = new CopyOnWriteArrayList<>();
-        this.vMinProtocolVersion = params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.PONG);
+        this.vMinProtocolVersion = params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.MINIMUM);
         this.wallets = new CopyOnWriteArrayList<>();
         this.context = Context.get();
 


### PR DESCRIPTION
It should be `NetworkParameters.ProtocolVersion.MINIMUM` (currently 70000).