### PR TITLE
TransactionInput: remove helper `duplicateDetached()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -496,11 +496,6 @@ public class TransactionInput extends Message {
         return getOutpoint().fromTx;
     }
 
-    /** Returns a copy of the input detached from its containing transaction, if need be. */
-    public TransactionInput duplicateDetached() {
-        return new TransactionInput(null, ByteBuffer.wrap(bitcoinSerialize()));
-    }
-
     /**
      * <p>Returns either RuleViolation.NONE if the input is standard, or which rule makes it non-standard if so.
      * The "IsStandard" rules control whether the default Bitcoin Core client blocks relay of a tx / refuses to mine it,

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -107,7 +107,7 @@ public class TransactionTest {
     public void duplicateOutPoint() {
         TransactionInput input = tx.getInput(0);
         input.setScriptBytes(new byte[1]);
-        tx.addInput(input.duplicateDetached());
+        tx.addInput(input);
         tx.verify();
     }
 


### PR DESCRIPTION
It is only used from a test, and that test works just as well by just copying the reference.