### PR TITLE
TransactionInput, TransactionOutput: make `setParent()` protected

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -513,7 +513,7 @@ public class TransactionInput extends Message {
         return DefaultRiskAnalysis.isInputStandard(this);
     }
 
-    public final void setParent(@Nullable Transaction parent) {
+    protected final void setParent(@Nullable Transaction parent) {
         if (this.parent != null && this.parent != parent && parent != null) {
             // After old parent is unlinked it won't be able to receive notice if this child
             // changes internally.  To be safe we invalidate the parent cache to ensure it rebuilds

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -406,7 +406,7 @@ public class TransactionOutput extends Message {
         return new TransactionOutput(null, Coin.valueOf(value), Arrays.copyOf(scriptBytes, scriptBytes.length));
     }
 
-    public final void setParent(@Nullable Transaction parent) {
+    protected final void setParent(@Nullable Transaction parent) {
         if (this.parent != null && this.parent != parent && parent != null) {
             // After old parent is unlinked it won't be able to receive notice if this child
             // changes internally.  To be safe we invalidate the parent cache to ensure it rebuilds


### PR DESCRIPTION
Rather than using this method, we should prefer passing the parent transaction via constructor.