### PR TITLE
Block: use ArrayList consistently for transactions field

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -49,7 +49,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -204,7 +203,7 @@ public class Block extends BaseMessage {
         this.difficultyTarget = difficultyTarget;
         this.nonce = nonce;
         this.prevBlockHash = Sha256Hash.ZERO_HASH;
-        this.transactions = new LinkedList<>(Objects.requireNonNull(transactions));
+        this.transactions = new ArrayList<>(Objects.requireNonNull(transactions));
     }
 
     /**
@@ -227,7 +226,7 @@ public class Block extends BaseMessage {
         this.difficultyTarget = difficultyTarget;
         this.nonce = nonce;
         this.transactions = (transactions != null)
-                ? new LinkedList<>(transactions)
+                ? new ArrayList<>(transactions)
                 : null;
     }
 
@@ -691,7 +690,6 @@ public class Block extends BaseMessage {
     void addTransaction(Transaction t, boolean runSanityChecks) {
         unCacheTransactions();
         if (transactions == null) {
-            // TODO: This creates ArrayList, elsewhere in Block we use LinkedList, which should it be?
             transactions = new ArrayList<>();
         }
         if (runSanityChecks && transactions.size() == 0 && !t.isCoinBase())

--- a/core/src/main/java/org/bitcoinj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/MainNetParams.java
@@ -33,7 +33,7 @@ public class MainNetParams extends BitcoinNetworkParams {
     public static final int MAINNET_MAJORITY_WINDOW = 1000;
     public static final int MAINNET_MAJORITY_REJECT_BLOCK_OUTDATED = 950;
     public static final int MAINNET_MAJORITY_ENFORCE_BLOCK_UPGRADE = 750;
-    private static final long GENESIS_TIME = 1231006505;
+    private static final Instant GENESIS_TIME = Instant.ofEpochSecond(1231006505);
     private static final long GENESIS_NONCE = 2083236893;
     private static final Sha256Hash GENESIS_HASH = Sha256Hash.wrap("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
 
@@ -134,10 +134,7 @@ public class MainNetParams extends BitcoinNetworkParams {
     public Block getGenesisBlock() {
         synchronized (GENESIS_HASH) {
             if (genesisBlock == null) {
-                genesisBlock = Block.createGenesis();
-                genesisBlock.setDifficultyTarget(Block.STANDARD_MAX_DIFFICULTY_TARGET);
-                genesisBlock.setTime(Instant.ofEpochSecond(GENESIS_TIME));
-                genesisBlock.setNonce(GENESIS_NONCE);
+                genesisBlock = Block.createGenesis(GENESIS_TIME, Block.STANDARD_MAX_DIFFICULTY_TARGET, GENESIS_NONCE);
                 checkState(genesisBlock.getHash().equals(GENESIS_HASH), () -> "invalid genesis hash");
             }
         }

--- a/core/src/main/java/org/bitcoinj/params/RegTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/RegTestParams.java
@@ -30,7 +30,7 @@ import static org.bitcoinj.base.internal.Preconditions.checkState;
  * Network parameters for the regression test mode of bitcoind in which all blocks are trivially solvable.
  */
 public class RegTestParams extends BitcoinNetworkParams {
-    private static final long GENESIS_TIME = 1296688602;
+    private static final Instant GENESIS_TIME = Instant.ofEpochSecond(1296688602);
     private static final long GENESIS_NONCE = 2;
     private static final Sha256Hash GENESIS_HASH = Sha256Hash.wrap("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206");
 
@@ -82,10 +82,7 @@ public class RegTestParams extends BitcoinNetworkParams {
     public Block getGenesisBlock() {
         synchronized (GENESIS_HASH) {
             if (genesisBlock == null) {
-                genesisBlock = Block.createGenesis();
-                genesisBlock.setDifficultyTarget(Block.EASIEST_DIFFICULTY_TARGET);
-                genesisBlock.setTime(Instant.ofEpochSecond(GENESIS_TIME));
-                genesisBlock.setNonce(GENESIS_NONCE);
+                genesisBlock = Block.createGenesis(GENESIS_TIME, Block.EASIEST_DIFFICULTY_TARGET, GENESIS_NONCE);
                 checkState(genesisBlock.getHash().equals(GENESIS_HASH), () ->
                         "invalid genesis hash");
             }

--- a/core/src/main/java/org/bitcoinj/params/SigNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/SigNetParams.java
@@ -35,7 +35,7 @@ public class SigNetParams extends BitcoinNetworkParams {
     public static final int TESTNET_MAJORITY_REJECT_BLOCK_OUTDATED = 75;
     public static final int TESTNET_MAJORITY_ENFORCE_BLOCK_UPGRADE = 51;
     private static final long GENESIS_DIFFICULTY = 0x1e0377ae;
-    private static final long GENESIS_TIME = 1598918400;
+    private static final Instant GENESIS_TIME = Instant.ofEpochSecond(1598918400);
     private static final long GENESIS_NONCE = 52613770;
     private static final Sha256Hash GENESIS_HASH = Sha256Hash.wrap("00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6");
 
@@ -79,10 +79,7 @@ public class SigNetParams extends BitcoinNetworkParams {
     public Block getGenesisBlock() {
         synchronized (GENESIS_HASH) {
             if (genesisBlock == null) {
-                genesisBlock = Block.createGenesis();
-                genesisBlock.setDifficultyTarget(GENESIS_DIFFICULTY);
-                genesisBlock.setTime(Instant.ofEpochSecond(GENESIS_TIME));
-                genesisBlock.setNonce(GENESIS_NONCE);
+                genesisBlock = Block.createGenesis(GENESIS_TIME, GENESIS_DIFFICULTY, GENESIS_NONCE);
                 checkState(genesisBlock.getHash().equals(GENESIS_HASH), () ->
                         "invalid genesis hash");
             }

--- a/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
@@ -40,7 +40,7 @@ public class TestNet3Params extends BitcoinNetworkParams {
     public static final int TESTNET_MAJORITY_WINDOW = 100;
     public static final int TESTNET_MAJORITY_REJECT_BLOCK_OUTDATED = 75;
     public static final int TESTNET_MAJORITY_ENFORCE_BLOCK_UPGRADE = 51;
-    private static final long GENESIS_TIME = 1296688602;
+    private static final Instant GENESIS_TIME = Instant.ofEpochSecond(1296688602);
     private static final long GENESIS_NONCE = 414098458;
     private static final Sha256Hash GENESIS_HASH = Sha256Hash.wrap("000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943");
 
@@ -88,10 +88,7 @@ public class TestNet3Params extends BitcoinNetworkParams {
     public Block getGenesisBlock() {
         synchronized (GENESIS_HASH) {
             if (genesisBlock == null) {
-                genesisBlock = Block.createGenesis();
-                genesisBlock.setDifficultyTarget(Block.STANDARD_MAX_DIFFICULTY_TARGET);
-                genesisBlock.setTime(Instant.ofEpochSecond(GENESIS_TIME));
-                genesisBlock.setNonce(GENESIS_NONCE);
+                genesisBlock = Block.createGenesis(GENESIS_TIME, Block.STANDARD_MAX_DIFFICULTY_TARGET, GENESIS_NONCE);
                 checkState(genesisBlock.getHash().equals(GENESIS_HASH), () ->
                         "invalid genesis hash");
             }

--- a/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
@@ -73,9 +73,7 @@ public class UnitTestParams extends BitcoinNetworkParams {
     public Block getGenesisBlock() {
         synchronized (this) {
             if (genesisBlock == null) {
-                genesisBlock = Block.createGenesis();
-                genesisBlock.setDifficultyTarget(Block.EASIEST_DIFFICULTY_TARGET);
-                genesisBlock.setTime(TimeUtils.currentTime());
+                genesisBlock = Block.createGenesis(TimeUtils.currentTime(), Block.EASIEST_DIFFICULTY_TARGET);
             }
         }
         return genesisBlock;

--- a/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
@@ -414,24 +414,26 @@ public class BlockChainTest {
 
     // Some blocks from the test net.
     private static Block getBlock2() throws Exception {
-        Block b2 = new Block(Block.BLOCK_VERSION_GENESIS);
-        b2.setMerkleRoot(Sha256Hash.wrap("20222eb90f5895556926c112bb5aa0df4ab5abc3107e21a6950aec3b2e3541e2"));
-        b2.setNonce(875942400L);
-        b2.setTime(Instant.ofEpochSecond(1296688946L));
-        b2.setDifficultyTarget(0x1d00ffff);
-        b2.setPrevBlockHash(Sha256Hash.wrap("00000000b873e79784647a6c82962c70d228557d24a747ea4d1b8bbe878e1206"));
+        Block b2 = new Block(Block.BLOCK_VERSION_GENESIS,
+                Sha256Hash.wrap("00000000b873e79784647a6c82962c70d228557d24a747ea4d1b8bbe878e1206"), // prev
+                Sha256Hash.wrap("20222eb90f5895556926c112bb5aa0df4ab5abc3107e21a6950aec3b2e3541e2"), // merkle
+                Instant.ofEpochSecond(1296688946L),
+                0x1d00ffff,
+                875942400L,
+                null);
         assertEquals("000000006c02c8ea6e4ff69651f7fcde348fb9d557a06e6957b65552002a7820", b2.getHashAsString());
         Block.verifyHeader(b2);
         return b2;
     }
 
     private static Block getBlock1() throws Exception {
-        Block b1 = new Block(Block.BLOCK_VERSION_GENESIS);
-        b1.setMerkleRoot(Sha256Hash.wrap("f0315ffc38709d70ad5647e22048358dd3745f3ce3874223c80a7c92fab0c8ba"));
-        b1.setNonce(1924588547);
-        b1.setTime(Instant.ofEpochSecond(1296688928));
-        b1.setDifficultyTarget(0x1d00ffff);
-        b1.setPrevBlockHash(Sha256Hash.wrap("000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"));
+        Block b1 = new Block(Block.BLOCK_VERSION_GENESIS,
+                Sha256Hash.wrap("000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"), // prev
+                Sha256Hash.wrap("f0315ffc38709d70ad5647e22048358dd3745f3ce3874223c80a7c92fab0c8ba"), // merkle
+                Instant.ofEpochSecond(1296688928),
+                0x1d00ffff,
+                1924588547,
+                null);
         assertEquals("00000000b873e79784647a6c82962c70d228557d24a747ea4d1b8bbe878e1206", b1.getHashAsString());
         Block.verifyHeader(b1);
         return b1;

--- a/core/src/test/java/org/bitcoinj/core/BlockTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockTest.java
@@ -336,10 +336,9 @@ public class BlockTest {
 
     @Test
     public void testGenesisBlock() {
-        Block genesisBlock = Block.createGenesis();
-        genesisBlock.setDifficultyTarget(0x1d00ffffL);
-        genesisBlock.setTime(Instant.ofEpochSecond(1231006505L));
-        genesisBlock.setNonce(2083236893);
+        Block genesisBlock = Block.createGenesis(Instant.ofEpochSecond(1231006505L),
+                0x1d00ffffL,
+                2083236893);
         assertEquals(Sha256Hash.wrap("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"), genesisBlock.getHash());
     }
 }


### PR DESCRIPTION
This is a child of and follow-up to PR #3135 