### PR TITLE
README: Fix link to GitLab pipelines

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
 image:https://github.com/bitcoinj/bitcoinj/workflows/Java%20CI/badge.svg[GitHub Build Status,link=https://github.com/bitcoinj/bitcoinj/actions]
-image:https://gitlab.com/bitcoinj/bitcoinj/badges/master/pipeline.svg[GitLab Build Status,link=https://gitlab.com/bitcoinj/bitcoinj/pipelines]
+image:https://gitlab.com/bitcoinj/bitcoinj/badges/master/pipeline.svg[GitLab Build Status,link=https://gitlab.com/bitcoinj/bitcoinj/-/pipelines]
 image:https://coveralls.io/repos/bitcoinj/bitcoinj/badge.png?branch=master[Coverage Status,link=https://coveralls.io/r/bitcoinj/bitcoinj?branch=master]
 
 image::https://kiwiirc.com/buttons/irc.freenode.net/bitcoinj.png[Visit our IRC channel,link=https://kiwiirc.com/client/irc.freenode.net/bitcoinj]


### PR DESCRIPTION
This is a 2-character change that fixes a broken link to https://gitlab.com/bitcoinj/bitcoinj/-/pipelines