### PR TITLE
Buffers, Messages: in various `parse()` methods, throw `BufferUnderflowException` if read length doesn't fit an int

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/VarInt.java
+++ b/core/src/main/java/org/bitcoinj/base/VarInt.java
@@ -107,12 +107,35 @@ public class VarInt {
         originallyEncodedSize = copy.originallyEncodedSize;
     }
 
+    /**
+     * Gets the value as a long. For values greater than {@link Long#MAX_VALUE} the returned long
+     * will be negative. It is still to be interpreted as an unsigned value.
+     *
+     * @return value as a long
+     */
     public long longValue() {
         return value;
     }
 
-    public int intValue() {
-        return Math.toIntExact(value);
+    /**
+     * Determine if the value would fit an int, i.e. it is in the range of {@code 0} to {@link Integer#MAX_VALUE}.
+     * If this is true, it's safe to call {@link #intValue()}.
+     *
+     * @return true if the value fits an int, false otherwise
+     */
+    public boolean fitsInt() {
+        return value >= 0 && value <= Integer.MAX_VALUE;
+    }
+
+    /**
+     * Gets the value as an unsigned int in the range of {@code 0} to {@link Integer#MAX_VALUE}.
+     *
+     * @return value as an unsigned int
+     * @throws ArithmeticException if the value doesn't fit an int
+     */
+    public int intValue() throws ArithmeticException {
+        check(fitsInt(), () -> new ArithmeticException("value too large for an int: " + value));
+        return (int) value;
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/base/internal/Buffers.java
+++ b/core/src/main/java/org/bitcoinj/base/internal/Buffers.java
@@ -56,8 +56,9 @@ public class Buffers {
      * @throws BufferUnderflowException if the read value extends beyond the remaining bytes of the buffer
      */
     public static byte[] readLengthPrefixedBytes(ByteBuffer buf) throws BufferUnderflowException {
-        int length = VarInt.read(buf).intValue();
-        return readBytes(buf, length);
+        VarInt length = VarInt.read(buf);
+        check(length.fitsInt(), BufferUnderflowException::new);
+        return readBytes(buf, length.intValue());
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/AddressV1Message.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressV1Message.java
@@ -28,6 +28,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Objects;
 
+import static org.bitcoinj.base.internal.Preconditions.check;
 import static org.bitcoinj.base.internal.Preconditions.checkArgument;
 
 /**
@@ -48,7 +49,8 @@ public class AddressV1Message extends AddressMessage {
 
     @Override
     protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
-        final VarInt numAddressesVarInt = VarInt.read(payload);
+        VarInt numAddressesVarInt = VarInt.read(payload);
+        check(numAddressesVarInt.fitsInt(), BufferUnderflowException::new);
         int numAddresses = numAddressesVarInt.intValue();
         // Guard against ultra large messages that will crash us.
         if (numAddresses > MAX_ADDRESSES)

--- a/core/src/main/java/org/bitcoinj/core/AddressV2Message.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressV2Message.java
@@ -26,6 +26,7 @@ import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 
+import static org.bitcoinj.base.internal.Preconditions.check;
 import static org.bitcoinj.base.internal.Preconditions.checkArgument;
 
 /**
@@ -47,7 +48,8 @@ public class AddressV2Message extends AddressMessage {
 
     @Override
     protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
-        final VarInt numAddressesVarInt = VarInt.read(payload);
+        VarInt numAddressesVarInt = VarInt.read(payload);
+        check(numAddressesVarInt.fitsInt(), BufferUnderflowException::new);
         int numAddresses = numAddressesVarInt.intValue();
         // Guard against ultra large messages that will crash us.
         if (numAddresses > MAX_ADDRESSES)

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -55,6 +55,7 @@ import java.util.Locale;
 
 import static org.bitcoinj.base.Coin.FIFTY_COINS;
 import static org.bitcoinj.base.Sha256Hash.hashTwice;
+import static org.bitcoinj.base.internal.Preconditions.check;
 import static org.bitcoinj.base.internal.Preconditions.checkState;
 
 /**
@@ -196,8 +197,9 @@ public class Block extends Message {
     /**
      * Parse transactions from the block.
      */
-    protected void parseTransactions(ByteBuffer payload) throws ProtocolException {
+    protected void parseTransactions(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         VarInt numTransactionsVarInt = VarInt.read(payload);
+        check(numTransactionsVarInt.fitsInt(), BufferUnderflowException::new);
         int numTransactions = numTransactionsVarInt.intValue();
         transactions = new ArrayList<>(Math.min(numTransactions, Utils.MAX_INITIAL_ARRAY_LENGTH));
         for (int i = 0; i < numTransactions; i++) {

--- a/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
@@ -26,6 +26,8 @@ import java.io.OutputStream;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 
+import static org.bitcoinj.base.internal.Preconditions.check;
+
 /**
  * <p>Represents the "getblocks" P2P network message, which requests the hashes of the parts of the block chain we're
  * missing. Those blocks can then be downloaded with a {@link GetDataMessage}.</p>
@@ -51,7 +53,9 @@ public class GetBlocksMessage extends Message {
     @Override
     protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         version = ByteUtils.readUint32(payload);
-        int startCount = VarInt.read(payload).intValue();
+        VarInt startCountVarInt = VarInt.read(payload);
+        check(startCountVarInt.fitsInt(), BufferUnderflowException::new);
+        int startCount = startCountVarInt.intValue();
         if (startCount > 500)
             throw new ProtocolException("Number of locators cannot be > 500, received: " + startCount);
         locator = new BlockLocator();

--- a/core/src/main/java/org/bitcoinj/core/HeadersMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/HeadersMessage.java
@@ -29,6 +29,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.bitcoinj.base.internal.Preconditions.check;
+
 /**
  * <p>A protocol message that contains a repeated series of block headers, sent in response to the "getheaders" command.
  * This is useful when you want to traverse the chain but know you don't care about the block contents, for example,
@@ -69,7 +71,9 @@ public class HeadersMessage extends Message {
 
     @Override
     protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
-        int numHeaders = VarInt.read(payload).intValue();
+        VarInt numHeadersVarInt = VarInt.read(payload);
+        check(numHeadersVarInt.fitsInt(), BufferUnderflowException::new);
+        int numHeaders = numHeadersVarInt.intValue();
         if (numHeaders > MAX_HEADERS)
             throw new ProtocolException("Too many headers: got " + numHeaders + " which is larger than " +
                                          MAX_HEADERS);

--- a/core/src/main/java/org/bitcoinj/core/ListMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/ListMessage.java
@@ -30,6 +30,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.bitcoinj.base.internal.Preconditions.check;
+
 /**
  * <p>Abstract superclass of classes with list based payload, ie InventoryMessage and GetDataMessage.</p>
  * 
@@ -65,7 +67,9 @@ public abstract class ListMessage extends Message {
 
     @Override
     protected void parse(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
-        int arrayLen = VarInt.read(payload).intValue();
+        VarInt arrayLenVarInt = VarInt.read(payload);
+        check(arrayLenVarInt.fitsInt(), BufferUnderflowException::new);
+        int arrayLen = arrayLenVarInt.intValue();
         if (arrayLen > MAX_INVENTORY_ITEMS)
             throw new ProtocolException("Too many items in INV message: " + arrayLen);
 

--- a/core/src/main/java/org/bitcoinj/core/PartialMerkleTree.java
+++ b/core/src/main/java/org/bitcoinj/core/PartialMerkleTree.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 import static org.bitcoinj.base.internal.ByteUtils.checkBitLE;
 import static org.bitcoinj.base.internal.ByteUtils.reverseBytes;
 import static org.bitcoinj.base.internal.ByteUtils.writeInt32LE;
+import static org.bitcoinj.base.internal.Preconditions.check;
 
 /**
  * <p>A data structure that contains proofs of block inclusion for one or more transactions, in an efficient manner.</p>
@@ -82,7 +83,9 @@ public class PartialMerkleTree {
      */
     public static PartialMerkleTree read(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         int transactionCount = (int) ByteUtils.readUint32(payload);
-        int nHashes = VarInt.read(payload).intValue();
+        VarInt nHashesVarInt = VarInt.read(payload);
+        check(nHashesVarInt.fitsInt(), BufferUnderflowException::new);
+        int nHashes = nHashesVarInt.intValue();
         List<Sha256Hash> hashes = new ArrayList<>(Math.min(nHashes, Utils.MAX_INITIAL_ARRAY_LENGTH));
         for (int i = 0; i < nHashes; i++)
             hashes.add(Sha256Hash.read(payload));

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -69,6 +69,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeMap;
 
+import static org.bitcoinj.base.internal.Preconditions.check;
 import static org.bitcoinj.base.internal.Preconditions.checkArgument;
 import static org.bitcoinj.base.internal.Preconditions.checkState;
 import static org.bitcoinj.core.ProtocolVersion.WITNESS_VERSION;
@@ -637,6 +638,7 @@ public class Transaction extends Message {
 
     private void parseInputs(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         VarInt numInputsVarInt = VarInt.read(payload);
+        check(numInputsVarInt.fitsInt(), BufferUnderflowException::new);
         int numInputs = numInputsVarInt.intValue();
         inputs = new ArrayList<>(Math.min((int) numInputs, Utils.MAX_INITIAL_ARRAY_LENGTH));
         for (long i = 0; i < numInputs; i++) {
@@ -652,6 +654,7 @@ public class Transaction extends Message {
 
     private void parseOutputs(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         VarInt numOutputsVarInt = VarInt.read(payload);
+        check(numOutputsVarInt.fitsInt(), BufferUnderflowException::new);
         int numOutputs = numOutputsVarInt.intValue();
         outputs = new ArrayList<>(Math.min((int) numOutputs, Utils.MAX_INITIAL_ARRAY_LENGTH));
         for (long i = 0; i < numOutputs; i++) {

--- a/core/src/main/java/org/bitcoinj/core/TransactionWitness.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionWitness.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import static org.bitcoinj.base.internal.Preconditions.check;
 import static org.bitcoinj.base.internal.Preconditions.checkArgument;
 
 public class TransactionWitness {
@@ -92,7 +93,9 @@ public class TransactionWitness {
      * @throws BufferUnderflowException if the read message extends beyond the remaining bytes of the payload
      */
     public static TransactionWitness read(ByteBuffer payload) throws BufferUnderflowException {
-        int pushCount = VarInt.read(payload).intValue();
+        VarInt pushCountVarInt = VarInt.read(payload);
+        check(pushCountVarInt.fitsInt(), BufferUnderflowException::new);
+        int pushCount = pushCountVarInt.intValue();
         List<byte[]> pushes = new ArrayList<>(Math.min(pushCount, Utils.MAX_INITIAL_ARRAY_LENGTH));
         for (int y = 0; y < pushCount; y++)
             pushes.add(Buffers.readLengthPrefixedBytes(payload));

--- a/core/src/test/java/org/bitcoinj/base/VarIntTest.java
+++ b/core/src/test/java/org/bitcoinj/base/VarIntTest.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnitParamsRunner.class)
 public class VarIntTest {
@@ -34,6 +35,7 @@ public class VarIntTest {
     @Parameters(method = "integerTestVectors")
     public void testIntCreation(int value, int size) {
         VarInt a = VarInt.of(value);
+        assertTrue(a.fitsInt());
         assertEquals(value, a.intValue());
         assertEquals(size, a.getSizeInBytes());
         assertEquals(size, a.getOriginalSizeInBytes());
@@ -45,6 +47,7 @@ public class VarIntTest {
     @Parameters(method = "longTestVectors")
     public void testIntGetErr(int value, int size) {
         VarInt a = VarInt.of(value);
+        assertFalse(a.fitsInt());
         a.intValue();
     }
 
@@ -52,6 +55,7 @@ public class VarIntTest {
     @Parameters(method = "longTestVectors")
     public void testIntGetErr2(int value, int size) {
         VarInt a = VarInt.of(value);
+        assertFalse(a.fitsInt());
         VarInt.ofBytes(a.serialize(), 0).intValue();
     }
 
@@ -89,10 +93,7 @@ public class VarIntTest {
                 new Object[]{ 0x7FFF, 3},
                 new Object[]{ 0x8000, 3},
                 new Object[]{ 0x10000, 5},
-                new Object[]{ Integer.MIN_VALUE, 9},
                 new Object[]{ Integer.MAX_VALUE, 5},
-                // -1 shouldn't normally be passed, but at least stay consistent (bug regression test)
-                new Object[]{ -1, 9}
         };
     }
 
@@ -105,9 +106,9 @@ public class VarIntTest {
                 new Object[]{ 0xAABBCCDDL, 5},
                 new Object[]{ 0xFFFFFFFFL, 5},
                 new Object[]{ 0xCAFEBABEDEADBEEFL, 9},
+                new Object[]{ Integer.MIN_VALUE, 9},
                 new Object[]{ Long.MIN_VALUE, 9},
                 new Object[]{ Long.MAX_VALUE, 9},
-                // -1 shouldn't normally be passed, but at least stay consistent (bug regression test)
                 new Object[]{ -1L, 9}
         };
     }


### PR DESCRIPTION
(followup PR to #3024) 

Previously, `ArithmeticException` was thrown which is unlikely to be handled by consumers.
    
`BufferUnderflowException` is the correct exception to throw, under the assumption that a giant length can't be followed by a collection of equally giant length.
