### PR TITLE
GitHub Actions gradle.yml: build with Java 20

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
         java-version: [ '17' ]
         distribution: [ 'graalvm-community' ]
-        gradle: ['7.6.2']
+        gradle: ['8.3']
       fail-fast: false
     name: ${{ matrix.os }} JDK ${{ matrix.java-version }}.${{ matrix.distribution }}
     steps:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         java: ['11', '17', '19']
         distribution: ['temurin']
-        gradle: ['7.6.2']
+        gradle: ['8.3']
         include:
           # Special case to test something close to Debian config with the oldest supported (standard) Gradle on Ubuntu
           - os: ubuntu-latest

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        java: ['11', '17', '19']
+        java: ['11', '17', '20']
         distribution: ['temurin']
         gradle: ['8.3']
         include:


### PR DESCRIPTION
This is a test branch/PR that shows the steps necessary to get to a Java 20 build.

The next steps are:

1. Merge #3059 (or an alternative solution to get Protobuf ready for Gradle 8)
2. Start using Gradle 8.x on GitHub Actions
3. Start using Java 20 on GitHub Actions

The three commits in this (rebased) branch correspond to the above 3 steps.
