### PR TITLE
StoredBlock: make `deserializeCompact()` not use `MessageSerializer`

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
+++ b/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
@@ -145,7 +145,7 @@ public class CheckpointManager {
             for (int i = 0; i < numCheckpoints; i++) {
                 if (dis.read(buffer.array(), 0, size) < size)
                     throw new IOException("Incomplete read whilst loading checkpoints.");
-                StoredBlock block = StoredBlock.deserializeCompact(params.getDefaultSerializer(), buffer);
+                StoredBlock block = StoredBlock.deserializeCompact(buffer);
                 ((Buffer) buffer).position(0);
                 checkpoints.put(block.getHeader().time(), block);
             }
@@ -183,7 +183,7 @@ public class CheckpointManager {
                 ((Buffer) buffer).position(0);
                 buffer.put(bytes);
                 ((Buffer) buffer).position(0);
-                StoredBlock block = StoredBlock.deserializeCompact(params.getDefaultSerializer(), buffer);
+                StoredBlock block = StoredBlock.deserializeCompact(buffer);
                 checkpoints.put(block.getHeader().time(), block);
             }
             HashCode hash = hasher.hash();

--- a/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
@@ -246,7 +246,7 @@ public class SPVBlockStore implements BlockStore {
                 buffer.get(scratch);
                 if (Arrays.equals(scratch, targetHashBytes)) {
                     // Found the target.
-                    StoredBlock storedBlock = StoredBlock.deserializeCompact(params.getDefaultSerializer(), buffer);
+                    StoredBlock storedBlock = StoredBlock.deserializeCompact(buffer);
                     blockCache.put(hash, storedBlock);
                     return storedBlock;
                 }

--- a/core/src/test/java/org/bitcoinj/core/CheckpointManagerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/CheckpointManagerTest.java
@@ -56,8 +56,6 @@ public class CheckpointManagerTest {
     @Test
     public void canReadTextualStream() throws IOException {
         expect(params.getId()).andReturn("org/bitcoinj/core/checkpointmanagertest/validTextualFormat");
-        expect(params.getSerializer()).andReturn(
-                new BitcoinSerializer(params, ProtocolVersion.CURRENT.intValue()));
         replay(params);
         new CheckpointManager(params, null);
     }


### PR DESCRIPTION
Its usecase is limited to fixed formats, currently binary checkpoints and `.spv` block stores.