### PR TITLE
BitcoinSerializer: remove equals() and hashCode()

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
+++ b/core/src/main/java/org/bitcoinj/core/BitcoinSerializer.java
@@ -421,18 +421,4 @@ public class BitcoinSerializer extends MessageSerializer {
             System.arraycopy(header, cursor, checksum, 0, 4);
         }
     }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || !(o instanceof BitcoinSerializer)) return false;
-        BitcoinSerializer other = (BitcoinSerializer) o;
-        return Objects.equals(packetMagic, other.packetMagic) &&
-                protocolVersion == other.protocolVersion;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(network, protocolVersion);
-    }
 }

--- a/core/src/main/java/org/bitcoinj/params/BitcoinNetworkParams.java
+++ b/core/src/main/java/org/bitcoinj/params/BitcoinNetworkParams.java
@@ -248,7 +248,7 @@ public abstract class BitcoinNetworkParams extends NetworkParameters {
 
     @Override
     public BitcoinSerializer getSerializer() {
-        return new BitcoinSerializer(this);
+        return new BitcoinSerializer(network);
     }
 
     @Override

--- a/core/src/test/java/org/bitcoinj/core/CheckpointManagerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/CheckpointManagerTest.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.core;
 
+import org.bitcoinj.base.BitcoinNetwork;
 import org.easymock.EasyMockRunner;
 import org.easymock.Mock;
 import org.junit.Test;
@@ -57,7 +58,7 @@ public class CheckpointManagerTest {
     public void canReadTextualStream() throws IOException {
         expect(params.getId()).andReturn("org/bitcoinj/core/checkpointmanagertest/validTextualFormat");
         expect(params.getSerializer()).andReturn(
-                new BitcoinSerializer(params, ProtocolVersion.CURRENT.intValue()));
+                new BitcoinSerializer(BitcoinNetwork.MAINNET, ProtocolVersion.CURRENT.intValue()));
         replay(params);
         new CheckpointManager(params, null);
     }

--- a/core/src/test/java/org/bitcoinj/core/SendHeadersMessageTest.java
+++ b/core/src/test/java/org/bitcoinj/core/SendHeadersMessageTest.java
@@ -17,7 +17,7 @@
 package org.bitcoinj.core;
 
 import com.google.common.io.BaseEncoding;
-import org.bitcoinj.params.RegTestParams;
+import org.bitcoinj.base.BitcoinNetwork;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertTrue;
 
 public class SendHeadersMessageTest {
     private static final BaseEncoding HEX = BaseEncoding.base16().lowerCase();
-    private static final NetworkParameters REGTEST = RegTestParams.get();
 
     @Test
     public void decodeAndEncode() throws Exception {
@@ -40,7 +39,7 @@ public class SendHeadersMessageTest {
                         + "c96fe88d4a0f01ed9dedae2b6f9e00da94cad0fecaae66ecf689bf71b50000000000000000000000000000000000000000000000000");
 
         ByteBuffer buffer = ByteBuffer.wrap(message);
-        BitcoinSerializer serializer = new BitcoinSerializer(REGTEST);
+        BitcoinSerializer serializer = new BitcoinSerializer(BitcoinNetwork.REGTEST);
         assertTrue(serializer.deserialize(buffer) instanceof SendHeadersMessage);
     }
 }

--- a/integration-test/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTest.java
@@ -56,7 +56,7 @@ import static org.junit.Assert.fail;
 
 @RunWith(value = Parameterized.class)
 public class FilteredBlockAndPartialMerkleTreeTest extends TestWithPeerGroup {
-    private static final BitcoinSerializer SERIALIZER = new BitcoinSerializer(TESTNET);
+    private static final BitcoinSerializer SERIALIZER = new BitcoinSerializer(BitcoinNetwork.TESTNET);
 
     @Parameterized.Parameters
     public static Collection<ClientType[]> parameters() {


### PR DESCRIPTION
These methods are not needed.

(Child of PR #2919)