### PR TITLE
Wallet: refactor estimateVirtualBytesForSigning

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -5538,13 +5538,12 @@ public class Wallet extends BaseTaggableObject
         Coin feePerKb = (ensureMinRequiredFee && requestedFeePerKb.isLessThan(Transaction.REFERENCE_DEFAULT_MIN_TX_FEE))
                 ? Transaction.REFERENCE_DEFAULT_MIN_TX_FEE
                 : requestedFeePerKb;
-        int vSize = tx.getVsize() + estimateVirtualBytesForSigning(coinSelection);
+        int vSize = tx.getVsize() + estimateVirtualBytesForSigning(coinSelection.outputs());
         return feePerKb.multiply(vSize).divide(1000);
     }
 
-    private int estimateVirtualBytesForSigning(CoinSelection selection) {
-        return selection.outputs()
-                .stream()
+    private int estimateVirtualBytesForSigning(List<TransactionOutput> outputs) {
+        return outputs.stream()
                 .map(TransactionOutput::getScriptPubKey)
                 .map(script -> {
                     try {

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -5545,32 +5545,33 @@ public class Wallet extends BaseTaggableObject
     private int estimateVirtualBytesForSigning(List<TransactionOutput> outputs) {
         return outputs.stream()
                 .map(TransactionOutput::getScriptPubKey)
-                .map(script -> {
-                    try {
-                        if (ScriptPattern.isP2PKH(script)) {
-                            ECKey key = findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2PKH(script), ScriptType.P2PKH);
-                            Objects.requireNonNull(key, "Coin selection includes unspendable outputs");
-                            return script.getNumberOfBytesRequiredToSpend(key, null);
-                        } else if (ScriptPattern.isP2WPKH(script)) {
-                            ECKey key = findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2WH(script), ScriptType.P2WPKH);
-                            Objects.requireNonNull(key, "Coin selection includes unspendable outputs");
-                            return IntMath.divide(script.getNumberOfBytesRequiredToSpend(key, null), 4,
-                                    RoundingMode.CEILING); // round up
-                        } else if (ScriptPattern.isP2SH(script)) {
-                            Script redeemScript = findRedeemDataFromScriptHash(ScriptPattern.extractHashFromP2SH(script)).redeemScript;
-                            Objects.requireNonNull(redeemScript, "Coin selection includes unspendable outputs");
-                            return script.getNumberOfBytesRequiredToSpend(null, redeemScript);
-                        } else {
-                            return script.getNumberOfBytesRequiredToSpend(null, null);
-                        }
-                    } catch (ScriptException e) {
-                        // If this happens it means an output script in a wallet tx could not be understood. That should never
-                        // happen, if it does it means the wallet has got into an inconsistent state.
-                        throw new IllegalStateException(e);
-                    }
-                })
-                .mapToInt(size -> size)
+                .mapToInt(this::estimateVirtualBytesForSigning)
                 .sum();
+    }
+
+    private int estimateVirtualBytesForSigning(Script script) {
+        try {
+            if (ScriptPattern.isP2PKH(script)) {
+                ECKey key = findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2PKH(script), ScriptType.P2PKH);
+                Objects.requireNonNull(key, "Coin selection includes unspendable outputs");
+                return script.getNumberOfBytesRequiredToSpend(key, null);
+            } else if (ScriptPattern.isP2WPKH(script)) {
+                ECKey key = findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2WH(script), ScriptType.P2WPKH);
+                Objects.requireNonNull(key, "Coin selection includes unspendable outputs");
+                return IntMath.divide(script.getNumberOfBytesRequiredToSpend(key, null), 4,
+                        RoundingMode.CEILING); // round up
+            } else if (ScriptPattern.isP2SH(script)) {
+                Script redeemScript = findRedeemDataFromScriptHash(ScriptPattern.extractHashFromP2SH(script)).redeemScript;
+                Objects.requireNonNull(redeemScript, "Coin selection includes unspendable outputs");
+                return script.getNumberOfBytesRequiredToSpend(null, redeemScript);
+            } else {
+                return script.getNumberOfBytesRequiredToSpend(null, null);
+            }
+        } catch (ScriptException e) {
+            // If this happens it means an output script in a wallet tx could not be understood. That should never
+            // happen, if it does it means the wallet has got into an inconsistent state.
+            throw new IllegalStateException(e);
+        }
     }
 
     //endregion


### PR DESCRIPTION
* Use functional-style 
* Use `List<TransactionOutput>` rather than `CoinSelector`
* Factor out method that calculates bytes for a single scriptPubKey.

This is two separate commits (and was originally a child of PR #3140)  