### PR TITLE
core/build.gradle: conditionally use withSourcesJar/withJavadocJar

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -97,19 +97,29 @@ jar {
     }
 }
 
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
 
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
+def minGradleSourcesJavadocVersion = GradleVersion.version("6.0")
+if (GradleVersion.current().compareTo(minGradleSourcesJavadocVersion) > 0) {
+    java {
+        withSourcesJar()
+        withJavadocJar()
+    }
+} else {
+    // This is not compatible with building with Gradle 8/Java 20
+    task javadocJar(type: Jar, dependsOn: javadoc) {
+        classifier = 'javadoc'
+        from javadoc.destinationDir
+    }
 
-artifacts {
-    archives sourcesJar
-    archives javadocJar
+    task sourcesJar(type: Jar, dependsOn: classes) {
+        classifier = 'sources'
+        from sourceSets.main.allSource
+    }
+
+    artifacts {
+        archives sourcesJar
+        archives javadocJar
+    }
 }
 
 publishing {
@@ -117,9 +127,10 @@ publishing {
         mavenJava(MavenPublication) {
             artifactId = 'bitcoinj-core'
             from components.java
-            artifact sourcesJar
-            artifact javadocJar
-
+            if (GradleVersion.current().compareTo(minGradleSourcesJavadocVersion) > 0) {
+                artifact sourcesJar
+                artifact javadocJar
+            }
             pom {
                 description = 'A Java Bitcoin library'
             }


### PR DESCRIPTION
`withSourcesJar()` and `withJavadocJar()` are the cleanest way to do this with recent Gradle versions, but require conditionals because they won't work on Gradle versions earlier than Gradle 6.0.

`classifier` is removed in Gradle 8.x so this PR or an equivalent PR (see PR #3058) that also replaces `classifier` is needed to compile with Gradle 8.x (and Java 20)