### PR TITLE
BuffersTest: move the two tests that check extreme message lengths to here from `MessageTest`

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/BuffersTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BuffersTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.nio.Buffer;
+import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.Random;
@@ -54,5 +55,21 @@ public class BuffersTest {
             random.nextBytes(bytes);
             return bytes;
         }).limit(10).iterator();
+    }
+
+    // If readStr() is vulnerable this causes OutOfMemory
+    @Test(expected = BufferUnderflowException.class)
+    public void readStrOfExtremeLength() {
+        VarInt length = VarInt.of(Integer.MAX_VALUE);
+        ByteBuffer payload = ByteBuffer.wrap(length.serialize());
+        Buffers.readLengthPrefixedString(payload);
+    }
+
+    // If readBytes() is vulnerable this causes OutOfMemory
+    @Test(expected = BufferUnderflowException.class)
+    public void readByteArrayOfExtremeLength() {
+        VarInt length = VarInt.of(Integer.MAX_VALUE);
+        ByteBuffer payload = ByteBuffer.wrap(length.serialize());
+        Buffers.readLengthPrefixedBytes(payload);
     }
 }

--- a/core/src/test/java/org/bitcoinj/core/MessageTest.java
+++ b/core/src/test/java/org/bitcoinj/core/MessageTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2014 Piotr Włodarek
- * Copyright 2015 Andreas Schildbach
+ * Copyright by the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,52 +16,5 @@
 
 package org.bitcoinj.core;
 
-import org.bitcoinj.base.VarInt;
-import org.bitcoinj.base.internal.Buffers;
-import org.bitcoinj.params.TestNet3Params;
-import org.junit.Test;
-
-import java.nio.BufferUnderflowException;
-import java.nio.ByteBuffer;
-
 public class MessageTest {
-    private static final NetworkParameters TESTNET = TestNet3Params.get();
-
-    // If readStr() is vulnerable this causes OutOfMemory
-    @Test(expected = ProtocolException.class)
-    public void readStrOfExtremeLength() {
-        VarInt length = VarInt.of(Integer.MAX_VALUE);
-        ByteBuffer payload = ByteBuffer.wrap(length.serialize());
-        new VarStrMessage(payload);
-    }
-
-    static class VarStrMessage extends Message {
-        public VarStrMessage(ByteBuffer payload) {
-            super(payload);
-        }
-
-        @Override
-        protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
-            Buffers.readLengthPrefixedString(payload);
-        }
-    }
-
-    // If readBytes() is vulnerable this causes OutOfMemory
-    @Test(expected = ProtocolException.class)
-    public void readByteArrayOfExtremeLength() {
-        VarInt length = VarInt.of(Integer.MAX_VALUE);
-        ByteBuffer payload = ByteBuffer.wrap(length.serialize());
-        new VarBytesMessage(payload);
-    }
-
-    static class VarBytesMessage extends Message {
-        public VarBytesMessage(ByteBuffer payload) {
-            super(payload);
-        }
-
-        @Override
-        protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
-            Buffers.readLengthPrefixedBytes(payload);
-        }
-    }
 }


### PR DESCRIPTION
It's much simpler to test the affected read helpers directly.