### PR TITLE
KeyChainGroup: migrate to `Network` from `NetworkParameters`

### DIFF
--- a/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
+++ b/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
@@ -508,7 +508,7 @@ public class WalletAppKit extends AbstractIdleService implements Closeable {
     }
 
     protected Wallet createWallet() {
-        KeyChainGroup.Builder kcg = KeyChainGroup.builder(params, structure);
+        KeyChainGroup.Builder kcg = KeyChainGroup.builder(network, structure);
         if (restoreFromSeed != null)
             kcg.fromSeed(restoreFromSeed, preferredOutputScriptType);
         else if (restoreFromKey != null)

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroupStructure.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroupStructure.java
@@ -62,7 +62,9 @@ public interface KeyChainGroupStructure {
      * @param outputScriptType output script type (purpose)
      * @param networkParameters network/coin type
      * @return The HD Path: purpose / coinType / accountIndex
+     * @deprecated use {@link #accountPathFor(ScriptType, Network)}
      */
+    @Deprecated
     default HDPath accountPathFor(ScriptType outputScriptType, NetworkParameters networkParameters) {
         return accountPathFor(outputScriptType, networkParameters.network());
     }

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -343,7 +343,7 @@ public class Wallet extends BaseTaggableObject
      * @return A new empty wallet
      */
     public static Wallet createDeterministic(Network network, ScriptType outputScriptType, KeyChainGroupStructure keyChainGroupStructure) {
-        return new Wallet(network, KeyChainGroup.builder(NetworkParameters.of(network), keyChainGroupStructure).fromRandom(outputScriptType).build());
+        return new Wallet(network, KeyChainGroup.builder(network, keyChainGroupStructure).fromRandom(outputScriptType).build());
     }
 
     /**
@@ -351,7 +351,7 @@ public class Wallet extends BaseTaggableObject
      */
     @Deprecated
     public static Wallet createDeterministic(NetworkParameters params, ScriptType outputScriptType, KeyChainGroupStructure keyChainGroupStructure) {
-        return new Wallet(params.network(), KeyChainGroup.builder(params, keyChainGroupStructure).fromRandom(outputScriptType).build());
+        return new Wallet(params.network(), KeyChainGroup.builder(params.network(), keyChainGroupStructure).fromRandom(outputScriptType).build());
     }
 
     /**
@@ -360,7 +360,7 @@ public class Wallet extends BaseTaggableObject
      * @param network network wallet will operate on
      */
     public static Wallet createBasic(Network network) {
-        return new Wallet(network, KeyChainGroup.createBasic(NetworkParameters.of(network)));
+        return new Wallet(network, KeyChainGroup.createBasic(network));
     }
 
     /**
@@ -400,7 +400,7 @@ public class Wallet extends BaseTaggableObject
      */
     public static Wallet fromSeed(Network network, DeterministicSeed seed, ScriptType outputScriptType,
             KeyChainGroupStructure structure) {
-        return new Wallet(network, KeyChainGroup.builder(NetworkParameters.of(network), structure).fromSeed(seed, outputScriptType).build());
+        return new Wallet(network, KeyChainGroup.builder(network, structure).fromSeed(seed, outputScriptType).build());
     }
 
     /**
@@ -423,7 +423,7 @@ public class Wallet extends BaseTaggableObject
             List<ChildNumber> accountPath) {
         DeterministicKeyChain chain = DeterministicKeyChain.builder().seed(seed).outputScriptType(outputScriptType)
                 .accountPath(accountPath).build();
-        return new Wallet(network, KeyChainGroup.builder(NetworkParameters.of(network)).addChain(chain).build());
+        return new Wallet(network, KeyChainGroup.builder(network).addChain(chain).build());
     }
 
     /**
@@ -443,7 +443,7 @@ public class Wallet extends BaseTaggableObject
             ScriptType outputScriptType) {
         DeterministicKeyChain chain = DeterministicKeyChain.builder().watch(watchKey).outputScriptType(outputScriptType)
                 .build();
-        return new Wallet(network, KeyChainGroup.builder(NetworkParameters.of(network)).addChain(chain).build());
+        return new Wallet(network, KeyChainGroup.builder(network).addChain(chain).build());
     }
 
     /**
@@ -515,7 +515,7 @@ public class Wallet extends BaseTaggableObject
             ScriptType outputScriptType) {
         DeterministicKeyChain chain = DeterministicKeyChain.builder().spend(spendKey).outputScriptType(outputScriptType)
                 .build();
-        return new Wallet(network, KeyChainGroup.builder(NetworkParameters.of(network)).addChain(chain).build());
+        return new Wallet(network, KeyChainGroup.builder(network).addChain(chain).build());
     }
 
     /**
@@ -526,7 +526,7 @@ public class Wallet extends BaseTaggableObject
                                          ScriptType outputScriptType) {
         DeterministicKeyChain chain = DeterministicKeyChain.builder().spend(spendKey).outputScriptType(outputScriptType)
                 .build();
-        return new Wallet(params.network(), KeyChainGroup.builder(params).addChain(chain).build());
+        return new Wallet(params.network(), KeyChainGroup.builder(params.network()).addChain(chain).build());
     }
 
     /**
@@ -595,7 +595,7 @@ public class Wallet extends BaseTaggableObject
             accountKey.clearCreationTime();
         DeterministicKeyChain chain = DeterministicKeyChain.builder().spend(accountKey)
                 .outputScriptType(outputScriptType).build();
-        return new Wallet(network, KeyChainGroup.builder(NetworkParameters.of(network)).addChain(chain).build());
+        return new Wallet(network, KeyChainGroup.builder(network).addChain(chain).build());
     }
 
     /**
@@ -5749,7 +5749,7 @@ public class Wallet extends BaseTaggableObject
                     log.info(
                             "All deterministic chains are currently rotating and we have no random keys, creating fresh {} chain: backup required after this.",
                             preferredScriptType);
-                    KeyChainGroup newChains = KeyChainGroup.builder(params, structure).fromRandom(preferredScriptType)
+                    KeyChainGroup newChains = KeyChainGroup.builder(network, structure).fromRandom(preferredScriptType)
                             .build();
                     if (keyChainGroup.isEncrypted()) {
                         if (aesKey == null)
@@ -5772,7 +5772,7 @@ public class Wallet extends BaseTaggableObject
                 log.info(
                         "No non-rotating random keys available, generating entirely new {} tree: backup required after this.",
                         preferredScriptType);
-                KeyChainGroup newChains = KeyChainGroup.builder(params, structure).fromRandom(preferredScriptType)
+                KeyChainGroup newChains = KeyChainGroup.builder(network, structure).fromRandom(preferredScriptType)
                         .build();
                 if (keyChainGroup.isEncrypted()) {
                     if (aesKey == null)

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -499,9 +499,9 @@ public class WalletProtobufSerializer {
         if (walletProto.hasEncryptionParameters()) {
             Protos.ScryptParameters encryptionParameters = walletProto.getEncryptionParameters();
             final KeyCrypterScrypt keyCrypter = new KeyCrypterScrypt(encryptionParameters);
-            keyChainGroup = KeyChainGroup.fromProtobufEncrypted(params, walletProto.getKeyList(), keyCrypter, keyChainFactory);
+            keyChainGroup = KeyChainGroup.fromProtobufEncrypted(params.network(), walletProto.getKeyList(), keyCrypter, keyChainFactory);
         } else {
-            keyChainGroup = KeyChainGroup.fromProtobufUnencrypted(params, walletProto.getKeyList(), keyChainFactory);
+            keyChainGroup = KeyChainGroup.fromProtobufUnencrypted(params.network(), walletProto.getKeyList(), keyChainFactory);
         }
         Wallet wallet = factory.create(params.network(), keyChainGroup);
 

--- a/core/src/test/java/org/bitcoinj/core/BloomFilterTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BloomFilterTest.java
@@ -85,7 +85,7 @@ public class BloomFilterTest {
         Address addr = privKey.getKey().toAddress(ScriptType.P2PKH, BitcoinNetwork.MAINNET);
         assertEquals("17Wx1GQfyPTNWpQMHrTwRSMTCAonSiZx9e", addr.toString());
 
-        KeyChainGroup group = KeyChainGroup.builder(MAINNET).build();
+        KeyChainGroup group = KeyChainGroup.builder(BitcoinNetwork.MAINNET).build();
         // Add a random key which happens to have been used in a recent generation
         group.importKeys(ECKey.fromPublicOnly(privKey.getKey()), ECKey.fromPublicOnly(ByteUtils.parseHex("03cb219f69f1b49468bd563239a86667e74a06fcba69ac50a08a5cbc42a5808e99")));
         Wallet wallet = new Wallet(BitcoinNetwork.MAINNET, group);

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -109,7 +109,7 @@ public class WalletProtobufSerializerTest {
         myKey = new ECKey();
         myKey.setCreationTime(Instant.ofEpochSecond(123456789L));
         myAddress = myKey.toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
-        myWallet = new Wallet(BitcoinNetwork.TESTNET, KeyChainGroup.builder(TESTNET).fromRandom(ScriptType.P2PKH).build());
+        myWallet = new Wallet(BitcoinNetwork.TESTNET, KeyChainGroup.builder(BitcoinNetwork.TESTNET).fromRandom(ScriptType.P2PKH).build());
         myWallet.importKey(myKey);
         mScriptCreationTime = TimeUtils.currentTime().minusSeconds(1234);
         myWallet.addWatchedAddress(myWatchedKey.toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET), mScriptCreationTime);

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -657,7 +657,7 @@ public class DeterministicKeyChainTest {
         DeterministicKey accountKey = HDKeyDerivation.deriveChildKey(coinLevelKey, new ChildNumber(0, true));
         accountKey = accountKey.dropParent();
         accountKey.setCreationTime(watchingKey.creationTime().get());
-        KeyChainGroup group = KeyChainGroup.builder(NetworkParameters.of(network)).addChain(DeterministicKeyChain.builder().spend(accountKey)
+        KeyChainGroup group = KeyChainGroup.builder(network).addChain(DeterministicKeyChain.builder().spend(accountKey)
                 .outputScriptType(bip44chain.getOutputScriptType()).build()).build();
         DeterministicKeyChain fromMasterKeyChain = group.getActiveKeyChain();
         assertEquals(BIP44_COIN_1_ACCOUNT_ZERO_PATH, fromMasterKeyChain.getAccountPath());

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -220,7 +220,7 @@ public class WalletTest extends TestWithWallet {
     @Test
     public void encryptDecryptWalletWithArbitraryPathAndScriptType() throws Exception {
         final byte[] ENTROPY = Sha256Hash.hash("don't use a string seed like this in real life".getBytes());
-        KeyChainGroup keyChainGroup = KeyChainGroup.builder(TESTNET)
+        KeyChainGroup keyChainGroup = KeyChainGroup.builder(BitcoinNetwork.TESTNET)
                 .addChain(DeterministicKeyChain.builder().seed(DeterministicSeed.ofEntropy(ENTROPY, "", Instant.ofEpochSecond(1389353062L)))
                         .outputScriptType(ScriptType.P2WPKH)
                         .accountPath(DeterministicKeyChain.BIP44_ACCOUNT_ZERO_PATH).build())
@@ -3220,7 +3220,7 @@ public class WalletTest extends TestWithWallet {
     @Test
     public void keyEvents() {
         // Check that we can register an event listener, generate some keys and the callbacks are invoked properly.
-        wallet = new Wallet(BitcoinNetwork.TESTNET, KeyChainGroup.builder(TESTNET).fromRandom(ScriptType.P2PKH).build());
+        wallet = new Wallet(BitcoinNetwork.TESTNET, KeyChainGroup.builder(BitcoinNetwork.TESTNET).fromRandom(ScriptType.P2PKH).build());
         final List<ECKey> keys = new LinkedList<>();
         wallet.addKeyChainEventListener(Threading.SAME_THREAD, keys::addAll);
         wallet.freshReceiveKey();
@@ -3504,7 +3504,7 @@ public class WalletTest extends TestWithWallet {
                 .outputScriptType(ScriptType.P2PKH).build();
         DeterministicKeyChain p2wpkhChain = DeterministicKeyChain.builder().random(new SecureRandom())
                 .outputScriptType(ScriptType.P2WPKH).build();
-        KeyChainGroup kcg = KeyChainGroup.builder(TESTNET).addChain(p2pkhChain).addChain(p2wpkhChain).build();
+        KeyChainGroup kcg = KeyChainGroup.builder(BitcoinNetwork.TESTNET).addChain(p2pkhChain).addChain(p2wpkhChain).build();
         Wallet wallet = new Wallet(BitcoinNetwork.TESTNET, kcg);
 
         // Set up one key from each chain.

--- a/integration-test/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
+++ b/integration-test/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
@@ -111,7 +111,7 @@ public class TestWithNetworkConnections {
         // Allow subclasses to override the wallet object with their own.
         if (wallet == null) {
             // Reduce the number of keys we need to work with to speed up these tests.
-            KeyChainGroup kcg = KeyChainGroup.builder(UNITTEST).lookaheadSize(4).lookaheadThreshold(2)
+            KeyChainGroup kcg = KeyChainGroup.builder(UNITTEST.network()).lookaheadSize(4).lookaheadThreshold(2)
                     .fromRandom(ScriptType.P2PKH).build();
             wallet = new Wallet(UNITTEST.network(), kcg);
             address = wallet.freshReceiveAddress(ScriptType.P2PKH);


### PR DESCRIPTION
Followup to #3044 and #3045.

It has one commit on top:

* KeyChainGroupStructure: deprecate `accountPathFor()` variant that takes `NetworkParameters`
  It seems this was forgotten earlier.
