### PR TITLE
TransactionInput: check range of `value`

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -130,6 +130,7 @@ public class TransactionInput {
 
     private TransactionInput(@Nullable Transaction parentTransaction, byte[] scriptBytes,
                             TransactionOutPoint outpoint, long sequence, @Nullable Coin value) {
+        checkArgument(value == null || value.signum() >= 0, () -> "value out of range: " + value);
         this.scriptBytes = scriptBytes;
         this.outpoint = outpoint;
         this.sequence = sequence;

--- a/core/src/test/java/org/bitcoinj/core/TransactionInputTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionInputTest.java
@@ -142,7 +142,12 @@ public class TransactionInputTest {
             byte[] randomBytes = new byte[100];
             random.nextBytes(randomBytes);
             return new TransactionInput(parent, randomBytes, TransactionOutPoint.UNCONNECTED,
-                    Coin.ofSat(random.nextLong()));
+                    Coin.ofSat(Math.abs(random.nextLong())));
         }).limit(10).iterator();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void negativeValue() {
+        new TransactionInput(new Transaction(), new byte[0], TransactionOutPoint.UNCONNECTED, Coin.ofSat(-1));
     }
 }


### PR DESCRIPTION
The value can't be negative. This also adds a test.