### PR TITLE
MultiplexingDiscovery: REGTEST fix

### DIFF
--- a/core/src/main/java/org/bitcoinj/net/discovery/MultiplexingDiscovery.java
+++ b/core/src/main/java/org/bitcoinj/net/discovery/MultiplexingDiscovery.java
@@ -38,6 +38,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import static org.bitcoinj.base.BitcoinNetwork.REGTEST;
 import static org.bitcoinj.base.internal.Preconditions.checkArgument;
 
 /**
@@ -89,7 +90,7 @@ public class MultiplexingDiscovery implements PeerDiscovery {
 
     private MultiplexingDiscovery(NetworkParameters params, List<PeerDiscovery> seeds, boolean parallelQueries,
                                   boolean shufflePeers) {
-        checkArgument(!seeds.isEmpty());
+        checkArgument(!seeds.isEmpty() || params.network() == REGTEST);
         this.netParams = params;
         this.seeds = seeds;
         this.parallelQueries = parallelQueries;

--- a/wallettool/src/test/java/org/bitcoinj/wallettool/WalletToolTest.java
+++ b/wallettool/src/test/java/org/bitcoinj/wallettool/WalletToolTest.java
@@ -16,6 +16,8 @@
 
 package org.bitcoinj.wallettool;
 
+import org.checkerframework.framework.qual.IgnoreInWholeProgramInference;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import picocli.CommandLine;
@@ -82,6 +84,20 @@ public class WalletToolTest {
         int exitCode = execute("create", "--wallet", walletFile, "--date", date);
 
         assertEquals(0, exitCode);
+    }
+
+    @Disabled("Requires a RegTest Bitcoin Core instance that is manually advanced by 1 block")
+    @Test
+    void waitForBlock(@TempDir File tempDir) {
+        String walletFile = tempDir.getPath() + "/wallet";
+        String date = "2023-05-01";
+        int createExitCode = execute("create", "--net", "regtest", "--wallet", walletFile, "--date", date);
+        assertEquals(0, createExitCode);
+
+        // TODO: Add a JSON-RPC client that can tell the server to generate 1 block
+
+        int syncExitCode = execute("sync", "--wallet", walletFile, "--net", "regtest", "--waitfor", "BLOCK");
+        assertEquals(0, syncExitCode);
     }
 
     /**


### PR DESCRIPTION
checkArgument should not throw with an empty seeds list *if* running on REGTEST.

I found this bug running `WalletTool` (see the @Disabled test that I added.)

The test is disabled because it requires a REGTEST node that is advanced 1 block (typically via `generateblocktoaddres`) during the course of the test.