### PR TITLE
WalletTool: Set peer address for REG_TEST

### DIFF
--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -1009,8 +1009,11 @@ public class WalletTool implements Callable<Integer> {
             peerGroup = new PeerGroup(net, chain);
         }
         peerGroup.setUserAgent("WalletTool", "1.0");
-        if (net == BitcoinNetwork.REGTEST)
+        if (net == BitcoinNetwork.REGTEST) {
+            peerGroup.addAddress(PeerAddress.localhost(params));
             peerGroup.setMinBroadcastConnections(1);
+            peerGroup.setMaxConnections(1);
+        }
         peerGroup.addWallet(wallet);
         if (peersStr != null) {
             String[] peerAddrs = peersStr.split(",");


### PR DESCRIPTION
On RegTest we need to add the localhost peer address to the PeerGroup and set max connections to 1, to avoid calling peer discovery.