### PR TITLE
Transaction: remove the input and output re-reading

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -640,13 +640,7 @@ public class Transaction extends Message {
         int numInputs = numInputsVarInt.intValue();
         inputs = new ArrayList<>(Math.min((int) numInputs, Utils.MAX_INITIAL_ARRAY_LENGTH));
         for (long i = 0; i < numInputs; i++) {
-            TransactionInput input = TransactionInput.read(payload.slice(), this);
-            inputs.add(input);
-            // intentionally read again, due to the slice above
-            Buffers.skipBytes(payload, TransactionOutPoint.BYTES);
-            VarInt scriptLenVarInt = VarInt.read(payload);
-            int scriptLen = scriptLenVarInt.intValue();
-            Buffers.skipBytes(payload, scriptLen + 4);
+            inputs.add(TransactionInput.read(payload, this));
         }
     }
 
@@ -655,13 +649,7 @@ public class Transaction extends Message {
         int numOutputs = numOutputsVarInt.intValue();
         outputs = new ArrayList<>(Math.min((int) numOutputs, Utils.MAX_INITIAL_ARRAY_LENGTH));
         for (long i = 0; i < numOutputs; i++) {
-            TransactionOutput output = TransactionOutput.read(payload.slice(), this);
-            outputs.add(output);
-            // intentionally read again, due to the slice above
-            Buffers.skipBytes(payload, 8); // value
-            VarInt scriptLenVarInt = VarInt.read(payload);
-            int scriptLen = scriptLenVarInt.intValue();
-            Buffers.skipBytes(payload, scriptLen);
+            outputs.add(TransactionOutput.read(payload, this));
         }
     }
 


### PR DESCRIPTION
We needed this to correctly determine the message length, but that requirement is gone.