### PR TITLE
Transaction: remove caches for (witness) transaction ID

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
@@ -231,7 +231,7 @@ public class BitcoinSerializer extends MessageSerializer {
         } else if (command.equals("getheaders")) {
             return new GetHeadersMessage(payload);
         } else if (command.equals("tx")) {
-            return makeTransaction(payload, hash);
+            return makeTransaction(payload);
         } else if (command.equals("sendaddrv2")) {
             check(!payload.hasRemaining(), ProtocolException::new);
             return new SendAddrV2Message();
@@ -333,7 +333,7 @@ public class BitcoinSerializer extends MessageSerializer {
      * serialization format support.
      */
     @Override
-    public Transaction makeTransaction(ByteBuffer payload, byte[] hashFromHeader)
+    public Transaction makeTransaction(ByteBuffer payload)
             throws ProtocolException {
         return new Transaction(payload, this);
     }

--- a/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
@@ -335,7 +335,7 @@ public class BitcoinSerializer extends MessageSerializer {
     @Override
     public Transaction makeTransaction(ByteBuffer payload, byte[] hashFromHeader)
             throws ProtocolException {
-        return new Transaction(payload, this, hashFromHeader);
+        return new Transaction(payload, this);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -201,7 +201,7 @@ public class Block extends Message {
         int numTransactions = numTransactionsVarInt.intValue();
         transactions = new ArrayList<>(Math.min(numTransactions, Utils.MAX_INITIAL_ARRAY_LENGTH));
         for (int i = 0; i < numTransactions; i++) {
-            Transaction tx = new Transaction(payload, serializer, null);
+            Transaction tx = new Transaction(payload, serializer);
             // Label the transaction as coming from the P2P network, so code that cares where we first saw it knows.
             tx.getConfidence().setSource(TransactionConfidence.Source.NETWORK);
             transactions.add(tx);

--- a/core/src/main/java/org/bitcoinj/core/DummySerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/DummySerializer.java
@@ -96,7 +96,7 @@ class DummySerializer extends MessageSerializer {
     }
 
     @Override
-    public Transaction makeTransaction(ByteBuffer payload, byte[] hash) throws UnsupportedOperationException {
+    public Transaction makeTransaction(ByteBuffer payload) throws UnsupportedOperationException {
         throw new UnsupportedOperationException(DEFAULT_EXCEPTION_MESSAGE);
     }
 

--- a/core/src/main/java/org/bitcoinj/core/MessageSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/MessageSerializer.java
@@ -101,20 +101,7 @@ public abstract class MessageSerializer {
      * serializer (i.e. for messages with no network parameters), or because
      * it does not support deserializing transactions.
      */
-    public abstract Transaction makeTransaction(ByteBuffer payload, byte[] hash) throws ProtocolException, UnsupportedOperationException;
-
-    /**
-     * Make a transaction from the payload. Extension point for alternative
-     * serialization format support.
-     * 
-     * @throws UnsupportedOperationException if this serializer/deserializer
-     * does not support deserialization. This can occur either because it's a dummy
-     * serializer (i.e. for messages with no network parameters), or because
-     * it does not support deserializing transactions.
-     */
-    public final Transaction makeTransaction(ByteBuffer payload) throws ProtocolException {
-        return makeTransaction(payload, null);
-    }
+    public abstract Transaction makeTransaction(ByteBuffer payload) throws ProtocolException, UnsupportedOperationException;
 
     public abstract void seekPastMagicBytes(ByteBuffer in) throws BufferUnderflowException;
 

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -587,9 +587,6 @@ public class Transaction extends Message {
      */
     public static final byte SIGHASH_ANYONECANPAY_VALUE = (byte) 0x80;
 
-    protected void unCache() {
-    }
-
     /**
      * Deserialize according to <a href="https://github.com/bitcoin/bips/blob/master/bip-0144.mediawiki">BIP144</a> or
      * the <a href="https://en.bitcoin.it/wiki/Protocol_documentation#tx">classic format</a>, depending on if the
@@ -874,7 +871,6 @@ public class Transaction extends Message {
      * Note that this also invalidates the length attribute
      */
     public void clearInputs() {
-        unCache();
         for (TransactionInput input : inputs) {
             input.setParent(null);
         }
@@ -897,7 +893,6 @@ public class Transaction extends Message {
      * @return the new input.
      */
     public TransactionInput addInput(TransactionInput input) {
-        unCache();
         input.setParent(this);
         inputs.add(input);
         return input;
@@ -1036,7 +1031,6 @@ public class Transaction extends Message {
      * Note that this also invalidates the length attribute
      */
     public void clearOutputs() {
-        unCache();
         for (TransactionOutput output : outputs) {
             output.setParent(null);
         }
@@ -1047,7 +1041,6 @@ public class Transaction extends Message {
      * Adds the given output to this transaction. The output must be completely initialized. Returns the given output.
      */
     public TransactionOutput addOutput(TransactionOutput to) {
-        unCache();
         to.setParent(this);
         outputs.add(to);
         return to;
@@ -1519,7 +1512,6 @@ public class Transaction extends Message {
      * standard and won't be relayed or included in the memory pool either.
      */
     public void setLockTime(long lockTime) {
-        unCache();
         boolean seqNumSet = false;
         for (TransactionInput input : inputs) {
             if (input.getSequenceNumber() != TransactionInput.NO_SEQUENCE) {
@@ -1541,7 +1533,6 @@ public class Transaction extends Message {
 
     public void setVersion(int version) {
         this.version = version;
-        unCache();
     }
 
     /** Returns an unmodifiable view of all inputs. */

--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -257,7 +257,6 @@ public class TransactionInput {
     public void setSequenceNumber(long sequence) {
         checkArgument(sequence >= 0 && sequence <= ByteUtils.MAX_UNSIGNED_INTEGER, () ->
                 "sequence out of range: " + sequence);
-        unCache();
         this.sequence = sequence;
     }
 
@@ -288,7 +287,6 @@ public class TransactionInput {
      * @param scriptBytes the scriptBytes to set
      */
     void setScriptBytes(byte[] scriptBytes) {
-        unCache();
         this.scriptSig = null;
         this.scriptBytes = scriptBytes;
     }
@@ -538,21 +536,7 @@ public class TransactionInput {
     }
 
     protected final void setParent(@Nullable Transaction parent) {
-        if (this.parent != null && this.parent != parent && parent != null) {
-            // After old parent is unlinked it won't be able to receive notice if this child
-            // changes internally.  To be safe we invalidate the parent cache to ensure it rebuilds
-            // manually on serialization.
-            this.parent.unCache();
-        }
         this.parent = parent;
-    }
-
-    /* (non-Javadoc)
-     * @see Message#unCache()
-     */
-    protected void unCache() {
-        if (parent != null)
-            parent.unCache();
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -182,7 +182,6 @@ public class TransactionOutput {
         // Negative values obviously make no sense, except for -1 which is used as a sentinel value when calculating
         // SIGHASH_SINGLE signatures, so unfortunately we have to allow that here.
         checkArgument(value.signum() >= 0 || value.equals(Coin.NEGATIVE_SATOSHI), () -> "value out of range: " + value);
-        unCache();
         this.value = value.value;
     }
 
@@ -438,21 +437,7 @@ public class TransactionOutput {
     }
 
     protected final void setParent(@Nullable Transaction parent) {
-        if (this.parent != null && this.parent != parent && parent != null) {
-            // After old parent is unlinked it won't be able to receive notice if this child
-            // changes internally.  To be safe we invalidate the parent cache to ensure it rebuilds
-            // manually on serialization.
-            this.parent.unCache();
-        }
         this.parent = parent;
-    }
-
-    /* (non-Javadoc)
-     * @see Message#unCache()
-     */
-    protected void unCache() {
-        if (parent != null)
-            parent.unCache();
     }
 
     @Override


### PR DESCRIPTION
I don't see any regression in unit test runtime, so it seems fine.

On the plus side, this removes a fair bit of complexity from `Transaction`, and usages of `TransactionInput.parent` and `TransactionOutput.parent`.