### PR TITLE
AddressParser: simplify by replacing Strict with Simple

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/Address.java
+++ b/core/src/main/java/org/bitcoinj/base/Address.java
@@ -50,7 +50,7 @@ public interface Address extends Comparable<Address> {
         AddressParser addressParser = DefaultAddressParser.fromNetworks();
         return (params != null)
                     ? addressParser.parseAddress(str, params.network())
-                    : addressParser.parseAddressAnyNetwork(str);
+                    : addressParser.parseAddress(str);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/base/AddressParser.java
+++ b/core/src/main/java/org/bitcoinj/base/AddressParser.java
@@ -23,12 +23,12 @@ import org.bitcoinj.base.exceptions.AddressFormatException;
  */
 public interface AddressParser {
     /**
-     * Parse an address that could be for any network
+     * Parse an address for any known/configured network
      * @param addressString string representation of address
      * @return A validated address object
      * @throws AddressFormatException invalid address string
      */
-    Address parseAddressAnyNetwork(String addressString) throws AddressFormatException;
+    Address parseAddress(String addressString) throws AddressFormatException;
 
     /**
      * Parse an address and validate for specified network
@@ -40,11 +40,43 @@ public interface AddressParser {
     Address parseAddress(String addressString, Network network) throws AddressFormatException;
 
     /**
+     * Parse an address for any known/configured network
+     * @param addressString string representation of address
+     * @return A validated address object
+     * @throws AddressFormatException invalid address string
+     * @deprecated Use {@link #parseAddress(String)}
+     */
+    @Deprecated /* Added in 0.17-alpha1, Deprecated after 0.17-alpha1, to be removed before 0.17 final */
+    default Address parseAddressAnyNetwork(String addressString) throws AddressFormatException {
+        return parseAddress(addressString);
+    }
+
+    /**
+     * Functional interface for address parsing. It takes a single parameter, like {@link AddressParser#parseAddress(String)}
+     * but its behavior is context-specific. This interface may be
+     * implemented by creating a partial application of ({@link AddressParser#parseAddress(String, Network)} providing
+     * a fixed value for {@link Network}. Or it may behave more like {@link #parseAddress(String)} with a context-specific
+     * list of networks.
+     */
+    @FunctionalInterface
+    interface Simple {
+        /**
+         * Parse an address in a context-specific way (i.e. with a configured list of valid networks)
+         * @param addressString string representation of address
+         * @return A validated address object
+         * @throws AddressFormatException invalid address string or not valid for network (provided by context)
+         */
+        Address parseAddress(String addressString) throws AddressFormatException;
+    }
+
+    /**
      * Functional interface for strict parsing. It takes a single parameter, like {@link AddressParser#parseAddressAnyNetwork(String)}
      * but is used in a context where a specific {@link Network} has been specified. This interface may be
      * implemented by creating a partial application of ({@link AddressParser#parseAddress(String, Network)} providing
      * a fixed value for {@link Network}.
+     * @deprecated You probably want to use {@link AddressParser.Simple}, though the semantics of <q>strict</q> no longer apply.
      */
+    @Deprecated  /* Added in 0.17-alpha1, Deprecated after 0.17-alpha1, to be removed before 0.17 final */
     @FunctionalInterface
     interface Strict {
         /**

--- a/core/src/main/java/org/bitcoinj/base/DefaultAddressParser.java
+++ b/core/src/main/java/org/bitcoinj/base/DefaultAddressParser.java
@@ -79,7 +79,7 @@ public class DefaultAddressParser implements AddressParser {
     }
 
     @Override
-    public Address parseAddressAnyNetwork(String addressString) throws AddressFormatException {
+    public Address parseAddress(String addressString) throws AddressFormatException {
         try {
             return parseBase58AnyNetwork(addressString);
         } catch (AddressFormatException.WrongNetwork x) {

--- a/core/src/main/java/org/bitcoinj/base/LegacyAddress.java
+++ b/core/src/main/java/org/bitcoinj/base/LegacyAddress.java
@@ -177,7 +177,7 @@ public class LegacyAddress implements Address {
         AddressParser parser = DefaultAddressParser.fromNetworks();
         return (LegacyAddress) ((params != null)
                 ? parser.parseAddress(base58, params.network())
-                : parser.parseAddressAnyNetwork(base58));
+                : parser.parseAddress(base58));
     }
 
     /**
@@ -255,7 +255,7 @@ public class LegacyAddress implements Address {
      */
     @Deprecated
     public static NetworkParameters getParametersFromAddress(String address) throws AddressFormatException {
-        return NetworkParameters.fromAddress(DefaultAddressParser.fromNetworks().parseAddressAnyNetwork(address));
+        return NetworkParameters.fromAddress(DefaultAddressParser.fromNetworks().parseAddress(address));
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/base/SegwitAddress.java
+++ b/core/src/main/java/org/bitcoinj/base/SegwitAddress.java
@@ -252,7 +252,7 @@ public class SegwitAddress implements Address {
      * @return constructed address
      * @throws AddressFormatException
      *             if something about the given bech32 address isn't right
-     * @deprecated Use {@link AddressParser#parseAddress(String, Network)} or {@link AddressParser#parseAddressAnyNetwork(String)}
+     * @deprecated Use {@link AddressParser#parseAddress(String, Network)} or {@link AddressParser#parseAddress(String)}
      */
     @Deprecated
     public static SegwitAddress fromBech32(@Nullable NetworkParameters params, String bech32)
@@ -260,7 +260,7 @@ public class SegwitAddress implements Address {
         AddressParser parser = DefaultAddressParser.fromNetworks();
         return (SegwitAddress) (params != null
                 ? parser.parseAddress(bech32, params.network())
-                : parser.parseAddressAnyNetwork(bech32)
+                : parser.parseAddress(bech32)
         );
     }
 

--- a/core/src/main/java/org/bitcoinj/uri/BitcoinURI.java
+++ b/core/src/main/java/org/bitcoinj/uri/BitcoinURI.java
@@ -197,7 +197,7 @@ public class BitcoinURI {
                 DefaultAddressParser addressParser = new DefaultAddressParser();
                 Address address = network != null ?
                         addressParser.parseAddress(addressToken, network) :
-                        addressParser.parseAddressAnyNetwork(addressToken);
+                        addressParser.parseAddress(addressToken);
                 putWithValidation(FIELD_ADDRESS, address);
             } catch (final AddressFormatException e) {
                 throw new BitcoinURIParseException("Bad address", e);

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -183,7 +183,7 @@ import static org.bitcoinj.base.internal.Preconditions.checkState;
  */
 public class Wallet extends BaseTaggableObject
     implements NewBestBlockListener, TransactionReceivedInBlockListener, PeerFilterProvider,
-        KeyBag, TransactionBag, ReorganizeListener, AddressParser.Strict {
+        KeyBag, TransactionBag, ReorganizeListener, AddressParser.Simple {
     private static final Logger log = LoggerFactory.getLogger(Wallet.class);
     private static final AddressParser addressParser = new DefaultAddressParser();
 

--- a/core/src/test/java/org/bitcoinj/base/AddressComparatorSortTest.java
+++ b/core/src/test/java/org/bitcoinj/base/AddressComparatorSortTest.java
@@ -50,7 +50,7 @@ public class AddressComparatorSortTest {
                     // Test net, Segwit
                     "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
                     "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
-            ).map(addressParser::parseAddressAnyNetwork)
+            ).map(addressParser::parseAddress)
             .collect(StreamUtils.toUnmodifiableList());
 
     @Test

--- a/core/src/test/java/org/bitcoinj/base/LegacyAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/base/LegacyAddressTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -134,9 +133,9 @@ public class LegacyAddressTest {
     @Test
     public void getNetwork() {
         AddressParser parser = new DefaultAddressParser();
-        Network mainNet = parser.parseAddressAnyNetwork("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL").network();
+        Network mainNet = parser.parseAddress("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL").network();
         assertEquals(MAINNET, mainNet);
-        Network testNet = parser.parseAddressAnyNetwork("n4eA2nbYqErp7H6jebchxAN59DmNpksexv").network();
+        Network testNet = parser.parseAddress("n4eA2nbYqErp7H6jebchxAN59DmNpksexv").network();
         assertEquals(TESTNET, testNet);
     }
 
@@ -148,17 +147,17 @@ public class LegacyAddressTest {
         Networks.register(altNetParams);
         try {
             // Check if can parse address
-            Address altAddress = DefaultAddressParser.fromNetworks().parseAddressAnyNetwork("LLxSnHLN2CYyzB5eWTR9K9rS9uWtbTQFb6");
+            Address altAddress = DefaultAddressParser.fromNetworks().parseAddress("LLxSnHLN2CYyzB5eWTR9K9rS9uWtbTQFb6");
             assertEquals(altNetParams.getId(), altAddress.network().id());
             // Check if main network works as before
-            Address mainAddress = new DefaultAddressParser().parseAddressAnyNetwork("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL");
+            Address mainAddress = new DefaultAddressParser().parseAddress("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL");
             assertEquals(MAINNET.id(), mainAddress.network().id());
         } finally {
             // Unregister network. Do this in a finally block so other tests don't fail if the try block fails to complete
             Networks.unregister(altNetParams);
         }
         try {
-            DefaultAddressParser.fromNetworks().parseAddressAnyNetwork("LLxSnHLN2CYyzB5eWTR9K9rS9uWtbTQFb6");
+            DefaultAddressParser.fromNetworks().parseAddress("LLxSnHLN2CYyzB5eWTR9K9rS9uWtbTQFb6");
             fail();
         } catch (AddressFormatException e) { }
     }
@@ -178,11 +177,11 @@ public class LegacyAddressTest {
         try {
 
             // Check if can parse address
-            Address altAddress = customParser.parseAddressAnyNetwork("LLxSnHLN2CYyzB5eWTR9K9rS9uWtbTQFb6");
+            Address altAddress = customParser.parseAddress("LLxSnHLN2CYyzB5eWTR9K9rS9uWtbTQFb6");
             assertEquals(altNetParams.getId(), altAddress.network().id());
 
             // Check if main network works with custom parser
-            Address mainAddress = customParser.parseAddressAnyNetwork("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL");
+            Address mainAddress = customParser.parseAddress("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL");
             assertEquals(MAINNET.id(), mainAddress.network().id());
 
         } finally {
@@ -192,7 +191,7 @@ public class LegacyAddressTest {
 
 
         try {
-            new DefaultAddressParser().parseAddressAnyNetwork("LLxSnHLN2CYyzB5eWTR9K9rS9uWtbTQFb6");
+            new DefaultAddressParser().parseAddress("LLxSnHLN2CYyzB5eWTR9K9rS9uWtbTQFb6");
             fail();
         } catch (AddressFormatException e) { }
     }
@@ -209,9 +208,9 @@ public class LegacyAddressTest {
 
         AddressParser parser = new DefaultAddressParser();
         // Test that we can determine what network a P2SH address belongs to
-        Network mainNet = parser.parseAddressAnyNetwork("35b9vsyH1KoFT5a5KtrKusaCcPLkiSo1tU").network();
+        Network mainNet = parser.parseAddress("35b9vsyH1KoFT5a5KtrKusaCcPLkiSo1tU").network();
         assertEquals(MAINNET, mainNet);
-        Network testNet = parser.parseAddressAnyNetwork("2MuVSxtfivPKJe93EC1Tb9UhJtGhsoWEHCe").network();
+        Network testNet = parser.parseAddress("2MuVSxtfivPKJe93EC1Tb9UhJtGhsoWEHCe").network();
         assertEquals(TESTNET, testNet);
 
         // Test that we can convert them from hashes

--- a/core/src/test/java/org/bitcoinj/base/SegwitAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/base/SegwitAddressTest.java
@@ -118,7 +118,7 @@ public class SegwitAddressTest {
     public void example_p2wpkh_regtest_any_network() {
         String bcrt1_bech32 = "bcrt1qspfueag7fvty7m8htuzare3xs898zvh30fttu2";
 
-        Address address = addressParser.parseAddressAnyNetwork(bcrt1_bech32);
+        Address address = addressParser.parseAddress(bcrt1_bech32);
 
         assertEquals(REGTEST, address.network());
         assertEquals("00148053ccf51e4b164f6cf75f05d1e62681ca7132f1",
@@ -145,7 +145,7 @@ public class SegwitAddressTest {
     @Test
     public void validAddresses() {
         for (AddressData valid : VALID_ADDRESSES) {
-            SegwitAddress address = (SegwitAddress) addressParser.parseAddressAnyNetwork(valid.address);
+            SegwitAddress address = (SegwitAddress) addressParser.parseAddress(valid.address);
 
             assertEquals(valid.expectedNetwork, address.network());
             assertEquals(valid.expectedScriptPubKey,
@@ -203,7 +203,7 @@ public class SegwitAddressTest {
     public void invalidAddresses() {
         for (String invalid : INVALID_ADDRESSES) {
             try {
-                addressParser.parseAddressAnyNetwork(invalid);
+                addressParser.parseAddress(invalid);
                 fail(invalid);
             } catch (AddressFormatException x) {
                 // expected
@@ -239,17 +239,17 @@ public class SegwitAddressTest {
 
     @Test(expected = AddressFormatException.InvalidDataLength.class)
     public void fromBech32_version0_invalidLength() {
-        addressParser.parseAddressAnyNetwork("BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P");
+        addressParser.parseAddress("BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P");
     }
 
     @Test(expected = AddressFormatException.InvalidDataLength.class)
     public void fromBech32_tooShort() {
-        addressParser.parseAddressAnyNetwork("bc1rw5uspcuh");
+        addressParser.parseAddress("bc1rw5uspcuh");
     }
 
     @Test(expected = AddressFormatException.InvalidDataLength.class)
     public void fromBech32_tooLong() {
-        addressParser.parseAddressAnyNetwork("bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90");
+        addressParser.parseAddress("bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90");
     }
 
     @Test(expected = AddressFormatException.InvalidDataLength.class)
@@ -270,7 +270,7 @@ public class SegwitAddressTest {
 
     @Test(expected = AddressFormatException.InvalidPrefix.class)
     public void fromBech32_invalidHrp() {
-        addressParser.parseAddressAnyNetwork("tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty");
+        addressParser.parseAddress("tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty");
     }
 
     @Test(expected = AddressFormatException.WrongNetwork.class)

--- a/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
@@ -87,7 +87,7 @@ public class ForwardingService implements Closeable {
             forwardingAddress = addressParser.parseAddress(args[0], network);
         } else {
             // Else network not-specified, extract network from address
-            forwardingAddress = addressParser.parseAddressAnyNetwork(args[0]);
+            forwardingAddress = addressParser.parseAddress(args[0]);
             network = (BitcoinNetwork) forwardingAddress.network();
         }
     }

--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/controls/BitcoinAddressValidator.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/controls/BitcoinAddressValidator.java
@@ -28,11 +28,11 @@ import org.bitcoinj.walletfx.utils.TextFieldValidator;
  * if the address is invalid for those params, and enable/disable the nodes.
  */
 public class BitcoinAddressValidator {
-    private final AddressParser.Strict parser;
+    private final AddressParser.Simple parser;
     private Node[] nodes;
 
 
-    public BitcoinAddressValidator(AddressParser.Strict parser, TextField field, Node... nodes) {
+    public BitcoinAddressValidator(AddressParser.Simple parser, TextField field, Node... nodes) {
         this.parser = parser;
         this.nodes = nodes;
 


### PR DESCRIPTION
These changes simplify the interface and change the names to more closely match the use-cases we've been seeing internally and externally with alpha1.

parseAddressAnyNetwork() was both verbose and misleading. AddressParser.Strict was being used (for example in the JavaFX wallet) more as a context-specific simplification of the parent interface than as a "strict" implementation.


parseAddressAnyNetwork() is deprecated as is the Strict sub-interface. They should probably be removed in or before 0.17 final.

This addresses part of Issue #3021, though in a slightly different way than the code proposed in the issue. (The changes proposed in the issue make migration/deprecation harder)