### PR TITLE
TransactionOutPoint: make `hash` and `index` final/immutable

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
@@ -243,8 +243,8 @@ public class FullPrunedBlockChain extends AbstractBlockChain {
                     // outputs.
                     for (int index = 0; index < tx.getInputs().size(); index++) {
                         TransactionInput in = tx.getInputs().get(index);
-                        UTXO prevOut = blockStore.getTransactionOutput(in.getOutpoint().getHash(),
-                                in.getOutpoint().getIndex());
+                        UTXO prevOut = blockStore.getTransactionOutput(in.getOutpoint().hash(),
+                                in.getOutpoint().index());
                         if (prevOut == null)
                             throw new VerificationException("Attempted to spend a non-existent or already spent output!");
                         // Coinbases can't be spent until they mature, to avoid re-orgs destroying entire transaction
@@ -374,8 +374,8 @@ public class FullPrunedBlockChain extends AbstractBlockChain {
                     if (!isCoinBase) {
                         for (int index = 0; index < tx.getInputs().size(); index++) {
                             final TransactionInput in = tx.getInputs().get(index);
-                            final UTXO prevOut = blockStore.getTransactionOutput(in.getOutpoint().getHash(),
-                                    in.getOutpoint().getIndex());
+                            final UTXO prevOut = blockStore.getTransactionOutput(in.getOutpoint().hash(),
+                                    in.getOutpoint().index());
                             if (prevOut == null)
                                 throw new VerificationException("Attempted spend of a non-existent or already spent output!");
                             if (prevOut.isCoinbase() && newBlock.getHeight() - prevOut.getHeight() < params.getSpendableCoinbaseDepth())

--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -101,7 +101,7 @@ public abstract class Message {
         log.error("Error: {} class has not implemented bitcoinSerializeToStream method.  Generating message with no payload", getClass());
     }
 
-    /** @deprecated use {@link Transaction#getTxId()}, {@link Block#getHash()}, {@link FilteredBlock#getHash()} or {@link TransactionOutPoint#getHash()} */
+    /** @deprecated use {@link Transaction#getTxId()}, {@link Block#getHash()}, {@link FilteredBlock#getHash()} or {@link TransactionOutPoint#hash()} */
     @Deprecated
     public Sha256Hash getHash() {
         throw new UnsupportedOperationException();

--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -840,7 +840,7 @@ public class Peer extends PeerSocketHandler {
         // We may end up requesting transactions that we've already downloaded and thrown away here.
         // There may be multiple inputs that connect to the same transaction.
         Set<Sha256Hash> txIdsToRequest = rootTx.getInputs().stream()
-                .map(input -> input.getOutpoint().getHash())
+                .map(input -> input.getOutpoint().hash())
                 .collect(Collectors.toSet());
         lock.lock();
         try {

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -1430,8 +1430,8 @@ public class Transaction extends Message {
             if (!anyoneCanPay) {
                 ByteArrayOutputStream bosHashPrevouts = new ByteArrayOutputStream(256);
                 for (TransactionInput input : this.inputs) {
-                    bosHashPrevouts.write(input.getOutpoint().getHash().serialize());
-                    writeInt32LE(input.getOutpoint().getIndex(), bosHashPrevouts);
+                    bosHashPrevouts.write(input.getOutpoint().hash().serialize());
+                    writeInt32LE(input.getOutpoint().index(), bosHashPrevouts);
                 }
                 hashPrevouts = Sha256Hash.hashTwice(bosHashPrevouts.toByteArray());
             }
@@ -1468,8 +1468,8 @@ public class Transaction extends Message {
             writeInt32LE(version, bos);
             bos.write(hashPrevouts);
             bos.write(hashSequence);
-            bos.write(inputs.get(inputIndex).getOutpoint().getHash().serialize());
-            writeInt32LE(inputs.get(inputIndex).getOutpoint().getIndex(), bos);
+            bos.write(inputs.get(inputIndex).getOutpoint().hash().serialize());
+            writeInt32LE(inputs.get(inputIndex).getOutpoint().index(), bos);
             bos.write(VarInt.of(scriptCode.length).serialize());
             bos.write(scriptCode);
             writeInt64LE(BigInteger.valueOf(prevValue.getValue()), bos);

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -29,7 +29,6 @@ import org.bitcoinj.wallet.KeyBag;
 import org.bitcoinj.wallet.RedeemData;
 
 import javax.annotation.Nullable;
-import java.nio.Buffer;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
@@ -51,9 +50,9 @@ public class TransactionOutPoint {
             new TransactionOutPoint(ByteUtils.MAX_UNSIGNED_INTEGER, Sha256Hash.ZERO_HASH);
 
     /** Hash of the transaction to which we refer. */
-    private Sha256Hash hash;
+    private final Sha256Hash hash;
     /** Which output of that transaction we are talking about. */
-    private long index;
+    private final long index;
 
     // This is not part of bitcoin serialization. It points to the connected transaction.
     Transaction fromTx;
@@ -219,32 +218,31 @@ public class TransactionOutPoint {
     /**
      * Returns the hash of the transaction this outpoint references/spends/is connected to.
      */
-    public Sha256Hash getHash() {
+    public Sha256Hash hash() {
         return hash;
     }
 
     /**
-     * @param hash new hash
-     * @deprecated Don't mutate this class -- create a new instance instead.
+     * @return the index of this outpoint
      */
-    @Deprecated
-    void setHash(Sha256Hash hash) {
-        this.hash = hash;
-    }
-
-    public long getIndex() {
+    public long index() {
         return index;
     }
 
     /**
-     * @param index new index
-     * @deprecated Don't mutate this class -- create a new instance instead.
+     * @deprecated Use {@link #hash()}
      */
     @Deprecated
-    public void setIndex(long index) {
-        checkArgument(index >= 0 && index <= ByteUtils.MAX_UNSIGNED_INTEGER, () ->
-                "index out of range: " + index);
-        this.index = index;
+    public Sha256Hash getHash() {
+        return hash();
+    }
+
+    /**
+     * @deprecated Use {@link #index()}
+     */
+    @Deprecated
+    public long getIndex() {
+        return index();
     }
 
     @Override
@@ -252,11 +250,11 @@ public class TransactionOutPoint {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         TransactionOutPoint other = (TransactionOutPoint) o;
-        return getIndex() == other.getIndex() && getHash().equals(other.getHash());
+        return index() == other.index() && hash().equals(other.hash());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getIndex(), getHash());
+        return Objects.hash(index(), hash());
     }
 }

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -2207,7 +2207,7 @@ public class Wallet extends BaseTaggableObject
             for (Transaction anotherTx : txPool) {
                 if (anotherTx.equals(tx)) continue;
                 for (TransactionInput input : anotherTx.getInputs()) {
-                    if (input.getOutpoint().getHash().equals(tx.getTxId())) {
+                    if (input.getOutpoint().hash().equals(tx.getTxId())) {
                         if (txQueue.get(anotherTx.getTxId()) == null) {
                             txQueue.put(anotherTx.getTxId(), anotherTx);
                             txSet.add(anotherTx);
@@ -2398,7 +2398,7 @@ public class Wallet extends BaseTaggableObject
     /** Finds if tx is NOT spending other txns which are in the specified confidence type */
     private boolean isNotSpendingTxnsInConfidenceType(Transaction tx, ConfidenceType confidenceType) {
         for (TransactionInput txInput : tx.getInputs()) {
-            Transaction connectedTx = this.getTransaction(txInput.getOutpoint().getHash());
+            Transaction connectedTx = this.getTransaction(txInput.getOutpoint().hash());
             if (connectedTx != null && connectedTx.getConfidence().getConfidenceType().equals(confidenceType)) {
                 return false;
             }
@@ -2435,7 +2435,7 @@ public class Wallet extends BaseTaggableObject
     /** Finds whether txA spends txB */
     boolean spends(Transaction txA, Transaction txB) {
         for (TransactionInput txInput : txA.getInputs()) {
-            if (txInput.getOutpoint().getHash().equals(txB.getTxId())) {
+            if (txInput.getOutpoint().hash().equals(txB.getTxId())) {
                 return true;
             }
         }
@@ -4569,7 +4569,7 @@ public class Wallet extends BaseTaggableObject
 
                 RedeemData redeemData = txIn.getConnectedRedeemData(maybeDecryptingKeyBag);
                 Objects.requireNonNull(redeemData, () ->
-                        "Transaction exists in wallet that we cannot redeem: " + txIn.getOutpoint().getHash());
+                        "Transaction exists in wallet that we cannot redeem: " + txIn.getOutpoint().hash());
                 txIn.setScriptSig(scriptPubKey.createEmptyInputScript(redeemData.keys.get(0), redeemData.redeemScript));
                 txIn.setWitness(scriptPubKey.createEmptyWitness(redeemData.keys.get(0)));
             }

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -271,8 +271,8 @@ public class WalletProtobufSerializer {
         for (TransactionInput input : tx.getInputs()) {
             Protos.TransactionInput.Builder inputBuilder = Protos.TransactionInput.newBuilder()
                 .setScriptBytes(ByteString.copyFrom(input.getScriptBytes()))
-                .setTransactionOutPointHash(hashToByteString(input.getOutpoint().getHash()))
-                .setTransactionOutPointIndex((int) input.getOutpoint().getIndex());
+                .setTransactionOutPointHash(hashToByteString(input.getOutpoint().hash()))
+                .setTransactionOutPointIndex((int) input.getOutpoint().index());
             if (input.hasSequence())
                 inputBuilder.setSequence((int) input.getSequenceNumber());
             if (input.getValue() != null)

--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -201,7 +201,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         }
         
         WeakReference<UTXO> out = new WeakReference<>
-                (store.getTransactionOutput(transactionOutPoint.getHash(), transactionOutPoint.getIndex()));
+                (store.getTransactionOutput(transactionOutPoint.hash(), transactionOutPoint.index()));
         rollingBlock = rollingBlock.createNextBlock(null);
         
         Transaction t = new Transaction();

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -1131,7 +1131,8 @@ public class FullBlockTestGenerator {
         {
             Transaction tx = new Transaction();
             tx.addOutput(new TransactionOutput(tx, ZERO, new byte[] {}));
-            b58.getSpendableOutput().outpoint.setIndex(42);
+            // Replace the TransactionOutPoint with an out-of-range OutPoint
+            b58.getSpendableOutput().outpoint = new TransactionOutPoint(42, tx);;
             addOnlyInputToTransaction(tx, b58);
             b58.addTransaction(tx);
         }
@@ -1683,7 +1684,7 @@ public class FullBlockTestGenerator {
                 NewBlock block = createNextBlock(lastBlock, nextHeight++, null, null);
                 while (block.block.getMessageSize() < Block.MAX_BLOCK_SIZE - 500) {
                     Transaction tx = new Transaction();
-                    tx.addInput(lastOutput.getHash(), lastOutput.getIndex(), OP_NOP_SCRIPT);
+                    tx.addInput(lastOutput.hash(), lastOutput.index(), OP_NOP_SCRIPT);
                     tx.addOutput(ZERO, OP_TRUE_SCRIPT);
                     tx.addOutput(ZERO, OP_TRUE_SCRIPT);
                     lastOutput = new TransactionOutPoint(1, tx.getTxId());
@@ -1848,13 +1849,13 @@ public class FullBlockTestGenerator {
 
         public BlockAndValidity(NewBlock block, boolean connects, boolean throwsException, Sha256Hash hashChainTipAfterBlock, int heightAfterBlock, String blockName) {
             this(block.block, connects, throwsException, hashChainTipAfterBlock, heightAfterBlock, blockName);
-            coinbaseBlockMap.put(block.getCoinbaseOutput().outpoint.getHash(), block.getHash());
+            coinbaseBlockMap.put(block.getCoinbaseOutput().outpoint.hash(), block.getHash());
             Integer blockHeight = blockToHeightMap.get(block.block.getPrevBlockHash());
             if (blockHeight != null) {
                 blockHeight++;
                 for (Transaction t : block.block.getTransactions())
                     for (TransactionInput in : t.getInputs()) {
-                        Sha256Hash blockSpendingHash = coinbaseBlockMap.get(in.getOutpoint().getHash());
+                        Sha256Hash blockSpendingHash = coinbaseBlockMap.get(in.getOutpoint().hash());
                         checkState(blockSpendingHash == null || blockToHeightMap.get(blockSpendingHash) == null ||
                                 blockToHeightMap.get(blockSpendingHash) == blockHeight - params.getSpendableCoinbaseDepth());
                     }

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -164,7 +164,7 @@ public class WalletProtobufSerializerTest {
         assertEquals(Protos.Transaction.Pool.PENDING, t1p.getPool());
         assertFalse(t1p.hasLockTime());
         assertFalse(t1p.getTransactionInput(0).hasSequence());
-        assertArrayEquals(t1.getInputs().get(0).getOutpoint().getHash().getBytes(),
+        assertArrayEquals(t1.getInputs().get(0).getOutpoint().hash().getBytes(),
                 t1p.getTransactionInput(0).getTransactionOutPointHash().toByteArray());
         assertEquals(0, t1p.getTransactionInput(0).getTransactionOutPointIndex());
         assertEquals(t1p.getTransactionOutput(0).getValue(), v1.value);

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -2111,7 +2111,7 @@ public class WalletTest extends TestWithWallet {
         for (int i = 0; i < ITERATIONS; i++) {
             Transaction spend = wallet.createSend(OTHER_ADDRESS, COIN);
             assertEquals(spend.getInputs().size(), 1);
-            assertEquals("Failed on iteration " + i, spend.getInput(0).getOutpoint().getHash(), txns[i].getTxId());
+            assertEquals("Failed on iteration " + i, spend.getInput(0).getOutpoint().hash(), txns[i].getTxId());
             wallet.commitTx(spend);
         }
     }

--- a/examples/src/main/java/org/bitcoinj/examples/GenerateLowSTests.java
+++ b/examples/src/main/java/org/bitcoinj/examples/GenerateLowSTests.java
@@ -148,7 +148,7 @@ public class GenerateLowSTests {
             Script scriptPubKey = txIn.getConnectedOutput().getScriptPubKey();
             RedeemData redeemData = txIn.getConnectedRedeemData(bag);
             Objects.requireNonNull(redeemData, () ->
-                    "Transaction exists in wallet that we cannot redeem: " + txIn.getOutpoint().getHash());
+                    "Transaction exists in wallet that we cannot redeem: " + txIn.getOutpoint().hash());
             txIn.setScriptSig(scriptPubKey.createEmptyInputScript(redeemData.keys.get(0), redeemData.redeemScript));
         }
     }

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -643,7 +643,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         inbound(p1, tx);
         // p1 requests dep resolution, p2 is quiet.
         assertTrue(outbound(p1) instanceof GetDataMessage);
-        final Sha256Hash dephash = tx.getInput(0).getOutpoint().getHash();
+        final Sha256Hash dephash = tx.getInput(0).getOutpoint().hash();
         final InventoryItem inv = new InventoryItem(InventoryItem.Type.TRANSACTION, dephash);
         inbound(p1, new NotFoundMessage(Collections.singletonList(inv)));
         assertNull(outbound(p1));

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -562,9 +562,9 @@ public class PeerTest extends TestWithNetworkConnections {
         //      -> [t8]
         // The ones in brackets are assumed to be in the chain and are represented only by hashes.
         Transaction t2 = createFakeTx(COIN, to);
-        Sha256Hash t5hash = t2.getInput(0).getOutpoint().getHash();
+        Sha256Hash t5hash = t2.getInput(0).getOutpoint().hash();
         Transaction t4 = createFakeTx(COIN, new ECKey());
-        Sha256Hash t6hash = t4.getInput(0).getOutpoint().getHash();
+        Sha256Hash t6hash = t4.getInput(0).getOutpoint().hash();
         t4.addOutput(COIN, new ECKey());
         Transaction t3 = new Transaction();
         t3.addInput(t4.getOutput(0));
@@ -612,7 +612,7 @@ public class PeerTest extends TestWithNetworkConnections {
         assertFalse(futures.isDone());
         // It will recursively ask for the dependencies of t2: t5 and t4, but not t3 because it already found t4.
         getdata = (GetDataMessage) outbound(writeTarget);
-        assertEquals(getdata.getItems().get(0).hash, t2.getInput(0).getOutpoint().getHash());
+        assertEquals(getdata.getItems().get(0).hash, t2.getInput(0).getOutpoint().hash());
         // t5 isn't found and t4 is.
         notFound = new NotFoundMessage();
         notFound.addItem(new InventoryItem(InventoryItem.Type.TRANSACTION, t5hash));
@@ -830,7 +830,7 @@ public class PeerTest extends TestWithNetworkConnections {
         t2.addInput(t1.getOutput(0));
         t2.addOutput(COIN, wallet.currentChangeAddress());
         inbound(writeTarget, t2);
-        final InventoryItem inventoryItem = new InventoryItem(InventoryItem.Type.TRANSACTION, t2.getInput(0).getOutpoint().getHash());
+        final InventoryItem inventoryItem = new InventoryItem(InventoryItem.Type.TRANSACTION, t2.getInput(0).getOutpoint().hash());
         final NotFoundMessage nfm = new NotFoundMessage(Lists.newArrayList(inventoryItem));
         inbound(writeTarget, nfm);
         pingAndWait(writeTarget);


### PR DESCRIPTION
* make `hash` and `index` `final`
* Remove deprecated `setHash()` and `setIndex()`
* Fix generation of  `b58`  in `FullBlockTestGenerator` that relies on `setIndex()`

This depends on PR #2975