### PR TITLE
MemoryBlockStore: construct with genesis block not NetParams

### DIFF
--- a/core/src/main/java/org/bitcoinj/store/MemoryBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryBlockStore.java
@@ -17,7 +17,6 @@
 package org.bitcoinj.store;
 
 import org.bitcoinj.core.Block;
-import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.core.StoredBlock;
 import org.bitcoinj.core.VerificationException;
@@ -37,9 +36,9 @@ public class MemoryBlockStore implements BlockStore {
     };
     private StoredBlock chainHead;
 
-    public MemoryBlockStore(NetworkParameters params) {
+    public MemoryBlockStore(Block genesisBlock) {
         try {
-            Block genesisHeader = params.getGenesisBlock().cloneAsHeader();
+            Block genesisHeader = genesisBlock.cloneAsHeader();
             StoredBlock storedGenesis = new StoredBlock(genesisHeader, genesisHeader.getWork(), 0);
             put(storedGenesis);
             setChainHead(storedGenesis);

--- a/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
@@ -93,7 +93,7 @@ public class BitcoindComparisonTool {
         ver.appendToSubVer("BlockAcceptanceComparisonTool", "1.1", null);
         ver.localServices = Services.of(Services.NODE_NETWORK);
         final Peer bitcoind = new Peer(PARAMS, ver, PeerAddress.localhost(PARAMS),
-                new BlockChain(PARAMS, new MemoryBlockStore(PARAMS)));
+                new BlockChain(PARAMS, new MemoryBlockStore(PARAMS.getGenesisBlock())));
         checkState(bitcoind.getVersionMessage().hasBlockChain());
 
         final BlockWrapper currentBlock = new BlockWrapper();

--- a/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
@@ -83,7 +83,7 @@ public class BlockChainTest {
     private static final NetworkParameters MAINNET = MainNetParams.get();
 
     private void resetBlockStore() {
-        blockStore = new MemoryBlockStore(UNITTEST);
+        blockStore = new MemoryBlockStore(UNITTEST.getGenesisBlock());
     }
 
     @Before
@@ -91,7 +91,7 @@ public class BlockChainTest {
         BriefLogFormatter.initVerbose();
         TimeUtils.setMockClock(); // Use mock clock
         Context.propagate(new Context(100, Coin.ZERO, false, false));
-        testNetChain = new BlockChain(TESTNET, Wallet.createDeterministic(TESTNET, ScriptType.P2PKH), new MemoryBlockStore(TESTNET));
+        testNetChain = new BlockChain(TESTNET, Wallet.createDeterministic(TESTNET, ScriptType.P2PKH), new MemoryBlockStore(TESTNET.getGenesisBlock()));
         Context.propagate(new Context(100, Coin.ZERO, false, false));
         NetworkParameters params = TESTNET;
         wallet = new Wallet(params, KeyChainGroup.builder(params).fromRandom(ScriptType.P2PKH).build()) {
@@ -255,7 +255,7 @@ public class BlockChainTest {
 
     private void testDeprecatedBlockVersion(final long deprecatedVersion, final long newVersion)
             throws Exception {
-        final BlockStore versionBlockStore = new MemoryBlockStore(UNITTEST);
+        final BlockStore versionBlockStore = new MemoryBlockStore(UNITTEST.getGenesisBlock());
         final BlockChain versionChain = new BlockChain(UNITTEST, versionBlockStore);
 
         // Build a historical chain of version 3 blocks
@@ -436,7 +436,7 @@ public class BlockChainTest {
 
     @Test
     public void estimatedBlockTime() throws Exception {
-        BlockChain prod = new BlockChain(MAINNET, new MemoryBlockStore(MAINNET));
+        BlockChain prod = new BlockChain(MAINNET, new MemoryBlockStore(MAINNET.getGenesisBlock()));
         Instant t = prod.estimateBlockTimeInstant(200000);
         // The actual date of block 200,000 was 2012-09-22 10:47:00
         Instant expected = Instant.from(DateTimeFormatter.ISO_INSTANT.parse("2012-10-23T15:35:05Z"));

--- a/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
@@ -71,7 +71,7 @@ public class ChainSplitTest {
         BriefLogFormatter.init();
         TimeUtils.setMockClock(); // Use mock clock
         Context.propagate(new Context(100, Coin.ZERO, false, true));
-        MemoryBlockStore blockStore = new MemoryBlockStore(TESTNET);
+        MemoryBlockStore blockStore = new MemoryBlockStore(TESTNET.getGenesisBlock());
         wallet = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH);
         ECKey key1 = wallet.freshReceiveKey();
         ECKey key2 = wallet.freshReceiveKey();

--- a/core/src/test/java/org/bitcoinj/core/ParseByteCacheTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ParseByteCacheTest.java
@@ -65,7 +65,7 @@ public class ParseByteCacheTest {
     private static final NetworkParameters MAINNET = MainNetParams.get();
 
     private void resetBlockStore() {
-        blockStore = new MemoryBlockStore(TESTNET);
+        blockStore = new MemoryBlockStore(TESTNET.getGenesisBlock());
     }
     
     @Before

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -263,7 +263,7 @@ public class WalletProtobufSerializerTest {
     public void testAppearedAtChainHeightDepthAndWorkDone() throws Exception {
         // Test the TransactionConfidence appearedAtChainHeight, depth and workDone field are stored.
         Context.propagate(new Context(100, Transaction.DEFAULT_TX_FEE, false, true));
-        BlockChain chain = new BlockChain(TESTNET, myWallet, new MemoryBlockStore(TESTNET));
+        BlockChain chain = new BlockChain(TESTNET, myWallet, new MemoryBlockStore(TESTNET.getGenesisBlock()));
 
         final ArrayList<Transaction> txns = new ArrayList<>(2);
         myWallet.addCoinsReceivedEventListener((wallet, tx, prevBalance, newBalance) -> txns.add(tx));
@@ -402,7 +402,7 @@ public class WalletProtobufSerializerTest {
         Block b = TESTNET.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, myKey.getPubKey(), FIFTY_COINS, Block.BLOCK_HEIGHT_GENESIS);
         Transaction coinbase = b.getTransactions().get(0);
         assertTrue(coinbase.isCoinBase());
-        BlockChain chain = new BlockChain(TESTNET, myWallet, new MemoryBlockStore(TESTNET));
+        BlockChain chain = new BlockChain(TESTNET, myWallet, new MemoryBlockStore(TESTNET.getGenesisBlock()));
         assertTrue(chain.add(b));
         // Wallet now has a coinbase tx in it.
         assertEquals(1, myWallet.getTransactions(true).size());

--- a/core/src/test/java/org/bitcoinj/testing/TestWithWallet.java
+++ b/core/src/test/java/org/bitcoinj/testing/TestWithWallet.java
@@ -71,7 +71,7 @@ public class TestWithWallet {
         wallet = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH, KeyChainGroupStructure.BIP32);
         myKey = wallet.freshReceiveKey();
         myAddress = wallet.freshReceiveAddress(ScriptType.P2PKH);
-        blockStore = new MemoryBlockStore(TESTNET);
+        blockStore = new MemoryBlockStore(TESTNET.getGenesisBlock());
         chain = new BlockChain(TESTNET, wallet, blockStore);
     }
 

--- a/core/src/test/java/org/bitcoinj/utils/VersionTallyTest.java
+++ b/core/src/test/java/org/bitcoinj/utils/VersionTallyTest.java
@@ -107,7 +107,7 @@ public class VersionTallyTest {
     @Test
     public void testInitialize() throws BlockStoreException {
         Context.propagate(new Context(100, Transaction.DEFAULT_TX_FEE, false, true));
-        final BlockStore blockStore = new MemoryBlockStore(TESTNET);
+        final BlockStore blockStore = new MemoryBlockStore(TESTNET.getGenesisBlock());
         final BlockChain chain = new BlockChain(TESTNET, blockStore);
 
         // Build a historical chain of version 2 blocks

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -153,7 +153,7 @@ public class WalletTest extends TestWithWallet {
 
     private void createMarriedWallet(int threshold, int numKeys, boolean addSigners) throws BlockStoreException {
         wallet = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH);
-        blockStore = new MemoryBlockStore(TESTNET);
+        blockStore = new MemoryBlockStore(TESTNET.getGenesisBlock());
         chain = new BlockChain(TESTNET, wallet, blockStore);
 
         List<DeterministicKey> followingKeys = new ArrayList<>();
@@ -3296,7 +3296,7 @@ public class WalletTest extends TestWithWallet {
         DeterministicKey watchKey = wallet.getWatchingKey();
         String serialized = watchKey.serializePubB58(TESTNET.network());
         Wallet wallet = Wallet.fromWatchingKeyB58(TESTNET, serialized);
-        blockStore = new MemoryBlockStore(TESTNET);
+        blockStore = new MemoryBlockStore(TESTNET.getGenesisBlock());
         chain = new BlockChain(TESTNET, wallet, blockStore);
 
         final DeterministicKeyChain keyChain = DeterministicKeyChain.builder().random(new SecureRandom()).build();

--- a/examples/src/main/java/org/bitcoinj/examples/FetchBlock.java
+++ b/examples/src/main/java/org/bitcoinj/examples/FetchBlock.java
@@ -58,7 +58,7 @@ public class FetchBlock implements Callable<Integer> {
         System.out.println("Connecting to node");
         final Network network = BitcoinNetwork.TESTNET;
         final NetworkParameters params = NetworkParameters.of(network);
-        BlockStore blockStore = new MemoryBlockStore(params);
+        BlockStore blockStore = new MemoryBlockStore(params.getGenesisBlock());
         BlockChain chain = new BlockChain(params, blockStore);
         PeerGroup peerGroup = new PeerGroup(network, chain);
         if (localhost) {

--- a/examples/src/main/java/org/bitcoinj/examples/FetchTransactions.java
+++ b/examples/src/main/java/org/bitcoinj/examples/FetchTransactions.java
@@ -39,7 +39,7 @@ public class FetchTransactions {
         final Network network = BitcoinNetwork.TESTNET;
         final NetworkParameters params = NetworkParameters.of(network);
 
-        BlockStore blockStore = new MemoryBlockStore(params);
+        BlockStore blockStore = new MemoryBlockStore(params.getGenesisBlock());
         BlockChain chain = new BlockChain(params, blockStore);
         PeerGroup peerGroup = new PeerGroup(network, chain);
         peerGroup.start();

--- a/examples/src/main/java/org/bitcoinj/examples/PrivateKeys.java
+++ b/examples/src/main/java/org/bitcoinj/examples/PrivateKeys.java
@@ -70,7 +70,7 @@ public class PrivateKeys {
             Address destination = wallet.parseAddress(args[1]);
 
             // Find the transactions that involve those coins.
-            final MemoryBlockStore blockStore = new MemoryBlockStore(params);
+            final MemoryBlockStore blockStore = new MemoryBlockStore(params.getGenesisBlock());
             BlockChain chain = new BlockChain(params, wallet, blockStore);
 
             final PeerGroup peerGroup = new PeerGroup(network, chain);

--- a/examples/src/main/java/org/bitcoinj/examples/RefreshWallet.java
+++ b/examples/src/main/java/org/bitcoinj/examples/RefreshWallet.java
@@ -41,7 +41,7 @@ public class RefreshWallet {
         // Set up the components and link them together.
         final Network network = BitcoinNetwork.TESTNET;
         final NetworkParameters params = NetworkParameters.of(network);
-        BlockStore blockStore = new MemoryBlockStore(params);
+        BlockStore blockStore = new MemoryBlockStore(params.getGenesisBlock());
         BlockChain chain = new BlockChain(params, wallet, blockStore);
 
         final PeerGroup peerGroup = new PeerGroup(network, chain);

--- a/integration-test/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTest.java
@@ -70,7 +70,7 @@ public class FilteredBlockAndPartialMerkleTreeTest extends TestWithPeerGroup {
 
     @Before
     public void setUp() throws Exception {
-        MemoryBlockStore store = new MemoryBlockStore(TESTNET);
+        MemoryBlockStore store = new MemoryBlockStore(TESTNET.getGenesisBlock());
 
         // Cheat and place the previous block (block 100000) at the head of the block store without supporting blocks
         store.put(new StoredBlock(SERIALIZER.makeBlock(ByteBuffer.wrap(ByteUtils.parseHex("0100000050120119172a610421a6c3011dd330d9df07b63616c2cc1f1cd00200000000006657a9252aacd5c0b2940996ecff952228c3067cc38d4885efb5a4ac4247e9f337221b4d4c86041b0f2b5710"))),

--- a/integration-test/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
+++ b/integration-test/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
@@ -100,7 +100,7 @@ public class TestWithNetworkConnections {
     }
 
     public void setUp() throws Exception {
-        setUp(new MemoryBlockStore(UNITTEST));
+        setUp(new MemoryBlockStore(UNITTEST.getGenesisBlock()));
     }
     
     public void setUp(BlockStore blockStore) throws Exception {

--- a/integration-test/src/test/java/org/bitcoinj/testing/TestWithPeerGroup.java
+++ b/integration-test/src/test/java/org/bitcoinj/testing/TestWithPeerGroup.java
@@ -71,7 +71,7 @@ public class TestWithPeerGroup extends TestWithNetworkConnections {
 
     @Override
     public void setUp() throws Exception {
-        setUp(new MemoryBlockStore(UNITTEST));
+        setUp(new MemoryBlockStore(UNITTEST.getGenesisBlock()));
     }
 
     @Override

--- a/tools/src/main/java/org/bitcoinj/tools/BlockImporter.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BlockImporter.java
@@ -48,7 +48,7 @@ public class BlockImporter {
                 break;
             case "Mem":
                 checkArgument(args.length == 2);
-                store = new MemoryBlockStore(params);
+                store = new MemoryBlockStore(params.getGenesisBlock());
                 break;
             case "SPV":
                 checkArgument(args.length == 3);

--- a/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
@@ -100,7 +100,7 @@ public class BuildCheckpoints implements Callable<Integer> {
 
         // Configure bitcoinj to fetch only headers, not save them to disk, connect to a local fully synced/validated
         // node and to save block headers that are on interval boundaries, as long as they are <1 month old.
-        final BlockStore store = new MemoryBlockStore(params);
+        final BlockStore store = new MemoryBlockStore(params.getGenesisBlock());
         final BlockChain chain = new BlockChain(params, store);
         final PeerGroup peerGroup = new PeerGroup(net, chain);
 


### PR DESCRIPTION
Since MemoryBlockStore is mostly used for testing, we probably don't need a deprecated constructor with NetworkParameters.
