### PR TITLE
Wallet.completeTx: use forEach to add inputs to req.tx

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4589,8 +4589,8 @@ public class Wallet extends BaseTaggableObject
                 log.info("  emptying {}", bestCoinSelection.totalValue().toFriendlyString());
             }
 
-            for (TransactionOutput output : bestCoinSelection.outputs())
-                req.tx.addInput(output);
+            bestCoinSelection.outputs()
+                    .forEach(req.tx::addInput);
 
             if (req.emptyWallet) {
                 if (!adjustOutputDownwardsForFee(req.tx, bestCoinSelection, req.feePerKb, req.ensureMinRequiredFee))


### PR DESCRIPTION
(This is in preparation for a forthcoming PR, but is also a reasonable standalone change)