### PR TITLE
BitcoinURI: rework exception handling for amount field

### DIFF
--- a/core/src/main/java/org/bitcoinj/uri/BitcoinURI.java
+++ b/core/src/main/java/org/bitcoinj/uri/BitcoinURI.java
@@ -224,15 +224,11 @@ public class BitcoinURI {
                 // Decode the amount (contains an optional decimal component to 8dp).
                 try {
                     Coin amount = Coin.parseCoin(valueToken);
-                    if (network.exceedsMaxMoney(amount))
-                        throw new BitcoinURIParseException("Max number of coins exceeded");
                     if (amount.signum() < 0)
-                        throw new ArithmeticException("Negative coins specified");
+                        throw new OptionalFieldValidationException("negative amount not allowed: " + valueToken);
                     putWithValidation(FIELD_AMOUNT, amount);
                 } catch (IllegalArgumentException e) {
-                    throw new OptionalFieldValidationException(String.format(Locale.US, "'%s' is not a valid amount", valueToken), e);
-                } catch (ArithmeticException e) {
-                    throw new OptionalFieldValidationException(String.format(Locale.US, "'%s' has too many decimal places", valueToken), e);
+                    throw new OptionalFieldValidationException("not a valid amount: " + valueToken, e);
                 }
             } else {
                 if (nameToken.startsWith("req-")) {

--- a/core/src/test/java/org/bitcoinj/uri/BitcoinURITest.java
+++ b/core/src/test/java/org/bitcoinj/uri/BitcoinURITest.java
@@ -25,6 +25,7 @@ import org.bitcoinj.params.Networks;
 import org.bitcoinj.testing.MockAltNetworkParams;
 import org.junit.Test;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Locale;
@@ -216,6 +217,11 @@ public class BitcoinURITest {
         testObject = new BitcoinURI(BITCOIN_SCHEME + ":" + MAINNET_GOOD_ADDRESS
                 + "?amount=6543210", MAINNET);
         assertEquals("654321000000000", testObject.getAmount().toString());
+
+        // the maximum amount
+        testObject = new BitcoinURI(BITCOIN_SCHEME + ":" + MAINNET_GOOD_ADDRESS
+                + "?amount=" + new BigDecimal(Long.MAX_VALUE).movePointLeft(8), MAINNET);
+        assertEquals(Long.MAX_VALUE, testObject.getAmount().longValue());
     }
 
     /**
@@ -403,8 +409,9 @@ public class BitcoinURITest {
 
     @Test(expected = BitcoinURIParseException.class)
     public void testBad_TooLargeAmount() throws BitcoinURIParseException {
+        BigDecimal tooLargeByOne = new BigDecimal(Long.MAX_VALUE).add(BigDecimal.ONE);
         new BitcoinURI(BITCOIN_SCHEME + ":" + MAINNET_GOOD_ADDRESS
-                + "?amount=100000000", MAINNET);
+                + "?amount=" + tooLargeByOne.movePointLeft(8), MAINNET);
     }
 
     @Test


### PR DESCRIPTION
* The check against `maxMoney` is removed. There BIP21 spec does not restrict the amount towards positive infinity. The new maximum is now dictated by `Coin.parseCoin()`: `Long.MAX_VALUE` satoshis
* The check for negative amounts now throws `OptionalFieldValidationException` directly, rather than re-throwing via `ArithmeticException`.
* Exception messages now use string concatenation like everywhere else.
* Tests around the new max amount are added/changed.