### PR TITLE
Use TransactionOutput.serialize() not bitcoinSerialize()

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -232,7 +232,7 @@ public class TransactionOutput {
         // so dust is a spendable txout less than
         // 98*dustRelayFee/1000 (in satoshis).
         // 294 satoshis at the default rate of 3000 sat/kB.
-        long size = this.bitcoinSerialize().length;
+        long size = this.serialize().length;
         final Script script = getScriptPubKey();
         if (ScriptPattern.isP2PKH(script) || ScriptPattern.isP2PK(script) || ScriptPattern.isP2SH(script))
             size += 32 + 4 + 1 + 107 + 4; // 148

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -5397,7 +5397,7 @@ public class Wallet extends BaseTaggableObject
             }
             for (int i = 0; i < req.tx.getOutputs().size(); i++) {
                 TransactionOutput output = TransactionOutput.read(
-                        ByteBuffer.wrap(req.tx.getOutput(i).bitcoinSerialize()), tx);
+                        ByteBuffer.wrap(req.tx.getOutput(i).serialize()), tx);
                 if (req.recipientsPayFees) {
                     // Subtract fee equally from each selected recipient
                     output.setValue(output.getValue().subtract(fee.divide(req.tx.getOutputs().size())));


### PR DESCRIPTION
Fix the last two usages of this deprecated method.