### PR TITLE
core/build.gradle: Use archiveClassifier if available

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -97,13 +97,23 @@ jar {
     }
 }
 
+def minGradleArchiveClassifierVersion = GradleVersion.version("5.0")
+
 task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
+    if (GradleVersion.current().compareTo(minGradleArchiveClassifierVersion) > 0) {
+        archiveClassifier.set('javadoc')
+    } else {
+        classifier = 'javadoc'
+    }
     from javadoc.destinationDir
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
+    if (GradleVersion.current().compareTo(minGradleArchiveClassifierVersion) > 0) {
+        archiveClassifier.set('sources')
+    } else {
+        classifier = 'sources'
+    }
     from sourceSets.main.allSource
 }
 


### PR DESCRIPTION
`classifier` is removed in Gradle 8.x, so use `archiveClassifier` if Gradle 5.0 or later.

classifier is removed in Gradle 8.x so this PR or an equivalent PR (see PR #3057) that also replaces classifier is needed to compile with Gradle 8.x (and Java 20)