### PR TITLE
DefaultCoinSelector, AllowUnconfirmedCoinSelector: remove singleton pattern

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/AllowUnconfirmedCoinSelector.java
+++ b/core/src/main/java/org/bitcoinj/wallet/AllowUnconfirmedCoinSelector.java
@@ -23,17 +23,12 @@ import org.bitcoinj.core.Transaction;
  * confirmed yet. However immature coinbases will not be included (would be a protocol violation).
  */
 public class AllowUnconfirmedCoinSelector extends DefaultCoinSelector {
-    @Override protected boolean shouldSelect(Transaction tx) {
+    @Override
+    protected boolean shouldSelect(Transaction tx) {
         return true;
     }
 
-    private static AllowUnconfirmedCoinSelector instance;
-
-    /** Returns a global static instance of the selector. */
     public static AllowUnconfirmedCoinSelector get() {
-        // This doesn't have to be thread safe as the object has no state, so discarded duplicates are harmless.
-        if (instance == null)
-            instance = new AllowUnconfirmedCoinSelector();
-        return instance;
+        return new AllowUnconfirmedCoinSelector();
     }
 }

--- a/core/src/main/java/org/bitcoinj/wallet/DefaultCoinSelector.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DefaultCoinSelector.java
@@ -104,14 +104,7 @@ public class DefaultCoinSelector implements CoinSelector {
                (confidence.numBroadcastPeers() > 0 || tx.getParams().network() == BitcoinNetwork.REGTEST);
     }
 
-    private static DefaultCoinSelector instance;
-
-    /** Returns a global static instance of the selector. */
     public static DefaultCoinSelector get() {
-        // This doesn't have to be thread safe as the object has no state, so discarded duplicates are
-        // harmless.
-        if (instance == null)
-            instance = new DefaultCoinSelector();
-        return instance;
+        return new DefaultCoinSelector();
     }
 }


### PR DESCRIPTION
Instantiating these classes is cheap, as they're stateless. And we only do that once per `Wallet` instance.