### PR TITLE
TransactionOutput: divorce from `Message`

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -694,7 +694,7 @@ public class Transaction extends Message {
         int numOutputs = numOutputsVarInt.intValue();
         outputs = new ArrayList<>(Math.min((int) numOutputs, Utils.MAX_INITIAL_ARRAY_LENGTH));
         for (long i = 0; i < numOutputs; i++) {
-            TransactionOutput output = new TransactionOutput(this, payload.slice());
+            TransactionOutput output = TransactionOutput.read(payload.slice(), this);
             outputs.add(output);
             // intentionally read again, due to the slice above
             Buffers.skipBytes(payload, 8); // value
@@ -1529,7 +1529,7 @@ public class Transaction extends Message {
         // txout_count, txouts
         stream.write(VarInt.of(outputs.size()).serialize());
         for (TransactionOutput out : outputs)
-            out.bitcoinSerializeToStream(stream);
+            stream.write(out.serialize());
         // script_witnisses
         if (useSegwit) {
             for (TransactionInput in : inputs) {

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -5282,8 +5282,8 @@ public class Wallet extends BaseTaggableObject
                 result.updatedOutputValues = new ArrayList<>();
             }
             for (int i = 0; i < req.tx.getOutputs().size(); i++) {
-                TransactionOutput output = new TransactionOutput(tx,
-                        ByteBuffer.wrap(req.tx.getOutputs().get(i).bitcoinSerialize()));
+                TransactionOutput output = TransactionOutput.read(
+                        ByteBuffer.wrap(req.tx.getOutputs().get(i).bitcoinSerialize()), tx);
                 if (req.recipientsPayFees) {
                     // Subtract fee equally from each selected recipient
                     output.setValue(output.getValue().subtract(fee.divide(req.tx.getOutputs().size())));

--- a/core/src/test/java/org/bitcoinj/core/TransactionOutputTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionOutputTest.java
@@ -16,6 +16,8 @@
 
 package org.bitcoinj.core;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Coin;
@@ -31,15 +33,21 @@ import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Random;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(JUnitParamsRunner.class)
 public class TransactionOutputTest extends TestWithWallet {
 
     @Before
@@ -116,5 +124,23 @@ public class TransactionOutputTest extends TestWithWallet {
         TransactionOutput p2wpkh = new TransactionOutput(null, Coin.COIN, myKey.toAddress(ScriptType.P2WPKH,
                 BitcoinNetwork.TESTNET));
         p2wpkh.toString();
+    }
+
+    @Test
+    @Parameters(method = "randomOutputs")
+    public void write(TransactionOutput output) {
+        ByteBuffer buf = ByteBuffer.allocate(output.getMessageSize());
+        output.write(buf);
+        assertFalse(buf.hasRemaining());
+    }
+
+    private Iterator<TransactionOutput> randomOutputs() {
+        Random random = new Random();
+        Transaction parent = new Transaction();
+        return Stream.generate(() -> {
+            byte[] randomBytes = new byte[100];
+            random.nextBytes(randomBytes);
+            return new TransactionOutput(parent, Coin.ofSat(Math.abs(random.nextLong())), randomBytes);
+        }).limit(10).iterator();
     }
 }

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -741,7 +741,7 @@ public class TransactionTest {
             long outputsSize = hackOutputsSize ? Integer.MAX_VALUE : getOutputs().size();
             stream.write(VarInt.of(outputsSize).serialize());
             for (TransactionOutput out : getOutputs())
-                out.bitcoinSerializeToStream(stream);
+                stream.write(out.serialize());
             // script_witnisses
             if (useSegwit) {
                 for (TransactionInput in : getInputs()) {


### PR DESCRIPTION
It is never sent on its own, so it doesn't need to be a `Message`.

* A static constructur `read()` replaces the native constructor that deserialized from a payload.
* A `write()` helper replaces `bitcoinSerializeToStream()`.
* A `serialize()` helper replaces `bitcoinSerialize()`.

This comes with a test.