### PR TITLE
PeerAddress: divorce from `Message`

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AddressMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressMessage.java
@@ -16,11 +16,8 @@
 
 package org.bitcoinj.core;
 
-import org.bitcoinj.base.VarInt;
 import org.bitcoinj.net.discovery.PeerDiscovery;
 
-import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
@@ -36,16 +33,6 @@ public abstract class AddressMessage extends Message {
 
     AddressMessage(ByteBuffer payload) throws ProtocolException {
         super(payload);
-    }
-
-    @Override
-    protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
-        if (addresses == null)
-            return;
-        stream.write(VarInt.of(addresses.size()).serialize());
-        for (PeerAddress addr : addresses) {
-            addr.bitcoinSerializeToStream(stream);
-        }
     }
 
     public abstract void addAddress(PeerAddress address);

--- a/core/src/main/java/org/bitcoinj/core/AddressV1Message.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressV1Message.java
@@ -21,9 +21,14 @@ import org.bitcoinj.base.VarInt;
 import org.bitcoinj.base.internal.InternalUtils;
 import org.bitcoinj.net.discovery.PeerDiscovery;
 
+import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Objects;
+
+import static org.bitcoinj.base.internal.Preconditions.checkArgument;
 
 /**
  * Represents an "addr" message on the P2P network, which contains broadcast IP addresses of other peers. This is
@@ -49,15 +54,23 @@ public class AddressV1Message extends AddressMessage {
         if (numAddresses > MAX_ADDRESSES)
             throw new ProtocolException("Address message too large.");
         addresses = new ArrayList<>(numAddresses);
-        MessageSerializer serializer = new DummySerializer(1);
         for (int i = 0; i < numAddresses; i++) {
-            PeerAddress addr = new PeerAddress(payload, serializer);
-            addresses.add(addr);
+            addresses.add(PeerAddress.read(payload, 1));
         }
     }
 
     public void addAddress(PeerAddress address) {
         addresses.add(address);
+    }
+
+    @Override
+    protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
+        if (addresses == null)
+            return;
+        stream.write(VarInt.of(addresses.size()).serialize());
+        for (PeerAddress addr : addresses) {
+            stream.write(addr.serialize(1));
+        }
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -1041,12 +1041,12 @@ public class PeerGroup implements TransactionBroadcaster {
 
     /** Convenience method for {@link #addAddress(PeerAddress)}. */
     public void addAddress(InetAddress address) {
-        addAddress(new PeerAddress(address, params.getPort()));
+        addAddress(PeerAddress.simple(address, params.getPort()));
     }
 
     /** Convenience method for {@link #addAddress(PeerAddress, int)}. */
     public void addAddress(InetAddress address, int priority) {
-        addAddress(new PeerAddress(address, params.getPort()), priority);
+        addAddress(PeerAddress.simple(address, params.getPort()), priority);
     }
 
     /**
@@ -1092,7 +1092,7 @@ public class PeerGroup implements TransactionBroadcaster {
                 log.warn(e.getMessage());
                 continue;
             }
-            for (InetSocketAddress address : addresses) addressList.add(new PeerAddress(address));
+            for (InetSocketAddress address : addresses) addressList.add(PeerAddress.simple(address));
             if (addressList.size() >= maxPeersToDiscoverCount) break;
         }
         if (!addressList.isEmpty()) {
@@ -1462,7 +1462,7 @@ public class PeerGroup implements TransactionBroadcaster {
     public Peer connectTo(InetSocketAddress address) {
         lock.lock();
         try {
-            PeerAddress peerAddress = new PeerAddress(address);
+            PeerAddress peerAddress = PeerAddress.simple(address);
             backoffMap.put(peerAddress, new ExponentialBackoff(peerBackoffParams));
             return connectTo(peerAddress, true, vConnectTimeout);
         } finally {

--- a/core/src/main/java/org/bitcoinj/core/PeerSocketHandler.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerSocketHandler.java
@@ -67,7 +67,7 @@ public abstract class PeerSocketHandler implements TimeoutHandler, StreamConnect
     private BitcoinSerializer.BitcoinPacketHeader header;
 
     public PeerSocketHandler(NetworkParameters params, InetSocketAddress remoteIp) {
-        this(params, new PeerAddress(remoteIp));
+        this(params, PeerAddress.simple(remoteIp));
     }
 
     public PeerSocketHandler(NetworkParameters params, PeerAddress peerAddress) {

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -820,7 +820,7 @@ public class WalletProtobufSerializer {
             }
             int port = proto.getPort();
             Services services = Services.of(proto.getServices());
-            PeerAddress address = new PeerAddress(ip, port, services);
+            PeerAddress address = PeerAddress.inet(ip, port, services, Instant.EPOCH);
             confidence.markBroadcastBy(address);
         }
         if (confidenceProto.hasLastBroadcastedAt())

--- a/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
@@ -19,6 +19,7 @@ package org.bitcoinj.core;
 
 import com.google.common.io.BaseEncoding;
 import org.bitcoinj.base.internal.ByteUtils;
+import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.TestNet3Params;
 import org.junit.Test;
@@ -28,6 +29,7 @@ import java.math.BigInteger;
 import java.net.InetAddress;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -76,7 +78,7 @@ public class BitcoinSerializerTest {
         assertEquals(31, addressMessage.getMessageSize());
 
         addressMessage.addAddress(new PeerAddress(InetAddress.getLocalHost(), MAINNET.getPort(),
-                Services.none(), new DummySerializer(1)));
+                Services.none(), TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS)));
         bos = new ByteArrayOutputStream(61);
         serializer.serialize(addressMessage, bos);
         assertEquals(61, addressMessage.getMessageSize());

--- a/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
@@ -77,7 +77,7 @@ public class BitcoinSerializerTest {
         serializer.serialize(addressMessage, bos);
         assertEquals(31, addressMessage.getMessageSize());
 
-        addressMessage.addAddress(new PeerAddress(InetAddress.getLocalHost(), MAINNET.getPort(),
+        addressMessage.addAddress(PeerAddress.inet(InetAddress.getLocalHost(), MAINNET.getPort(),
                 Services.none(), TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS)));
         bos = new ByteArrayOutputStream(61);
         serializer.serialize(addressMessage, bos);

--- a/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
@@ -191,8 +191,8 @@ public class ChainSplitTest {
         wallet.commitTx(spend);
         // Waiting for confirmation ... make it eligible for selection.
         assertEquals(Coin.ZERO, wallet.getBalance());
-        spend.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByAddress(new byte[]{1, 2, 3, 4}), TESTNET.getPort()));
-        spend.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByAddress(new byte[]{5,6,7,8}), TESTNET.getPort()));
+        spend.getConfidence().markBroadcastBy(PeerAddress.simple(InetAddress.getByAddress(new byte[]{1, 2, 3, 4}), TESTNET.getPort()));
+        spend.getConfidence().markBroadcastBy(PeerAddress.simple(InetAddress.getByAddress(new byte[]{5,6,7,8}), TESTNET.getPort()));
         assertEquals(ConfidenceType.PENDING, spend.getConfidence().getConfidenceType());
         assertEquals(valueOf(40, 0), wallet.getBalance());
         Block b2 = b1.createNextBlock(someOtherGuy);

--- a/core/src/test/java/org/bitcoinj/core/PeerAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerAddressTest.java
@@ -52,7 +52,7 @@ public class PeerAddressTest {
     @Test
     public void roundtrip_ipv4_addressV2Variant() throws Exception {
         Instant time = TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS);
-        PeerAddress pa = new PeerAddress(InetAddress.getByName("1.2.3.4"), 1234, Services.none(), time);
+        PeerAddress pa = PeerAddress.inet(InetAddress.getByName("1.2.3.4"), 1234, Services.none(), time);
         byte[] serialized = pa.serialize(2);
         PeerAddress pa2 = PeerAddress.read(ByteBuffer.wrap(serialized), 2);
         assertEquals("1.2.3.4", pa2.getAddr().getHostAddress());
@@ -64,7 +64,7 @@ public class PeerAddressTest {
     @Test
     public void roundtrip_ipv4_addressVariant() throws Exception {
         Instant time = TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS);
-        PeerAddress pa = new PeerAddress(InetAddress.getByName("1.2.3.4"), 1234, Services.none(), time);
+        PeerAddress pa = PeerAddress.inet(InetAddress.getByName("1.2.3.4"), 1234, Services.none(), time);
         byte[] serialized = pa.serialize(1);
         PeerAddress pa2 = PeerAddress.read(ByteBuffer.wrap(serialized), 1);
         assertEquals("1.2.3.4", pa2.getAddr().getHostAddress());
@@ -76,7 +76,7 @@ public class PeerAddressTest {
     @Test
     public void roundtrip_ipv6_addressV2Variant() throws Exception {
         Instant time = TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS);
-        PeerAddress pa = new PeerAddress(InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334"), 1234,
+        PeerAddress pa = PeerAddress.inet(InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334"), 1234,
                 Services.none(), time);
         byte[] serialized = pa.serialize(2);
         PeerAddress pa2 = PeerAddress.read(ByteBuffer.wrap(serialized), 2);
@@ -89,7 +89,7 @@ public class PeerAddressTest {
     @Test
     public void roundtrip_ipv6_addressVariant() throws Exception {
         Instant time = TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS);
-        PeerAddress pa = new PeerAddress(InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334"), 1234,
+        PeerAddress pa = PeerAddress.inet(InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334"), 1234,
                 Services.none(), time);
         byte[] serialized = pa.serialize(1);
         PeerAddress pa2 = PeerAddress.read(ByteBuffer.wrap(serialized), 1);

--- a/core/src/test/java/org/bitcoinj/core/PeerAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PeerAddressTest.java
@@ -44,7 +44,7 @@ public class PeerAddressTest {
     public void equalsContract() {
         EqualsVerifier.forClass(PeerAddress.class)
                 .suppress(Warning.NONFINAL_FIELDS)
-                .withIgnoredFields("time", "serializer")
+                .withIgnoredFields("time")
                 .usingGetClass()
                 .verify();
     }
@@ -52,10 +52,9 @@ public class PeerAddressTest {
     @Test
     public void roundtrip_ipv4_addressV2Variant() throws Exception {
         Instant time = TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS);
-        MessageSerializer serializer = new DummySerializer(2);
-        PeerAddress pa = new PeerAddress(InetAddress.getByName("1.2.3.4"), 1234, Services.none(), serializer);
-        byte[] serialized = pa.bitcoinSerialize();
-        PeerAddress pa2 = new PeerAddress(ByteBuffer.wrap(serialized), serializer);
+        PeerAddress pa = new PeerAddress(InetAddress.getByName("1.2.3.4"), 1234, Services.none(), time);
+        byte[] serialized = pa.serialize(2);
+        PeerAddress pa2 = PeerAddress.read(ByteBuffer.wrap(serialized), 2);
         assertEquals("1.2.3.4", pa2.getAddr().getHostAddress());
         assertEquals(1234, pa2.getPort());
         assertEquals(Services.none(), pa2.getServices());
@@ -65,10 +64,9 @@ public class PeerAddressTest {
     @Test
     public void roundtrip_ipv4_addressVariant() throws Exception {
         Instant time = TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS);
-        MessageSerializer serializer = new DummySerializer(1);
-        PeerAddress pa = new PeerAddress(InetAddress.getByName("1.2.3.4"), 1234, Services.none(), serializer);
-        byte[] serialized = pa.bitcoinSerialize();
-        PeerAddress pa2 = new PeerAddress(ByteBuffer.wrap(serialized), serializer);
+        PeerAddress pa = new PeerAddress(InetAddress.getByName("1.2.3.4"), 1234, Services.none(), time);
+        byte[] serialized = pa.serialize(1);
+        PeerAddress pa2 = PeerAddress.read(ByteBuffer.wrap(serialized), 1);
         assertEquals("1.2.3.4", pa2.getAddr().getHostAddress());
         assertEquals(1234, pa2.getPort());
         assertEquals(Services.none(), pa2.getServices());
@@ -78,11 +76,10 @@ public class PeerAddressTest {
     @Test
     public void roundtrip_ipv6_addressV2Variant() throws Exception {
         Instant time = TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS);
-        MessageSerializer serializer = new DummySerializer(2);
         PeerAddress pa = new PeerAddress(InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334"), 1234,
-                Services.none(), serializer);
-        byte[] serialized = pa.bitcoinSerialize();
-        PeerAddress pa2 = new PeerAddress(ByteBuffer.wrap(serialized), serializer);
+                Services.none(), time);
+        byte[] serialized = pa.serialize(2);
+        PeerAddress pa2 = PeerAddress.read(ByteBuffer.wrap(serialized), 2);
         assertEquals("2001:db8:85a3:0:0:8a2e:370:7334", pa2.getAddr().getHostAddress());
         assertEquals(1234, pa2.getPort());
         assertEquals(Services.none(), pa2.getServices());
@@ -92,11 +89,10 @@ public class PeerAddressTest {
     @Test
     public void roundtrip_ipv6_addressVariant() throws Exception {
         Instant time = TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS);
-        MessageSerializer serializer = new DummySerializer(1);
         PeerAddress pa = new PeerAddress(InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334"), 1234,
-                Services.none(), serializer);
-        byte[] serialized = pa.bitcoinSerialize();
-        PeerAddress pa2 = new PeerAddress(ByteBuffer.wrap(serialized), serializer);
+                Services.none(), time);
+        byte[] serialized = pa.serialize(1);
+        PeerAddress pa2 = PeerAddress.read(ByteBuffer.wrap(serialized), 1);
         assertEquals("2001:db8:85a3:0:0:8a2e:370:7334", pa2.getAddr().getHostAddress());
         assertEquals(1234, pa2.getPort());
         assertEquals(Services.none(), pa2.getServices());
@@ -106,8 +102,7 @@ public class PeerAddressTest {
     @Test
     @Parameters(method = "deserializeToStringValues")
     public void deserializeToString(int version, String expectedToString, String hex) {
-        MessageSerializer serializer = new DummySerializer(version);
-        PeerAddress pa = new PeerAddress(ByteBuffer.wrap(ByteUtils.parseHex(hex)), serializer);
+        PeerAddress pa = PeerAddress.read(ByteBuffer.wrap(ByteUtils.parseHex(hex)), version);
 
         assertEquals(expectedToString, pa.toString());
     }

--- a/core/src/test/java/org/bitcoinj/core/TxConfidenceTableTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TxConfidenceTableTest.java
@@ -61,9 +61,9 @@ public class TxConfidenceTableTest {
         tx2 = FakeTxBuilder.createFakeTxWithChangeAddress(COIN, to, change);
         assertEquals(tx1.getTxId(), tx2.getTxId());
 
-        address1 = new PeerAddress(InetAddress.getByAddress(new byte[] { 127, 0, 0, 1 }), TESTNET.getPort());
-        address2 = new PeerAddress(InetAddress.getByAddress(new byte[] { 127, 0, 0, 2 }), TESTNET.getPort());
-        address3 = new PeerAddress(InetAddress.getByAddress(new byte[] { 127, 0, 0, 3 }), TESTNET.getPort());
+        address1 = PeerAddress.simple(InetAddress.getByAddress(new byte[] { 127, 0, 0, 1 }), TESTNET.getPort());
+        address2 = PeerAddress.simple(InetAddress.getByAddress(new byte[] { 127, 0, 0, 2 }), TESTNET.getPort());
+        address3 = PeerAddress.simple(InetAddress.getByAddress(new byte[] { 127, 0, 0, 3 }), TESTNET.getPort());
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -139,8 +139,8 @@ public class WalletProtobufSerializerTest {
         // Check basic tx serialization.
         Coin v1 = COIN;
         Transaction t1 = createFakeTx(TESTNET.network(), v1, myAddress);
-        t1.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByName("1.2.3.4"), TESTNET.getPort()));
-        t1.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByName("5.6.7.8"), TESTNET.getPort()));
+        t1.getConfidence().markBroadcastBy(PeerAddress.simple(InetAddress.getByName("1.2.3.4"), TESTNET.getPort()));
+        t1.getConfidence().markBroadcastBy(PeerAddress.simple(InetAddress.getByName("5.6.7.8"), TESTNET.getPort()));
         t1.getConfidence().setSource(TransactionConfidence.Source.NETWORK);
         myWallet.receivePending(t1, null);
         Wallet wallet1 = roundTrip(myWallet);

--- a/core/src/test/java/org/bitcoinj/wallet/DefaultCoinSelectorTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DefaultCoinSelectorTest.java
@@ -69,9 +69,9 @@ public class DefaultCoinSelectorTest extends TestWithWallet {
         assertFalse(DefaultCoinSelector.isSelectable(t, BitcoinNetwork.TESTNET));
         t.getConfidence().setSource(TransactionConfidence.Source.SELF);
         assertFalse(DefaultCoinSelector.isSelectable(t, BitcoinNetwork.TESTNET));
-        t.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByName("1.2.3.4"), TESTNET.getPort()));
+        t.getConfidence().markBroadcastBy(PeerAddress.simple(InetAddress.getByName("1.2.3.4"), TESTNET.getPort()));
         assertTrue(DefaultCoinSelector.isSelectable(t, BitcoinNetwork.TESTNET));
-        t.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByName("5.6.7.8"), TESTNET.getPort()));
+        t.getConfidence().markBroadcastBy(PeerAddress.simple(InetAddress.getByName("5.6.7.8"), TESTNET.getPort()));
         assertTrue(DefaultCoinSelector.isSelectable(t, BitcoinNetwork.TESTNET));
         t = new Transaction();
         t.getConfidence().setConfidenceType(TransactionConfidence.ConfidenceType.BUILDING);

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -492,8 +492,8 @@ public class WalletTest extends TestWithWallet {
         final LinkedList<Transaction> txns = new LinkedList<>();
         wallet.addCoinsSentEventListener((wallet1, tx, prevBalance, newBalance) -> txns.add(tx));
 
-        t.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByAddress(new byte[]{1,2,3,4}), TESTNET.getPort()));
-        t.getConfidence().markBroadcastBy(new PeerAddress(InetAddress.getByAddress(new byte[]{10,2,3,4}), TESTNET.getPort()));
+        t.getConfidence().markBroadcastBy(PeerAddress.simple(InetAddress.getByAddress(new byte[]{1,2,3,4}), TESTNET.getPort()));
+        t.getConfidence().markBroadcastBy(PeerAddress.simple(InetAddress.getByAddress(new byte[]{10,2,3,4}), TESTNET.getPort()));
         wallet.commitTx(t);
         Threading.waitForUserCode();
         assertEquals(1, wallet.getPoolSize(WalletTransaction.Pool.PENDING));

--- a/examples/src/main/java/org/bitcoinj/examples/PrintPeers.java
+++ b/examples/src/main/java/org/bitcoinj/examples/PrintPeers.java
@@ -83,7 +83,7 @@ public class PrintPeers {
         for (final InetAddress addr : addrs) {
             InetSocketAddress address = new InetSocketAddress(addr, params.getPort());
             final Peer peer = new Peer(params, new VersionMessage(params, 0),
-                    new PeerAddress(address), null);
+                    PeerAddress.simple(address), null);
             final CompletableFuture<Void> future = new CompletableFuture<>();
             // Once the connection has completed version handshaking ...
             peer.addConnectedEventListener((p, peerCount) -> {

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -94,7 +94,7 @@ public class PeerTest extends TestWithNetworkConnections {
         super.setUp();
         VersionMessage ver = new VersionMessage(TESTNET, 100);
         InetSocketAddress address = new InetSocketAddress(InetAddress.getLoopbackAddress(), 4000);
-        peer = new Peer(TESTNET, ver, new PeerAddress(address), blockChain);
+        peer = new Peer(TESTNET, ver, PeerAddress.simple(address), blockChain);
         peer.addWallet(wallet);
     }
 
@@ -275,7 +275,7 @@ public class PeerTest extends TestWithNetworkConnections {
         // Check co-ordination of which peer to download via the memory pool.
         VersionMessage ver = new VersionMessage(TESTNET, 100);
         InetSocketAddress address = new InetSocketAddress(InetAddress.getLoopbackAddress(), 4242);
-        Peer peer2 = new Peer(TESTNET, ver, new PeerAddress(address), blockChain);
+        Peer peer2 = new Peer(TESTNET, ver, PeerAddress.simple(address), blockChain);
         peer2.addWallet(wallet);
         VersionMessage peerVersion = new VersionMessage(TESTNET, OTHER_PEER_CHAIN_HEIGHT);
         peerVersion.clientVersion = 70001;

--- a/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
@@ -244,7 +244,7 @@ public class BuildCheckpoints implements Callable<Integer> {
     }
 
     private static void startPeerGroup(PeerGroup peerGroup, InetAddress ipAddress) {
-        final PeerAddress peerAddress = new PeerAddress(ipAddress, params.getPort());
+        final PeerAddress peerAddress = PeerAddress.simple(ipAddress, params.getPort());
         System.out.println("Connecting to " + peerAddress + "...");
         peerGroup.addAddress(peerAddress);
         peerGroup.start();

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -1022,7 +1022,7 @@ public class WalletTool implements Callable<Integer> {
             String[] peerAddrs = peersStr.split(",");
             for (String peer : peerAddrs) {
                 try {
-                    peerGroup.addAddress(new PeerAddress(InetAddress.getByName(peer), params.getPort()));
+                    peerGroup.addAddress(PeerAddress.simple(InetAddress.getByName(peer), params.getPort()));
                 } catch (UnknownHostException e) {
                     System.err.println("Could not understand peer domain name/IP address: " + peer + ": " + e.getMessage());
                     System.exit(1);


### PR DESCRIPTION
It is never sent on its own, so it doesn't need to be a `Message`.

* Static constructur `read(protocolVariant)` replaces the native constructor that deserialized from a payload.
* `write()` helper replaces `bitcoinSerializeToStream()`.
* `serialize()` and `getMessageSize()` helpers replace `bitcoinSerialize()`.