### PR TITLE
TransactionOutPoint: refactor to interface w/nested `Connected` class

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -849,7 +849,7 @@ public class Block extends Message {
      * @return created block
      */
     @VisibleForTesting
-    Block createNextBlock(@Nullable Address to, long version, @Nullable TransactionOutPoint prevOut, Instant time,
+    Block createNextBlock(@Nullable Address to, long version, @Nullable TransactionOutPoint.Connected prevOut, Instant time,
                           byte[] pubKey, Coin coinbaseValue, int height) {
         Block b = new Block(version);
         b.setDifficultyTarget(difficultyTarget);
@@ -862,7 +862,7 @@ public class Block extends Message {
             // The input does not really need to be a valid signature, as long as it has the right general form.
             TransactionInput input;
             if (prevOut == null) {
-                prevOut = new TransactionOutPoint(0, nextTestOutPointHash());
+                prevOut = new TransactionOutPoint.Connected(0, nextTestOutPointHash());
             }
             input = new TransactionInput(t, Script.createInputScript(EMPTY_BYTES, EMPTY_BYTES), prevOut);
             t.addInput(input);
@@ -905,7 +905,7 @@ public class Block extends Message {
      * @return created block
      */
     @VisibleForTesting
-    public Block createNextBlock(@Nullable Address to, TransactionOutPoint prevOut) {
+    public Block createNextBlock(@Nullable Address to, TransactionOutPoint.Connected prevOut) {
         return createNextBlock(to, BLOCK_VERSION_GENESIS, prevOut, time().plusSeconds(5), pubkeyForTesting,
                 FIFTY_COINS, BLOCK_HEIGHT_UNKNOWN);
     }
@@ -945,7 +945,7 @@ public class Block extends Message {
      */
     @VisibleForTesting
     public Block createNextBlockWithCoinbase(long version, byte[] pubKey, Coin coinbaseValue, int height) {
-        return createNextBlock(null, version, (TransactionOutPoint) null, TimeUtils.currentTime(), pubKey,
+        return createNextBlock(null, version, (TransactionOutPoint.Connected) null, TimeUtils.currentTime(), pubKey,
                 coinbaseValue, height);
     }
 
@@ -960,7 +960,7 @@ public class Block extends Message {
      */
     @VisibleForTesting
     Block createNextBlockWithCoinbase(long version, byte[] pubKey, int height) {
-        return createNextBlock(null, version, (TransactionOutPoint) null, TimeUtils.currentTime(), pubKey,
+        return createNextBlock(null, version, (TransactionOutPoint.Connected) null, TimeUtils.currentTime(), pubKey,
                 FIFTY_COINS, height);
     }
 

--- a/core/src/main/java/org/bitcoinj/core/BloomFilter.java
+++ b/core/src/main/java/org/bitcoinj/core/BloomFilter.java
@@ -256,7 +256,7 @@ public class BloomFilter extends Message {
     }
 
     /** Inserts the given transaction outpoint. */
-    public synchronized void insert(TransactionOutPoint outpoint) {
+    public synchronized void insert(TransactionOutPoint.Connected outpoint) {
         insert(outpoint.serialize());
     }
 

--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -101,7 +101,7 @@ public abstract class Message {
         log.error("Error: {} class has not implemented bitcoinSerializeToStream method.  Generating message with no payload", getClass());
     }
 
-    /** @deprecated use {@link Transaction#getTxId()}, {@link Block#getHash()}, {@link FilteredBlock#getHash()} or {@link TransactionOutPoint#hash()} */
+    /** @deprecated use {@link Transaction#getTxId()}, {@link Block#getHash()}, {@link FilteredBlock#getHash()} or {@link TransactionOutPoint.Connected#hash()} */
     @Deprecated
     public Sha256Hash getHash() {
         throw new UnsupportedOperationException();

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -682,7 +682,7 @@ public class Transaction extends Message {
             TransactionInput input = TransactionInput.read(payload.slice(), this);
             inputs.add(input);
             // intentionally read again, due to the slice above
-            Buffers.skipBytes(payload, TransactionOutPoint.BYTES);
+            Buffers.skipBytes(payload, TransactionOutPoint.Connected.BYTES);
             VarInt scriptLenVarInt = VarInt.read(payload);
             int scriptLen = scriptLenVarInt.intValue();
             Buffers.skipBytes(payload, scriptLen + 4);
@@ -835,7 +835,7 @@ public class Transaction extends Message {
                         s.append(in.getWitness());
                         s.append('\n');
                     }
-                    final TransactionOutPoint outpoint = in.getOutpoint();
+                    final TransactionOutPoint.Connected outpoint = in.getOutpoint();
                     final TransactionOutput connectedOutput = outpoint.getConnectedOutput();
                     s.append(indent).append("        ");
                     if (connectedOutput != null) {
@@ -952,7 +952,7 @@ public class Transaction extends Message {
      * @return the newly created input.
      */
     public TransactionInput addInput(Sha256Hash spendTxHash, long outputIndex, Script script) {
-        return addInput(new TransactionInput(this, script.getProgram(), new TransactionOutPoint(outputIndex, spendTxHash)));
+        return addInput(new TransactionInput(this, script.getProgram(), new TransactionOutPoint.Connected(outputIndex, spendTxHash)));
     }
 
     /**
@@ -970,7 +970,7 @@ public class Transaction extends Message {
      * @return The newly created input
      * @throws ScriptException if the scriptPubKey is something we don't know how to sign.
      */
-    public TransactionInput addSignedInput(TransactionOutPoint prevOut, Script scriptPubKey, Coin amount, ECKey sigKey,
+    public TransactionInput addSignedInput(TransactionOutPoint.Connected prevOut, Script scriptPubKey, Coin amount, ECKey sigKey,
                                            SigHash sigHash, boolean anyoneCanPay) throws ScriptException {
         // Verify the API user didn't try to do operations out of order.
         checkState(!outputs.isEmpty(), () ->
@@ -1011,10 +1011,10 @@ public class Transaction extends Message {
      * @param anyoneCanPay anyone-can-pay hashing
      * @return The newly created input
      * @throws ScriptException if the scriptPubKey is something we don't know how to sign.
-     * @deprecated Use {@link Transaction#addSignedInput(TransactionOutPoint, Script, Coin, ECKey, SigHash, boolean)}
+     * @deprecated Use {@link Transaction#addSignedInput(TransactionOutPoint.Connected, Script, Coin, ECKey, SigHash, boolean)}
      */
     @Deprecated
-    public TransactionInput addSignedInput(TransactionOutPoint prevOut, Script scriptPubKey, ECKey sigKey,
+    public TransactionInput addSignedInput(TransactionOutPoint.Connected prevOut, Script scriptPubKey, ECKey sigKey,
                                            SigHash sigHash, boolean anyoneCanPay) throws ScriptException {
         return addSignedInput(prevOut, scriptPubKey, null, sigKey, sigHash, anyoneCanPay);
     }
@@ -1030,7 +1030,7 @@ public class Transaction extends Message {
      * @return The newly created input
      * @throws ScriptException if the scriptPubKey is something we don't know how to sign.
      */
-    public TransactionInput addSignedInput(TransactionOutPoint prevOut, Script scriptPubKey, Coin amount, ECKey sigKey) throws ScriptException {
+    public TransactionInput addSignedInput(TransactionOutPoint.Connected prevOut, Script scriptPubKey, Coin amount, ECKey sigKey) throws ScriptException {
         return addSignedInput(prevOut, scriptPubKey, amount, sigKey, SigHash.ALL, false);
     }
 
@@ -1040,10 +1040,10 @@ public class Transaction extends Message {
      * @param sigKey The signing key
      * @return The newly created input
      * @throws ScriptException if the scriptPubKey is something we don't know how to sign.
-     * @deprecated Use {@link Transaction#addSignedInput(TransactionOutPoint, Script, Coin, ECKey)}
+     * @deprecated Use {@link Transaction#addSignedInput(TransactionOutPoint.Connected, Script, Coin, ECKey)}
      */
     @Deprecated
-    public TransactionInput addSignedInput(TransactionOutPoint prevOut, Script scriptPubKey, ECKey sigKey) throws ScriptException {
+    public TransactionInput addSignedInput(TransactionOutPoint.Connected prevOut, Script scriptPubKey, ECKey sigKey) throws ScriptException {
         return addSignedInput(prevOut, scriptPubKey, null, sigKey);
     }
 
@@ -1061,7 +1061,7 @@ public class Transaction extends Message {
     /**
      * Adds an input that points to the given output and contains a valid signature for it, calculated using the
      * signing key.
-     * @see Transaction#addSignedInput(TransactionOutPoint, Script, Coin, ECKey, SigHash, boolean)
+     * @see Transaction#addSignedInput(TransactionOutPoint.Connected, Script, Coin, ECKey, SigHash, boolean)
      * @param output output to sign and use as input
      * @param sigKey The signing key
      * @param sigHash enum specifying how the transaction hash is calculated

--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -75,7 +75,7 @@ public class TransactionInput {
     // Allows for altering transactions after they were broadcast. Values below NO_SEQUENCE-1 mean it can be altered.
     private long sequence;
     // Data needed to connect to the output of the transaction we're gathering coins from.
-    private TransactionOutPoint outpoint;
+    private TransactionOutPoint.Connected outpoint;
     // The "script bytes" might not actually be a script. In coinbase transactions where new coins are minted there
     // is no input transaction, so instead the scriptBytes contains some extra stuff (like a rollover nonce) that we
     // don't care about much. The bytes are turned into a Script object (cached below) on demand via a getter.
@@ -99,7 +99,7 @@ public class TransactionInput {
         Objects.requireNonNull(parentTransaction);
         checkArgument(scriptBytes.length >= 2 && scriptBytes.length <= 100, () ->
                 "script must be between 2 and 100 bytes: " + scriptBytes.length);
-        return new TransactionInput(parentTransaction, scriptBytes, TransactionOutPoint.UNCONNECTED);
+        return new TransactionInput(parentTransaction, scriptBytes, TransactionOutPoint.Connected.UNCONNECTED);
     }
 
     /**
@@ -112,24 +112,24 @@ public class TransactionInput {
      */
     public static TransactionInput read(ByteBuffer payload, Transaction parentTransaction) throws BufferUnderflowException, ProtocolException {
         Objects.requireNonNull(parentTransaction);
-        TransactionOutPoint outpoint = TransactionOutPoint.read(payload);
+        TransactionOutPoint.Connected outpoint = TransactionOutPoint.Connected.read(payload);
         byte[] scriptBytes = Buffers.readLengthPrefixedBytes(payload);
         long sequence = ByteUtils.readUint32(payload);
         return new TransactionInput(parentTransaction, scriptBytes, outpoint, sequence, null);
     }
 
     public TransactionInput(@Nullable Transaction parentTransaction, byte[] scriptBytes,
-                            TransactionOutPoint outpoint) {
+                            TransactionOutPoint.Connected outpoint) {
         this(parentTransaction, scriptBytes, outpoint, NO_SEQUENCE, null);
     }
 
     public TransactionInput(@Nullable Transaction parentTransaction, byte[] scriptBytes,
-                            TransactionOutPoint outpoint, @Nullable Coin value) {
+                            TransactionOutPoint.Connected outpoint, @Nullable Coin value) {
         this(parentTransaction, scriptBytes, outpoint, NO_SEQUENCE, value);
     }
 
     private TransactionInput(@Nullable Transaction parentTransaction, byte[] scriptBytes,
-                            TransactionOutPoint outpoint, long sequence, @Nullable Coin value) {
+                             TransactionOutPoint.Connected outpoint, long sequence, @Nullable Coin value) {
         this.scriptBytes = scriptBytes;
         this.outpoint = outpoint;
         this.sequence = sequence;
@@ -144,9 +144,9 @@ public class TransactionInput {
         super();
         long outputIndex = output.getIndex();
         if(output.getParentTransaction() != null ) {
-            outpoint = new TransactionOutPoint(outputIndex, output.getParentTransaction());
+            outpoint = new TransactionOutPoint.Connected(outputIndex, output.getParentTransaction());
         } else {
-            outpoint = new TransactionOutPoint(output);
+            outpoint = new TransactionOutPoint.Connected(output);
         }
         scriptBytes = EMPTY_ARRAY;
         sequence = NO_SEQUENCE;
@@ -201,7 +201,7 @@ public class TransactionInput {
      * @return size of the serialized message in bytes
      */
     public int getMessageSize() {
-        int size = TransactionOutPoint.BYTES;
+        int size = TransactionOutPoint.Connected.BYTES;
         size += VarInt.sizeOf(scriptBytes.length) + scriptBytes.length;
         size += 4; // sequence
         return size;
@@ -264,7 +264,7 @@ public class TransactionInput {
      * @return The previous output transaction reference, as an OutPoint structure.  This contains the 
      * data needed to connect to the output of the transaction we're gathering coins from.
      */
-    public TransactionOutPoint getOutpoint() {
+    public TransactionOutPoint.Connected getOutpoint() {
         return outpoint;
     }
 
@@ -355,7 +355,7 @@ public class TransactionInput {
 
     /**
      * Alias for getOutpoint().getConnectedRedeemData(keyBag)
-     * @see TransactionOutPoint#getConnectedRedeemData(KeyBag)
+     * @see TransactionOutPoint.Connected#getConnectedRedeemData(KeyBag)
      */
     @Nullable
     public RedeemData getConnectedRedeemData(KeyBag keyBag) throws ScriptException {

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -39,222 +39,236 @@ import static org.bitcoinj.base.internal.Preconditions.checkState;
 
 /**
  * <p>This message is a reference or pointer to an output of a different transaction.</p>
- * 
+ *
  * <p>Instances of this class are not safe for use by multiple threads.</p>
  */
-public class TransactionOutPoint {
-    public static final int BYTES = 36;
-
-    /** Special outpoint that normally marks a coinbase input. It's also used as a test dummy. */
-    public static final TransactionOutPoint UNCONNECTED =
-            new TransactionOutPoint(ByteUtils.MAX_UNSIGNED_INTEGER, Sha256Hash.ZERO_HASH);
-
-    /** Hash of the transaction to which we refer. */
-    private final Sha256Hash hash;
-    /** Which output of that transaction we are talking about. */
-    private final long index;
-
-    // This is not part of bitcoin serialization. It points to the connected transaction.
-    Transaction fromTx;
-
-    // The connected output.
-    TransactionOutput connectedOutput;
-
-    /**
-     * Deserialize this transaction outpoint from a given payload.
-     *
-     * @param payload payload to deserialize from
-     * @return read transaction outpoint
-     * @throws BufferUnderflowException if the read message extends beyond the remaining bytes of the payload
-     */
-    public static TransactionOutPoint read(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
-        Sha256Hash hash = Sha256Hash.read(payload);
-        long index = ByteUtils.readUint32(payload);
-        return new TransactionOutPoint(index, hash);
-    }
-
-    public TransactionOutPoint(long index, Transaction fromTx) {
-        super();
-        checkArgument(index >= 0 && index <= ByteUtils.MAX_UNSIGNED_INTEGER, () ->
-                "index out of range: " + index);
-        this.index = index;
-        this.hash = fromTx.getTxId();
-        this.fromTx = fromTx;
-    }
-
-    public TransactionOutPoint(long index, Sha256Hash hash) {
-        super();
-        checkArgument(index >= 0 && index <= ByteUtils.MAX_UNSIGNED_INTEGER, () ->
-                "index out of range: " + index);
-        this.index = index;
-        this.hash = hash;
-    }
-
-    public TransactionOutPoint(TransactionOutput connectedOutput) {
-        this(connectedOutput.getIndex(), connectedOutput.getParentTransactionHash());
-        this.connectedOutput = connectedOutput;
-    }
-
-    /**
-     * Write this transaction outpoint into the given buffer.
-     *
-     * @param buf buffer to write into
-     * @return the buffer
-     * @throws BufferOverflowException if the outpoint doesn't fit the remaining buffer
-     */
-    public ByteBuffer write(ByteBuffer buf) throws BufferOverflowException {
-        buf.put(hash.serialize());
-        ByteUtils.writeInt32LE(index, buf);
-        return buf;
-    }
-
-    /**
-     * Allocates a byte array and writes this transaction outpoint into it.
-     *
-     * @return byte array containing the transaction outpoint
-     */
-    public byte[] serialize() {
-        return write(ByteBuffer.allocate(BYTES)).array();
-    }
-
-    /** @deprecated use {@link #serialize()} */
-    @Deprecated
-    public byte[] bitcoinSerialize() {
-        return serialize();
-    }
-
-    /** @deprecated use {@link #BYTES} */
-    @Deprecated
-    public int getMessageSize() {
-        return BYTES;
-    }
-
-    /**
-     * An outpoint is a part of a transaction input that points to the output of another transaction. If we have both
-     * sides in memory, and they have been linked together, this returns a pointer to the connected output, or null
-     * if there is no such connection.
-     */
-    @Nullable
-    public TransactionOutput getConnectedOutput() {
-        if (fromTx != null) {
-            return fromTx.getOutputs().get((int) index);
-        } else if (connectedOutput != null) {
-            return connectedOutput;
-        }
-        return null;
-    }
-
-    /**
-     * Returns the pubkey script from the connected output.
-     * @throws java.lang.NullPointerException if there is no connected output.
-     */
-    public byte[] getConnectedPubKeyScript() {
-        byte[] result = Objects.requireNonNull(getConnectedOutput()).getScriptBytes();
-        checkState(result.length > 0);
-        return result;
-    }
-
-    /**
-     * Returns the ECKey identified in the connected output, for either P2PKH, P2WPKH or P2PK scripts.
-     * For P2SH scripts you can use {@link #getConnectedRedeemData(KeyBag)} and then get the
-     * key from RedeemData.
-     * If the script form cannot be understood, throws ScriptException.
-     *
-     * @return an ECKey or null if the connected key cannot be found in the wallet.
-     */
-    @Nullable
-    public ECKey getConnectedKey(KeyBag keyBag) throws ScriptException {
-        TransactionOutput connectedOutput = getConnectedOutput();
-        Objects.requireNonNull(connectedOutput, "Input is not connected so cannot retrieve key");
-        Script connectedScript = connectedOutput.getScriptPubKey();
-        if (ScriptPattern.isP2PKH(connectedScript)) {
-            byte[] addressBytes = ScriptPattern.extractHashFromP2PKH(connectedScript);
-            return keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2PKH);
-        } else if (ScriptPattern.isP2WPKH(connectedScript)) {
-            byte[] addressBytes = ScriptPattern.extractHashFromP2WH(connectedScript);
-            return keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2WPKH);
-        } else if (ScriptPattern.isP2PK(connectedScript)) {
-            byte[] pubkeyBytes = ScriptPattern.extractKeyFromP2PK(connectedScript);
-            return keyBag.findKeyFromPubKey(pubkeyBytes);
-        } else {
-            throw new ScriptException(ScriptError.SCRIPT_ERR_UNKNOWN_ERROR, "Could not understand form of connected output script: " + connectedScript);
-        }
-    }
-
-    /**
-     * Returns the RedeemData identified in the connected output, for either P2PKH, P2WPKH, P2PK
-     * or P2SH scripts.
-     * If the script forms cannot be understood, throws ScriptException.
-     *
-     * @return a RedeemData or null if the connected data cannot be found in the wallet.
-     */
-    @Nullable
-    public RedeemData getConnectedRedeemData(KeyBag keyBag) throws ScriptException {
-        TransactionOutput connectedOutput = getConnectedOutput();
-        Objects.requireNonNull(connectedOutput, "Input is not connected so cannot retrieve key");
-        Script connectedScript = connectedOutput.getScriptPubKey();
-        if (ScriptPattern.isP2PKH(connectedScript)) {
-            byte[] addressBytes = ScriptPattern.extractHashFromP2PKH(connectedScript);
-            return RedeemData.of(keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2PKH), connectedScript);
-        } else if (ScriptPattern.isP2WPKH(connectedScript)) {
-            byte[] addressBytes = ScriptPattern.extractHashFromP2WH(connectedScript);
-            return RedeemData.of(keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2WPKH), connectedScript);
-        } else if (ScriptPattern.isP2PK(connectedScript)) {
-            byte[] pubkeyBytes = ScriptPattern.extractKeyFromP2PK(connectedScript);
-            return RedeemData.of(keyBag.findKeyFromPubKey(pubkeyBytes), connectedScript);
-        } else if (ScriptPattern.isP2SH(connectedScript)) {
-            byte[] scriptHash = ScriptPattern.extractHashFromP2SH(connectedScript);
-            return keyBag.findRedeemDataFromScriptHash(scriptHash);
-        } else {
-            throw new ScriptException(ScriptError.SCRIPT_ERR_UNKNOWN_ERROR, "Could not understand form of connected output script: " + connectedScript);
-        }
-    }
-
-    @Override
-    public String toString() {
-        return hash + ":" + index;
-    }
-
+public interface TransactionOutPoint {
     /**
      * Returns the hash of the transaction this outpoint references/spends/is connected to.
      */
-    public Sha256Hash hash() {
-        return hash;
-    }
+    Sha256Hash hash();
 
     /**
      * @return the index of this outpoint
      */
-    public long index() {
-        return index;
-    }
+    long index();
+    
+    class Connected implements TransactionOutPoint {
+        public static final int BYTES = 36;
 
-    /**
-     * @deprecated Use {@link #hash()}
-     */
-    @Deprecated
-    public Sha256Hash getHash() {
-        return hash();
-    }
+        /** Special outpoint that normally marks a coinbase input. It's also used as a test dummy. */
+        public static final Connected UNCONNECTED =
+                new Connected(ByteUtils.MAX_UNSIGNED_INTEGER, Sha256Hash.ZERO_HASH);
 
-    /**
-     * @deprecated Use {@link #index()}
-     */
-    @Deprecated
-    public long getIndex() {
-        return index();
-    }
+        /** Hash of the transaction to which we refer. */
+        private final Sha256Hash hash;
+        /** Which output of that transaction we are talking about. */
+        private final long index;
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        TransactionOutPoint other = (TransactionOutPoint) o;
-        return index() == other.index() && hash().equals(other.hash());
-    }
+        // This is not part of bitcoin serialization. It points to the connected transaction.
+        Transaction fromTx;
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(index(), hash());
+        // The connected output.
+        TransactionOutput connectedOutput;
+
+        /**
+         * Deserialize this transaction outpoint from a given payload.
+         *
+         * @param payload payload to deserialize from
+         * @return read transaction outpoint
+         * @throws BufferUnderflowException if the read message extends beyond the remaining bytes of the payload
+         */
+        public static Connected read(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
+            Sha256Hash hash = Sha256Hash.read(payload);
+            long index = ByteUtils.readUint32(payload);
+            return new Connected(index, hash);
+        }
+
+        public Connected(long index, Transaction fromTx) {
+            super();
+            checkArgument(index >= 0 && index <= ByteUtils.MAX_UNSIGNED_INTEGER, () ->
+                    "index out of range: " + index);
+            this.index = index;
+            this.hash = fromTx.getTxId();
+            this.fromTx = fromTx;
+        }
+
+        public Connected(long index, Sha256Hash hash) {
+            super();
+            checkArgument(index >= 0 && index <= ByteUtils.MAX_UNSIGNED_INTEGER, () ->
+                    "index out of range: " + index);
+            this.index = index;
+            this.hash = hash;
+        }
+
+        public Connected(TransactionOutput connectedOutput) {
+            this(connectedOutput.getIndex(), connectedOutput.getParentTransactionHash());
+            this.connectedOutput = connectedOutput;
+        }
+
+        /**
+         * Write this transaction outpoint into the given buffer.
+         *
+         * @param buf buffer to write into
+         * @return the buffer
+         * @throws BufferOverflowException if the outpoint doesn't fit the remaining buffer
+         */
+        public ByteBuffer write(ByteBuffer buf) throws BufferOverflowException {
+            buf.put(hash.serialize());
+            ByteUtils.writeInt32LE(index, buf);
+            return buf;
+        }
+
+        /**
+         * Allocates a byte array and writes this transaction outpoint into it.
+         *
+         * @return byte array containing the transaction outpoint
+         */
+        public byte[] serialize() {
+            return write(ByteBuffer.allocate(BYTES)).array();
+        }
+
+        /** @deprecated use {@link #serialize()} */
+        @Deprecated
+        public byte[] bitcoinSerialize() {
+            return serialize();
+        }
+
+        /** @deprecated use {@link #BYTES} */
+        @Deprecated
+        public int getMessageSize() {
+            return BYTES;
+        }
+
+        /**
+         * An outpoint is a part of a transaction input that points to the output of another transaction. If we have both
+         * sides in memory, and they have been linked together, this returns a pointer to the connected output, or null
+         * if there is no such connection.
+         */
+        @Nullable
+        public TransactionOutput getConnectedOutput() {
+            if (fromTx != null) {
+                return fromTx.getOutputs().get((int) index);
+            } else if (connectedOutput != null) {
+                return connectedOutput;
+            }
+            return null;
+        }
+
+        /**
+         * Returns the pubkey script from the connected output.
+         * @throws java.lang.NullPointerException if there is no connected output.
+         */
+        public byte[] getConnectedPubKeyScript() {
+            byte[] result = Objects.requireNonNull(getConnectedOutput()).getScriptBytes();
+            checkState(result.length > 0);
+            return result;
+        }
+
+        /**
+         * Returns the ECKey identified in the connected output, for either P2PKH, P2WPKH or P2PK scripts.
+         * For P2SH scripts you can use {@link #getConnectedRedeemData(KeyBag)} and then get the
+         * key from RedeemData.
+         * If the script form cannot be understood, throws ScriptException.
+         *
+         * @return an ECKey or null if the connected key cannot be found in the wallet.
+         */
+        @Nullable
+        public ECKey getConnectedKey(KeyBag keyBag) throws ScriptException {
+            TransactionOutput connectedOutput = getConnectedOutput();
+            Objects.requireNonNull(connectedOutput, "Input is not connected so cannot retrieve key");
+            Script connectedScript = connectedOutput.getScriptPubKey();
+            if (ScriptPattern.isP2PKH(connectedScript)) {
+                byte[] addressBytes = ScriptPattern.extractHashFromP2PKH(connectedScript);
+                return keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2PKH);
+            } else if (ScriptPattern.isP2WPKH(connectedScript)) {
+                byte[] addressBytes = ScriptPattern.extractHashFromP2WH(connectedScript);
+                return keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2WPKH);
+            } else if (ScriptPattern.isP2PK(connectedScript)) {
+                byte[] pubkeyBytes = ScriptPattern.extractKeyFromP2PK(connectedScript);
+                return keyBag.findKeyFromPubKey(pubkeyBytes);
+            } else {
+                throw new ScriptException(ScriptError.SCRIPT_ERR_UNKNOWN_ERROR, "Could not understand form of connected output script: " + connectedScript);
+            }
+        }
+
+        /**
+         * Returns the RedeemData identified in the connected output, for either P2PKH, P2WPKH, P2PK
+         * or P2SH scripts.
+         * If the script forms cannot be understood, throws ScriptException.
+         *
+         * @return a RedeemData or null if the connected data cannot be found in the wallet.
+         */
+        @Nullable
+        public RedeemData getConnectedRedeemData(KeyBag keyBag) throws ScriptException {
+            TransactionOutput connectedOutput = getConnectedOutput();
+            Objects.requireNonNull(connectedOutput, "Input is not connected so cannot retrieve key");
+            Script connectedScript = connectedOutput.getScriptPubKey();
+            if (ScriptPattern.isP2PKH(connectedScript)) {
+                byte[] addressBytes = ScriptPattern.extractHashFromP2PKH(connectedScript);
+                return RedeemData.of(keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2PKH), connectedScript);
+            } else if (ScriptPattern.isP2WPKH(connectedScript)) {
+                byte[] addressBytes = ScriptPattern.extractHashFromP2WH(connectedScript);
+                return RedeemData.of(keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2WPKH), connectedScript);
+            } else if (ScriptPattern.isP2PK(connectedScript)) {
+                byte[] pubkeyBytes = ScriptPattern.extractKeyFromP2PK(connectedScript);
+                return RedeemData.of(keyBag.findKeyFromPubKey(pubkeyBytes), connectedScript);
+            } else if (ScriptPattern.isP2SH(connectedScript)) {
+                byte[] scriptHash = ScriptPattern.extractHashFromP2SH(connectedScript);
+                return keyBag.findRedeemDataFromScriptHash(scriptHash);
+            } else {
+                throw new ScriptException(ScriptError.SCRIPT_ERR_UNKNOWN_ERROR, "Could not understand form of connected output script: " + connectedScript);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return hash + ":" + index;
+        }
+
+        /**
+         * Returns the hash of the transaction this outpoint references/spends/is connected to.
+         */
+        @Override
+        public Sha256Hash hash() {
+            return hash;
+        }
+
+        /**
+         * @return the index of this outpoint
+         */
+        @Override
+        public long index() {
+            return index;
+        }
+
+        /**
+         * @deprecated Use {@link #hash()}
+         */
+        @Deprecated
+        public Sha256Hash getHash() {
+            return hash();
+        }
+
+        /**
+         * @deprecated Use {@link #index()}
+         */
+        @Deprecated
+        public long getIndex() {
+            return index();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TransactionOutPoint other = (TransactionOutPoint) o;
+            return index() == other.index() && hash().equals(other.hash());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(index(), hash());
+        }
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -408,11 +408,11 @@ public class TransactionOutput extends Message {
     }
 
     /**
-     * Returns a new {@link TransactionOutPoint}, which is essentially a structure pointing to this output.
+     * Returns a new {@link TransactionOutPoint.Connected}, which is essentially a structure pointing to this output.
      * Requires that this output is not detached.
      */
-    public TransactionOutPoint getOutPointFor() {
-        return new TransactionOutPoint(getIndex(), getParentTransaction());
+    public TransactionOutPoint.Connected getOutPointFor() {
+        return new TransactionOutPoint.Connected(getIndex(), getParentTransaction());
     }
 
     /** Returns a copy of the output detached from its containing transaction, if need be. */

--- a/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
@@ -42,7 +42,7 @@ import java.util.Set;
 
 /**
  * Used as a key for memory map (to avoid having to think about NetworkParameters,
- * which is required for {@link TransactionOutPoint}
+ * which is required for {@link TransactionOutPoint.Connected}
  */
 class StoredTransactionOutPoint {
 

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -5009,7 +5009,7 @@ public class Wallet extends BaseTaggableObject
 
     //region Bloom filtering
 
-    private final ArrayList<TransactionOutPoint> bloomOutPoints = new ArrayList<>();
+    private final ArrayList<TransactionOutPoint.Connected> bloomOutPoints = new ArrayList<>();
     // Used to track whether we must automatically begin/end a filter calculation and calc outpoints/take the locks.
     private final AtomicInteger bloomFilterGuard = new AtomicInteger(0);
 
@@ -5110,7 +5110,7 @@ public class Wallet extends BaseTaggableObject
                     }
                 }
             }
-            for (TransactionOutPoint point : bloomOutPoints)
+            for (TransactionOutPoint.Connected point : bloomOutPoints)
                 filter.insert(point);
             return filter;
         } finally {

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -645,7 +645,7 @@ public class WalletProtobufSerializer {
 
         for (Protos.TransactionInput inputProto : txProto.getTransactionInputList()) {
             byte[] scriptBytes = inputProto.getScriptBytes().toByteArray();
-            TransactionOutPoint outpoint = new TransactionOutPoint(
+            TransactionOutPoint.Connected outpoint = new TransactionOutPoint.Connected(
                     inputProto.getTransactionOutPointIndex() & 0xFFFFFFFFL,
                     byteStringToHash(inputProto.getTransactionOutPointHash())
             );

--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -193,7 +193,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         Block rollingBlock = PARAMS.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
         chain.add(rollingBlock);
         TransactionOutput spendableOutput = rollingBlock.getTransactions().get(0).getOutput(0);
-        TransactionOutPoint transactionOutPoint = spendableOutput.getOutPointFor();
+        TransactionOutPoint.Connected transactionOutPoint = spendableOutput.getOutPointFor();
         Script spendableOutputScriptPubKey = spendableOutput.getScriptPubKey();
         for (int i = 1; i < PARAMS.getSpendableCoinbaseDepth(); i++) {
             rollingBlock = rollingBlock.createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
@@ -267,7 +267,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         chain.add(rollingBlock);
         Transaction transaction = rollingBlock.getTransactions().get(0);
         TransactionOutput spendableOutput = transaction.getOutput(0);
-        TransactionOutPoint spendableOutputPoint = spendableOutput.getOutPointFor();
+        TransactionOutPoint.Connected spendableOutputPoint = spendableOutput.getOutPointFor();
         Script spendableOutputScriptPubKey = spendableOutput.getScriptPubKey();
         for (int i = 1; i < PARAMS.getSpendableCoinbaseDepth(); i++) {
             rollingBlock = rollingBlock.createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
@@ -319,7 +319,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         chain.add(rollingBlock);
         Transaction transaction = rollingBlock.getTransactions().get(0);
         TransactionOutput spendableOutput = transaction.getOutput(0);
-        TransactionOutPoint spendableOutPoint = new TransactionOutPoint(0, transaction.getTxId());
+        TransactionOutPoint.Connected spendableOutPoint = new TransactionOutPoint.Connected(0, transaction.getTxId());
         Script spendableOutputScriptPubKey = spendableOutput.getScriptPubKey();
         for (int i = 1; i < PARAMS.getSpendableCoinbaseDepth(); i++) {
             rollingBlock = rollingBlock.createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -115,18 +115,18 @@ class NewBlock {
 }
 
 class TransactionOutPointWithValue {
-    public TransactionOutPoint outpoint;
+    public TransactionOutPoint.Connected outpoint;
     public Coin value;
     public Script scriptPubKey;
 
-    public TransactionOutPointWithValue(TransactionOutPoint outpoint, Coin value, Script scriptPubKey) {
+    public TransactionOutPointWithValue(TransactionOutPoint.Connected outpoint, Coin value, Script scriptPubKey) {
         this.outpoint = outpoint;
         this.value = value;
         this.scriptPubKey = scriptPubKey;
     }
 
     public TransactionOutPointWithValue(Transaction tx, int output) {
-        this(new TransactionOutPoint(output, tx.getTxId()),
+        this(new TransactionOutPoint.Connected(output, tx.getTxId()),
                 tx.getOutput(output).getValue(), tx.getOutput(output).getScriptPubKey());
     }
 }
@@ -214,14 +214,14 @@ public class FullBlockTestGenerator {
         Block chainHead = params.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, coinbaseOutKeyPubKey, chainHeadHeight);
         blocks.add(new BlockAndValidity(chainHead, true, false, chainHead.getHash(), 1, "Initial Block"));
         spendableOutputs.offer(new TransactionOutPointWithValue(
-                new TransactionOutPoint(0, chainHead.getTransactions().get(0).getTxId()),
+                new TransactionOutPoint.Connected(0, chainHead.getTransactions().get(0).getTxId()),
                 FIFTY_COINS, chainHead.getTransactions().get(0).getOutputs().get(0).getScriptPubKey()));
         for (int i = 1; i < params.getSpendableCoinbaseDepth(); i++) {
             chainHead = chainHead.createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, coinbaseOutKeyPubKey, chainHeadHeight);
             chainHeadHeight++;
             blocks.add(new BlockAndValidity(chainHead, true, false, chainHead.getHash(), i+1, "Initial Block chain output generation"));
             spendableOutputs.offer(new TransactionOutPointWithValue(
-                    new TransactionOutPoint(0, chainHead.getTransactions().get(0).getTxId()),
+                    new TransactionOutPoint.Connected(0, chainHead.getTransactions().get(0).getTxId()),
                     FIFTY_COINS, chainHead.getTransactions().get(0).getOutputs().get(0).getScriptPubKey()));
         }
 
@@ -706,13 +706,13 @@ public class FullBlockTestGenerator {
             scriptPubKey.write(OP_EQUAL);
 
             Coin lastOutputValue = out11.value.subtract(SATOSHI);
-            TransactionOutPoint lastOutPoint;
+            TransactionOutPoint.Connected lastOutPoint;
             {
                 Transaction tx = new Transaction();
                 tx.addOutput(new TransactionOutput(tx, SATOSHI, scriptPubKey.toByteArray()));
                 tx.addOutput(new TransactionOutput(tx, lastOutputValue, new byte[]{OP_1}));
                 addOnlyInputToTransaction(tx, out11);
-                lastOutPoint = new TransactionOutPoint(1, tx.getTxId());
+                lastOutPoint = new TransactionOutPoint.Connected(1, tx.getTxId());
                 b39.addTransaction(tx);
             }
             b39numP2SHOutputs++;
@@ -725,7 +725,7 @@ public class FullBlockTestGenerator {
                 tx.addOutput(new TransactionOutput(tx, SATOSHI, scriptPubKey.toByteArray()));
                 tx.addOutput(new TransactionOutput(tx, lastOutputValue, new byte[]{OP_1}));
                 tx.addInput(new TransactionInput(tx, new byte[]{OP_1}, lastOutPoint));
-                lastOutPoint = new TransactionOutPoint(1, tx.getTxId());
+                lastOutPoint = new TransactionOutPoint.Connected(1, tx.getTxId());
 
                 if (b39.block.getMessageSize() + tx.getMessageSize() < Block.MAX_BLOCK_SIZE) {
                     b39.addTransaction(tx);
@@ -750,7 +750,7 @@ public class FullBlockTestGenerator {
             int numTxes = (Block.MAX_BLOCK_SIGOPS - sigOps) / b39sigOpsPerOutput;
             checkState(numTxes <= b39numP2SHOutputs);
 
-            TransactionOutPoint lastOutPoint = new TransactionOutPoint(1, b40.block.getTransactions().get(1).getTxId());
+            TransactionOutPoint.Connected lastOutPoint = new TransactionOutPoint.Connected(1, b40.block.getTransactions().get(1).getTxId());
 
             byte[] scriptSig = null;
             for (int i = 1; i <= numTxes; i++) {
@@ -759,7 +759,7 @@ public class FullBlockTestGenerator {
                 tx.addInput(new TransactionInput(tx, new byte[]{OP_1}, lastOutPoint));
 
                 TransactionInput input = new TransactionInput(tx, new byte[]{},
-                        new TransactionOutPoint(0, b39.block.getTransactions().get(i).getTxId()));
+                        new TransactionOutPoint.Connected(0, b39.block.getTransactions().get(i).getTxId()));
                 tx.addInput(input);
 
                 if (scriptSig == null) {
@@ -786,7 +786,7 @@ public class FullBlockTestGenerator {
 
                 input.setScriptBytes(scriptSig);
 
-                lastOutPoint = new TransactionOutPoint(0, tx.getTxId());
+                lastOutPoint = new TransactionOutPoint.Connected(0, tx.getTxId());
 
                 b40.addTransaction(tx);
             }
@@ -815,7 +815,7 @@ public class FullBlockTestGenerator {
                         / b39sigOpsPerOutput;
                 checkState(numTxes <= b39numP2SHOutputs);
 
-                TransactionOutPoint lastOutPoint = new TransactionOutPoint(
+                TransactionOutPoint.Connected lastOutPoint = new TransactionOutPoint.Connected(
                         1, b41.block.getTransactions().get(1).getTxId());
 
                 byte[] scriptSig = null;
@@ -826,7 +826,7 @@ public class FullBlockTestGenerator {
                     tx.addInput(new TransactionInput(tx, new byte[] { OP_1 }, lastOutPoint));
 
                     TransactionInput input = new TransactionInput(tx, new byte[] {},
-                            new TransactionOutPoint(0, b39.block.getTransactions().get(i).getTxId()));
+                            new TransactionOutPoint.Connected(0, b39.block.getTransactions().get(i).getTxId()));
                     tx.addInput(input);
 
                     if (scriptSig == null) {
@@ -859,7 +859,7 @@ public class FullBlockTestGenerator {
 
                     input.setScriptBytes(scriptSig);
 
-                    lastOutPoint = new TransactionOutPoint(0,
+                    lastOutPoint = new TransactionOutPoint.Connected(0,
                             tx.getTxId());
 
                     b41.addTransaction(tx);
@@ -1085,21 +1085,21 @@ public class FullBlockTestGenerator {
             Transaction tx2 = new Transaction();
             tx2.addOutput(new TransactionOutput(tx2, SATOSHI, new byte[] {OP_TRUE}));
             addOnlyInputToTransaction(tx2, new TransactionOutPointWithValue(
-                    new TransactionOutPoint(0, tx1.getTxId()),
+                    new TransactionOutPoint.Connected(0, tx1.getTxId()),
                     SATOSHI, tx1.getOutputs().get(0).getScriptPubKey()));
             b57p2.addTransaction(tx2);
 
             b56p2txToDuplicate1 = new Transaction();
             b56p2txToDuplicate1.addOutput(new TransactionOutput(b56p2txToDuplicate1, SATOSHI, new byte[]{OP_TRUE}));
             addOnlyInputToTransaction(b56p2txToDuplicate1, new TransactionOutPointWithValue(
-                    new TransactionOutPoint(0, tx2.getTxId()),
+                    new TransactionOutPoint.Connected(0, tx2.getTxId()),
                     SATOSHI, tx2.getOutputs().get(0).getScriptPubKey()));
             b57p2.addTransaction(b56p2txToDuplicate1);
 
             b56p2txToDuplicate2 = new Transaction();
             b56p2txToDuplicate2.addOutput(new TransactionOutput(b56p2txToDuplicate2, SATOSHI, new byte[]{}));
             addOnlyInputToTransaction(b56p2txToDuplicate2, new TransactionOutPointWithValue(
-                    new TransactionOutPoint(0, b56p2txToDuplicate1.getTxId()),
+                    new TransactionOutPoint.Connected(0, b56p2txToDuplicate1.getTxId()),
                     SATOSHI, b56p2txToDuplicate1.getOutputs().get(0).getScriptPubKey()));
             b57p2.addTransaction(b56p2txToDuplicate2);
         }
@@ -1132,7 +1132,7 @@ public class FullBlockTestGenerator {
             Transaction tx = new Transaction();
             tx.addOutput(new TransactionOutput(tx, ZERO, new byte[] {}));
             // Replace the TransactionOutPoint with an out-of-range OutPoint
-            b58.getSpendableOutput().outpoint = new TransactionOutPoint(42, tx);
+            b58.getSpendableOutput().outpoint = new TransactionOutPoint.Connected(42, tx);
             addOnlyInputToTransaction(tx, b58);
             b58.addTransaction(tx);
         }
@@ -1526,7 +1526,7 @@ public class FullBlockTestGenerator {
             Transaction tx2 = new Transaction();
             tx2.addOutput(new TransactionOutput(tx2, ZERO, new byte[]{OP_TRUE}));
             tx2.addInput(new TransactionInput(tx2, new byte[] { OP_FALSE },
-                    new TransactionOutPoint(0, tx1.getTxId())));
+                    new TransactionOutPoint.Connected(0, tx1.getTxId())));
             b83.addTransaction(tx2);
         }
         b83.solve();
@@ -1556,24 +1556,24 @@ public class FullBlockTestGenerator {
             Transaction tx2 = new Transaction();
             tx2.addOutput(new TransactionOutput(tx2, ZERO, new byte[]{OP_RETURN}));
             tx2.addOutput(new TransactionOutput(tx2, ZERO, new byte[]{OP_RETURN}));
-            tx2.addInput(new TransactionInput(tx2, new byte[]{OP_TRUE}, new TransactionOutPoint(1, b84tx1)));
+            tx2.addInput(new TransactionInput(tx2, new byte[]{OP_TRUE}, new TransactionOutPoint.Connected(1, b84tx1)));
             b84.addTransaction(tx2);
 
             Transaction tx3 = new Transaction();
             tx3.addOutput(new TransactionOutput(tx3, ZERO, new byte[]{OP_RETURN}));
             tx3.addOutput(new TransactionOutput(tx3, ZERO, new byte[]{OP_TRUE}));
-            tx3.addInput(new TransactionInput(tx3, new byte[]{OP_TRUE}, new TransactionOutPoint(2, b84tx1)));
+            tx3.addInput(new TransactionInput(tx3, new byte[]{OP_TRUE}, new TransactionOutPoint.Connected(2, b84tx1)));
             b84.addTransaction(tx3);
 
             Transaction tx4 = new Transaction();
             tx4.addOutput(new TransactionOutput(tx4, ZERO, new byte[]{OP_TRUE}));
             tx4.addOutput(new TransactionOutput(tx4, ZERO, new byte[]{OP_RETURN}));
-            tx4.addInput(new TransactionInput(tx4, new byte[]{OP_TRUE}, new TransactionOutPoint(3, b84tx1)));
+            tx4.addInput(new TransactionInput(tx4, new byte[]{OP_TRUE}, new TransactionOutPoint.Connected(3, b84tx1)));
             b84.addTransaction(tx4);
 
             Transaction tx5 = new Transaction();
             tx5.addOutput(new TransactionOutput(tx5, ZERO, new byte[]{OP_RETURN}));
-            tx5.addInput(new TransactionInput(tx5, new byte[]{OP_TRUE}, new TransactionOutPoint(4, b84tx1)));
+            tx5.addInput(new TransactionInput(tx5, new byte[]{OP_TRUE}, new TransactionOutPoint.Connected(4, b84tx1)));
             b84.addTransaction(tx5);
         }
         b84.solve();
@@ -1598,7 +1598,7 @@ public class FullBlockTestGenerator {
         {
             Transaction tx = new Transaction();
             tx.addOutput(new TransactionOutput(tx, ZERO, new byte[] {OP_TRUE}));
-            tx.addInput(new TransactionInput(tx, new byte[]{OP_TRUE}, new TransactionOutPoint(0, b84tx1)));
+            tx.addInput(new TransactionInput(tx, new byte[]{OP_TRUE}, new TransactionOutPoint.Connected(0, b84tx1)));
             b89.addTransaction(tx);
             b89.solve();
         }
@@ -1674,7 +1674,7 @@ public class FullBlockTestGenerator {
             checkArgument(blockStorageFile != null);
 
             NewBlock lastBlock = b1001;
-            TransactionOutPoint lastOutput = new TransactionOutPoint(1, b1001.block.getTransactions().get(1).getTxId());
+            TransactionOutPoint lastOutput = new TransactionOutPoint.Connected(1, b1001.block.getTransactions().get(1).getTxId());
             int blockCountAfter1001;
             int nextHeight = heightAfter1001;
 
@@ -1687,7 +1687,7 @@ public class FullBlockTestGenerator {
                     tx.addInput(lastOutput.hash(), lastOutput.index(), OP_NOP_SCRIPT);
                     tx.addOutput(ZERO, OP_TRUE_SCRIPT);
                     tx.addOutput(ZERO, OP_TRUE_SCRIPT);
-                    lastOutput = new TransactionOutPoint(1, tx.getTxId());
+                    lastOutput = new TransactionOutPoint.Connected(1, tx.getTxId());
                     hashesToSpend.add(tx.getTxId());
                     block.addTransaction(tx);
                 }

--- a/core/src/test/java/org/bitcoinj/core/TransactionInputTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionInputTest.java
@@ -141,7 +141,7 @@ public class TransactionInputTest {
         return Stream.generate(() -> {
             byte[] randomBytes = new byte[100];
             random.nextBytes(randomBytes);
-            return new TransactionInput(parent, randomBytes, TransactionOutPoint.UNCONNECTED,
+            return new TransactionInput(parent, randomBytes, TransactionOutPoint.Connected.UNCONNECTED,
                     Coin.ofSat(random.nextLong()));
         }).limit(10).iterator();
     }

--- a/core/src/test/java/org/bitcoinj/core/TransactionOutPointTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionOutPointTest.java
@@ -35,22 +35,22 @@ import static org.junit.Assert.assertFalse;
 public class TransactionOutPointTest {
     @Test
     @Parameters(method = "randomOutPoints")
-    public void readAndWrite(TransactionOutPoint outpoint) {
-        ByteBuffer buf = ByteBuffer.allocate(TransactionOutPoint.BYTES);
+    public void readAndWrite(TransactionOutPoint.Connected outpoint) {
+        ByteBuffer buf = ByteBuffer.allocate(TransactionOutPoint.Connected.BYTES);
         outpoint.write(buf);
         assertFalse(buf.hasRemaining());
         ((Buffer) buf).rewind();
-        TransactionOutPoint outpointCopy = TransactionOutPoint.read(buf);
+        TransactionOutPoint outpointCopy = TransactionOutPoint.Connected.read(buf);
         assertFalse(buf.hasRemaining());
         assertEquals(outpoint, outpointCopy);
     }
 
-    private Iterator<TransactionOutPoint> randomOutPoints() {
+    private Iterator<TransactionOutPoint.Connected> randomOutPoints() {
         Random random = new Random();
         return Stream.generate(() -> {
             byte[] randomBytes = new byte[Sha256Hash.LENGTH];
             random.nextBytes(randomBytes);
-            return new TransactionOutPoint(Integer.toUnsignedLong(random.nextInt()), Sha256Hash.wrap(randomBytes));
+            return new TransactionOutPoint.Connected(Integer.toUnsignedLong(random.nextInt()), Sha256Hash.wrap(randomBytes));
         }).limit(10).iterator();
     }
 }

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -176,7 +176,7 @@ public class TransactionTest {
 
         // add fake transaction input
         TransactionInput input = new TransactionInput(null, ScriptBuilder.createEmpty().getProgram(),
-                new TransactionOutPoint(0, Sha256Hash.ZERO_HASH));
+                new TransactionOutPoint.Connected(0, Sha256Hash.ZERO_HASH));
         tx.addInput(input);
         length += input.getMessageSize();
 
@@ -214,7 +214,7 @@ public class TransactionTest {
         ECKey fromKey = new ECKey();
         Address fromAddress = fromKey.toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
         Transaction tx = new Transaction();
-        TransactionOutPoint outPoint = new TransactionOutPoint(0, utxo_id);
+        TransactionOutPoint.Connected outPoint = new TransactionOutPoint.Connected(0, utxo_id);
         TransactionOutput output = new TransactionOutput(null, inAmount, fromAddress);
         tx.addOutput(outAmount, toAddr);
         TransactionInput input = tx.addSignedInput(outPoint, ScriptBuilder.createOutputScript(fromAddress), inAmount, fromKey);
@@ -237,7 +237,7 @@ public class TransactionTest {
         ECKey fromKey = new ECKey();
         Address fromAddress = fromKey.toAddress(ScriptType.P2WPKH, BitcoinNetwork.TESTNET);
         Transaction tx = new Transaction();
-        TransactionOutPoint outPoint = new TransactionOutPoint(0, utxo_id);
+        TransactionOutPoint.Connected outPoint = new TransactionOutPoint.Connected(0, utxo_id);
         tx.addOutput(outAmount, toAddr);
         TransactionInput input = tx.addSignedInput(outPoint, ScriptBuilder.createOutputScript(fromAddress), inAmount, fromKey);
 
@@ -505,7 +505,7 @@ public class TransactionTest {
     @Test
     public void testToStringWhenIteratingOverAnInputCatchesAnException() {
         Transaction tx = FakeTxBuilder.createFakeTx(TESTNET);
-        TransactionInput ti = new TransactionInput(tx, new byte[0], TransactionOutPoint.UNCONNECTED) {
+        TransactionInput ti = new TransactionInput(tx, new byte[0], TransactionOutPoint.Connected.UNCONNECTED) {
             @Override
             public Script getScriptSig() throws ScriptException {
                 throw new ScriptException(ScriptError.SCRIPT_ERR_UNKNOWN_ERROR, "");

--- a/core/src/test/java/org/bitcoinj/protocols/payments/PaymentSessionTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/payments/PaymentSessionTest.java
@@ -91,7 +91,7 @@ public class PaymentSessionTest {
 
         // Send the payment and verify that the correct information is sent.
         // Add a dummy input to tx so it is considered valid.
-        tx.addInput(new TransactionInput(tx, outputToMe.getScriptBytes(), TransactionOutPoint.UNCONNECTED));
+        tx.addInput(new TransactionInput(tx, outputToMe.getScriptBytes(), TransactionOutPoint.Connected.UNCONNECTED));
         ArrayList<Transaction> txns = new ArrayList<>();
         txns.add(tx);
         Address refundAddr = serverKey.toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
@@ -131,7 +131,7 @@ public class PaymentSessionTest {
         assertTrue(paymentSession.isExpired());
         // Send the payment and verify that an exception is thrown.
         // Add a dummy input to tx so it is considered valid.
-        tx.addInput(new TransactionInput(tx, outputToMe.getScriptBytes(), TransactionOutPoint.UNCONNECTED));
+        tx.addInput(new TransactionInput(tx, outputToMe.getScriptBytes(), TransactionOutPoint.Connected.UNCONNECTED));
         ArrayList<Transaction> txns = new ArrayList<>();
         txns.add(tx);
 

--- a/core/src/test/java/org/bitcoinj/script/ScriptTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptTest.java
@@ -248,7 +248,7 @@ public class ScriptTest {
     public void testOp0() {
         // Check that OP_0 doesn't NPE and pushes an empty stack frame.
         Transaction tx = new Transaction();
-        tx.addInput(new TransactionInput(tx, new byte[0], TransactionOutPoint.UNCONNECTED));
+        tx.addInput(new TransactionInput(tx, new byte[0], TransactionOutPoint.Connected.UNCONNECTED));
         Script script = new ScriptBuilder().smallNum(0).build();
 
         LinkedList<byte[]> stack = new LinkedList<>();
@@ -343,7 +343,7 @@ public class ScriptTest {
                 index = ByteUtils.MAX_UNSIGNED_INTEGER;
             String script = input.get(2).asText();
             Sha256Hash sha256Hash = Sha256Hash.wrap(ByteUtils.parseHex(hash));
-            scriptPubKeys.put(new TransactionOutPoint(index, sha256Hash), parseScriptString(script));
+            scriptPubKeys.put(new TransactionOutPoint.Connected(index, sha256Hash), parseScriptString(script));
         }
         return scriptPubKeys;
     }
@@ -354,7 +354,7 @@ public class ScriptTest {
         tx.setLockTime(0);
 
         TransactionInput txInput = new TransactionInput(null,
-                new ScriptBuilder().number(0).number(0).build().getProgram(), TransactionOutPoint.UNCONNECTED);
+                new ScriptBuilder().number(0).number(0).build().getProgram(), TransactionOutPoint.Connected.UNCONNECTED);
         txInput.setSequenceNumber(TransactionInput.NO_SEQUENCE);
         tx.addInput(txInput);
 
@@ -370,7 +370,7 @@ public class ScriptTest {
         tx.setLockTime(0);
 
         TransactionInput txInput = new TransactionInput(creditingTransaction, scriptSig.getProgram(),
-                TransactionOutPoint.UNCONNECTED);
+                TransactionOutPoint.Connected.UNCONNECTED);
         txInput.setSequenceNumber(TransactionInput.NO_SEQUENCE);
         tx.addInput(txInput);
 

--- a/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
@@ -162,7 +162,7 @@ public class DefaultRiskAnalysisTest {
         // Test non-standard script as an input.
         Transaction tx = new Transaction();
         assertEquals(DefaultRiskAnalysis.RuleViolation.NONE, DefaultRiskAnalysis.isStandard(tx));
-        tx.addInput(new TransactionInput(null, nonStandardScript, TransactionOutPoint.UNCONNECTED));
+        tx.addInput(new TransactionInput(null, nonStandardScript, TransactionOutPoint.Connected.UNCONNECTED));
         assertEquals(DefaultRiskAnalysis.RuleViolation.SHORTEST_POSSIBLE_PUSHDATA, DefaultRiskAnalysis.isStandard(tx));
         // Test non-standard script as an output.
         tx.clearInputs();
@@ -176,14 +176,14 @@ public class DefaultRiskAnalysisTest {
         TransactionSignature sig = TransactionSignature.dummy();
         Script scriptOk = ScriptBuilder.createInputScript(sig);
         assertEquals(RuleViolation.NONE,
-                DefaultRiskAnalysis.isInputStandard(new TransactionInput(null, scriptOk.getProgram(), TransactionOutPoint.UNCONNECTED)));
+                DefaultRiskAnalysis.isInputStandard(new TransactionInput(null, scriptOk.getProgram(), TransactionOutPoint.Connected.UNCONNECTED)));
 
         byte[] sigBytes = sig.encodeToBitcoin();
         // Appending a zero byte makes the signature uncanonical without violating DER encoding.
         Script scriptUncanonicalEncoding = new ScriptBuilder().data(Arrays.copyOf(sigBytes, sigBytes.length + 1))
                 .build();
         assertEquals(RuleViolation.SIGNATURE_CANONICAL_ENCODING, DefaultRiskAnalysis.isInputStandard(
-                new TransactionInput(null, scriptUncanonicalEncoding.getProgram(), TransactionOutPoint.UNCONNECTED)));
+                new TransactionInput(null, scriptUncanonicalEncoding.getProgram(), TransactionOutPoint.Connected.UNCONNECTED)));
     }
 
     @Test
@@ -193,7 +193,7 @@ public class DefaultRiskAnalysisTest {
         Script scriptHighS = ScriptBuilder
                 .createInputScript(new TransactionSignature(sig.r, ECKey.CURVE.getN().subtract(sig.s)));
         assertEquals(RuleViolation.SIGNATURE_CANONICAL_ENCODING, DefaultRiskAnalysis.isInputStandard(
-                new TransactionInput(null, scriptHighS.getProgram(), TransactionOutPoint.UNCONNECTED)));
+                new TransactionInput(null, scriptHighS.getProgram(), TransactionOutPoint.Connected.UNCONNECTED)));
 
         // This is a real transaction. Its signatures S component is "low".
         Transaction tx1 = new Transaction(ByteBuffer.wrap(ByteUtils.parseHex(

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -752,7 +752,7 @@ public class WalletTest extends TestWithWallet {
         EasyMock.expect(to.isAvailableForSpending()).andReturn(true);
         EasyMock.expect(to.isMineOrWatched(wallet)).andReturn(true);
         EasyMock.expect(to.getSpentBy()).andReturn(
-                new TransactionInput(null, new byte[0], TransactionOutPoint.UNCONNECTED));
+                new TransactionInput(null, new byte[0], TransactionOutPoint.Connected.UNCONNECTED));
 
         Transaction tx = FakeTxBuilder.createFakeTxWithoutChange(to);
 
@@ -1676,7 +1676,7 @@ public class WalletTest extends TestWithWallet {
     public void watchingScriptsBloomFilter() {
         Address watchedAddress = new ECKey().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
         Transaction t1 = createFakeTx(TESTNET, CENT, watchedAddress);
-        TransactionOutPoint outPoint = new TransactionOutPoint(0, t1);
+        TransactionOutPoint.Connected outPoint = new TransactionOutPoint.Connected(0, t1);
         wallet.addWatchedAddress(watchedAddress);
 
         // Note that this has a 1e-12 chance of failing this unit test due to a false positive
@@ -1730,7 +1730,7 @@ public class WalletTest extends TestWithWallet {
 
         for (Address addr : addressesForRemoval) {
             Transaction t1 = createFakeTx(TESTNET, CENT, addr);
-            TransactionOutPoint outPoint = new TransactionOutPoint(0, t1);
+            TransactionOutPoint.Connected outPoint = new TransactionOutPoint.Connected(0, t1);
 
             // Note that this has a 1e-12 chance of failing this unit test due to a false positive
             assertFalse(wallet.getBloomFilter(1e-12).contains(outPoint.serialize()));
@@ -1749,7 +1749,7 @@ public class WalletTest extends TestWithWallet {
         assertTrue(wallet.getBloomFilter(falsePositiveRate).contains(address.getHash()));
 
         Transaction t1 = createFakeTx(TESTNET, CENT, address);
-        TransactionOutPoint outPoint = new TransactionOutPoint(0, t1);
+        TransactionOutPoint.Connected outPoint = new TransactionOutPoint.Connected(0, t1);
 
         assertFalse(wallet.getBloomFilter(falsePositiveRate).contains(outPoint.serialize()));
 
@@ -2775,7 +2775,7 @@ public class WalletTest extends TestWithWallet {
 
         // However, if there is no connected output, we will grab a COIN output anyway and add the CENT to fee
         SendRequest request3 = SendRequest.to(OTHER_ADDRESS, CENT);
-        request3.tx.addInput(new TransactionInput(request3.tx, new byte[] {}, new TransactionOutPoint(0, tx3.getTxId())));
+        request3.tx.addInput(new TransactionInput(request3.tx, new byte[] {}, new TransactionOutPoint.Connected(0, tx3.getTxId())));
         // Now completeTx will result in two inputs, two outputs and a fee of a CENT
         // Note that it is simply assumed that the inputs are correctly signed, though in fact the first is not
         request3.shuffleOutputs = false;

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -636,7 +636,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         Transaction tx = FakeTxBuilder.createFakeTx(COIN, key);
         Transaction tx2 = new Transaction();
         tx2.addInput(tx.getOutput(0));
-        TransactionOutPoint outpoint = tx2.getInput(0).getOutpoint();
+        TransactionOutPoint.Connected outpoint = tx2.getInput(0).getOutpoint();
         assertTrue(p1.lastReceivedFilter.contains(key.getPubKey()));
         assertTrue(p1.lastReceivedFilter.contains(key.getPubKeyHash()));
         assertFalse(p1.lastReceivedFilter.contains(tx.getTxId().getBytes()));

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -573,9 +573,9 @@ public class PeerTest extends TestWithNetworkConnections {
         t1.addInput(t2.getOutput(0));
         t1.addInput(t3.getOutput(0));
         Sha256Hash t7hash = Sha256Hash.wrap("2b801dd82f01d17bbde881687bf72bc62e2faa8ab8133d36fcb8c3abe7459da6");
-        t1.addInput(new TransactionInput(t1, new byte[]{}, new TransactionOutPoint(0, t7hash)));
+        t1.addInput(new TransactionInput(t1, new byte[]{}, new TransactionOutPoint.Connected(0, t7hash)));
         Sha256Hash t8hash = Sha256Hash.wrap("3b801dd82f01d17bbde881687bf72bc62e2faa8ab8133d36fcb8c3abe7459da6");
-        t1.addInput(new TransactionInput(t1, new byte[]{}, new TransactionOutPoint(1, t8hash)));
+        t1.addInput(new TransactionInput(t1, new byte[]{}, new TransactionOutPoint.Connected(1, t8hash)));
         t1.addOutput(COIN, to);
         t1 = roundTripTransaction(t1);
         t2 = roundTripTransaction(t2);
@@ -648,7 +648,7 @@ public class PeerTest extends TestWithNetworkConnections {
         // The ones in brackets are assumed to be in the chain and are represented only by hashes.
         Sha256Hash t4hash = Sha256Hash.wrap("2b801dd82f01d17bbde881687bf72bc62e2faa8ab8133d36fcb8c3abe7459da6");
         Transaction t3 = new Transaction();
-        t3.addInput(new TransactionInput(t3, new byte[]{}, new TransactionOutPoint(0, t4hash)));
+        t3.addInput(new TransactionInput(t3, new byte[]{}, new TransactionOutPoint.Connected(0, t4hash)));
         t3.addOutput(COIN, new ECKey());
         t3 = roundTripTransaction(t3);
         Transaction t2 = new Transaction();
@@ -751,7 +751,7 @@ public class PeerTest extends TestWithNetworkConnections {
         t2.setLockTime(999999);
         // Add a fake input to t3 that goes nowhere.
         Sha256Hash t3 = Sha256Hash.of("abc".getBytes(StandardCharsets.UTF_8));
-        t2.addInput(new TransactionInput(t2, new byte[]{}, new TransactionOutPoint(0, t3)));
+        t2.addInput(new TransactionInput(t2, new byte[]{}, new TransactionOutPoint.Connected(0, t3)));
         t2.getInput(0).setSequenceNumber(0xDEADBEEF);
         t2.addOutput(COIN, new ECKey());
         Transaction t1 = new Transaction();
@@ -824,7 +824,7 @@ public class PeerTest extends TestWithNetworkConnections {
         });
         connect();
         Transaction t1 = new Transaction();
-        t1.addInput(new TransactionInput(t1, new byte[0], TransactionOutPoint.UNCONNECTED));
+        t1.addInput(new TransactionInput(t1, new byte[0], TransactionOutPoint.Connected.UNCONNECTED));
         t1.addOutput(COIN, new ECKey().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET));
         Transaction t2 = new Transaction();
         t2.addInput(t1.getOutput(0));


### PR DESCRIPTION
* Wrap `TransactionOutPoint` in a parent interface
* The implementing class is `TransactionOutPoint.Connected` and has no behavior changes.

The next step is to add an "unconnected" implementation and begin to distinguish the two with `instanceof` (or possibly an `isConnected()` method.)  