### PR TITLE
Transaction: move `isMature()` to `Wallet.isTransactionMature()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -756,19 +756,6 @@ public class Transaction extends Message {
         return inputs.size() == 1 && inputs.get(0).isCoinBase();
     }
 
-    /**
-     * A transaction is mature if it is either a building coinbase tx that is as deep or deeper than the required coinbase depth, or a non-coinbase tx.
-     */
-    public boolean isMature() {
-        if (!isCoinBase())
-            return true;
-
-        if (getConfidence().getConfidenceType() != ConfidenceType.BUILDING)
-            return false;
-
-        return getConfidence().getDepthInBlocks() >= params.getSpendableCoinbaseDepth();
-    }
-
     @Override
     public String toString() {
         MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this);

--- a/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
@@ -331,7 +331,7 @@ public class BlockChainTest {
         // The coinbase tx is not yet available to spend.
         assertEquals(Coin.ZERO, testNetWallet.getBalance());
         assertEquals(FIFTY_COINS, testNetWallet.getBalance(BalanceType.ESTIMATED));
-        assertFalse(coinbaseTransaction.isMature());
+        assertFalse(testNetWallet.isTransactionMature(coinbaseTransaction));
 
         // Attempt to spend the coinbase - this should fail as the coinbase is not mature yet.
         try {
@@ -353,7 +353,7 @@ public class BlockChainTest {
             assertEquals(FIFTY_COINS, testNetWallet.getBalance(BalanceType.ESTIMATED));
 
             // The coinbase transaction is still not mature.
-            assertFalse(coinbaseTransaction.isMature());
+            assertFalse(testNetWallet.isTransactionMature(coinbaseTransaction));
 
             // Attempt to spend the coinbase - this should fail.
             try {
@@ -371,7 +371,7 @@ public class BlockChainTest {
         // Wallet now has the coinbase transaction available for spend.
         assertEquals(FIFTY_COINS, testNetWallet.getBalance());
         assertEquals(FIFTY_COINS, testNetWallet.getBalance(BalanceType.ESTIMATED));
-        assertTrue(coinbaseTransaction.isMature());
+        assertTrue(testNetWallet.isTransactionMature(coinbaseTransaction));
 
         // Create a spend with the coinbase BTC to the address in the second wallet - this should now succeed.
         Transaction coinbaseSend2 = testNetWallet.createSend(addressToSendTo, valueOf(49, 0));

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -34,6 +34,7 @@ import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptError;
 import org.bitcoinj.script.ScriptException;
 import org.bitcoinj.testing.FakeTxBuilder;
+import org.bitcoinj.wallet.Wallet;
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
@@ -184,16 +185,17 @@ public class TransactionTest {
 
     @Test
     public void testIsMatureReturnsFalseIfTransactionIsCoinbaseAndConfidenceTypeIsNotEqualToBuilding() {
+        Wallet wallet = Wallet.createBasic(TESTNET);
         Transaction tx = FakeTxBuilder.createFakeCoinbaseTx(TESTNET);
 
         tx.getConfidence().setConfidenceType(ConfidenceType.UNKNOWN);
-        assertFalse(tx.isMature());
+        assertFalse(wallet.isTransactionMature(tx));
 
         tx.getConfidence().setConfidenceType(ConfidenceType.PENDING);
-        assertFalse(tx.isMature());
+        assertFalse(wallet.isTransactionMature(tx));
 
         tx.getConfidence().setConfidenceType(ConfidenceType.DEAD);
-        assertFalse(tx.isMature());
+        assertFalse(wallet.isTransactionMature(tx));
     }
 
     @Test


### PR DESCRIPTION
That method is only needed in `Wallet`, so it's good to have it there. On top of that, Wallet will be able to provide `NetworkParameters` for a long time.