### PR TITLE
UnitTestParams: don't `solve()` the genesis block for unit tests

### DIFF
--- a/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
@@ -76,7 +76,6 @@ public class UnitTestParams extends BitcoinNetworkParams {
                 genesisBlock = Block.createGenesis();
                 genesisBlock.setDifficultyTarget(Block.EASIEST_DIFFICULTY_TARGET);
                 genesisBlock.setTime(TimeUtils.currentTime());
-                genesisBlock.solve();
             }
         }
         return genesisBlock;


### PR DESCRIPTION
It won't really solve it anyway, because the difficulty check is disabled.