### PR TITLE
Upgrade to Bouncy Castle 1.73

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,7 +10,7 @@ plugins {
 version = '0.17-SNAPSHOT'
 
 dependencies {
-    api 'org.bouncycastle:bcprov-jdk15to18:1.72'
+    api 'org.bouncycastle:bcprov-jdk15to18:1.73'
     api 'com.google.guava:guava:31.1-android'
     api 'com.google.protobuf:protobuf-javalite:3.22.3'
     implementation 'org.slf4j:slf4j-api:2.0.7'


### PR DESCRIPTION
I'm not sure if we can start using the `bcprov-jdk18on` variant. (We are currently using the `bcprov-jdk15to18` variant.) So this PR just increments the version number from `1.72` to `1.73`.
