### PR TITLE
Buffers.readLengthPrefixedBytes: handle prefix too big

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/internal/Buffers.java
+++ b/core/src/main/java/org/bitcoinj/base/internal/Buffers.java
@@ -17,6 +17,8 @@
 package org.bitcoinj.base.internal;
 
 import org.bitcoinj.base.VarInt;
+import org.bitcoinj.core.Message;
+import org.bitcoinj.core.ProtocolException;
 
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
@@ -54,10 +56,12 @@ public class Buffers {
      * @param buf buffer to read from
      * @return read bytes
      * @throws BufferUnderflowException if the read value extends beyond the remaining bytes of the buffer
+     * @throws ProtocolException if the length prefix is greater than the maximum allowed message size
      */
-    public static byte[] readLengthPrefixedBytes(ByteBuffer buf) throws BufferUnderflowException {
-        int length = VarInt.read(buf).intValue();
-        return readBytes(buf, length);
+    public static byte[] readLengthPrefixedBytes(ByteBuffer buf) throws BufferUnderflowException, ProtocolException {
+        long length = VarInt.read(buf).longValue();
+        check(length < Message.MAX_SIZE, () -> new ProtocolException("length prefix too long"));
+        return readBytes(buf, (int) length);
     }
 
     /**

--- a/core/src/test/java/org/bitcoinj/core/BuffersTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BuffersTest.java
@@ -55,4 +55,15 @@ public class BuffersTest {
             return bytes;
         }).limit(10).iterator();
     }
+
+    @Test(expected = ProtocolException.class)
+    public void readLengthPrefixedBytesPrefixTooBig() {
+        // Construct a pathological buffer with a prefix equal to max message size and no subsequent data
+        VarInt tooBig = VarInt.of(Message.MAX_SIZE);
+        ByteBuffer buf = ByteBuffer.allocate(tooBig.getSizeInBytes());
+        tooBig.write(buf);
+        assertFalse(buf.hasRemaining());
+        ((Buffer) buf).rewind();
+        Buffers.readLengthPrefixedBytes(buf);
+    }
 }


### PR DESCRIPTION
This assumes that `Buffers.readLengthPrefixedBytes` will only be used for parsing data that conforms to the max size for Bitcoin P2P messages. If that is unreasonable assumptions we could alternatively make sure that the `VarInt` does not exceed the remaining size of the `ByteBuffer`. 