### PR TITLE
Threading.THREAD_POOL: Use j.u.c.ExecutorService

### DIFF
--- a/core/src/main/java/org/bitcoinj/protocols/payments/PaymentSession.java
+++ b/core/src/main/java/org/bitcoinj/protocols/payments/PaymentSession.java
@@ -17,7 +17,6 @@
 package org.bitcoinj.protocols.payments;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.bitcoin.protocols.payments.Protos;
 import org.bitcoinj.base.Address;
@@ -50,6 +49,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 
 /**
  * <p>Provides a standard implementation of the Payment Protocol (BIP 0070)</p>
@@ -79,7 +79,7 @@ import java.util.concurrent.CompletableFuture;
  * @see <a href="https://github.com/bitcoin/bips/blob/master/bip-0070.mediawiki">BIP 0070</a>
  */
 public class PaymentSession {
-    private final static ListeningExecutorService executor = Threading.THREAD_POOL;
+    private final static ExecutorService executor = Threading.THREAD_POOL;
     private NetworkParameters params;
     private Protos.PaymentRequest paymentRequest;
     private Protos.PaymentDetails paymentDetails;

--- a/core/src/main/java/org/bitcoinj/utils/Threading.java
+++ b/core/src/main/java/org/bitcoinj/utils/Threading.java
@@ -17,8 +17,6 @@
 package org.bitcoinj.utils;
 
 import com.google.common.util.concurrent.CycleDetectingLockFactory;
-import com.google.common.util.concurrent.ListeningExecutorService;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.bitcoinj.base.internal.PlatformUtils;
 import org.slf4j.Logger;
@@ -185,12 +183,10 @@ public class Threading {
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     /** A caching thread pool that creates daemon threads, which won't keep the JVM alive waiting for more work. */
-    public static ListeningExecutorService THREAD_POOL = MoreExecutors.listeningDecorator(
-            Executors.newCachedThreadPool(r -> {
-                Thread t = new Thread(r);
-                t.setName("Threading.THREAD_POOL worker");
-                t.setDaemon(true);
-                return t;
-            })
-    );
+    public static ExecutorService THREAD_POOL = Executors.newCachedThreadPool(r -> {
+        Thread t = new Thread(r);
+        t.setName("Threading.THREAD_POOL worker");
+        t.setDaemon(true);
+        return t;
+    });
 }


### PR DESCRIPTION
Guava's ListeningExecutorService is no longer needed.

Update type of private executor in PaymentSession to match.