### PR TITLE
GitHub graalvm.yml workflow: use latest GraalVM

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -9,19 +9,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        java: [ '17' ]
-        graalvm: [ '22.3.1' ]
+        java-version: [ '17' ]
+        distribution: [ 'graalvm-community' ]
         gradle: ['7.6.1']
       fail-fast: false
-    name: ${{ matrix.os }} JDK ${{ matrix.graalvm }}.${{ matrix.java }}
+    name: ${{ matrix.os }} JDK ${{ matrix.java-version }}.${{ matrix.distribution }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v1
       - name: Set up GraalVM
         uses: graalvm/setup-graalvm@v1
         with:
-          version: ${{ matrix.graalvm }}
-          java-version: ${{ matrix.java }}
+          java-version: ${{ matrix.java-version }}
+          distribution: ${{ matrix.distribution }}
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build with Gradle


### PR DESCRIPTION
As of June 13, 2023, GraalVM versioning has changed and now matches the versioning system of the JDK.

The latest release of GraalVM for JDK 17 is now 17.0.7.