### PR TITLE
BlockStore and subclasses: remove getParams()

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/UTXOProvider.java
+++ b/core/src/main/java/org/bitcoinj/core/UTXOProvider.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.core;
 
+import org.bitcoinj.base.Network;
 import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.store.FullPrunedBlockStore;
 
@@ -44,8 +45,8 @@ public interface UTXOProvider {
     int getChainHeadHeight() throws UTXOProviderException;
 
     /**
-     * The {@link NetworkParameters} of this provider.
+     * The {@link Network} of this provider.
      * @return The network parameters.
      */
-    NetworkParameters getParams();
+    Network network();
 }

--- a/core/src/main/java/org/bitcoinj/store/BlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/BlockStore.java
@@ -17,7 +17,6 @@
 package org.bitcoinj.store;
 
 import org.bitcoinj.core.BlockChain;
-import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.core.StoredBlock;
 
@@ -60,10 +59,4 @@ public interface BlockStore {
     
     /** Closes the store. */
     void close() throws BlockStoreException;
-
-    /**
-     * Get the {@link NetworkParameters} of this store.
-     * @return The network params.
-     */
-    NetworkParameters getParams();
 }

--- a/core/src/main/java/org/bitcoinj/store/MemoryBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryBlockStore.java
@@ -36,16 +36,13 @@ public class MemoryBlockStore implements BlockStore {
         }
     };
     private StoredBlock chainHead;
-    private NetworkParameters params;
 
     public MemoryBlockStore(NetworkParameters params) {
-        // Insert the genesis block.
         try {
             Block genesisHeader = params.getGenesisBlock().cloneAsHeader();
             StoredBlock storedGenesis = new StoredBlock(genesisHeader, genesisHeader.getWork(), 0);
             put(storedGenesis);
             setChainHead(storedGenesis);
-            this.params = params;
         } catch (BlockStoreException | VerificationException e) {
             throw new RuntimeException(e);  // Cannot happen.
         }
@@ -79,10 +76,5 @@ public class MemoryBlockStore implements BlockStore {
     @Override
     public void close() {
         blockMap = null;
-    }
-
-    @Override
-    public NetworkParameters getParams() {
-        return params;
     }
 }

--- a/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
@@ -410,12 +410,7 @@ public class MemoryFullPrunedBlockStore implements FullPrunedBlockStore {
                 return true;
         return false;
     }
-
-    @Override
-    public NetworkParameters getParams() {
-        return params;
-    }
-
+    
     @Override
     public Network network() {
         return params.network();

--- a/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.store;
 
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.crypto.ECKey;
@@ -413,6 +414,11 @@ public class MemoryFullPrunedBlockStore implements FullPrunedBlockStore {
     @Override
     public NetworkParameters getParams() {
         return params;
+    }
+
+    @Override
+    public Network network() {
+        return params.network();
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
@@ -309,11 +309,6 @@ public class SPVBlockStore implements BlockStore {
         }
     }
 
-    @Override
-    public NetworkParameters getParams() {
-        return params;
-    }
-
     protected static final int RECORD_SIZE = 32 /* hash */ + StoredBlock.COMPACT_SERIALIZED_SIZE;
 
     // File format:

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4744,7 +4744,7 @@ public class Wallet extends BaseTaggableObject
     public void setUTXOProvider(@Nullable UTXOProvider provider) {
         lock.lock();
         try {
-            checkArgument(provider == null || provider.getParams().equals(params));
+            checkArgument(provider == null || provider.network() == params.network());
             this.vUTXOProvider = provider;
         } finally {
             lock.unlock();

--- a/core/src/test/java/org/bitcoinj/core/TransactionInputTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionInputTest.java
@@ -18,7 +18,9 @@ package org.bitcoinj.core;
 
 import com.google.common.collect.Lists;
 import org.bitcoinj.base.Address;
+import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.crypto.ECKey;
@@ -74,8 +76,8 @@ public class TransactionInputTest {
                 ScriptBuilder.createOutputScript(a));
         w.setUTXOProvider(new UTXOProvider() {
             @Override
-            public NetworkParameters getParams() {
-                return TESTNET;
+            public Network network() {
+                return BitcoinNetwork.TESTNET;
             }
 
             @Override


### PR DESCRIPTION
Nothing in bitcoinj is using this method and applications should not be getting their NetworkParameters from their storage layer, so I think it is ok to remove this without deprecation.
