### PR TITLE
Transaction, Block: make `verify*()` static helper methods

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
@@ -497,7 +497,7 @@ public abstract class AbstractBlockChain {
             // are only lightly verified: presence in a valid connecting block is taken as proof of validity. See the
             // article here for more details: https://bitcoinj.github.io/security-model
             try {
-                block.verifyHeader();
+                Block.verifyHeader(block);
                 storedPrev = getStoredBlockInCurrentScope(block.getPrevBlockHash());
                 if (storedPrev != null) {
                     height = storedPrev.getHeight() + 1;
@@ -506,7 +506,7 @@ public abstract class AbstractBlockChain {
                 }
                 flags = params.getBlockVerificationFlags(block, versionTally, height);
                 if (shouldVerifyTransactions())
-                    block.verifyTransactions(height, flags);
+                    Block.verifyTransactions(params, block, height, flags);
             } catch (VerificationException e) {
                 log.error("Failed to verify block: ", e);
                 log.error(block.getHashAsString());

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -684,8 +684,8 @@ public class Block extends Message {
         checkTransactions(height, flags);
         checkMerkleRoot();
         checkSigOps();
-        for (Transaction transaction : transactions)
-            transaction.verify();
+        for (Transaction tx : transactions)
+            Transaction.verify(params, tx);
         }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -713,7 +713,7 @@ public class Peer extends PeerSocketHandler {
 
     protected void processTransaction(final Transaction tx) throws VerificationException {
         // Check a few basic syntax issues to ensure the received TX isn't nonsense.
-        tx.verify();
+        tx.verify(params, tx);
         lock.lock();
         try {
             if (log.isDebugEnabled())

--- a/core/src/main/java/org/bitcoinj/protocols/payments/PaymentProtocol.java
+++ b/core/src/main/java/org/bitcoinj/protocols/payments/PaymentProtocol.java
@@ -345,7 +345,6 @@ public class PaymentProtocol {
             @Nullable List<Protos.Output> refundOutputs, @Nullable String memo, @Nullable byte[] merchantData) {
         Protos.Payment.Builder builder = Protos.Payment.newBuilder();
         for (Transaction transaction : transactions) {
-            transaction.verify();
             builder.addTransactions(ByteString.copyFrom(transaction.bitcoinSerialize()));
         }
         if (refundOutputs != null) {

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -2002,7 +2002,7 @@ public class Wallet extends BaseTaggableObject
         // spend against one of our other pending transactions.
         lock.lock();
         try {
-            tx.verify();
+            Transaction.verify(params, tx);
             // Ignore it if we already know about this transaction. Receiving a pending transaction never moves it
             // between pools.
             EnumSet<Pool> containingPools = getContainingPools(tx);
@@ -2782,7 +2782,7 @@ public class Wallet extends BaseTaggableObject
      * @throws VerificationException If transaction fails to verify
      */
     public boolean maybeCommitTx(Transaction tx) throws VerificationException {
-        tx.verify();
+        Transaction.verify(params, tx);
         lock.lock();
         try {
             if (pending.containsKey(tx.getTxId()))

--- a/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
@@ -402,7 +402,7 @@ public class BlockChainTest {
         b2.setDifficultyTarget(0x1d00ffff);
         b2.setPrevBlockHash(Sha256Hash.wrap("00000000b873e79784647a6c82962c70d228557d24a747ea4d1b8bbe878e1206"));
         assertEquals("000000006c02c8ea6e4ff69651f7fcde348fb9d557a06e6957b65552002a7820", b2.getHashAsString());
-        b2.verifyHeader();
+        Block.verifyHeader(b2);
         return b2;
     }
 
@@ -414,7 +414,7 @@ public class BlockChainTest {
         b1.setDifficultyTarget(0x1d00ffff);
         b1.setPrevBlockHash(Sha256Hash.wrap("000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"));
         assertEquals("00000000b873e79784647a6c82962c70d228557d24a747ea4d1b8bbe878e1206", b1.getHashAsString());
-        b1.verifyHeader();
+        Block.verifyHeader(b1);
         return b1;
     }
 

--- a/core/src/test/java/org/bitcoinj/core/BlockTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockTest.java
@@ -81,7 +81,7 @@ public class BlockTest {
 
     @Test
     public void testBlockVerification() {
-        block700000.verify(Block.BLOCK_HEIGHT_GENESIS, EnumSet.noneOf(Block.VerifyFlag.class));
+        Block.verify(TESTNET, block700000, Block.BLOCK_HEIGHT_GENESIS, EnumSet.noneOf(Block.VerifyFlag.class));
     }
     
     @Test
@@ -103,7 +103,7 @@ public class BlockTest {
         Block block = TWEAK_TESTNET.getDefaultSerializer().makeBlock(ByteBuffer.wrap(block700000Bytes));
         block.setNonce(12346);
         try {
-            block.verify(Block.BLOCK_HEIGHT_GENESIS, EnumSet.noneOf(Block.VerifyFlag.class));
+            Block.verify(TWEAK_TESTNET, block, Block.BLOCK_HEIGHT_GENESIS, EnumSet.noneOf(Block.VerifyFlag.class));
             fail();
         } catch (VerificationException e) {
             // Expected.
@@ -112,18 +112,18 @@ public class BlockTest {
         // from containing artificially weak difficulties.
         block.setDifficultyTarget(Block.EASIEST_DIFFICULTY_TARGET);
         // Now it should pass.
-        block.verify(Block.BLOCK_HEIGHT_GENESIS, EnumSet.noneOf(Block.VerifyFlag.class));
+        Block.verify(TWEAK_TESTNET, block, Block.BLOCK_HEIGHT_GENESIS, EnumSet.noneOf(Block.VerifyFlag.class));
         // Break the nonce again at the lower difficulty level so we can try solving for it.
         block.setNonce(1);
         try {
-            block.verify(Block.BLOCK_HEIGHT_GENESIS, EnumSet.noneOf(Block.VerifyFlag.class));
+            Block.verify(TWEAK_TESTNET, block, Block.BLOCK_HEIGHT_GENESIS, EnumSet.noneOf(Block.VerifyFlag.class));
             fail();
         } catch (VerificationException e) {
             // Expected to fail as the nonce is no longer correct.
         }
         // Should find an acceptable nonce.
         block.solve();
-        block.verify(Block.BLOCK_HEIGHT_GENESIS, EnumSet.noneOf(Block.VerifyFlag.class));
+        Block.verify(TWEAK_TESTNET, block, Block.BLOCK_HEIGHT_GENESIS, EnumSet.noneOf(Block.VerifyFlag.class));
     }
 
     @Test
@@ -134,7 +134,7 @@ public class BlockTest {
         block700000.transactions.set(0, tx2);
         block700000.transactions.set(1, tx1);
         try {
-            block700000.verify(Block.BLOCK_HEIGHT_GENESIS, EnumSet.noneOf(Block.VerifyFlag.class));
+            Block.verify(TESTNET, block700000, Block.BLOCK_HEIGHT_GENESIS, EnumSet.noneOf(Block.VerifyFlag.class));
             fail();
         } catch (VerificationException e) {
             // We should get here.
@@ -168,7 +168,7 @@ public class BlockTest {
 
         // Check block.
         assertEquals("0000000004053156021d8e42459d284220a7f6e087bf78f30179c3703ca4eefa", block.getHashAsString());
-        block.verify(21066, EnumSet.of(Block.VerifyFlag.HEIGHT_IN_COINBASE));
+        Block.verify(TESTNET, block, 21066, EnumSet.of(Block.VerifyFlag.HEIGHT_IN_COINBASE));
 
         // Testnet block 32768 (hash 000000007590ba495b58338a5806c2b6f10af921a70dbd814e0da3c6957c0c03)
         // contains a coinbase transaction whose height is three bytes, but could
@@ -180,7 +180,7 @@ public class BlockTest {
 
         // Check block.
         assertEquals("000000007590ba495b58338a5806c2b6f10af921a70dbd814e0da3c6957c0c03", block.getHashAsString());
-        block.verify(32768, EnumSet.of(Block.VerifyFlag.HEIGHT_IN_COINBASE));
+        Block.verify(TESTNET, block, 32768, EnumSet.of(Block.VerifyFlag.HEIGHT_IN_COINBASE));
     }
 
     @Test
@@ -199,7 +199,7 @@ public class BlockTest {
 
         // Check block.
         assertNotNull(block169482);
-        block169482.verify(169482, EnumSet.noneOf(Block.VerifyFlag.class));
+        Block.verify(MAINNET, block169482, 169482, EnumSet.noneOf(Block.VerifyFlag.class));
         assertEquals(BLOCK_NONCE, block169482.getNonce());
 
         StoredBlock storedBlock = new StoredBlock(block169482, BigInteger.ONE, 169482); // Nonsense work - not used in test.

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -89,19 +89,19 @@ public class TransactionTest {
     @Test(expected = VerificationException.EmptyInputsOrOutputs.class)
     public void emptyOutputs() {
         tx.clearOutputs();
-        tx.verify();
+        Transaction.verify(TESTNET, tx);
     }
 
     @Test(expected = VerificationException.EmptyInputsOrOutputs.class)
     public void emptyInputs() {
         tx.clearInputs();
-        tx.verify();
+        Transaction.verify(TESTNET, tx);
     }
 
     @Test(expected = VerificationException.LargerThanMaxBlockSize.class)
     public void tooHuge() {
         tx.getInput(0).setScriptBytes(new byte[Block.MAX_BLOCK_SIZE]);
-        tx.verify();
+        Transaction.verify(TESTNET, tx);
     }
 
     @Test(expected = VerificationException.DuplicatedOutPoint.class)
@@ -109,13 +109,13 @@ public class TransactionTest {
         TransactionInput input = tx.getInput(0);
         input.setScriptBytes(new byte[1]);
         tx.addInput(input);
-        tx.verify();
+        Transaction.verify(TESTNET, tx);
     }
 
     @Test(expected = VerificationException.NegativeValueOutput.class)
     public void negativeOutput() {
         tx.getOutput(0).setValue(Coin.NEGATIVE_SATOSHI);
-        tx.verify();
+        Transaction.verify(TESTNET, tx);
     }
 
     @Test(expected = VerificationException.ExcessiveValue.class)
@@ -123,20 +123,20 @@ public class TransactionTest {
         Coin half = BitcoinNetwork.MAX_MONEY.divide(2).add(Coin.SATOSHI);
         tx.getOutput(0).setValue(half);
         tx.addOutput(half, ADDRESS);
-        tx.verify();
+        Transaction.verify(TESTNET, tx);
     }
 
     @Test(expected = VerificationException.UnexpectedCoinbaseInput.class)
     public void coinbaseInputInNonCoinbaseTX() {
         tx.addInput(Sha256Hash.ZERO_HASH, 0xFFFFFFFFL, new ScriptBuilder().data(new byte[10]).build());
-        tx.verify();
+        Transaction.verify(TESTNET, tx);
     }
 
     @Test(expected = VerificationException.CoinbaseScriptSizeOutOfRange.class)
     public void coinbaseScriptSigTooSmall() {
         tx.clearInputs();
         tx.addInput(Sha256Hash.ZERO_HASH, 0xFFFFFFFFL, new ScriptBuilder().build());
-        tx.verify();
+        Transaction.verify(TESTNET, tx);
     }
 
     @Test(expected = VerificationException.CoinbaseScriptSizeOutOfRange.class)
@@ -144,7 +144,7 @@ public class TransactionTest {
         tx.clearInputs();
         TransactionInput input = tx.addInput(Sha256Hash.ZERO_HASH, 0xFFFFFFFFL, new ScriptBuilder().data(new byte[99]).build());
         assertEquals(101, input.getScriptBytes().length);
-        tx.verify();
+        Transaction.verify(TESTNET, tx);
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/script/ScriptTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptTest.java
@@ -392,7 +392,7 @@ public class ScriptTest {
             try {
                 Map<TransactionOutPoint, Script> scriptPubKeys = parseScriptPubKeys(test.get(0));
                 transaction = TESTNET.getDefaultSerializer().makeTransaction(ByteBuffer.wrap(ByteUtils.parseHex(test.get(1).asText().toLowerCase())));
-                transaction.verify();
+                Transaction.verify(TESTNET, transaction);
                 Set<VerifyFlag> verifyFlags = parseVerifyFlags(test.get(2).asText());
 
                 for (int i = 0; i < transaction.getInputs().size(); i++) {
@@ -433,7 +433,7 @@ public class ScriptTest {
 
             boolean valid = true;
             try {
-                transaction.verify();
+                Transaction.verify(TESTNET, transaction);
             } catch (VerificationException e) {
                 valid = false;
             }


### PR DESCRIPTION
Two commits, one each for Transaction and Block.

I think it's fair that these must become independant, so that the data classes need not keep the parameters for the validation. We can move the validation to separate classes later if needed.