### PR TITLE
TransactionOutput: remove `params` from constructors

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -261,7 +261,7 @@ public class Block extends Message {
     private static Transaction createGenesisTransaction(NetworkParameters n, byte[] inputScriptBytes, Coin amount, byte[] scriptPubKeyBytes) {
         Transaction t = new Transaction(n);
         t.addInput(new TransactionInput(t, inputScriptBytes));
-        t.addOutput(new TransactionOutput(n, t, amount, scriptPubKeyBytes));
+        t.addOutput(new TransactionOutput(t, amount, scriptPubKeyBytes));
         return t;
     }
 
@@ -893,7 +893,7 @@ public class Block extends Message {
         // counter in the scriptSig so every transaction has a different hash.
         coinbase.addInput(new TransactionInput(coinbase,
                 inputBuilder.build().getProgram()));
-        coinbase.addOutput(new TransactionOutput(params, coinbase, value,
+        coinbase.addOutput(new TransactionOutput(coinbase, value,
                 ScriptBuilder.createP2PKOutputScript(ECKey.fromPublicOnly(pubKeyTo)).getProgram()));
         transactions.add(coinbase);
     }
@@ -929,7 +929,7 @@ public class Block extends Message {
         if (to != null) {
             // Add a transaction paying 50 coins to the "to" address.
             Transaction t = new Transaction(params);
-            t.addOutput(new TransactionOutput(params, t, FIFTY_COINS, to));
+            t.addOutput(new TransactionOutput(t, FIFTY_COINS, to));
             // The input does not really need to be a valid signature, as long as it has the right general form.
             TransactionInput input;
             if (prevOut == null) {

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -708,7 +708,7 @@ public class Transaction extends Message {
         int numOutputs = numOutputsVarInt.intValue();
         outputs = new ArrayList<>(Math.min((int) numOutputs, Utils.MAX_INITIAL_ARRAY_LENGTH));
         for (long i = 0; i < numOutputs; i++) {
-            TransactionOutput output = new TransactionOutput(params, this, payload.slice());
+            TransactionOutput output = new TransactionOutput(this, payload.slice());
             outputs.add(output);
             // intentionally read again, due to the slice above
             Buffers.skipBytes(payload, 8); // value
@@ -1121,7 +1121,7 @@ public class Transaction extends Message {
      * Creates an output based on the given address and value, adds it to this transaction, and returns the new output.
      */
     public TransactionOutput addOutput(Coin value, Address address) {
-        return addOutput(new TransactionOutput(params, this, value, address));
+        return addOutput(new TransactionOutput(this, value, address));
     }
 
     /**
@@ -1129,7 +1129,7 @@ public class Transaction extends Message {
      * transaction, and returns the new output.
      */
     public TransactionOutput addOutput(Coin value, ECKey pubkey) {
-        return addOutput(new TransactionOutput(params, this, value, pubkey));
+        return addOutput(new TransactionOutput(this, value, pubkey));
     }
 
     /**
@@ -1137,7 +1137,7 @@ public class Transaction extends Message {
      * you won't normally need to use it unless you're doing unusual things.
      */
     public TransactionOutput addOutput(Coin value, Script script) {
-        return addOutput(new TransactionOutput(params, this, value, script.getProgram()));
+        return addOutput(new TransactionOutput(this, value, script.getProgram()));
     }
 
 
@@ -1326,7 +1326,7 @@ public class Transaction extends Message {
                 // that position are "nulled out". Unintuitively, the value in a "null" transaction is set to -1.
                 tx.outputs = new ArrayList<>(tx.outputs.subList(0, inputIndex + 1));
                 for (int i = 0; i < inputIndex; i++)
-                    tx.outputs.set(i, new TransactionOutput(tx.params, tx, Coin.NEGATIVE_SATOSHI, new byte[] {}));
+                    tx.outputs.set(i, new TransactionOutput(tx, Coin.NEGATIVE_SATOSHI, new byte[] {}));
                 // The signature isn't broken by new versions of the transaction issued by other parties.
                 for (int i = 0; i < tx.inputs.size(); i++)
                     if (i != inputIndex)

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -77,12 +77,11 @@ public class TransactionOutput extends Message {
     /**
      * Deserializes a transaction output message. This is usually part of a transaction message.
      *
-     * @param params NetworkParameters object.
      * @param payload Bitcoin protocol formatted byte array containing message content.
      * @throws ProtocolException
      */
-    public TransactionOutput(NetworkParameters params, @Nullable Transaction parent, ByteBuffer payload) throws ProtocolException {
-        super(params, payload);
+    public TransactionOutput(@Nullable Transaction parent, ByteBuffer payload) throws ProtocolException {
+        super(payload);
         setParent(parent);
         availableForSpending = true;
     }
@@ -92,8 +91,8 @@ public class TransactionOutput extends Message {
      * something like {@link Coin#valueOf(int, int)}. Typically you would use
      * {@link Transaction#addOutput(Coin, Address)} instead of creating a TransactionOutput directly.
      */
-    public TransactionOutput(NetworkParameters params, @Nullable Transaction parent, Coin value, Address to) {
-        this(params, parent, value, ScriptBuilder.createOutputScript(to).getProgram());
+    public TransactionOutput(@Nullable Transaction parent, Coin value, Address to) {
+        this(parent, value, ScriptBuilder.createOutputScript(to).getProgram());
     }
 
     /**
@@ -101,18 +100,16 @@ public class TransactionOutput extends Message {
      * amount should be created with something like {@link Coin#valueOf(int, int)}. Typically you would use
      * {@link Transaction#addOutput(Coin, ECKey)} instead of creating an output directly.
      */
-    public TransactionOutput(NetworkParameters params, @Nullable Transaction parent, Coin value, ECKey to) {
-        this(params, parent, value, ScriptBuilder.createP2PKOutputScript(to).getProgram());
+    public TransactionOutput(@Nullable Transaction parent, Coin value, ECKey to) {
+        this(parent, value, ScriptBuilder.createP2PKOutputScript(to).getProgram());
     }
 
-    public TransactionOutput(NetworkParameters params, @Nullable Transaction parent, Coin value, byte[] scriptBytes) {
-        super(params);
+    public TransactionOutput(@Nullable Transaction parent, Coin value, byte[] scriptBytes) {
+        super();
         // Negative values obviously make no sense, except for -1 which is used as a sentinel value when calculating
         // SIGHASH_SINGLE signatures, so unfortunately we have to allow that here.
         checkArgument(value.signum() >= 0 || value.equals(Coin.NEGATIVE_SATOSHI), () ->
                 "negative values not allowed");
-        checkArgument(!params.network().exceedsMaxMoney(value), () ->
-                "values larger than MAX_MONEY not allowed");
         this.value = value.value;
         this.scriptBytes = scriptBytes;
         setParent(parent);
@@ -407,7 +404,7 @@ public class TransactionOutput extends Message {
 
     /** Returns a copy of the output detached from its containing transaction, if need be. */
     public TransactionOutput duplicateDetached() {
-        return new TransactionOutput(params, null, Coin.valueOf(value), Arrays.copyOf(scriptBytes, scriptBytes.length));
+        return new TransactionOutput(null, Coin.valueOf(value), Arrays.copyOf(scriptBytes, scriptBytes.length));
     }
 
     public final void setParent(@Nullable Transaction parent) {

--- a/core/src/main/java/org/bitcoinj/protocols/payments/PaymentSession.java
+++ b/core/src/main/java/org/bitcoinj/protocols/payments/PaymentSession.java
@@ -322,7 +322,7 @@ public class PaymentSession {
     public SendRequest getSendRequest() {
         Transaction tx = new Transaction(params);
         for (Protos.Output output : paymentDetails.getOutputsList())
-            tx.addOutput(new TransactionOutput(params, tx, Coin.valueOf(output.getAmount()), output.getScript().toByteArray()));
+            tx.addOutput(new TransactionOutput(tx, Coin.valueOf(output.getAmount()), output.getScript().toByteArray()));
         return SendRequest.forTx(tx).fromPaymentDetails(paymentDetails);
     }
 

--- a/core/src/main/java/org/bitcoinj/testing/FakeTxBuilder.java
+++ b/core/src/main/java/org/bitcoinj/testing/FakeTxBuilder.java
@@ -78,8 +78,7 @@ public class FakeTxBuilder {
         TransactionInput input = new TransactionInput(null, new byte[0], outpoint);
         Transaction tx = new Transaction(params);
         tx.addInput(input);
-        TransactionOutput outputToMe = new TransactionOutput(params, tx, Coin.FIFTY_COINS,
-                randomAddress(params));
+        TransactionOutput outputToMe = new TransactionOutput(tx, Coin.FIFTY_COINS, randomAddress(params));
         tx.addOutput(outputToMe);
 
         checkState(tx.isCoinBase());
@@ -92,14 +91,14 @@ public class FakeTxBuilder {
      */
     public static Transaction createFakeTxWithChangeAddress(NetworkParameters params, Coin value, Address to, Address changeOutput) {
         Transaction t = new Transaction(params);
-        TransactionOutput outputToMe = new TransactionOutput(params, t, value, to);
+        TransactionOutput outputToMe = new TransactionOutput(t, value, to);
         t.addOutput(outputToMe);
-        TransactionOutput change = new TransactionOutput(params, t, valueOf(1, 11), changeOutput);
+        TransactionOutput change = new TransactionOutput(t, valueOf(1, 11), changeOutput);
         t.addOutput(change);
         // Make a previous tx simply to send us sufficient coins. This prev tx is not really valid but it doesn't
         // matter for our purposes.
         Transaction prevTx = new Transaction(params);
-        TransactionOutput prevOut = new TransactionOutput(params, prevTx, value, to);
+        TransactionOutput prevOut = new TransactionOutput(prevTx, value, to);
         prevTx.addOutput(prevOut);
         // Connect it.
         t.addInput(prevOut).setScriptSig(ScriptBuilder.createInputScript(TransactionSignature.dummy()));
@@ -114,7 +113,7 @@ public class FakeTxBuilder {
      */
     public static Transaction createFakeTxWithoutChangeAddress(NetworkParameters params, Coin value, Address to) {
         Transaction t = new Transaction(params);
-        TransactionOutput outputToMe = new TransactionOutput(params, t, value, to);
+        TransactionOutput outputToMe = new TransactionOutput(t, value, to);
         t.addOutput(outputToMe);
 
         // Make a random split in the output value so we get a distinct hash when we call this multiple times with same args
@@ -128,7 +127,7 @@ public class FakeTxBuilder {
         // Make a previous tx simply to send us sufficient coins. This prev tx is not really valid but it doesn't
         // matter for our purposes.
         Transaction prevTx1 = new Transaction(params);
-        TransactionOutput prevOut1 = new TransactionOutput(params, prevTx1, Coin.valueOf(split), to);
+        TransactionOutput prevOut1 = new TransactionOutput(prevTx1, Coin.valueOf(split), to);
         prevTx1.addOutput(prevOut1);
         // Connect it.
         t.addInput(prevOut1).setScriptSig(ScriptBuilder.createInputScript(TransactionSignature.dummy()));
@@ -136,7 +135,7 @@ public class FakeTxBuilder {
 
         // Do it again
         Transaction prevTx2 = new Transaction(params);
-        TransactionOutput prevOut2 = new TransactionOutput(params, prevTx2, Coin.valueOf(value.getValue() - split), to);
+        TransactionOutput prevOut2 = new TransactionOutput(prevTx2, Coin.valueOf(value.getValue() - split), to);
         prevTx2.addOutput(prevOut2);
         t.addInput(prevOut2).setScriptSig(ScriptBuilder.createInputScript(TransactionSignature.dummy()));
 
@@ -158,14 +157,14 @@ public class FakeTxBuilder {
      */
     public static Transaction createFakeTx(NetworkParameters params, Coin value, ECKey to) {
         Transaction t = new Transaction(params);
-        TransactionOutput outputToMe = new TransactionOutput(params, t, value, to);
+        TransactionOutput outputToMe = new TransactionOutput(t, value, to);
         t.addOutput(outputToMe);
-        TransactionOutput change = new TransactionOutput(params, t, valueOf(1, 11), new ECKey());
+        TransactionOutput change = new TransactionOutput(t, valueOf(1, 11), new ECKey());
         t.addOutput(change);
         // Make a previous tx simply to send us sufficient coins. This prev tx is not really valid but it doesn't
         // matter for our purposes.
         Transaction prevTx = new Transaction(params);
-        TransactionOutput prevOut = new TransactionOutput(params, prevTx, value, to);
+        TransactionOutput prevOut = new TransactionOutput(prevTx, value, to);
         prevTx.addOutput(prevOut);
         // Connect it.
         t.addInput(prevOut);
@@ -181,19 +180,19 @@ public class FakeTxBuilder {
         // Create fake TXes of sufficient realism to exercise the unit tests. This transaction send BTC from the
         // from address, to the to address with to one to somewhere else to simulate change.
         Transaction t = new Transaction(params);
-        TransactionOutput outputToMe = new TransactionOutput(params, t, value, to);
+        TransactionOutput outputToMe = new TransactionOutput(t, value, to);
         t.addOutput(outputToMe);
-        TransactionOutput change = new TransactionOutput(params, t, valueOf(1, 11), randomAddress(params));
+        TransactionOutput change = new TransactionOutput(t, valueOf(1, 11), randomAddress(params));
         t.addOutput(change);
         // Make a feeder tx that sends to the from address specified. This feeder tx is not really valid but it doesn't
         // matter for our purposes.
         Transaction feederTx = new Transaction(params);
-        TransactionOutput feederOut = new TransactionOutput(params, feederTx, value, from);
+        TransactionOutput feederOut = new TransactionOutput(feederTx, value, from);
         feederTx.addOutput(feederOut);
 
         // make a previous tx that sends from the feeder to the from address
         Transaction prevTx = new Transaction(params);
-        TransactionOutput prevOut = new TransactionOutput(params, prevTx, value, to);
+        TransactionOutput prevOut = new TransactionOutput(prevTx, value, to);
         prevTx.addOutput(prevOut);
 
         // Connect up the txes
@@ -232,17 +231,17 @@ public class FakeTxBuilder {
         Address someBadGuy = randomAddress(params);
 
         doubleSpends.prevTx = new Transaction(params);
-        TransactionOutput prevOut = new TransactionOutput(params, doubleSpends.prevTx, value, someBadGuy);
+        TransactionOutput prevOut = new TransactionOutput(doubleSpends.prevTx, value, someBadGuy);
         doubleSpends.prevTx.addOutput(prevOut);
 
         doubleSpends.t1 = new Transaction(params);
-        TransactionOutput o1 = new TransactionOutput(params, doubleSpends.t1, value, to);
+        TransactionOutput o1 = new TransactionOutput(doubleSpends.t1, value, to);
         doubleSpends.t1.addOutput(o1);
         doubleSpends.t1.addInput(prevOut);
 
         doubleSpends.t2 = new Transaction(params);
         doubleSpends.t2.addInput(prevOut);
-        TransactionOutput o2 = new TransactionOutput(params, doubleSpends.t2, value, someBadGuy);
+        TransactionOutput o2 = new TransactionOutput(doubleSpends.t2, value, someBadGuy);
         doubleSpends.t2.addOutput(o2);
 
         try {

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4669,7 +4669,7 @@ public class Wallet extends BaseTaggableObject
                 int depth = chainHeight - output.getHeight() + 1; // the current depth of the output (1 = same as head).
                 // Do not try and spend coinbases that were mined too recently, the protocol forbids it.
                 if (!excludeImmatureCoinbases || !coinbase || depth >= params.getSpendableCoinbaseDepth()) {
-                    candidates.add(new FreeStandingTransactionOutput(params, output, chainHeight));
+                    candidates.add(new FreeStandingTransactionOutput(output, chainHeight));
                 }
             }
         } catch (UTXOProviderException e) {
@@ -4765,11 +4765,10 @@ public class Wallet extends BaseTaggableObject
 
         /**
          * Construct a freestanding Transaction Output.
-         * @param params The network parameters.
          * @param output The stored output (freestanding).
          */
-        public FreeStandingTransactionOutput(NetworkParameters params, UTXO output, int chainHeight) {
-            super(params, null, output.getValue(), output.getScript().getProgram());
+        public FreeStandingTransactionOutput(UTXO output, int chainHeight) {
+            super(null, output.getValue(), output.getScript().getProgram());
             this.output = output;
             this.chainHeight = chainHeight;
         }
@@ -5269,7 +5268,7 @@ public class Wallet extends BaseTaggableObject
                 result.updatedOutputValues = new ArrayList<>();
             }
             for (int i = 0; i < req.tx.getOutputs().size(); i++) {
-                TransactionOutput output = new TransactionOutput(params, tx,
+                TransactionOutput output = new TransactionOutput(tx,
                         ByteBuffer.wrap(req.tx.getOutputs().get(i).bitcoinSerialize()));
                 if (req.recipientsPayFees) {
                     // Subtract fee equally from each selected recipient
@@ -5303,7 +5302,7 @@ public class Wallet extends BaseTaggableObject
                 Address changeAddress = req.changeAddress;
                 if (changeAddress == null)
                     changeAddress = currentChangeAddress();
-                TransactionOutput changeOutput = new TransactionOutput(params, tx, change, changeAddress);
+                TransactionOutput changeOutput = new TransactionOutput(tx, change, changeAddress);
                 if (req.recipientsPayFees && changeOutput.isDust()) {
                     // We do not move dust-change to fees, because the sender would end up paying more than requested.
                     // This would be against the purpose of the all-inclusive feature.

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -639,7 +639,7 @@ public class WalletProtobufSerializer {
         for (Protos.TransactionOutput outputProto : txProto.getTransactionOutputList()) {
             Coin value = Coin.valueOf(outputProto.getValue());
             byte[] scriptBytes = outputProto.getScriptBytes().toByteArray();
-            TransactionOutput output = new TransactionOutput(params, tx, value, scriptBytes);
+            TransactionOutput output = new TransactionOutput(tx, value, scriptBytes);
             tx.addOutput(output);
         }
 

--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -160,7 +160,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
 
         rollingBlock = rollingBlock.createNextBlock(null);
         Transaction t = new Transaction(PARAMS);
-        t.addOutput(new TransactionOutput(PARAMS, t, FIFTY_COINS, new byte[] {}));
+        t.addOutput(new TransactionOutput(t, FIFTY_COINS, new byte[] {}));
         TransactionInput input = t.addInput(spendableOutput);
         // Invalid script.
         input.clearScriptBytes();
@@ -206,7 +206,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         
         Transaction t = new Transaction(PARAMS);
         // Entirely invalid scriptPubKey
-        t.addOutput(new TransactionOutput(PARAMS, t, FIFTY_COINS, new byte[]{}));
+        t.addOutput(new TransactionOutput(t, FIFTY_COINS, new byte[]{}));
         t.addSignedInput(transactionOutPoint, spendableOutputScriptPubKey, spendableOutput.getValue(), outKey);
         rollingBlock.addTransaction(t);
         rollingBlock.solve();
@@ -282,7 +282,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         Coin totalAmount = Coin.ZERO;
 
         Transaction t = new Transaction(PARAMS);
-        t.addOutput(new TransactionOutput(PARAMS, t, amount, toKey));
+        t.addOutput(new TransactionOutput(t, amount, toKey));
         t.addSignedInput(spendableOutputPoint, spendableOutputScriptPubKey, spendableOutput.getValue(), outKey);
         rollingBlock.addTransaction(t);
         rollingBlock.solve();
@@ -337,7 +337,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         Coin amount = Coin.valueOf(100000000);
 
         Transaction t = new Transaction(PARAMS);
-        t.addOutput(new TransactionOutput(PARAMS, t, amount, toKey));
+        t.addOutput(new TransactionOutput(t, amount, toKey));
         t.addSignedInput(spendableOutPoint, spendableOutputScriptPubKey, spendableOutput.getValue(), outKey);
         rollingBlock.addTransaction(t);
         rollingBlock.solve();

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -345,7 +345,7 @@ public class FullBlockTestGenerator {
             Transaction tx = new Transaction(params);
             byte[] outputScript = new byte[Block.MAX_BLOCK_SIGOPS - sigOps];
             Arrays.fill(outputScript, (byte) OP_CHECKSIG);
-            tx.addOutput(new TransactionOutput(params, tx, SATOSHI, outputScript));
+            tx.addOutput(new TransactionOutput(tx, SATOSHI, outputScript));
             addOnlyInputToTransaction(tx, b15);
             b15.addTransaction(tx);
 
@@ -370,7 +370,7 @@ public class FullBlockTestGenerator {
             Transaction tx = new Transaction(params);
             byte[] outputScript = new byte[Block.MAX_BLOCK_SIGOPS - sigOps + 1];
             Arrays.fill(outputScript, (byte) OP_CHECKSIG);
-            tx.addOutput(new TransactionOutput(params, tx, SATOSHI, outputScript));
+            tx.addOutput(new TransactionOutput(tx, SATOSHI, outputScript));
             addOnlyInputToTransaction(tx, b16);
             b16.addTransaction(tx);
 
@@ -391,7 +391,7 @@ public class FullBlockTestGenerator {
         NewBlock b17 = createNextBlock(b15, chainHeadHeight + 7, out6, null);
         {
             Transaction tx = new Transaction(params);
-            tx.addOutput(new TransactionOutput(params, tx, SATOSHI, new byte[] {}));
+            tx.addOutput(new TransactionOutput(tx, SATOSHI, new byte[] {}));
             addOnlyInputToTransaction(tx, b3);
             b17.addTransaction(tx);
         }
@@ -407,7 +407,7 @@ public class FullBlockTestGenerator {
         NewBlock b18 = createNextBlock(b13, chainHeadHeight + 6, out5, null);
         {
             Transaction tx = new Transaction(params);
-            tx.addOutput(new TransactionOutput(params, tx, SATOSHI, new byte[] {}));
+            tx.addOutput(new TransactionOutput(tx, SATOSHI, new byte[] {}));
             addOnlyInputToTransaction(tx, b3);
             b18.addTransaction(tx);
         }
@@ -449,7 +449,7 @@ public class FullBlockTestGenerator {
             Transaction tx = new Transaction(params);
             byte[] outputScript = new byte[Block.MAX_BLOCK_SIZE - b23.block.getMessageSize() - 65];
             Arrays.fill(outputScript, (byte) OP_FALSE);
-            tx.addOutput(new TransactionOutput(params, tx, ZERO, outputScript));
+            tx.addOutput(new TransactionOutput(tx, ZERO, outputScript));
             addOnlyInputToTransaction(tx, b23);
             b23.addTransaction(tx);
         }
@@ -463,7 +463,7 @@ public class FullBlockTestGenerator {
             Transaction tx = new Transaction(params);
             byte[] outputScript = new byte[Block.MAX_BLOCK_SIZE - b24.block.getMessageSize() - 64];
             Arrays.fill(outputScript, (byte) OP_FALSE);
-            tx.addOutput(new TransactionOutput(params, tx, ZERO, outputScript));
+            tx.addOutput(new TransactionOutput(tx, ZERO, outputScript));
             addOnlyInputToTransaction(tx, b24);
             b24.addTransaction(tx);
         }
@@ -535,7 +535,7 @@ public class FullBlockTestGenerator {
             Transaction tx = new Transaction(params);
             byte[] outputScript = new byte[(Block.MAX_BLOCK_SIGOPS - sigOps)/20];
             Arrays.fill(outputScript, (byte) OP_CHECKMULTISIG);
-            tx.addOutput(new TransactionOutput(params, tx, SATOSHI, outputScript));
+            tx.addOutput(new TransactionOutput(tx, SATOSHI, outputScript));
             addOnlyInputToTransaction(tx, b31);
             b31.addTransaction(tx);
         }
@@ -557,7 +557,7 @@ public class FullBlockTestGenerator {
             Arrays.fill(outputScript, (byte) OP_CHECKMULTISIG);
             for (int i = 0; i < (Block.MAX_BLOCK_SIGOPS - sigOps)%20; i++)
                 outputScript[i] = (byte) OP_CHECKSIG;
-            tx.addOutput(new TransactionOutput(params, tx, SATOSHI, outputScript));
+            tx.addOutput(new TransactionOutput(tx, SATOSHI, outputScript));
             addOnlyInputToTransaction(tx, b32);
             b32.addTransaction(tx);
         }
@@ -573,7 +573,7 @@ public class FullBlockTestGenerator {
             Transaction tx = new Transaction(params);
             byte[] outputScript = new byte[(Block.MAX_BLOCK_SIGOPS - sigOps)/20];
             Arrays.fill(outputScript, (byte) OP_CHECKMULTISIGVERIFY);
-            tx.addOutput(new TransactionOutput(params, tx, SATOSHI, outputScript));
+            tx.addOutput(new TransactionOutput(tx, SATOSHI, outputScript));
             addOnlyInputToTransaction(tx, b33);
             b33.addTransaction(tx);
         }
@@ -595,7 +595,7 @@ public class FullBlockTestGenerator {
             Arrays.fill(outputScript, (byte) OP_CHECKMULTISIGVERIFY);
             for (int i = 0; i < (Block.MAX_BLOCK_SIGOPS - sigOps)%20; i++)
                 outputScript[i] = (byte) OP_CHECKSIG;
-            tx.addOutput(new TransactionOutput(params, tx, SATOSHI, outputScript));
+            tx.addOutput(new TransactionOutput(tx, SATOSHI, outputScript));
             addOnlyInputToTransaction(tx, b34);
             b34.addTransaction(tx);
         }
@@ -611,7 +611,7 @@ public class FullBlockTestGenerator {
             Transaction tx = new Transaction(params);
             byte[] outputScript = new byte[Block.MAX_BLOCK_SIGOPS - sigOps];
             Arrays.fill(outputScript, (byte) OP_CHECKSIGVERIFY);
-            tx.addOutput(new TransactionOutput(params, tx, SATOSHI, outputScript));
+            tx.addOutput(new TransactionOutput(tx, SATOSHI, outputScript));
             addOnlyInputToTransaction(tx, b35);
             b35.addTransaction(tx);
         }
@@ -631,7 +631,7 @@ public class FullBlockTestGenerator {
             Transaction tx = new Transaction(params);
             byte[] outputScript = new byte[Block.MAX_BLOCK_SIGOPS - sigOps + 1];
             Arrays.fill(outputScript, (byte) OP_CHECKSIGVERIFY);
-            tx.addOutput(new TransactionOutput(params, tx, SATOSHI, outputScript));
+            tx.addOutput(new TransactionOutput(tx, SATOSHI, outputScript));
             addOnlyInputToTransaction(tx, b36);
             b36.addTransaction(tx);
         }
@@ -649,7 +649,7 @@ public class FullBlockTestGenerator {
         NewBlock b37 = createNextBlock(b35, chainHeadHeight + 12, out11, null);
         {
             Transaction tx = new Transaction(params);
-            tx.addOutput(new TransactionOutput(params, tx, SATOSHI, new byte[] {}));
+            tx.addOutput(new TransactionOutput(tx, SATOSHI, new byte[] {}));
             addOnlyInputToTransaction(tx, out11); // double spend out11
             b37.addTransaction(tx);
         }
@@ -659,7 +659,7 @@ public class FullBlockTestGenerator {
         NewBlock b38 = createNextBlock(b35, chainHeadHeight + 12, out11, null);
         {
             Transaction tx = new Transaction(params);
-            tx.addOutput(new TransactionOutput(params, tx, SATOSHI, new byte[] {}));
+            tx.addOutput(new TransactionOutput(tx, SATOSHI, new byte[] {}));
             // Attempt to spend b37's first non-coinbase tx, at which point b37 was still considered valid
             addOnlyInputToTransaction(tx, b37);
             b38.addTransaction(tx);
@@ -709,8 +709,8 @@ public class FullBlockTestGenerator {
             TransactionOutPoint lastOutPoint;
             {
                 Transaction tx = new Transaction(params);
-                tx.addOutput(new TransactionOutput(params, tx, SATOSHI, scriptPubKey.toByteArray()));
-                tx.addOutput(new TransactionOutput(params, tx, lastOutputValue, new byte[]{OP_1}));
+                tx.addOutput(new TransactionOutput(tx, SATOSHI, scriptPubKey.toByteArray()));
+                tx.addOutput(new TransactionOutput(tx, lastOutputValue, new byte[]{OP_1}));
                 addOnlyInputToTransaction(tx, out11);
                 lastOutPoint = new TransactionOutPoint(1, tx.getTxId());
                 b39.addTransaction(tx);
@@ -722,8 +722,8 @@ public class FullBlockTestGenerator {
                 Transaction tx = new Transaction(params);
 
                 lastOutputValue = lastOutputValue.subtract(SATOSHI);
-                tx.addOutput(new TransactionOutput(params, tx, SATOSHI, scriptPubKey.toByteArray()));
-                tx.addOutput(new TransactionOutput(params, tx, lastOutputValue, new byte[]{OP_1}));
+                tx.addOutput(new TransactionOutput(tx, SATOSHI, scriptPubKey.toByteArray()));
+                tx.addOutput(new TransactionOutput(tx, lastOutputValue, new byte[]{OP_1}));
                 tx.addInput(new TransactionInput(tx, new byte[]{OP_1}, lastOutPoint));
                 lastOutPoint = new TransactionOutPoint(1, tx.getTxId());
 
@@ -755,7 +755,7 @@ public class FullBlockTestGenerator {
             byte[] scriptSig = null;
             for (int i = 1; i <= numTxes; i++) {
                 Transaction tx = new Transaction(params);
-                tx.addOutput(new TransactionOutput(params, tx, SATOSHI, new byte[] {OP_1}));
+                tx.addOutput(new TransactionOutput(tx, SATOSHI, new byte[] {OP_1}));
                 tx.addInput(new TransactionInput(tx, new byte[]{OP_1}, lastOutPoint));
 
                 TransactionInput input = new TransactionInput(tx, new byte[]{},
@@ -796,7 +796,7 @@ public class FullBlockTestGenerator {
             tx.addInput(new TransactionInput(tx, new byte[]{OP_1}, lastOutPoint));
             byte[] scriptPubKey = new byte[Block.MAX_BLOCK_SIGOPS - sigOps + 1];
             Arrays.fill(scriptPubKey, (byte) OP_CHECKSIG);
-            tx.addOutput(new TransactionOutput(params, tx, ZERO, scriptPubKey));
+            tx.addOutput(new TransactionOutput(tx, ZERO, scriptPubKey));
             b40.addTransaction(tx);
         }
         b40.solve();
@@ -821,7 +821,7 @@ public class FullBlockTestGenerator {
                 byte[] scriptSig = null;
                 for (int i = 1; i <= numTxes; i++) {
                     Transaction tx = new Transaction(params);
-                    tx.addOutput(new TransactionOutput(params, tx, Coin
+                    tx.addOutput(new TransactionOutput(tx, Coin
                             .SATOSHI, new byte[] {OP_1}));
                     tx.addInput(new TransactionInput(tx, new byte[] { OP_1 }, lastOutPoint));
 
@@ -870,7 +870,7 @@ public class FullBlockTestGenerator {
                 tx.addInput(new TransactionInput(tx, new byte[] { OP_1 }, lastOutPoint));
                 byte[] scriptPubKey = new byte[Block.MAX_BLOCK_SIGOPS - sigOps];
                 Arrays.fill(scriptPubKey, (byte) OP_CHECKSIG);
-                tx.addOutput(new TransactionOutput(params, tx, ZERO, scriptPubKey));
+                tx.addOutput(new TransactionOutput(tx, ZERO, scriptPubKey));
                 b41.addTransaction(tx);
             }
             b41.solve();
@@ -906,10 +906,10 @@ public class FullBlockTestGenerator {
 
             Transaction t = new Transaction(params);
             // Entirely invalid scriptPubKey to ensure we aren't pre-verifying too much
-            t.addOutput(new TransactionOutput(params, t, ZERO, new byte[] {OP_PUSHDATA1 - 1 }));
-            t.addOutput(new TransactionOutput(params, t, SATOSHI, outScriptBytes));
+            t.addOutput(new TransactionOutput(t, ZERO, new byte[] {OP_PUSHDATA1 - 1 }));
+            t.addOutput(new TransactionOutput(t, SATOSHI, outScriptBytes));
             // Spendable output
-            t.addOutput(new TransactionOutput(params, t, ZERO, new byte[] {OP_1}));
+            t.addOutput(new TransactionOutput(t, ZERO, new byte[] {OP_1}));
             addOnlyInputToTransaction(t, out14);
             b44.addTransaction(t);
 
@@ -929,10 +929,10 @@ public class FullBlockTestGenerator {
 
             Transaction t = new Transaction(params);
             // Entirely invalid scriptPubKey to ensure we aren't pre-verifying too much
-            t.addOutput(new TransactionOutput(params, t, ZERO, new byte[] {OP_PUSHDATA1 - 1 }));
-            t.addOutput(new TransactionOutput(params, t, SATOSHI, outScriptBytes));
+            t.addOutput(new TransactionOutput(t, ZERO, new byte[] {OP_PUSHDATA1 - 1 }));
+            t.addOutput(new TransactionOutput(t, SATOSHI, outScriptBytes));
             // Spendable output
-            t.addOutput(new TransactionOutput(params, t, ZERO, new byte[] {OP_1}));
+            t.addOutput(new TransactionOutput(t, ZERO, new byte[] {OP_1}));
             addOnlyInputToTransaction(t, out15);
             try {
                 b45.addTransaction(t);
@@ -1008,7 +1008,7 @@ public class FullBlockTestGenerator {
         {
             Transaction coinbase = new Transaction(params);
             coinbase.addInput(new TransactionInput(coinbase, new byte[]{(byte) 0xff, 110, 1}));
-            coinbase.addOutput(new TransactionOutput(params, coinbase, SATOSHI, outScriptBytes));
+            coinbase.addOutput(new TransactionOutput(coinbase, SATOSHI, outScriptBytes));
             b51.block.addTransaction(coinbase, false);
         }
         b51.solve();
@@ -1018,7 +1018,7 @@ public class FullBlockTestGenerator {
         NewBlock b52 = createNextBlock(b44, chainHeadHeight + 16, out15, null);
         {
             Transaction tx = new Transaction(params);
-            tx.addOutput(new TransactionOutput(params, tx, SATOSHI, new byte[] {}));
+            tx.addOutput(new TransactionOutput(tx, SATOSHI, new byte[] {}));
             addOnlyInputToTransaction(tx, b52);
             b52.addTransaction(tx);
             b52.addTransaction(tx);
@@ -1058,7 +1058,7 @@ public class FullBlockTestGenerator {
         Transaction b56txToDuplicate;
         {
             b56txToDuplicate = new Transaction(params);
-            b56txToDuplicate.addOutput(new TransactionOutput(params, b56txToDuplicate, SATOSHI, new byte[] {}));
+            b56txToDuplicate.addOutput(new TransactionOutput(b56txToDuplicate, SATOSHI, new byte[] {}));
             addOnlyInputToTransaction(b56txToDuplicate, b57);
             b57.addTransaction(b56txToDuplicate);
         }
@@ -1078,26 +1078,26 @@ public class FullBlockTestGenerator {
         Transaction b56p2txToDuplicate1, b56p2txToDuplicate2;
         {
             Transaction tx1 = new Transaction(params);
-            tx1.addOutput(new TransactionOutput(params, tx1, SATOSHI, new byte[] {OP_TRUE}));
+            tx1.addOutput(new TransactionOutput(tx1, SATOSHI, new byte[] {OP_TRUE}));
             addOnlyInputToTransaction(tx1, b57p2);
             b57p2.addTransaction(tx1);
 
             Transaction tx2 = new Transaction(params);
-            tx2.addOutput(new TransactionOutput(params, tx2, SATOSHI, new byte[] {OP_TRUE}));
+            tx2.addOutput(new TransactionOutput(tx2, SATOSHI, new byte[] {OP_TRUE}));
             addOnlyInputToTransaction(tx2, new TransactionOutPointWithValue(
                     new TransactionOutPoint(0, tx1.getTxId()),
                     SATOSHI, tx1.getOutputs().get(0).getScriptPubKey()));
             b57p2.addTransaction(tx2);
 
             b56p2txToDuplicate1 = new Transaction(params);
-            b56p2txToDuplicate1.addOutput(new TransactionOutput(params, b56p2txToDuplicate1, SATOSHI, new byte[]{OP_TRUE}));
+            b56p2txToDuplicate1.addOutput(new TransactionOutput(b56p2txToDuplicate1, SATOSHI, new byte[]{OP_TRUE}));
             addOnlyInputToTransaction(b56p2txToDuplicate1, new TransactionOutPointWithValue(
                     new TransactionOutPoint(0, tx2.getTxId()),
                     SATOSHI, tx2.getOutputs().get(0).getScriptPubKey()));
             b57p2.addTransaction(b56p2txToDuplicate1);
 
             b56p2txToDuplicate2 = new Transaction(params);
-            b56p2txToDuplicate2.addOutput(new TransactionOutput(params, b56p2txToDuplicate2, SATOSHI, new byte[]{}));
+            b56p2txToDuplicate2.addOutput(new TransactionOutput(b56p2txToDuplicate2, SATOSHI, new byte[]{}));
             addOnlyInputToTransaction(b56p2txToDuplicate2, new TransactionOutPointWithValue(
                     new TransactionOutPoint(0, b56p2txToDuplicate1.getTxId()),
                     SATOSHI, b56p2txToDuplicate1.getOutputs().get(0).getScriptPubKey()));
@@ -1130,7 +1130,7 @@ public class FullBlockTestGenerator {
         NewBlock b58 = createNextBlock(b57, chainHeadHeight + 18, out17, null);
         {
             Transaction tx = new Transaction(params);
-            tx.addOutput(new TransactionOutput(params, tx, ZERO, new byte[] {}));
+            tx.addOutput(new TransactionOutput(tx, ZERO, new byte[] {}));
             b58.getSpendableOutput().outpoint.setIndex(42);
             addOnlyInputToTransaction(tx, b58);
             b58.addTransaction(tx);
@@ -1142,7 +1142,7 @@ public class FullBlockTestGenerator {
         NewBlock b59 = createNextBlock(b57, chainHeadHeight + 18, out17, null);
         {
             Transaction tx = new Transaction(params);
-            tx.addOutput(new TransactionOutput(params, tx,
+            tx.addOutput(new TransactionOutput(tx,
                     b59.getSpendableOutput().value.add(SATOSHI), new byte[]{}));
             addOnlyInputToTransaction(tx, b59);
             b59.addTransaction(tx);
@@ -1208,7 +1208,7 @@ public class FullBlockTestGenerator {
             Transaction tx = new Transaction(params);
             byte[] outputScript = new byte[Block.MAX_BLOCK_SIZE - b64Original.block.getMessageSize() - 65];
             Arrays.fill(outputScript, (byte) OP_FALSE);
-            tx.addOutput(new TransactionOutput(params, tx, ZERO, outputScript));
+            tx.addOutput(new TransactionOutput(tx, ZERO, outputScript));
             addOnlyInputToTransaction(tx, b64Original);
             b64Original.addTransaction(tx);
             b64Original.solve();
@@ -1380,7 +1380,7 @@ public class FullBlockTestGenerator {
             // If we push an element that is too large, the CHECKSIGs after that push are still counted
             outputScript[Block.MAX_BLOCK_SIGOPS - sigOps] = OP_PUSHDATA4;
             ByteUtils.writeInt32LE(Script.MAX_SCRIPT_ELEMENT_SIZE + 1, outputScript, Block.MAX_BLOCK_SIGOPS - sigOps + 1);
-            tx.addOutput(new TransactionOutput(params, tx, SATOSHI, outputScript));
+            tx.addOutput(new TransactionOutput(tx, SATOSHI, outputScript));
             addOnlyInputToTransaction(tx, b73);
             b73.addTransaction(tx);
         }
@@ -1402,7 +1402,7 @@ public class FullBlockTestGenerator {
             outputScript[Block.MAX_BLOCK_SIGOPS - sigOps + 3] = (byte)0xff;
             outputScript[Block.MAX_BLOCK_SIGOPS - sigOps + 4] = (byte)0xff;
             outputScript[Block.MAX_BLOCK_SIGOPS - sigOps + 5] = (byte)0xff;
-            tx.addOutput(new TransactionOutput(params, tx, SATOSHI, outputScript));
+            tx.addOutput(new TransactionOutput(tx, SATOSHI, outputScript));
             addOnlyInputToTransaction(tx, b74);
             b74.addTransaction(tx);
         }
@@ -1424,7 +1424,7 @@ public class FullBlockTestGenerator {
             outputScript[Block.MAX_BLOCK_SIGOPS - sigOps + 2] = (byte)0xff;
             outputScript[Block.MAX_BLOCK_SIGOPS - sigOps + 3] = (byte)0xff;
             outputScript[Block.MAX_BLOCK_SIGOPS - sigOps + 4] = (byte)0xff;
-            tx.addOutput(new TransactionOutput(params, tx, SATOSHI, outputScript));
+            tx.addOutput(new TransactionOutput(tx, SATOSHI, outputScript));
             addOnlyInputToTransaction(tx, b75);
             b75.addTransaction(tx);
         }
@@ -1446,7 +1446,7 @@ public class FullBlockTestGenerator {
             // If we push an element that is filled with CHECKSIGs, they (obviously) arent counted
             outputScript[Block.MAX_BLOCK_SIGOPS - sigOps] = OP_PUSHDATA4;
             ByteUtils.writeInt32LE(Block.MAX_BLOCK_SIGOPS, outputScript, Block.MAX_BLOCK_SIGOPS - sigOps + 1);
-            tx.addOutput(new TransactionOutput(params, tx, SATOSHI, outputScript));
+            tx.addOutput(new TransactionOutput(tx, SATOSHI, outputScript));
             addOnlyInputToTransaction(tx, b76);
             b76.addTransaction(tx);
         }
@@ -1518,12 +1518,12 @@ public class FullBlockTestGenerator {
         NewBlock b83 = createNextBlock(b82, chainHeadHeight + 29, null, null);
         {
             Transaction tx1 = new Transaction(params);
-            tx1.addOutput(new TransactionOutput(params, tx1, out28.value,
+            tx1.addOutput(new TransactionOutput(tx1, out28.value,
                     new byte[]{OP_IF, (byte) OP_INVALIDOPCODE, OP_ELSE, OP_TRUE, OP_ENDIF}));
             addOnlyInputToTransaction(tx1, out28, 0);
             b83.addTransaction(tx1);
             Transaction tx2 = new Transaction(params);
-            tx2.addOutput(new TransactionOutput(params, tx2, ZERO, new byte[]{OP_TRUE}));
+            tx2.addOutput(new TransactionOutput(tx2, ZERO, new byte[]{OP_TRUE}));
             tx2.addInput(new TransactionInput(tx2, new byte[] { OP_FALSE },
                     new TransactionOutPoint(0, tx1.getTxId())));
             b83.addTransaction(tx2);
@@ -1544,34 +1544,34 @@ public class FullBlockTestGenerator {
         NewBlock b84 = createNextBlock(b83, chainHeadHeight + 30, out29, null);
         Transaction b84tx1 = new Transaction(params);
         {
-            b84tx1.addOutput(new TransactionOutput(params, b84tx1, ZERO, new byte[]{OP_RETURN}));
-            b84tx1.addOutput(new TransactionOutput(params, b84tx1, ZERO, new byte[]{OP_TRUE}));
-            b84tx1.addOutput(new TransactionOutput(params, b84tx1, ZERO, new byte[]{OP_TRUE}));
-            b84tx1.addOutput(new TransactionOutput(params, b84tx1, ZERO, new byte[]{OP_TRUE}));
-            b84tx1.addOutput(new TransactionOutput(params, b84tx1, ZERO, new byte[]{OP_TRUE}));
+            b84tx1.addOutput(new TransactionOutput(b84tx1, ZERO, new byte[]{OP_RETURN}));
+            b84tx1.addOutput(new TransactionOutput(b84tx1, ZERO, new byte[]{OP_TRUE}));
+            b84tx1.addOutput(new TransactionOutput(b84tx1, ZERO, new byte[]{OP_TRUE}));
+            b84tx1.addOutput(new TransactionOutput(b84tx1, ZERO, new byte[]{OP_TRUE}));
+            b84tx1.addOutput(new TransactionOutput(b84tx1, ZERO, new byte[]{OP_TRUE}));
             addOnlyInputToTransaction(b84tx1, b84);
             b84.addTransaction(b84tx1);
 
             Transaction tx2 = new Transaction(params);
-            tx2.addOutput(new TransactionOutput(params, tx2, ZERO, new byte[]{OP_RETURN}));
-            tx2.addOutput(new TransactionOutput(params, tx2, ZERO, new byte[]{OP_RETURN}));
+            tx2.addOutput(new TransactionOutput(tx2, ZERO, new byte[]{OP_RETURN}));
+            tx2.addOutput(new TransactionOutput(tx2, ZERO, new byte[]{OP_RETURN}));
             tx2.addInput(new TransactionInput(tx2, new byte[]{OP_TRUE}, new TransactionOutPoint(1, b84tx1)));
             b84.addTransaction(tx2);
 
             Transaction tx3 = new Transaction(params);
-            tx3.addOutput(new TransactionOutput(params, tx3, ZERO, new byte[]{OP_RETURN}));
-            tx3.addOutput(new TransactionOutput(params, tx3, ZERO, new byte[]{OP_TRUE}));
+            tx3.addOutput(new TransactionOutput(tx3, ZERO, new byte[]{OP_RETURN}));
+            tx3.addOutput(new TransactionOutput(tx3, ZERO, new byte[]{OP_TRUE}));
             tx3.addInput(new TransactionInput(tx3, new byte[]{OP_TRUE}, new TransactionOutPoint(2, b84tx1)));
             b84.addTransaction(tx3);
 
             Transaction tx4 = new Transaction(params);
-            tx4.addOutput(new TransactionOutput(params, tx4, ZERO, new byte[]{OP_TRUE}));
-            tx4.addOutput(new TransactionOutput(params, tx4, ZERO, new byte[]{OP_RETURN}));
+            tx4.addOutput(new TransactionOutput(tx4, ZERO, new byte[]{OP_TRUE}));
+            tx4.addOutput(new TransactionOutput(tx4, ZERO, new byte[]{OP_RETURN}));
             tx4.addInput(new TransactionInput(tx4, new byte[]{OP_TRUE}, new TransactionOutPoint(3, b84tx1)));
             b84.addTransaction(tx4);
 
             Transaction tx5 = new Transaction(params);
-            tx5.addOutput(new TransactionOutput(params, tx5, ZERO, new byte[]{OP_RETURN}));
+            tx5.addOutput(new TransactionOutput(tx5, ZERO, new byte[]{OP_RETURN}));
             tx5.addInput(new TransactionInput(tx5, new byte[]{OP_TRUE}, new TransactionOutPoint(4, b84tx1)));
             b84.addTransaction(tx5);
         }
@@ -1596,7 +1596,7 @@ public class FullBlockTestGenerator {
         NewBlock b89 = createNextBlock(b88, chainHeadHeight + 33, out32, null);
         {
             Transaction tx = new Transaction(params);
-            tx.addOutput(new TransactionOutput(params, tx, ZERO, new byte[] {OP_TRUE}));
+            tx.addOutput(new TransactionOutput(tx, ZERO, new byte[] {OP_TRUE}));
             tx.addInput(new TransactionInput(tx, new byte[]{OP_TRUE}, new TransactionOutPoint(0, b84tx1)));
             b89.addTransaction(tx);
             b89.solve();
@@ -1632,7 +1632,7 @@ public class FullBlockTestGenerator {
                 Transaction tx = new Transaction(params);
                 byte[] outputScript = new byte[Block.MAX_BLOCK_SIZE - nextBlock.block.getMessageSize() - 65];
                 Arrays.fill(outputScript, (byte) OP_FALSE);
-                tx.addOutput(new TransactionOutput(params, tx, ZERO, outputScript));
+                tx.addOutput(new TransactionOutput(tx, ZERO, outputScript));
                 addOnlyInputToTransaction(tx, nextBlock);
                 nextBlock.addTransaction(tx);
                 nextBlock.solve();
@@ -1772,9 +1772,9 @@ public class FullBlockTestGenerator {
         Transaction t = new Transaction(params);
         if (prevOut != null) {
             // Entirely invalid scriptPubKey to ensure we aren't pre-verifying too much
-            t.addOutput(new TransactionOutput(params, t, ZERO, new byte[] {(byte)(new Random().nextInt() & 0xff), uniquenessCounter++}));
+            t.addOutput(new TransactionOutput(t, ZERO, new byte[] {(byte)(new Random().nextInt() & 0xff), uniquenessCounter++}));
             // Spendable output
-            t.addOutput(new TransactionOutput(params, t, SATOSHI, new byte[] {OP_1}));
+            t.addOutput(new TransactionOutput(t, SATOSHI, new byte[] {OP_1}));
             addOnlyInputToTransaction(t, prevOut);
             block.addTransaction(t);
             block.solve();

--- a/core/src/test/java/org/bitcoinj/core/ParseByteCacheTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ParseByteCacheTest.java
@@ -83,7 +83,7 @@ public class ParseByteCacheTest {
         
         // add a second input so can test granularity of byte cache.
         Transaction prevTx = new Transaction(TESTNET);
-        TransactionOutput prevOut = new TransactionOutput(TESTNET, prevTx, COIN, wallet.currentReceiveKey().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET));
+        TransactionOutput prevOut = new TransactionOutput(prevTx, COIN, wallet.currentReceiveKey().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET));
         prevTx.addOutput(prevOut);
         // Connect it.
         tx1.addInput(prevOut);

--- a/core/src/test/java/org/bitcoinj/core/TransactionOutputTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionOutputTest.java
@@ -96,12 +96,12 @@ public class TransactionOutputTest extends TestWithWallet {
 
     @Test
     public void getMinNonDustValue() {
-        TransactionOutput p2pk = new TransactionOutput(TESTNET, null, Coin.COIN, myKey);
+        TransactionOutput p2pk = new TransactionOutput(null, Coin.COIN, myKey);
         assertEquals(Coin.valueOf(576), p2pk.getMinNonDustValue());
-        TransactionOutput p2pkh = new TransactionOutput(TESTNET, null, Coin.COIN, myKey.toAddress(ScriptType.P2PKH,
+        TransactionOutput p2pkh = new TransactionOutput(null, Coin.COIN, myKey.toAddress(ScriptType.P2PKH,
                 BitcoinNetwork.TESTNET));
         assertEquals(Coin.valueOf(546), p2pkh.getMinNonDustValue());
-        TransactionOutput p2wpkh = new TransactionOutput(TESTNET, null, Coin.COIN, myKey.toAddress(ScriptType.P2WPKH,
+        TransactionOutput p2wpkh = new TransactionOutput(null, Coin.COIN, myKey.toAddress(ScriptType.P2WPKH,
                 BitcoinNetwork.TESTNET));
         assertEquals(Coin.valueOf(294), p2wpkh.getMinNonDustValue());
     }

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -174,7 +174,7 @@ public class TransactionTest {
         length += input.getMessageSize();
 
         // add fake transaction output
-        TransactionOutput output = new TransactionOutput(TESTNET, null, Coin.COIN, ADDRESS);
+        TransactionOutput output = new TransactionOutput(null, Coin.COIN, ADDRESS);
         tx.addOutput(output);
         length += output.getMessageSize();
 
@@ -207,7 +207,7 @@ public class TransactionTest {
         Address fromAddress = fromKey.toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
         Transaction tx = new Transaction(TESTNET);
         TransactionOutPoint outPoint = new TransactionOutPoint(0, utxo_id);
-        TransactionOutput output = new TransactionOutput(TESTNET, null, inAmount, fromAddress);
+        TransactionOutput output = new TransactionOutput(null, inAmount, fromAddress);
         tx.addOutput(outAmount, toAddr);
         TransactionInput input = tx.addSignedInput(outPoint, ScriptBuilder.createOutputScript(fromAddress), inAmount, fromKey);
 
@@ -304,7 +304,7 @@ public class TransactionTest {
         assertEquals("025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee6357", key1.getPublicKeyAsHex());
         Script scriptPubKey1 = ScriptBuilder.createP2WPKHOutputScript(key1);
         assertEquals("00141d0f172a0ecb48aee1be1f2687d2963ae33f71a1", ByteUtils.formatHex(scriptPubKey1.getProgram()));
-        txIn1.connect(new TransactionOutput(TESTNET, null, Coin.COIN.multiply(6), scriptPubKey1.getProgram()));
+        txIn1.connect(new TransactionOutput(null, Coin.COIN.multiply(6), scriptPubKey1.getProgram()));
 
         assertEquals("63cec688ee06a91e913875356dd4dea2f8e0f2a2659885372da2a37e32c7532e",
                 tx.hashForSignature(0, scriptPubKey0, Transaction.SigHash.ALL, false).toString());

--- a/core/src/test/java/org/bitcoinj/protocols/payments/PaymentSessionTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/payments/PaymentSessionTest.java
@@ -73,7 +73,7 @@ public class PaymentSessionTest {
         Context.propagate(new Context());
         serverKey = new ECKey();
         tx = new Transaction(TESTNET);
-        outputToMe = new TransactionOutput(TESTNET, tx, amount, serverKey);
+        outputToMe = new TransactionOutput(tx, amount, serverKey);
         tx.addOutput(outputToMe);
     }
 
@@ -102,7 +102,7 @@ public class PaymentSessionTest {
         assertEquals(merchantData, payment.getMerchantData());
         assertEquals(1, payment.getRefundToCount());
         assertEquals(amount.value, payment.getRefundTo(0).getAmount());
-        TransactionOutput refundOutput = new TransactionOutput(TESTNET, null, amount, refundAddr);
+        TransactionOutput refundOutput = new TransactionOutput(null, amount, refundAddr);
         ByteString refundScript = ByteString.copyFrom(refundOutput.getScriptBytes());
         assertTrue(refundScript.equals(payment.getRefundTo(0).getScript()));
     }

--- a/core/src/test/java/org/bitcoinj/script/ScriptTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptTest.java
@@ -358,7 +358,7 @@ public class ScriptTest {
         txInput.setSequenceNumber(TransactionInput.NO_SEQUENCE);
         tx.addInput(txInput);
 
-        TransactionOutput txOutput = new TransactionOutput(TESTNET, tx, Coin.ZERO, scriptPubKey.getProgram());
+        TransactionOutput txOutput = new TransactionOutput(tx, Coin.ZERO, scriptPubKey.getProgram());
         tx.addOutput(txOutput);
 
         return tx;
@@ -373,7 +373,7 @@ public class ScriptTest {
         txInput.setSequenceNumber(TransactionInput.NO_SEQUENCE);
         tx.addInput(txInput);
 
-        TransactionOutput txOutput = new TransactionOutput(TESTNET, tx, creditingTransaction.getOutput(0).getValue(),
+        TransactionOutput txOutput = new TransactionOutput(tx, creditingTransaction.getOutput(0).getValue(),
                 new Script(new byte[] {}).getProgram());
         tx.addOutput(txOutput);
 

--- a/core/src/test/java/org/bitcoinj/wallet/DefaultCoinSelectorTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DefaultCoinSelectorTest.java
@@ -129,10 +129,10 @@ public class DefaultCoinSelectorTest extends TestWithWallet {
         // Add four outputs to a transaction with same value and destination. Select them all.
         Transaction t = new Transaction(TESTNET);
         List<TransactionOutput> outputs = Arrays.asList(
-            new TransactionOutput(TESTNET, t, Coin.valueOf(30302787), myAddress),
-            new TransactionOutput(TESTNET, t, Coin.valueOf(30302787), myAddress),
-            new TransactionOutput(TESTNET, t, Coin.valueOf(30302787), myAddress),
-            new TransactionOutput(TESTNET, t, Coin.valueOf(30302787), myAddress)
+            new TransactionOutput(t, Coin.valueOf(30302787), myAddress),
+            new TransactionOutput(t, Coin.valueOf(30302787), myAddress),
+            new TransactionOutput(t, Coin.valueOf(30302787), myAddress),
+            new TransactionOutput(t, Coin.valueOf(30302787), myAddress)
         );
         t.getConfidence().setConfidenceType(TransactionConfidence.ConfidenceType.BUILDING);
 

--- a/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
@@ -149,7 +149,7 @@ public class DefaultRiskAnalysisTest {
 
         Transaction edgeCaseTx = new Transaction(MAINNET);
         edgeCaseTx.addInput(MAINNET.getGenesisBlock().getTransactions().get(0).getOutput(0));
-        Coin dustThreshold = new TransactionOutput(MAINNET, null, Coin.COIN, key1).getMinNonDustValue();
+        Coin dustThreshold = new TransactionOutput(null, Coin.COIN, key1).getMinNonDustValue();
         edgeCaseTx.addOutput(dustThreshold, key1);
         assertEquals(RiskAnalysis.Result.OK, DefaultRiskAnalysis.FACTORY.create(wallet, edgeCaseTx, NO_DEPS).analyze());
     }
@@ -166,7 +166,7 @@ public class DefaultRiskAnalysisTest {
         // Test non-standard script as an output.
         tx.clearInputs();
         assertEquals(DefaultRiskAnalysis.RuleViolation.NONE, DefaultRiskAnalysis.isStandard(tx));
-        tx.addOutput(new TransactionOutput(MAINNET, null, COIN, nonStandardScript));
+        tx.addOutput(new TransactionOutput(null, COIN, nonStandardScript));
         assertEquals(DefaultRiskAnalysis.RuleViolation.SHORTEST_POSSIBLE_PUSHDATA, DefaultRiskAnalysis.isStandard(tx));
     }
 

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -703,7 +703,7 @@ public class WalletTest extends TestWithWallet {
         // This test ensures that isConsistent catches duplicate transactions, eg, because we submitted the same block
         // twice (this is not allowed).
         Transaction tx = createFakeTx(TESTNET, COIN, myAddress);
-        TransactionOutput output = new TransactionOutput(TESTNET, tx, valueOf(0, 5), OTHER_ADDRESS);
+        TransactionOutput output = new TransactionOutput(tx, valueOf(0, 5), OTHER_ADDRESS);
         tx.addOutput(output);
         wallet.receiveFromBlock(tx, null, BlockChain.NewBlockType.BEST_CHAIN, 0);
 
@@ -722,7 +722,7 @@ public class WalletTest extends TestWithWallet {
     public void isConsistent_pools() {
         // This test ensures that isConsistent catches transactions that are in incompatible pools.
         Transaction tx = createFakeTx(TESTNET, COIN, myAddress);
-        TransactionOutput output = new TransactionOutput(TESTNET, tx, valueOf(0, 5), OTHER_ADDRESS);
+        TransactionOutput output = new TransactionOutput(tx, valueOf(0, 5), OTHER_ADDRESS);
         tx.addOutput(output);
         wallet.receiveFromBlock(tx, null, BlockChain.NewBlockType.BEST_CHAIN, 0);
 
@@ -737,7 +737,7 @@ public class WalletTest extends TestWithWallet {
         // This test ensures that isConsistent catches transactions that are marked spent when
         // they aren't.
         Transaction tx = createFakeTx(TESTNET, COIN, myAddress);
-        TransactionOutput output = new TransactionOutput(TESTNET, tx, valueOf(0, 5), OTHER_ADDRESS);
+        TransactionOutput output = new TransactionOutput(tx, valueOf(0, 5), OTHER_ADDRESS);
         tx.addOutput(output);
         assertTrue(wallet.isConsistent());
 
@@ -781,7 +781,7 @@ public class WalletTest extends TestWithWallet {
         // This test covers a bug in which Transaction.getValueSentFromMe was calculating incorrectly.
         Transaction tx = createFakeTx(TESTNET, COIN, myAddress);
         // Now add another output (ie, change) that goes to some other address.
-        TransactionOutput output = new TransactionOutput(TESTNET, tx, valueOf(0, 5), OTHER_ADDRESS);
+        TransactionOutput output = new TransactionOutput(tx, valueOf(0, 5), OTHER_ADDRESS);
         tx.addOutput(output);
         // Note that tx is no longer valid: it spends more than it imports. However checking transactions balance
         // correctly isn't possible in SPV mode because value is a property of outputs not inputs. Without all
@@ -790,7 +790,7 @@ public class WalletTest extends TestWithWallet {
         // Now the other guy creates a transaction which spends that change.
         Transaction tx2 = new Transaction(TESTNET);
         tx2.addInput(output);
-        tx2.addOutput(new TransactionOutput(TESTNET, tx2, valueOf(0, 5), myAddress));
+        tx2.addOutput(new TransactionOutput(tx2, valueOf(0, 5), myAddress));
         // tx2 doesn't send any coins from us, even though the output is in the wallet.
         assertEquals(ZERO, tx2.getValueSentFromMe(wallet));
     }
@@ -815,7 +815,7 @@ public class WalletTest extends TestWithWallet {
         assertTrue(outbound1.getWalletOutputs(wallet).size() <= 1); //the change address at most
         // That other guy gives us the coins right back.
         Transaction inbound2 = new Transaction(TESTNET);
-        inbound2.addOutput(new TransactionOutput(TESTNET, inbound2, coinHalf, myAddress));
+        inbound2.addOutput(new TransactionOutput(inbound2, coinHalf, myAddress));
         assertTrue(outbound1.getWalletOutputs(wallet).size() >= 1);
         inbound2.addInput(outbound1.getOutputs().get(0));
         sendMoneyToWallet(AbstractBlockChain.NewBlockType.BEST_CHAIN, inbound2);
@@ -1135,7 +1135,7 @@ public class WalletTest extends TestWithWallet {
         // doubleSpends.t1 spends to our wallet. doubleSpends.t2 double spends somewhere else.
 
         Transaction t1b = new Transaction(TESTNET);
-        TransactionOutput t1bo = new TransactionOutput(TESTNET, t1b, valueOf(0, 50), OTHER_ADDRESS);
+        TransactionOutput t1bo = new TransactionOutput(t1b, valueOf(0, 50), OTHER_ADDRESS);
         t1b.addOutput(t1bo);
         t1b.addInput(doubleSpends.t1.getOutput(0));
 
@@ -1402,14 +1402,14 @@ public class WalletTest extends TestWithWallet {
         // Create two transactions that share the same input tx.
         Address badGuy = new ECKey().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
         Transaction doubleSpentTx = new Transaction(TESTNET);
-        TransactionOutput doubleSpentOut = new TransactionOutput(TESTNET, doubleSpentTx, nanos, badGuy);
+        TransactionOutput doubleSpentOut = new TransactionOutput(doubleSpentTx, nanos, badGuy);
         doubleSpentTx.addOutput(doubleSpentOut);
         Transaction t1 = new Transaction(TESTNET);
-        TransactionOutput o1 = new TransactionOutput(TESTNET, t1, nanos, myAddress);
+        TransactionOutput o1 = new TransactionOutput(t1, nanos, myAddress);
         t1.addOutput(o1);
         t1.addInput(doubleSpentOut);
         Transaction t2 = new Transaction(TESTNET);
-        TransactionOutput o2 = new TransactionOutput(TESTNET, t2, nanos, badGuy);
+        TransactionOutput o2 = new TransactionOutput(t2, nanos, badGuy);
         t2.addOutput(o2);
         t2.addInput(doubleSpentOut);
 
@@ -1850,7 +1850,7 @@ public class WalletTest extends TestWithWallet {
         ECKey k2 = wallet.freshReceiveKey();
         Coin v2 = valueOf(0, 50);
         Transaction t2 = new Transaction(TESTNET);
-        TransactionOutput o2 = new TransactionOutput(TESTNET, t2, v2, k2.toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET));
+        TransactionOutput o2 = new TransactionOutput(t2, v2, k2.toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET));
         t2.addOutput(o2);
         SendRequest req = SendRequest.forTx(t2);
         wallet.completeTx(req);
@@ -2199,7 +2199,7 @@ public class WalletTest extends TestWithWallet {
     public void sendDustTest() throws InsufficientMoneyException {
         // Tests sending dust, should throw DustySendRequested.
         Transaction tx = new Transaction(TESTNET);
-        Coin dustThreshold = new TransactionOutput(TESTNET, null, Coin.COIN, OTHER_ADDRESS).getMinNonDustValue();
+        Coin dustThreshold = new TransactionOutput(null, Coin.COIN, OTHER_ADDRESS).getMinNonDustValue();
         tx.addOutput(dustThreshold.subtract(SATOSHI), OTHER_ADDRESS);
         SendRequest request = SendRequest.forTx(tx);
         request.ensureMinRequiredFee = true;
@@ -2237,7 +2237,7 @@ public class WalletTest extends TestWithWallet {
         receiveATransaction(wallet, myAddress);
         Transaction tx = new Transaction(TESTNET);
         tx.addOutput(Coin.CENT, ScriptBuilder.createOpReturnScript("hello world!".getBytes()));
-        Coin dustThreshold = new TransactionOutput(TESTNET, null, Coin.COIN, OTHER_ADDRESS).getMinNonDustValue();
+        Coin dustThreshold = new TransactionOutput(null, Coin.COIN, OTHER_ADDRESS).getMinNonDustValue();
         tx.addOutput(dustThreshold.subtract(SATOSHI), OTHER_ADDRESS);
         SendRequest request = SendRequest.forTx(tx);
         request.ensureMinRequiredFee = true;
@@ -2376,7 +2376,7 @@ public class WalletTest extends TestWithWallet {
         SendRequest request17 = SendRequest.to(OTHER_ADDRESS, CENT);
         for (int i = 0; i < 22; i++)
             request17.tx.addOutput(CENT, OTHER_ADDRESS);
-        request17.tx.addOutput(new TransactionOutput(TESTNET, request17.tx, CENT, new byte[15]));
+        request17.tx.addOutput(new TransactionOutput(request17.tx, CENT, new byte[15]));
         request17.feePerKb = Transaction.DEFAULT_TX_FEE;
         request17.ensureMinRequiredFee = true;
         wallet.completeTx(request17);
@@ -2403,7 +2403,7 @@ public class WalletTest extends TestWithWallet {
         SendRequest request18 = SendRequest.to(OTHER_ADDRESS, CENT);
         for (int i = 0; i < 22; i++)
             request18.tx.addOutput(CENT, OTHER_ADDRESS);
-        request18.tx.addOutput(new TransactionOutput(TESTNET, request18.tx, CENT, new byte[17]));
+        request18.tx.addOutput(new TransactionOutput(request18.tx, CENT, new byte[17]));
         request18.feePerKb = Transaction.DEFAULT_TX_FEE;
         request18.ensureMinRequiredFee = true;
         wallet.completeTx(request18);
@@ -2520,7 +2520,7 @@ public class WalletTest extends TestWithWallet {
             request26.tx.addOutput(CENT, OTHER_ADDRESS);
         // Hardcoded tx length because actual length may vary depending on actual signature length
         Coin fee = Transaction.REFERENCE_DEFAULT_MIN_TX_FEE.multiply(3560).divide(1000);
-        Coin dustThresholdMinusOne = new TransactionOutput(TESTNET, null, Coin.COIN, OTHER_ADDRESS).getMinNonDustValue().subtract(SATOSHI);
+        Coin dustThresholdMinusOne = new TransactionOutput(null, Coin.COIN, OTHER_ADDRESS).getMinNonDustValue().subtract(SATOSHI);
         request26.tx.addOutput(CENT.subtract(fee.add(dustThresholdMinusOne)),
                 OTHER_ADDRESS);
         assertTrue(request26.tx.bitcoinSerialize().length > 1000);
@@ -2602,7 +2602,7 @@ public class WalletTest extends TestWithWallet {
         // Output when subtracted fee is dust
         // Hardcoded tx length because actual length may vary depending on actual signature length
         Coin fee4 = Transaction.DEFAULT_TX_FEE.multiply(227).divide(1000);
-        Coin dustThreshold = new TransactionOutput(TESTNET, null, Coin.COIN, OTHER_ADDRESS).getMinNonDustValue();
+        Coin dustThreshold = new TransactionOutput(null, Coin.COIN, OTHER_ADDRESS).getMinNonDustValue();
         valueToSend = fee4.add(dustThreshold).subtract(SATOSHI);
         SendRequest request4 = SendRequest.to(OTHER_ADDRESS, valueToSend);
         request4.feePerKb = Transaction.DEFAULT_TX_FEE;
@@ -2864,7 +2864,7 @@ public class WalletTest extends TestWithWallet {
 
         // Add an unsendable value
         block = new StoredBlock(block.getHeader().createNextBlock(OTHER_ADDRESS), BigInteger.ONE, 3);
-        Coin dustThresholdMinusOne = new TransactionOutput(TESTNET, null, Coin.COIN, OTHER_ADDRESS).getMinNonDustValue().subtract(SATOSHI);
+        Coin dustThresholdMinusOne = new TransactionOutput(null, Coin.COIN, OTHER_ADDRESS).getMinNonDustValue().subtract(SATOSHI);
         tx = createFakeTx(TESTNET, dustThresholdMinusOne, myAddress);
         wallet.receiveFromBlock(tx, block, AbstractBlockChain.NewBlockType.BEST_CHAIN, 0);
         try {

--- a/examples/src/main/java/org/bitcoinj/examples/GenerateLowSTests.java
+++ b/examples/src/main/java/org/bitcoinj/examples/GenerateLowSTests.java
@@ -87,7 +87,7 @@ public class GenerateLowSTests {
 
         final Transaction outputTransaction = new Transaction(params);
         final Transaction inputTransaction = new Transaction(params);
-        final TransactionOutput output = new TransactionOutput(params, inputTransaction, Coin.ZERO, key.toAddress(ScriptType.P2PKH, network));
+        final TransactionOutput output = new TransactionOutput(inputTransaction, Coin.ZERO, key.toAddress(ScriptType.P2PKH, network));
 
         inputTransaction.addOutput(output);
         outputTransaction.addInput(output);

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -427,7 +427,7 @@ public class PeerTest extends TestWithNetworkConnections {
         Block b2 = makeSolvedTestBlock(b1);
         Transaction t = new Transaction(TESTNET);
         t.addInput(b1.getTransactions().get(0).getOutput(0));
-        t.addOutput(new TransactionOutput(TESTNET, t, Coin.ZERO, new byte[Block.MAX_BLOCK_SIZE - 1000]));
+        t.addOutput(new TransactionOutput(t, Coin.ZERO, new byte[Block.MAX_BLOCK_SIZE - 1000]));
         b2.addTransaction(t);
 
         // Request the block.


### PR DESCRIPTION
To make this possible, a check for maximum value is removed.

I think this check is a bit esotheric anyway. The practical limit will of course be input values of a transaction. If we want such a check for a single output, I guess a (future) builder for `TransactionOutput` would be a better place.

On the plus side, a lot of passing through of `NetworkParameters` is unnecessary.