### PR TITLE
UTXOProvider: replace getParams() with network()

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/UTXOProvider.java
+++ b/core/src/main/java/org/bitcoinj/core/UTXOProvider.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.core;
 
+import org.bitcoinj.base.Network;
 import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.store.FullPrunedBlockStore;
 
@@ -44,8 +45,8 @@ public interface UTXOProvider {
     int getChainHeadHeight() throws UTXOProviderException;
 
     /**
-     * The {@link NetworkParameters} of this provider.
+     * The {@link Network} of this provider.
      * @return The network parameters.
      */
-    NetworkParameters getParams();
+    Network network();
 }

--- a/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.store;
 
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.crypto.ECKey;
@@ -413,6 +414,11 @@ public class MemoryFullPrunedBlockStore implements FullPrunedBlockStore {
     @Override
     public NetworkParameters getParams() {
         return params;
+    }
+
+    @Override
+    public Network network() {
+        return params.network();
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4744,7 +4744,7 @@ public class Wallet extends BaseTaggableObject
     public void setUTXOProvider(@Nullable UTXOProvider provider) {
         lock.lock();
         try {
-            checkArgument(provider == null || provider.getParams().equals(params));
+            checkArgument(provider == null || provider.network() == params.network());
             this.vUTXOProvider = provider;
         } finally {
             lock.unlock();

--- a/core/src/test/java/org/bitcoinj/core/TransactionInputTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionInputTest.java
@@ -18,7 +18,9 @@ package org.bitcoinj.core;
 
 import com.google.common.collect.Lists;
 import org.bitcoinj.base.Address;
+import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.crypto.ECKey;
@@ -74,8 +76,8 @@ public class TransactionInputTest {
                 ScriptBuilder.createOutputScript(a));
         w.setUTXOProvider(new UTXOProvider() {
             @Override
-            public NetworkParameters getParams() {
-                return TESTNET;
+            public Network network() {
+                return BitcoinNetwork.TESTNET;
             }
 
             @Override


### PR DESCRIPTION
Since this only affects FullPrunedBlockStore, this change doesn't need deprecation.