### PR TITLE
TransactionOutput: fix regression with calculating getMinNonDustValue() for the multisig case

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -234,7 +234,7 @@ public class TransactionOutput {
         // 294 satoshis at the default rate of 3000 sat/kB.
         long size = this.serialize().length;
         final Script script = getScriptPubKey();
-        if (ScriptPattern.isP2PKH(script) || ScriptPattern.isP2PK(script) || ScriptPattern.isP2SH(script))
+        if (ScriptPattern.isP2PKH(script) || ScriptPattern.isP2PK(script) || ScriptPattern.isP2SH(script) || ScriptPattern.isSentToMultisig(script))
             size += 32 + 4 + 1 + 107 + 4; // 148
         else if (ScriptPattern.isP2WH(script))
             size += 32 + 4 + 1 + (107 / 4) + 4; // 68


### PR DESCRIPTION
This fix was applied on the 0.16 branch by a5fa4004047851180a4602914d7732bd33c10d35, but is not on `master` and is not in `bitcoinj-0.17-alpha1`.