### PR TITLE
TransactionOutPoint: make fields `connectedOutput` and `fromTx` immutable

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -439,7 +439,7 @@ public class TransactionInput {
         } else if (outpoint.connectedOutput != null) {
             // The outpoint is connected using a UTXO based wallet, disconnect it.
             connectedOutput = outpoint.connectedOutput;
-            outpoint.connectedOutput = null;
+            outpoint = outpoint.disconnectOutput();
         } else {
             // The outpoint is not connected, do nothing.
             return false;

--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -409,7 +409,7 @@ public class TransactionInput {
             } else if (mode == ConnectMode.DISCONNECT_ON_CONFLICT) {
                 out.markAsUnspent();
             } else if (mode == ConnectMode.ABORT_ON_CONFLICT) {
-                outpoint.fromTx = out.getParentTransaction();
+                outpoint = outpoint.connectTransaction(out.getParentTransaction());
                 return TransactionInput.ConnectionResult.ALREADY_SPENT;
             }
         }
@@ -419,7 +419,7 @@ public class TransactionInput {
 
     /** Internal use only: connects this TransactionInput to the given output (updates pointers and spent flags) */
     public void connect(TransactionOutput out) {
-        outpoint.fromTx = out.getParentTransaction();
+        outpoint = outpoint.connectTransaction(out.getParentTransaction());
         out.markAsSpent(this);
         value = out.getValue();
     }
@@ -435,7 +435,7 @@ public class TransactionInput {
         if (outpoint.fromTx != null) {
             // The outpoint is connected using a "standard" wallet, disconnect it.
             connectedOutput = outpoint.fromTx.getOutput((int) outpoint.index());
-            outpoint.fromTx = null;
+            outpoint = outpoint.disconnectTransaction();
         } else if (outpoint.connectedOutput != null) {
             // The outpoint is connected using a UTXO based wallet, disconnect it.
             connectedOutput = outpoint.connectedOutput;

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -258,11 +258,11 @@ public class TransactionOutPoint {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         TransactionOutPoint other = (TransactionOutPoint) o;
-        return index() == other.index() && hash().equals(other.hash());
+        return index == other.index && hash.equals(other.hash);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(index(), hash());
+        return Objects.hash(index, hash);
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -55,7 +55,7 @@ public class TransactionOutPoint {
     private final long index;
 
     // This is not part of bitcoin serialization. It points to the connected transaction.
-    Transaction fromTx;
+    final Transaction fromTx;
 
     // The connected output.
     final TransactionOutput connectedOutput;
@@ -216,6 +216,23 @@ public class TransactionOutPoint {
      */
     public TransactionOutPoint disconnectOutput() {
         return new TransactionOutPoint(hash, index, fromTx, null);
+    }
+
+    /**
+     * Returns a copy of this outpoint, but with the provided transaction as fromTx.
+     * @param transaction transaction to set as fromTx
+     * @return outpoint with fromTx set
+     */
+    public TransactionOutPoint connectTransaction(Transaction transaction) {
+        return new TransactionOutPoint(hash, index, Objects.requireNonNull(transaction), connectedOutput);
+    }
+
+    /**
+     * Returns a copy of this outpoint, but with fromTx removed.
+     * @return outpoint with removed fromTx
+     */
+    public TransactionOutPoint disconnectTransaction() {
+        return new TransactionOutPoint(hash, index, null, connectedOutput);
     }
 
     @Override

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -312,7 +312,7 @@ public class TransactionTest {
         assertEquals("025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee6357", key1.getPublicKeyAsHex());
         Script scriptPubKey1 = ScriptBuilder.createP2WPKHOutputScript(key1);
         assertEquals("00141d0f172a0ecb48aee1be1f2687d2963ae33f71a1", ByteUtils.formatHex(scriptPubKey1.getProgram()));
-        txIn1.connect(new TransactionOutput(null, Coin.COIN.multiply(6), scriptPubKey1.getProgram()));
+        txIn1.connect(new TransactionOutput(tx, Coin.COIN.multiply(6), scriptPubKey1.getProgram()));
 
         assertEquals("63cec688ee06a91e913875356dd4dea2f8e0f2a2659885372da2a37e32c7532e",
                 tx.hashForSignature(0, scriptPubKey0, Transaction.SigHash.ALL, false).toString());


### PR DESCRIPTION
I'm not sure if we want to keep these fields in future, but at least they're immutable now.

It introduces methods for the cases where the fields need mutation. In this case, the entire `TransactionOutPoint` is reconstructed.