### PR TITLE
TransactionWitness: add read and write helpers

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -706,16 +706,8 @@ public class Transaction extends Message {
 
     private void parseWitnesses(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         int numWitnesses = inputs.size();
-        for (int i = 0; i < numWitnesses; i++) {
-            VarInt pushCountVarInt = VarInt.read(payload);
-            int pushCount = pushCountVarInt.intValue();
-            TransactionWitness witness = new TransactionWitness(pushCount);
-            getInput(i).setWitness(witness);
-            for (int y = 0; y < pushCount; y++) {
-                byte[] push = Buffers.readLengthPrefixedBytes(payload);
-                witness.setPush(y, push);
-            }
-        }
+        for (int i = 0; i < numWitnesses; i++)
+            getInput(i).setWitness(TransactionWitness.read(payload));
     }
 
     /** @return true of the transaction has any witnesses in any of its inputs */
@@ -1532,9 +1524,8 @@ public class Transaction extends Message {
             out.bitcoinSerializeToStream(stream);
         // script_witnisses
         if (useSegwit) {
-            for (TransactionInput in : inputs) {
-                in.getWitness().bitcoinSerializeToStream(stream);
-            }
+            for (TransactionInput in : inputs)
+                stream.write(in.getWitness().serialize());
         }
         // lock_time
         writeInt32LE(vLockTime.rawValue(), stream);

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -754,7 +754,7 @@ public class TransactionTest {
                         stream.write(push);
                     }
 
-                    in.getWitness().bitcoinSerializeToStream(stream);
+                    stream.write(in.getWitness().serialize());
                 }
             }
             // lock_time


### PR DESCRIPTION
* A static constructur `read()` deserializes from a payload.
* A `write()` helper replaces `bitcoinSerializeToStream()`.
* A `serialize()` helper gets the serialized bytes.

This comes with a test.