### PR TITLE
TransactionOutPoint: store connectedOutput when storing fromTx

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -435,6 +435,7 @@ public class TransactionInput {
             // The outpoint is connected using a "standard" wallet, disconnect it.
             connectedOutput = outpoint.fromTx.getOutput((int) outpoint.index());
             outpoint.fromTx = null;
+            outpoint.connectedOutput = null;
         } else if (outpoint.connectedOutput != null) {
             // The outpoint is connected using a UTXO based wallet, disconnect it.
             connectedOutput = outpoint.connectedOutput;

--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -563,7 +563,7 @@ public class TransactionInput {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         TransactionInput other = (TransactionInput) o;
-        return sequence == other.sequence && parent == other.parent
+        return sequence == other.sequence && parent != null && parent.equals(other.parent)
             && outpoint.equals(other.outpoint) && Arrays.equals(scriptBytes, other.scriptBytes);
     }
 

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -80,6 +80,7 @@ public class TransactionOutPoint {
         this.index = index;
         this.hash = fromTx.getTxId();
         this.fromTx = fromTx;
+        this.connectedOutput = Objects.requireNonNull(fromTx.getOutput(index));
     }
 
     public TransactionOutPoint(long index, Sha256Hash hash) {

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -443,7 +443,7 @@ public class TransactionOutput extends Message {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         TransactionOutput other = (TransactionOutput) o;
-        return value == other.value && (parent == null || (parent == other.parent && getIndex() == other.getIndex()))
+        return value == other.value && (parent == null || (parent.equals(other.parent) && getIndex() == other.getIndex()))
                 && Arrays.equals(scriptBytes, other.scriptBytes);
     }
 

--- a/core/src/test/java/org/bitcoinj/core/TransactionInputTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionInputTest.java
@@ -71,7 +71,7 @@ public class TransactionInputTest {
         TransactionInput txInToDisconnect = tx2.getInput(0);
 
         assertEquals(tx1, txInToDisconnect.getOutpoint().fromTx);
-        assertNull(txInToDisconnect.getOutpoint().connectedOutput);
+        assertEquals(tx1.getOutput(0), txInToDisconnect.getOutpoint().connectedOutput);
 
         txInToDisconnect.disconnect();
 


### PR DESCRIPTION
This requires related changes:

* Clear connectedOutput when clearing fromTx
* Change comparison in TransactionInputTest to reflect new behavior

Depends on PR #2737