### PR TITLE
VersionMessage: deprecate `isPingPongSupported()` and `ProtocolVersion.PONG`

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -554,6 +554,7 @@ public abstract class NetworkParameters {
 
     public static enum ProtocolVersion {
         MINIMUM(70000),
+        @Deprecated
         PONG(60001),
         BLOOM_FILTER(70001), // BIP37
         BLOOM_FILTER_BIP111(70011), // BIP111

--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -1545,8 +1545,6 @@ public class Peer extends PeerSocketHandler {
 
     protected CompletableFuture<Duration> sendPing(long nonce) {
         final VersionMessage ver = vPeerVersionMessage;
-        if (!ver.isPingPongSupported())
-            return FutureUtils.failedFuture(new ProtocolException("Peer version is too low for measurable pings: " + ver));
         if (pendingPings.size() > PENDING_PINGS_LIMIT) {
             log.info("{}: Too many pending pings, disconnecting", this);
             close();

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -1691,8 +1691,6 @@ public class PeerGroup implements TransactionBroadcaster {
                     return;  // Disabled.
                 }
                 for (Peer peer : getConnectedPeers()) {
-                    if (peer.getPeerVersionMessage().clientVersion < params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.PONG))
-                        continue;
                     peer.sendPing();
                 }
             } catch (Throwable e) {

--- a/core/src/main/java/org/bitcoinj/core/VersionMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionMessage.java
@@ -243,12 +243,10 @@ public class VersionMessage extends Message {
             throw new IllegalArgumentException("name contains invalid characters");
     }
 
-    /**
-     * Returns true if the clientVersion field is {@link NetworkParameters.ProtocolVersion#PONG} or higher.
-     * If it is then {@link Peer#sendPing()} is usable.
-     */
+    /** @deprecated just assume {@code true} */
+    @Deprecated
     public boolean isPingPongSupported() {
-        return clientVersion >= params.getProtocolVersionNum(NetworkParameters.ProtocolVersion.PONG);
+        return true;
     }
 
     /**


### PR DESCRIPTION
Our minimum version is at 70000 already.