### PR TITLE
Message: restore deprecated method `unsafeBitcoinSerialize()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/BaseMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/BaseMessage.java
@@ -52,12 +52,6 @@ public abstract class BaseMessage implements Message {
         return stream.toByteArray();
     }
 
-    /** @deprecated use {@link #serialize()} */
-    @Deprecated
-    public byte[] unsafeBitcoinSerialize() {
-        return serialize();
-    }
-
     /**
      * Serializes this message to the provided stream. If you just want the raw bytes use bitcoinSerialize().
      */

--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -56,4 +56,10 @@ public interface Message {
     default byte[] bitcoinSerialize()  {
         return serialize();
     }
+
+    /** @deprecated use {@link #serialize()} */
+    @Deprecated
+    default byte[] unsafeBitcoinSerialize() {
+        return serialize();
+    }
 }

--- a/core/src/test/java/org/bitcoinj/core/MessageTest.java
+++ b/core/src/test/java/org/bitcoinj/core/MessageTest.java
@@ -16,5 +16,14 @@
 
 package org.bitcoinj.core;
 
+import org.junit.Test;
+
 public class MessageTest {
+    @Test
+    public void deprecatedMembers() {
+        Message message = new UnknownMessage("dummy");
+        message.bitcoinSerialize();
+        message.unsafeBitcoinSerialize();
+        message.getMessageSize();
+    }
 }


### PR DESCRIPTION
Also adds a `deprecatedMembers()` test.