### PR TITLE
Block: move difficulty target range check to `AbstractBlockChain.add()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
@@ -34,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -477,6 +478,10 @@ public abstract class AbstractBlockChain {
             if (tryConnecting && orphanBlocks.containsKey(block.getHash())) {
                 return false;
             }
+
+            BigInteger target = block.getDifficultyTargetAsInteger();
+            if (target.signum() <= 0 || target.compareTo(params.maxTarget) > 0)
+                throw new VerificationException("Difficulty target is bad: " + target.toString());
 
             // If we want to verify transactions (ie we are running with full blocks), verify that block has transactions
             if (shouldVerifyTransactions() && block.getTransactions() == null)

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -456,10 +456,7 @@ public class Block extends Message {
      * is thrown.
      */
     public BigInteger getDifficultyTargetAsInteger() throws VerificationException {
-        BigInteger target = ByteUtils.decodeCompactBits(difficultyTarget);
-        if (target.signum() <= 0 || target.compareTo(params.maxTarget) > 0)
-            throw new VerificationException("Difficulty target is bad: " + target.toString());
-        return target;
+        return ByteUtils.decodeCompactBits(difficultyTarget);
     }
 
     /** Returns true if the hash of the block is OK (lower than difficulty target). */


### PR DESCRIPTION
It doesn't make much sense in a getter. It should be checked when adding a block to the chain, like all the other checks.