### PR TITLE
Enable Gradle Build Scans, separate settings-gradle4.gradle file

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,12 +12,6 @@ jobs:
         java: ['11', '17', '19']
         distribution: ['temurin']
         gradle: ['7.6.2']
-        include:
-          # Special case to test something close to Debian config with the oldest supported (standard) Gradle on Ubuntu
-          - os: ubuntu-latest
-            java: '11'
-            distribution: 'temurin'
-            gradle: '4.10.3'
       fail-fast: false
     name: JAVA ${{ matrix.distribution }} ${{ matrix.java }} OS ${{ matrix.os }} Gradle ${{ matrix.gradle }}
     steps:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ bullseye-jdk11:
     - apt-get update
     - apt-get -y install openjdk-11-jdk-headless gradle
   script:
-    - gradle build --stacktrace
+    - gradle -c settings-gradle4.gradle build --stacktrace
   after_script:
     - gradle --version
   artifacts:
@@ -18,7 +18,7 @@ bookworm-jdk17:
     - apt-get update
     - apt-get -y install openjdk-17-jdk-headless gradle
   script:
-    - gradle build --stacktrace
+    - gradle -c settings-gradle4.gradle build --stacktrace
   after_script:
     - gradle --version
   artifacts:

--- a/settings-gradle4.gradle
+++ b/settings-gradle4.gradle
@@ -1,0 +1,22 @@
+import org.gradle.util.GradleVersion
+
+// Minimum Gradle version for build
+def minGradleVersion = GradleVersion.version("4.4")
+
+rootProject.name = 'bitcoinj-parent'
+
+if (GradleVersion.current().compareTo(minGradleVersion) < 0) {
+    throw new GradleScriptException("bitcoinj build requires Gradle ${minGradleVersion} or later", null)
+}
+
+include 'core'
+project(':core').name = 'bitcoinj-core'
+
+include 'tools'
+project(':tools').name = 'bitcoinj-tools'
+
+include 'wallettool'
+project(':wallettool').name = 'bitcoinj-wallettool'
+
+include 'examples'
+project(':examples').name = 'bitcoinj-examples'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,12 +1,23 @@
+plugins {
+    id 'com.gradle.enterprise' version "3.14"
+}
+
+gradleEnterprise {
+    buildScan {
+        if (System.getenv("CI")) {
+            System.err.println "Environment variable 'CI' is set, Gradle Build Scan will be published"
+            publishAlways()
+            tag "CI"
+        }
+        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+        termsOfServiceAgree = "yes"
+    }
+}
+
 import org.gradle.util.GradleVersion
-import org.gradle.api.GradleScriptException
 
 // Minimum Gradle version for build
-def minGradleVersion = GradleVersion.version("4.4")
-// Minimum Gradle version for JUnit5
-def minJunit5GradleVersion = GradleVersion.version("4.6")
-// Minimum Gradle version for builds of JavaFX 11 module
-def minFxGradleVersion = GradleVersion.version("4.10")
+def minGradleVersion = GradleVersion.version("6.0")
 
 rootProject.name = 'bitcoinj-parent'
 
@@ -30,18 +41,8 @@ project(':wallettool').name = 'bitcoinj-wallettool'
 include 'examples'
 project(':examples').name = 'bitcoinj-examples'
 
-if (GradleVersion.current().compareTo(minFxGradleVersion) > 0) {
-    System.err.println "Including wallettemplate because ${GradleVersion.current()}"
-    include 'wallettemplate'
-    project(':wallettemplate').name = 'bitcoinj-wallettemplate'
-} else {
-    System.err.println "Skipping wallettemplate, requires Gradle ${minFxGradleVersion}+, currently running: ${GradleVersion.current()}"
-}
+include 'wallettemplate'
+project(':wallettemplate').name = 'bitcoinj-wallettemplate'
 
-if (GradleVersion.current().compareTo(minJunit5GradleVersion) >= 0) {
-    System.err.println "Including integration-test because ${GradleVersion.current()}"
-    include 'integration-test'
-    project(':integration-test').name = 'bitcoinj-integration-test'
-} else {
-    System.err.println "Skipping integration-test, requires Gradle ${minJunit5GradleVersion}+, currently running: ${GradleVersion.current()}"
-}
+include 'integration-test'
+project(':integration-test').name = 'bitcoinj-integration-test'


### PR DESCRIPTION
Build changes:

* Default Gradle Build requires Gradle 7 or later
* Legacy Gradle build uses `-c settings-gradle4.gradle`
* Default Gradle build includes Build Scan capability
* Always Publish Build Scans if `CI` environment variable is set.

CI changes:

* Remove special case Gradle 4.10.3 build from GitHub Actions
* Add `-c settings-gradle4.gradle` option to GitLab/Debian builds

Build Scans will help us to troubleshoot our intermittent CI failures.