### PR TITLE
Fixes duplicate inputs in `completeTx`

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4550,13 +4550,42 @@ public class Wallet extends BaseTaggableObject
             log.info("Completing send tx with {} outputs totalling {} and a fee of {}/vkB", req.tx.getOutputs().size(),
                     value.toFriendlyString(), req.feePerKb.toFriendlyString());
 
+            // Calculate a list of ALL potential candidates for spending and then ask a coin selector to provide us
+            // with the actual outputs that'll be used to gather the required amount of value. In this way, users
+            // can customize coin selection policies. The call below will ignore immature coinbases and outputs
+            // we don't have the keys for.
+            List<TransactionOutput> candidates = calculateAllSpendCandidates(true, req.missingSigsMode == MissingSigsMode.THROW);
+
             // If any inputs have already been added, we don't need to get their value from wallet
             Coin totalInput = Coin.ZERO;
-            for (TransactionInput input : req.tx.getInputs())
-                if (input.getConnectedOutput() != null)
-                    totalInput = totalInput.add(input.getConnectedOutput().getValue());
-                else
+            for (TransactionInput input : req.tx.getInputs()){
+
+                Coin inputValue = null;
+                if (input.getConnectedOutput() == null){
+                    // Check to see if the input can be matched with
+                    // a candidate from the wallet
+                    for(TransactionOutput candidate: candidates){
+                        TransactionOutPoint outpoint = input.getOutpoint();
+                        Sha256Hash parentTransactionHash = candidate.getParentTransactionHash();
+                        if(Objects.equals(parentTransactionHash, outpoint.getHash()) &&
+                                candidate.getIndex() == outpoint.index()){
+
+                            // Found a the matching candidate and can use its value
+                            inputValue = candidate.getValue();
+                            break;
+                        }
+                    }
+                } else {
+                    inputValue = input.getConnectedOutput().getValue();
+                }
+
+                if (inputValue != null){
+                    totalInput = totalInput.add(inputValue);
+                } else {
+                    // TODO: 2023-04-06 is this even a good idea just throwing away coins like this?
                     log.warn("SendRequest transaction already has inputs but we don't know how much they are worth - they will be added to fee.");
+                }
+            }
             value = value.subtract(totalInput);
 
             // Check for dusty sends and the OP_RETURN limit.
@@ -4571,12 +4600,6 @@ public class Wallet extends BaseTaggableObject
                 if (opReturnCount > 1) // Only 1 OP_RETURN per transaction allowed.
                     throw new MultipleOpReturnRequested();
             }
-
-            // Calculate a list of ALL potential candidates for spending and then ask a coin selector to provide us
-            // with the actual outputs that'll be used to gather the required amount of value. In this way, users
-            // can customize coin selection policies. The call below will ignore immature coinbases and outputs
-            // we don't have the keys for.
-            List<TransactionOutput> candidates = calculateAllSpendCandidates(true, req.missingSigsMode == MissingSigsMode.THROW);
 
             // Remove candidates already used in the SendRequest
             candidates = removeExistingInputs(candidates, req);

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -2855,6 +2855,8 @@ public class WalletTest extends TestWithWallet {
         wallet.receiveFromBlock(tx2, block, AbstractBlockChain.NewBlockType.BEST_CHAIN, 1);
         Transaction tx3 = createFakeTx(TESTNET.network(), CENT, myAddress);
         wallet.receiveFromBlock(tx3, block, AbstractBlockChain.NewBlockType.BEST_CHAIN, 2);
+        Transaction txOutsideWallet = createFakeTx(TESTNET.network(), CENT, OTHER_ADDRESS);
+        wallet.receiveFromBlock(txOutsideWallet, block, AbstractBlockChain.NewBlockType.BEST_CHAIN, 2);
 
         SendRequest request1 = SendRequest.to(OTHER_ADDRESS, CENT);
         // If we just complete as-is, we will use one of the COIN outputs to get higher priority,
@@ -2880,7 +2882,7 @@ public class WalletTest extends TestWithWallet {
 
         // However, if there is no connected output, we will grab a COIN output anyway and add the CENT to fee
         SendRequest request3 = SendRequest.to(OTHER_ADDRESS, CENT);
-        request3.tx.addInput(new TransactionInput(request3.tx, new byte[] {}, new TransactionOutPoint(0, tx3.getTxId())));
+        request3.tx.addInput(new TransactionInput(request3.tx, new byte[] {}, new TransactionOutPoint(0, txOutsideWallet.getTxId())));
         // Now completeTx will result in two inputs, two outputs and a fee of a CENT
         // Note that it is simply assumed that the inputs are correctly signed, though in fact the first is not
         request3.shuffleOutputs = false;


### PR DESCRIPTION
Proposed fix for https://github.com/bitcoinj/bitcoinj/issues/2063 . If the input is already in the transaction then it is not added again as an input to the transaction. This fix also checks the wallet for the value of an unconnected input and counts that towards `SendRequest.value`. This changes the current behaviour where the value of unconnected inputs is ignored and simply added to the transaction's fee which seems wasteful. 