### PR TITLE
Wallet: use Network in static factory methods

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -328,7 +328,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         rollingBlock = rollingBlock.createNextBlock(null);
 
         // Create 1 BTC spend to a key in this wallet (to ourselves).
-        Wallet wallet = Wallet.createDeterministic(PARAMS, ScriptType.P2PKH);
+        Wallet wallet = Wallet.createDeterministic(PARAMS.network(), ScriptType.P2PKH);
         assertEquals("Available balance is incorrect", Coin.ZERO, wallet.getBalance(Wallet.BalanceType.AVAILABLE));
         assertEquals("Estimated balance is incorrect", Coin.ZERO, wallet.getBalance(Wallet.BalanceType.ESTIMATED));
 

--- a/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
@@ -77,7 +77,7 @@ public class BlockChainTest {
         BriefLogFormatter.initVerbose();
         TimeUtils.setMockClock(); // Use mock clock
         Context.propagate(new Context(100, Coin.ZERO, false, false));
-        testNetWallet = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH);
+        testNetWallet = Wallet.createDeterministic(BitcoinNetwork.TESTNET, ScriptType.P2PKH);
         testNetStore = new MemoryBlockStore(TESTNET.getGenesisBlock());
         testNetChain = new BlockChain(TESTNET, testNetWallet, testNetStore);
         coinbaseTo = testNetWallet.currentReceiveKey().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
@@ -332,7 +332,7 @@ public class BlockChainTest {
         // Check that a coinbase transaction is only available to spend after NetworkParameters.getSpendableCoinbaseDepth() blocks.
 
         // Create a second wallet to receive the coinbase spend.
-        Wallet wallet2 = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH);
+        Wallet wallet2 = Wallet.createDeterministic(BitcoinNetwork.TESTNET, ScriptType.P2PKH);
         ECKey receiveKey = wallet2.freshReceiveKey();
         int height = 1;
         testNetChain.addWallet(wallet2);

--- a/core/src/test/java/org/bitcoinj/core/BlockTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockTest.java
@@ -208,7 +208,7 @@ public class BlockTest {
         // Create a wallet contain the miner's key that receives a spend from a coinbase.
         ECKey miningKey = DumpedPrivateKey.fromBase58(BitcoinNetwork.MAINNET, MINING_PRIVATE_KEY).getKey();
         assertNotNull(miningKey);
-        Wallet wallet = Wallet.createDeterministic(MAINNET, ScriptType.P2PKH);
+        Wallet wallet = Wallet.createDeterministic(BitcoinNetwork.MAINNET, ScriptType.P2PKH);
         wallet.importKey(miningKey);
 
         // Initial balance should be zero by construction.

--- a/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
@@ -72,7 +72,7 @@ public class ChainSplitTest {
         TimeUtils.setMockClock(); // Use mock clock
         Context.propagate(new Context(100, Coin.ZERO, false, true));
         MemoryBlockStore blockStore = new MemoryBlockStore(TESTNET.getGenesisBlock());
-        wallet = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH);
+        wallet = Wallet.createDeterministic(BitcoinNetwork.TESTNET, ScriptType.P2PKH);
         ECKey key1 = wallet.freshReceiveKey();
         ECKey key2 = wallet.freshReceiveKey();
         chain = new BlockChain(TESTNET, wallet, blockStore);

--- a/core/src/test/java/org/bitcoinj/core/ParseByteCacheTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ParseByteCacheTest.java
@@ -72,7 +72,7 @@ public class ParseByteCacheTest {
     public void setUp() throws Exception {
         TimeUtils.setMockClock(); // Use mock clock
         Context.propagate(new Context(100, Transaction.DEFAULT_TX_FEE, false, true));
-        Wallet wallet = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH);
+        Wallet wallet = Wallet.createDeterministic(BitcoinNetwork.TESTNET, ScriptType.P2PKH);
         wallet.freshReceiveKey();
 
         resetBlockStore();

--- a/core/src/test/java/org/bitcoinj/core/TransactionInputTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionInputTest.java
@@ -58,7 +58,7 @@ public class TransactionInputTest {
 
     @Test
     public void testStandardWalletDisconnect() throws Exception {
-        Wallet w = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH);
+        Wallet w = Wallet.createDeterministic(BitcoinNetwork.TESTNET, ScriptType.P2PKH);
         Address a = w.currentReceiveAddress();
         Transaction tx1 = FakeTxBuilder.createFakeTxWithoutChangeAddress(Coin.COIN, a);
         w.receivePending(tx1, null);
@@ -81,7 +81,7 @@ public class TransactionInputTest {
 
     @Test
     public void testUTXOWalletDisconnect() throws Exception {
-        Wallet w = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH);
+        Wallet w = Wallet.createDeterministic(BitcoinNetwork.TESTNET, ScriptType.P2PKH);
         Address a = w.currentReceiveAddress();
         final UTXO utxo = new UTXO(Sha256Hash.of(new byte[] { 1, 2, 3 }), 1, Coin.COIN, 0, false,
                 ScriptBuilder.createOutputScript(a));

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -192,7 +192,7 @@ public class TransactionTest {
 
     @Test
     public void testIsMatureReturnsFalseIfTransactionIsCoinbaseAndConfidenceTypeIsNotEqualToBuilding() {
-        Wallet wallet = Wallet.createBasic(TESTNET);
+        Wallet wallet = Wallet.createBasic(BitcoinNetwork.TESTNET);
         Transaction tx = FakeTxBuilder.createFakeCoinbaseTx();
 
         tx.getConfidence().setConfidenceType(ConfidenceType.UNKNOWN);

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -205,7 +205,7 @@ public class WalletProtobufSerializerTest {
         for (int i = 0 ; i < 20 ; i++) {
             myKey = new ECKey();
             myAddress = myKey.toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
-            myWallet = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH);
+            myWallet = Wallet.createDeterministic(BitcoinNetwork.TESTNET, ScriptType.P2PKH);
             myWallet.importKey(myKey);
             Wallet wallet1 = roundTrip(myWallet);
             ECKey foundKey = wallet1.findKeyFromPubKeyHash(myKey.getPubKeyHash(), null);
@@ -219,7 +219,7 @@ public class WalletProtobufSerializerTest {
         // Test the lastBlockSeenHash field works.
 
         // LastBlockSeenHash should be empty if never set.
-        Wallet wallet = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH);
+        Wallet wallet = Wallet.createDeterministic(BitcoinNetwork.TESTNET, ScriptType.P2PKH);
         Protos.Wallet walletProto = new WalletProtobufSerializer().walletToProto(wallet);
         ByteString lastSeenBlockHash = walletProto.getLastSeenBlockHash();
         assertTrue(lastSeenBlockHash.isEmpty());
@@ -245,7 +245,7 @@ public class WalletProtobufSerializerTest {
 
     @Test
     public void testSequenceNumber() throws Exception {
-        Wallet wallet = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH);
+        Wallet wallet = Wallet.createDeterministic(BitcoinNetwork.TESTNET, ScriptType.P2PKH);
         Transaction tx1 = createFakeTx(TESTNET.network(), Coin.COIN, wallet.currentReceiveAddress());
         tx1.getInput(0).setSequenceNumber(TransactionInput.NO_SEQUENCE);
         wallet.receivePending(tx1, null);
@@ -350,7 +350,7 @@ public class WalletProtobufSerializerTest {
     public void testRoundTripWatchingWallet() throws Exception {
         final String xpub = "tpubD9LrDvFDrB6wYNhbR2XcRRaT4yCa37TjBR3YthBQvrtEwEq6CKeEXUs3TppQd38rfxmxD1qLkC99iP3vKcKwLESSSYdFAftbrpuhSnsw6XM";
         final Instant creationTime = Instant.ofEpochSecond(1457019819);
-        Wallet wallet = Wallet.fromWatchingKeyB58(TESTNET, xpub, creationTime);
+        Wallet wallet = Wallet.fromWatchingKeyB58(BitcoinNetwork.TESTNET, xpub, creationTime);
         Wallet wallet2 = roundTrip(wallet);
         Wallet wallet3 = roundTrip(wallet2);
         assertEquals(xpub, wallet.getWatchingKey().serializePubB58(TESTNET.network()));
@@ -365,7 +365,7 @@ public class WalletProtobufSerializerTest {
     @Test
     public void testRoundTripMarriedWallet() throws Exception {
         // create 2-of-2 married wallet
-        myWallet = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH);
+        myWallet = Wallet.createDeterministic(BitcoinNetwork.TESTNET, ScriptType.P2PKH);
         final DeterministicKeyChain partnerChain = DeterministicKeyChain.builder().random(new SecureRandom()).build();
         DeterministicKey partnerKey = DeterministicKey.deserializeB58(null, partnerChain.getWatchingKey().serializePubB58(TESTNET.network()), TESTNET.network());
         MarriedKeyChain chain = MarriedKeyChain.builder()
@@ -437,7 +437,7 @@ public class WalletProtobufSerializerTest {
         assertTrue(wallet.getExtensions().containsKey("com.whatever.required"));
 
         // Non-mandatory extensions are ignored if the wallet doesn't know how to read them.
-        Wallet wallet2 = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH);
+        Wallet wallet2 = Wallet.createDeterministic(BitcoinNetwork.TESTNET, ScriptType.P2PKH);
         wallet2.addExtension(new FooWalletExtension("com.whatever.optional", false));
         Protos.Wallet proto2 = new WalletProtobufSerializer().walletToProto(wallet2);
         Wallet wallet5 = new WalletProtobufSerializer().readWallet(TESTNET, null, proto2);

--- a/core/src/test/java/org/bitcoinj/testing/TestWithWallet.java
+++ b/core/src/test/java/org/bitcoinj/testing/TestWithWallet.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.testing;
 
+import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.core.AbstractBlockChain;
@@ -68,7 +69,7 @@ public class TestWithWallet {
     public void setUp() throws Exception {
         BriefLogFormatter.init();
         Context.propagate(new Context(100, Coin.ZERO, false, true));
-        wallet = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH, KeyChainGroupStructure.BIP32);
+        wallet = Wallet.createDeterministic(BitcoinNetwork.TESTNET, ScriptType.P2PKH, KeyChainGroupStructure.BIP32);
         myKey = wallet.freshReceiveKey();
         myAddress = wallet.freshReceiveAddress(ScriptType.P2PKH);
         blockStore = new MemoryBlockStore(TESTNET.getGenesisBlock());

--- a/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
@@ -17,6 +17,7 @@
 
 package org.bitcoinj.wallet;
 
+import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.internal.ByteUtils;
@@ -62,7 +63,7 @@ public class DefaultRiskAnalysisTest {
     @Before
     public void setup() {
         Context.propagate(new Context());
-        wallet = Wallet.createDeterministic(MAINNET, ScriptType.P2PKH);
+        wallet = Wallet.createDeterministic(BitcoinNetwork.MAINNET, ScriptType.P2PKH);
         wallet.setLastBlockSeenHeight(1000);
         wallet.setLastBlockSeenTime(Instant.ofEpochSecond(TIMESTAMP));
     }

--- a/examples/src/main/java/org/bitcoinj/examples/BackupToMnemonicSeed.java
+++ b/examples/src/main/java/org/bitcoinj/examples/BackupToMnemonicSeed.java
@@ -17,9 +17,7 @@
 package org.bitcoinj.examples;
 
 import org.bitcoinj.base.BitcoinNetwork;
-import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
-import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.base.internal.InternalUtils;
 import org.bitcoinj.wallet.DeterministicSeed;
 import org.bitcoinj.wallet.Wallet;
@@ -36,8 +34,7 @@ public class BackupToMnemonicSeed {
 
     public static void main(String[] args) {
 
-        Network network = BitcoinNetwork.TESTNET;
-        Wallet wallet = Wallet.createDeterministic(NetworkParameters.of(network), ScriptType.P2PKH);
+        Wallet wallet = Wallet.createDeterministic(BitcoinNetwork.TESTNET, ScriptType.P2PKH);
 
         DeterministicSeed seed = wallet.getKeyChainSeed();
         System.out.println("seed: " + seed.toString());

--- a/examples/src/main/java/org/bitcoinj/examples/PrivateKeys.java
+++ b/examples/src/main/java/org/bitcoinj/examples/PrivateKeys.java
@@ -63,7 +63,7 @@ public class PrivateKeys {
             System.out.println("Address from private key is: " + key.toAddress(ScriptType.P2WPKH, network).toString());
 
             // Import the private key to a fresh wallet.
-            Wallet wallet = Wallet.createDeterministic(params, ScriptType.P2PKH);
+            Wallet wallet = Wallet.createDeterministic(network, ScriptType.P2PKH);
             wallet.importKey(key);
 
             // And the address ...

--- a/examples/src/main/java/org/bitcoinj/examples/RestoreFromSeed.java
+++ b/examples/src/main/java/org/bitcoinj/examples/RestoreFromSeed.java
@@ -51,7 +51,7 @@ public class RestoreFromSeed {
         DeterministicSeed seed = DeterministicSeed.ofMnemonic(seedCode, passphrase, creationtime);
 
         // The wallet class provides a easy fromSeed() function that loads a new wallet from a given seed.
-        Wallet wallet = Wallet.fromSeed(params, seed, ScriptType.P2PKH);
+        Wallet wallet = Wallet.fromSeed(network, seed, ScriptType.P2PKH);
 
         // Because we are importing an existing wallet which might already have transactions we must re-download the blockchain to make the wallet picks up these transactions
         // You can find some information about this in the guides: https://bitcoinj.github.io/working-with-the-wallet#setup

--- a/integration-test/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTest.java
@@ -77,7 +77,7 @@ public class FilteredBlockAndPartialMerkleTreeTest extends TestWithPeerGroup {
                 BigInteger.ONE, 100_000));
         store.setChainHead(store.get(Sha256Hash.wrap("000000000003ba27aa200b1cecaad478d2b00432346c3f1f3986da1afd33e506")));
 
-        wallet = Wallet.createBasic(TESTNET);
+        wallet = Wallet.createBasic(BitcoinNetwork.TESTNET);
         wallet.importKeys(Arrays.asList(ECKey.fromPublicOnly(ByteUtils.parseHex("04b27f7e9475ccf5d9a431cb86d665b8302c140144ec2397fce792f4a4e7765fecf8128534eaa71df04f93c74676ae8279195128a1506ebf7379d23dab8fca0f63")),
                 ECKey.fromPublicOnly(ByteUtils.parseHex("04732012cb962afa90d31b25d8fb0e32c94e513ab7a17805c14ca4c3423e18b4fb5d0e676841733cb83abaf975845c9f6f2a8097b7d04f4908b18368d6fc2d68ec")),
                 ECKey.fromPublicOnly(ByteUtils.parseHex("04cfb4113b3387637131ebec76871fd2760fc430dd16de0110f0eb07bb31ffac85e2607c189cb8582ea1ccaeb64ffd655409106589778f3000fdfe3263440b0350")),

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -275,7 +275,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         // Create a peer.
         InboundMessageQueuer p1 = connectPeer(1);
         
-        Wallet wallet2 = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
+        Wallet wallet2 = Wallet.createDeterministic(UNITTEST.network(), ScriptType.P2PKH);
         ECKey key2 = wallet2.freshReceiveKey();
         Address address2 = key2.toAddress(ScriptType.P2PKH, UNITTEST.network());
         
@@ -436,7 +436,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         final Instant now = TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS);
         peerGroup.start();
         assertTrue(peerGroup.fastCatchupTime().isAfter(now.minusSeconds(WEEK).minusSeconds(10000)));
-        Wallet w2 = Wallet.createDeterministic(UNITTEST, ScriptType.P2PKH);
+        Wallet w2 = Wallet.createDeterministic(UNITTEST.network(), ScriptType.P2PKH);
         ECKey key1 = new ECKey();
         key1.setCreationTime(now.minus(1, ChronoUnit.DAYS));  // One day ago.
         w2.importKey(key1);
@@ -798,7 +798,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         final int NUM_KEYS = 9;
 
         // First, grab a load of keys from the wallet, and then recreate it so it forgets that those keys were issued.
-        Wallet shadow = Wallet.fromSeed(wallet.getParams(), wallet.getKeyChainSeed(), ScriptType.P2PKH);
+        Wallet shadow = Wallet.fromSeed(wallet.network(), wallet.getKeyChainSeed(), ScriptType.P2PKH);
         List<ECKey> keys = new ArrayList<>(NUM_KEYS);
         for (int i = 0; i < NUM_KEYS; i++) {
             keys.add(shadow.freshReceiveKey());

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -694,7 +694,7 @@ public class PeerTest extends TestWithNetworkConnections {
         connectWithVersion(70001, Services.NODE_NETWORK);
         // Test that if we receive a relevant transaction that has a lock time, it doesn't result in a notification
         // until we explicitly opt in to seeing those.
-        Wallet wallet = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH);
+        Wallet wallet = Wallet.createDeterministic(BitcoinNetwork.TESTNET, ScriptType.P2PKH);
         ECKey key = wallet.freshReceiveKey();
         peer.addWallet(wallet);
         final Transaction[] vtx = new Transaction[1];
@@ -740,7 +740,7 @@ public class PeerTest extends TestWithNetworkConnections {
     private void checkTimeLockedDependency(boolean shouldAccept) throws Exception {
         // Initial setup.
         connectWithVersion(70001, Services.NODE_NETWORK);
-        Wallet wallet = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH);
+        Wallet wallet = Wallet.createDeterministic(BitcoinNetwork.TESTNET, ScriptType.P2PKH);
         ECKey key = wallet.freshReceiveKey();
         wallet.setAcceptRiskyTransactions(shouldAccept);
         peer.addWallet(wallet);

--- a/integration-test/src/test/java/org/bitcoinj/wallet/WalletAccountPathTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/wallet/WalletAccountPathTest.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.wallet;
 
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.Context;
 import org.bitcoinj.core.NetworkParameters;
@@ -59,7 +60,7 @@ public class WalletAccountPathTest {
     void walletStructurePathTest2(KeyChainGroupStructure structure, HDPath expectedPath, ScriptType scriptType,
                                   BitcoinNetwork network) throws IOException, UnreadableWalletException {
         // When we create a wallet with parameterized structure, network, and scriptType
-        Wallet wallet = createWallet(walletFile, NetworkParameters.of(network), structure, scriptType);
+        Wallet wallet = createWallet(walletFile, network, structure, scriptType);
 
         // Then the account path is as expected
         assertEquals(expectedPath, wallet.getActiveKeyChain().getAccountPath());
@@ -80,10 +81,10 @@ public class WalletAccountPathTest {
     }
 
     // Create a wallet, save it to a file, then reload from a file
-    private static Wallet createWallet(File walletFile, NetworkParameters params, KeyChainGroupStructure structure, ScriptType outputScriptType) throws IOException, UnreadableWalletException {
+    private static Wallet createWallet(File walletFile, Network network, KeyChainGroupStructure structure, ScriptType outputScriptType) throws IOException, UnreadableWalletException {
         Context.propagate(new Context());
         DeterministicSeed seed = new DeterministicSeed(testWalletMnemonic, null, "", Instant.now());
-        Wallet wallet = Wallet.fromSeed(params, seed, outputScriptType, structure);
+        Wallet wallet = Wallet.fromSeed(network, seed, outputScriptType, structure);
         wallet.saveToFile(walletFile);
         return Wallet.loadFromFile(walletFile);
     }

--- a/tools/src/main/java/org/bitcoinj/tools/WatchMempool.java
+++ b/tools/src/main/java/org/bitcoinj/tools/WatchMempool.java
@@ -24,6 +24,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.core.listeners.*;
 import org.bitcoinj.core.NetworkParameters;
@@ -31,7 +33,6 @@ import org.bitcoinj.core.Peer;
 import org.bitcoinj.core.PeerGroup;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.net.discovery.DnsDiscovery;
-import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.utils.BriefLogFormatter;
 import org.bitcoinj.wallet.DefaultRiskAnalysis;
 import org.bitcoinj.wallet.RiskAnalysis.Result;
@@ -40,7 +41,7 @@ import org.slf4j.LoggerFactory;
 
 public class WatchMempool {
     private static final Logger log = LoggerFactory.getLogger(WatchMempool.class);
-    private static final NetworkParameters PARAMS = MainNetParams.get();
+    private static final Network NETWORK = BitcoinNetwork.MAINNET;
     private static final List<Transaction> NO_DEPS = Collections.emptyList();
     private static final Map<String, Integer> counters = new HashMap<>();
     private static final String TOTAL_KEY = "TOTAL";
@@ -49,9 +50,9 @@ public class WatchMempool {
 
     public static void main(String[] args) throws InterruptedException {
         BriefLogFormatter.init();
-        PeerGroup peerGroup = new PeerGroup(PARAMS.network());
+        PeerGroup peerGroup = new PeerGroup(NETWORK);
         peerGroup.setMaxConnections(32);
-        peerGroup.addPeerDiscovery(new DnsDiscovery(PARAMS));
+        peerGroup.addPeerDiscovery(new DnsDiscovery(NetworkParameters.of(NETWORK)));
         peerGroup.addOnTransactionBroadcastListener((peer, tx) -> {
             Result result = DefaultRiskAnalysis.FACTORY.create(null, tx, NO_DEPS).analyze();
             incrementCounter(TOTAL_KEY);

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -18,6 +18,7 @@
 package org.bitcoinj.wallettool;
 
 import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.crypto.AesKey;
@@ -378,7 +379,7 @@ public class WalletTool implements Callable<Integer> {
         }
 
         if (action == ActionEnum.CREATE) {
-            createWallet(params, walletFile);
+            createWallet(net, walletFile);
             return 0;  // We're done.
         }
         if (!walletFile.exists()) {
@@ -1069,7 +1070,7 @@ public class WalletTool implements Callable<Integer> {
         }
     }
 
-    private void createWallet(NetworkParameters params, File walletFile) throws IOException {
+    private void createWallet(Network network, File walletFile) throws IOException {
         KeyChainGroupStructure keyChainGroupStructure = KeyChainGroupStructure.BIP32;
 
         if (walletFile.exists() && !force) {
@@ -1098,11 +1099,11 @@ public class WalletTool implements Callable<Integer> {
                 // not reached - all subclasses handled above
                 throw new RuntimeException(e);
             }
-            wallet = Wallet.fromSeed(params, seed, outputScriptType, keyChainGroupStructure);
+            wallet = Wallet.fromSeed(network, seed, outputScriptType, keyChainGroupStructure);
         } else if (watchKeyStr != null) {
-            wallet = Wallet.fromWatchingKeyB58(params, watchKeyStr, creationTime);
+            wallet = Wallet.fromWatchingKeyB58(network, watchKeyStr, creationTime);
         } else {
-            wallet = Wallet.createDeterministic(params, outputScriptType, keyChainGroupStructure);
+            wallet = Wallet.createDeterministic(network, outputScriptType, keyChainGroupStructure);
         }
         if (password != null)
             wallet.encrypt(password);


### PR DESCRIPTION
* Convert all static factory methods in `Wallet` to take `Network` instead of `NetworkParameters`
* Provide deprecated methods
* Update tests, examples, and tools.