### PR TITLE
Gradle build: Upgrade protobuf Gradle plugin (for Gradle 8, Java 20)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     // If using Gradle 7, use the compatible protobuf plugin, else use the one that works with oldest supported Gradle
     boolean isGradle7 = GradleVersion.current().compareTo(GradleVersion.version("7.0")) >= 0
-    def gradleProtobufVersion = isGradle7 ? "0.8.18" : "0.8.10"
+    def gradleProtobufVersion = isGradle7 ? "0.9.4" : "0.8.10"
     if (isGradle7) {
         System.err.println "Warning: Using com.google.protobuf:protobuf-gradle-plugin:${gradleProtobufVersion} because ${GradleVersion.current()}"
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -50,7 +50,6 @@ protobuf {
             }
         }
     }
-    generatedFilesBaseDir = new File(projectDir, '/src') // workaround for '$projectDir/src'
 }
 
 tasks.withType(Test) {


### PR DESCRIPTION
* ~~Upgrade protobuf-javalite to version 3.22.3~~
* Upgrade Gradle protobuf plugin to version 0.9.4 (if Gradle 7 or later)
* Remove generated ProtoBuf files, they're now produced in build/generated/...