### PR TITLE
Wallet tests: `TESTNET` is now `BitcoinNetwork.TESTNET`

### DIFF
--- a/core/src/test/java/org/bitcoinj/testing/TestWithWallet.java
+++ b/core/src/test/java/org/bitcoinj/testing/TestWithWallet.java
@@ -29,7 +29,6 @@ import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.VerificationException;
-import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.TestNet3Params;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.MemoryBlockStore;
@@ -52,8 +51,7 @@ import static org.bitcoinj.testing.FakeTxBuilder.createFakeTx;
  * fee per kilobyte to zero in setUp.
  */
 public class TestWithWallet {
-    protected static final NetworkParameters TESTNET = TestNet3Params.get();
-    protected static final NetworkParameters MAINNET = MainNetParams.get();
+    protected static final NetworkParameters TESTNET_PARAMS = TestNet3Params.get();
 
     protected ECKey myKey;
     protected Address myAddress;
@@ -72,7 +70,7 @@ public class TestWithWallet {
         wallet = Wallet.createDeterministic(BitcoinNetwork.TESTNET, ScriptType.P2PKH, KeyChainGroupStructure.BIP32);
         myKey = wallet.freshReceiveKey();
         myAddress = wallet.freshReceiveAddress(ScriptType.P2PKH);
-        blockStore = new MemoryBlockStore(TESTNET.getGenesisBlock());
+        blockStore = new MemoryBlockStore(TESTNET_PARAMS.getGenesisBlock());
         chain = new BlockChain(BitcoinNetwork.TESTNET, wallet, blockStore);
     }
 
@@ -102,7 +100,7 @@ public class TestWithWallet {
 
     @Nullable
     protected Transaction sendMoneyToWallet(Wallet wallet, AbstractBlockChain.NewBlockType type, Coin value, Address toAddress) throws VerificationException {
-        return sendMoneyToWallet(wallet, type, createFakeTx(TESTNET.network(), value, toAddress));
+        return sendMoneyToWallet(wallet, type, createFakeTx(BitcoinNetwork.TESTNET, value, toAddress));
     }
 
     @Nullable

--- a/core/src/test/java/org/bitcoinj/wallet/DefaultCoinSelectorTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DefaultCoinSelectorTest.java
@@ -21,12 +21,10 @@ import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.core.AbstractBlockChain;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.base.Coin;
-import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.PeerAddress;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionConfidence;
 import org.bitcoinj.core.TransactionOutput;
-import org.bitcoinj.params.RegTestParams;
 import org.bitcoinj.testing.FakeTxBuilder;
 import org.bitcoinj.testing.TestWithWallet;
 import org.junit.After;
@@ -39,6 +37,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+import static org.bitcoinj.base.BitcoinNetwork.REGTEST;
+import static org.bitcoinj.base.BitcoinNetwork.TESTNET;
 import static org.bitcoinj.base.Coin.CENT;
 import static org.bitcoinj.base.Coin.COIN;
 import static org.junit.Assert.assertEquals;
@@ -46,8 +46,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class DefaultCoinSelectorTest extends TestWithWallet {
-    private static final NetworkParameters REGTEST = RegTestParams.get();
-
     @Before
     @Override
     public void setUp() throws Exception {
@@ -66,20 +64,20 @@ public class DefaultCoinSelectorTest extends TestWithWallet {
         Transaction t;
         t = new Transaction();
         t.getConfidence().setConfidenceType(TransactionConfidence.ConfidenceType.PENDING);
-        assertFalse(DefaultCoinSelector.isSelectable(t, BitcoinNetwork.TESTNET));
+        assertFalse(DefaultCoinSelector.isSelectable(t, TESTNET));
         t.getConfidence().setSource(TransactionConfidence.Source.SELF);
-        assertFalse(DefaultCoinSelector.isSelectable(t, BitcoinNetwork.TESTNET));
-        t.getConfidence().markBroadcastBy(PeerAddress.simple(InetAddress.getByName("1.2.3.4"), TESTNET.getPort()));
-        assertTrue(DefaultCoinSelector.isSelectable(t, BitcoinNetwork.TESTNET));
-        t.getConfidence().markBroadcastBy(PeerAddress.simple(InetAddress.getByName("5.6.7.8"), TESTNET.getPort()));
-        assertTrue(DefaultCoinSelector.isSelectable(t, BitcoinNetwork.TESTNET));
+        assertFalse(DefaultCoinSelector.isSelectable(t, TESTNET));
+        t.getConfidence().markBroadcastBy(PeerAddress.simple(InetAddress.getByName("1.2.3.4"), TESTNET_PARAMS.getPort()));
+        assertTrue(DefaultCoinSelector.isSelectable(t, TESTNET));
+        t.getConfidence().markBroadcastBy(PeerAddress.simple(InetAddress.getByName("5.6.7.8"), TESTNET_PARAMS.getPort()));
+        assertTrue(DefaultCoinSelector.isSelectable(t, TESTNET));
         t = new Transaction();
         t.getConfidence().setConfidenceType(TransactionConfidence.ConfidenceType.BUILDING);
-        assertTrue(DefaultCoinSelector.isSelectable(t, BitcoinNetwork.TESTNET));
+        assertTrue(DefaultCoinSelector.isSelectable(t, TESTNET));
         t = new Transaction();
         t.getConfidence().setConfidenceType(TransactionConfidence.ConfidenceType.PENDING);
         t.getConfidence().setSource(TransactionConfidence.Source.SELF);
-        assertTrue(DefaultCoinSelector.isSelectable(t, BitcoinNetwork.REGTEST));
+        assertTrue(DefaultCoinSelector.isSelectable(t, REGTEST));
     }
 
     @Test
@@ -137,7 +135,7 @@ public class DefaultCoinSelectorTest extends TestWithWallet {
         );
         t.getConfidence().setConfidenceType(TransactionConfidence.ConfidenceType.BUILDING);
 
-        CoinSelector selector = DefaultCoinSelector.get(BitcoinNetwork.TESTNET);
+        CoinSelector selector = DefaultCoinSelector.get(TESTNET);
         CoinSelection selection = selector.select(COIN.multiply(2), outputs);
 
         assertTrue(selection.outputs().size() == 4);


### PR DESCRIPTION
* `TESTNET` is now `BitcoinNetwork.TESTNET`
* `REGTEST` is now `REGTEST `
* `TESTNET_PARAMS` is used for the NetworkParameters object
* This also removes some usage of deprecated methods