### PR TITLE
VersionMessage: inline helpers `isWitnessSupported()`, `hasBlockChain()` and `hasLimitedBlockChain()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -523,7 +523,7 @@ public class Peer extends PeerSocketHandler {
         // implementations claim to have a block chain in their services field but then report a height of zero, filter
         // them out here.
         Services services = peerVersionMessage.getServices();
-        if (!(services.has(Services.NODE_NETWORK) || services.has(Services.NODE_NETWORK_LIMITED)) ||
+        if (!services.anyOf(Services.NODE_NETWORK | Services.NODE_NETWORK_LIMITED) ||
                 (!params.allowEmptyPeerChain() && peerVersionMessage.bestHeight == 0)) {
             // Shut down the channel gracefully.
             log.info("{}: Peer does not have at least a recent part of the block chain.", this);

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -2379,9 +2379,9 @@ public class PeerGroup implements TransactionBroadcaster {
             final VersionMessage versionMessage = peer.getPeerVersionMessage();
             if (versionMessage.clientVersion < MINIMUM_VERSION)
                 continue;
-            if (!versionMessage.hasBlockChain())
+            if (!versionMessage.getServices().has(Services.NODE_NETWORK))
                 continue;
-            if (!versionMessage.isWitnessSupported())
+            if (!versionMessage.getServices().has(Services.NODE_WITNESS))
                 continue;
             final long peerHeight = peer.getBestHeight();
             if (peerHeight < mostCommonChainHeight || peerHeight > mostCommonChainHeight + 1)

--- a/core/src/main/java/org/bitcoinj/core/Services.java
+++ b/core/src/main/java/org/bitcoinj/core/Services.java
@@ -107,10 +107,20 @@ public class Services {
      * Checks if given specific node services are signaled by this bitfield.
      *
      * @param bitmask bitmask representing the services to be checked for
-     * @return true if the given services are allsignaled, false otherwise
+     * @return true if the given services are all signaled, false otherwise
      */
     public boolean has(long bitmask) {
         return (bits & bitmask) == bitmask;
+    }
+
+    /**
+     * Checks if at least one of the given node services is signaled by this bitfield.
+     *
+     * @param bitmask bitmask representing the services to be checked for
+     * @return true if at least one of the given services is signaled, false otherwise
+     */
+    public boolean anyOf(long bitmask) {
+        return (bits & bitmask) != 0;
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/VersionMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionMessage.java
@@ -113,6 +113,15 @@ public class VersionMessage extends Message {
         relayTxesBeforeFilter = true;
     }
 
+    /**
+     * Get the service bitfield that represents the node services being provided.
+     *
+     * @return service bitfield
+     */
+    public Services getServices() {
+        return localServices;
+    }
+
     @Override
     protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         clientVersion = (int) ByteUtils.readUint32(payload);
@@ -261,23 +270,5 @@ public class VersionMessage extends Message {
         if (localServices.has(Services.NODE_BLOOM))
             return true;
         return false;
-    }
-
-    /** Returns true if a peer can be asked for blocks and transactions including witness data. */
-    public boolean isWitnessSupported() {
-        return localServices.has(Services.NODE_WITNESS);
-    }
-
-    /**
-     * Returns true if the version message indicates the sender has a full copy of the block chain, or false if it's
-     * running in client mode (only has the headers).
-     */
-    public boolean hasBlockChain() {
-        return localServices.has(Services.NODE_NETWORK);
-    }
-
-    /** Returns true if the peer has at least the last two days worth of blockchain (BIP159). */
-    public boolean hasLimitedBlockChain() {
-        return hasBlockChain() || localServices.has(Services.NODE_NETWORK_LIMITED);
     }
 }

--- a/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
@@ -94,7 +94,7 @@ public class BitcoindComparisonTool {
         ver.localServices = Services.of(Services.NODE_NETWORK);
         final Peer bitcoind = new Peer(PARAMS, ver, PeerAddress.localhost(PARAMS),
                 new BlockChain(PARAMS, new MemoryBlockStore(PARAMS.getGenesisBlock())));
-        checkState(bitcoind.getVersionMessage().hasBlockChain());
+        checkState(bitcoind.getVersionMessage().getServices().has(Services.NODE_NETWORK));
 
         final BlockWrapper currentBlock = new BlockWrapper();
 

--- a/integration-test/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
+++ b/integration-test/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
@@ -27,6 +27,7 @@ import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Peer;
 import org.bitcoinj.core.Ping;
 import org.bitcoinj.core.Pong;
+import org.bitcoinj.core.Services;
 import org.bitcoinj.core.VersionAck;
 import org.bitcoinj.core.VersionMessage;
 import org.bitcoinj.core.listeners.PreMessageReceivedEventListener;
@@ -168,7 +169,7 @@ public class TestWithNetworkConnections {
     }
 
     protected InboundMessageQueuer connect(Peer peer, VersionMessage versionMessage) throws Exception {
-        checkArgument(versionMessage.hasBlockChain());
+        checkArgument(versionMessage.getServices().has(Services.NODE_NETWORK));
         final AtomicBoolean doneConnecting = new AtomicBoolean(false);
         final Thread thisThread = Thread.currentThread();
         peer.addDisconnectedEventListener((p, peerCount) -> {

--- a/integration-test/src/test/java/org/bitcoinj/testing/TestWithPeerGroup.java
+++ b/integration-test/src/test/java/org/bitcoinj/testing/TestWithPeerGroup.java
@@ -146,7 +146,7 @@ public class TestWithPeerGroup extends TestWithNetworkConnections {
     }
 
     protected InboundMessageQueuer connectPeer(int id, VersionMessage versionMessage) throws Exception {
-        checkArgument(versionMessage.hasBlockChain());
+        checkArgument(versionMessage.getServices().has(Services.NODE_NETWORK));
         InboundMessageQueuer writeTarget = connectPeerWithoutVersionExchange(id);
         // Complete handshake with the peer - send/receive version(ack)s, receive bloom filter
         writeTarget.sendMessage(versionMessage);
@@ -163,7 +163,7 @@ public class TestWithPeerGroup extends TestWithNetworkConnections {
     // handle peer discovered by PeerGroup
     protected InboundMessageQueuer handleConnectToPeer(int id, VersionMessage versionMessage) throws Exception {
         InboundMessageQueuer writeTarget = newPeerWriteTargetQueue.take();
-        checkArgument(versionMessage.hasBlockChain());
+        checkArgument(versionMessage.getServices().has(Services.NODE_NETWORK));
         // Complete handshake with the peer - send/receive version(ack)s, receive bloom filter
         writeTarget.sendMessage(versionMessage);
         writeTarget.sendMessage(new VersionAck());


### PR DESCRIPTION
Our API is now fluent enough that we don't need them any more.

We cannot provide deprecations because they'd need network parameters.