### PR TITLE
gitlab-ci.yml: create template job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,25 +1,29 @@
-before_script:
-  - apt-get update
+.debian-job-configuration: &debian-job-configuration
+  before_script:
+    - apt-get update
+  after_script:
+    - gradle --version
+  script:
+    - apt-get -y install $JDK_PKG gradle
+    - gradle build --stacktrace
 
-after_script:
-  - gradle --version
+.debian-test:
+  stage: test
+  variables:
+    JDK_PKG: openjdk-11-jdk-headless
+  artifacts:
+    name: bitcoinj-$CI_JOB_NAME-$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHORT_SHA
+    paths:
+      - core/build/libs/*.jar
 
 bullseye-jdk11:
+  <<: *debian-job-configuration
+  extends: .debian-test
   image: debian:bullseye-slim
-  script:
-    - apt-get -y install openjdk-11-jdk-headless gradle
-    - gradle build --stacktrace
-  artifacts:
-    name: bitcoinj-$CI_JOB_NAME-$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHORT_SHA
-    paths:
-      - core/build/libs/*.jar
 
 bookworm-jdk17:
+  <<: *debian-job-configuration
+  extends: .debian-test
   image: debian:bookworm-slim
-  script:
-    - apt-get -y install openjdk-17-jdk-headless gradle
-    - gradle build --stacktrace
-  artifacts:
-    name: bitcoinj-$CI_JOB_NAME-$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHORT_SHA
-    paths:
-      - core/build/libs/*.jar
+  variables:
+    JDK_PKG: openjdk-17-jdk-headless


### PR DESCRIPTION
* Add YAML anchor &debian-job-configuration
* Add template job named .debian-test
* Modify existing bullseye-jdk11 and bookworm-jdk17 jobs to extend it

This PR has two advantages:

1. It removes the global before_script/after_script settings that can interfere if we add other jobs
2. It allow common-code between the two debian jobs to be more easily maintained.

Having to use both YAML anchors and a template job to do this is not as elegant as I would like. We could just duplicate the `before_script` and `after_script` in each job.

(Update: see PR #3051 which simply puts the `before_script` and `after_script` in each job.)