### PR TITLE
TransactionOutPointTest: add test `deprecatedMembers()`

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/TransactionOutPointTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionOutPointTest.java
@@ -53,4 +53,13 @@ public class TransactionOutPointTest {
             return new TransactionOutPoint(Integer.toUnsignedLong(random.nextInt()), Sha256Hash.wrap(randomBytes));
         }).limit(10).iterator();
     }
+
+    @Test
+    public void deprecatedMembers() {
+        TransactionOutPoint outpoint = TransactionOutPoint.UNCONNECTED;
+        outpoint.getHash();
+        outpoint.getMessageSize();
+        outpoint.getIndex();
+        outpoint.bitcoinSerialize();
+    }
 }


### PR DESCRIPTION
The idea is any change in method signatures will be more visible in diffs.