### PR TITLE
WalletTool: after `send` action, print the entire transaction

### DIFF
--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -693,7 +693,8 @@ public class WalletTool implements Callable<Integer> {
         } catch (ScriptException e) {
             throw new RuntimeException(e);
         }
-        System.out.println(tx.getTxId());
+        System.out.println("id: " + tx.getTxId());
+        System.out.println("tx: " + ByteUtils.formatHex(tx.serialize()));
         if (offline) {
             wallet.commitTx(tx);
             return;


### PR DESCRIPTION
Currently, only the transaction hash is printed.

Alternatively, we could add a switch to select txid, tx or nothing. Feels a bit like overkill though.