### PR TITLE
Transaction: make `network` in `toString()` an optional parameter

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -3606,7 +3606,7 @@ public class Wallet extends BaseTaggableObject
             }
             if (tx.hasConfidence())
                 builder.append("  confidence: ").append(tx.getConfidence()).append('\n');
-            builder.append(tx.toString(chain, "  "));
+            builder.append(tx.toString(chain, network(), "  "));
         }
     }
 

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -463,6 +463,13 @@ public class TransactionTest {
     }
 
     @Test
+    public void testToString() {
+        int lengthWithAddresses = tx.toString(null, BitcoinNetwork.TESTNET).length();
+        int lengthWithoutAddresses = tx.toString(null, null).length();
+        assertTrue(lengthWithAddresses > lengthWithoutAddresses);
+    }
+
+    @Test
     public void testToStringWhenLockTimeIsSpecifiedInBlockHeight() {
         Transaction tx = FakeTxBuilder.createFakeTx(TESTNET);
         TransactionInput input = tx.getInput(0);
@@ -480,7 +487,7 @@ public class TransactionTest {
 
         replay(mockBlockChain);
 
-        String str = tx.toString(mockBlockChain, null);
+        String str = tx.toString(mockBlockChain, BitcoinNetwork.TESTNET);
 
         assertEquals(str.contains("block " + TEST_LOCK_TIME), true);
         assertEquals(str.contains("estimated to be reached at"), true);


### PR DESCRIPTION
If it isn't provided, standard output scripts cannot be converted to addresses.