### PR TITLE
remove use of Guava @VisibleForTesting on all package-private members

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -128,7 +128,7 @@ public class Block extends BaseMessage {
     private long nonce;
 
     // If null, it means this object holds only the headers.
-    @VisibleForTesting
+    // For testing only
     @Nullable List<Transaction> transactions;
 
     /** Stores the hash of the block. If null, getHash() will recalculate it. */
@@ -180,7 +180,7 @@ public class Block extends BaseMessage {
     }
 
     /** Special case constructor, used for unit tests. */
-    @VisibleForTesting
+    // For testing only
     Block(long setVersion) {
         // Set up a few basic things. We are not complete after this though.
         this(setVersion,
@@ -191,7 +191,7 @@ public class Block extends BaseMessage {
     }
 
     // For unit-test genesis blocks
-    @VisibleForTesting
+    // For testing only
     Block(long setVersion, Instant time, long difficultyTarget, List<Transaction> transactions) {
         this(setVersion, time, difficultyTarget, 0, transactions);
         // Solve for nonce?
@@ -522,7 +522,7 @@ public class Block extends BaseMessage {
         }
     }
 
-    @VisibleForTesting
+    // For testing only
     void checkWitnessRoot() throws VerificationException {
         Transaction coinbase = transactions.get(0);
         checkState(coinbase.isCoinBase());
@@ -666,7 +666,7 @@ public class Block extends BaseMessage {
     }
 
     /** Exists only for unit testing. */
-    @VisibleForTesting
+    // For testing only
     void setMerkleRoot(Sha256Hash value) {
         unCacheHeader();
         merkleRoot = value;
@@ -715,7 +715,7 @@ public class Block extends BaseMessage {
         return prevBlockHash;
     }
 
-    @VisibleForTesting
+    // For testing only
     void setPrevBlockHash(Sha256Hash prevBlockHash) {
         unCacheHeader();
         this.prevBlockHash = prevBlockHash;
@@ -748,7 +748,7 @@ public class Block extends BaseMessage {
         return Date.from(time());
     }
 
-    @VisibleForTesting
+    // For testing only
     void setTime(Instant time) {
         unCacheHeader();
         this.time = time.truncatedTo(ChronoUnit.SECONDS); // convert to Bitcoin time
@@ -769,7 +769,7 @@ public class Block extends BaseMessage {
     }
 
     /** Sets the difficulty target in compact form. */
-    @VisibleForTesting
+    // For testing only
     void setDifficultyTarget(long compactForm) {
         unCacheHeader();
         this.difficultyTarget = compactForm;
@@ -785,7 +785,7 @@ public class Block extends BaseMessage {
     }
 
     /** Sets the nonce and clears any cached data. */
-    @VisibleForTesting
+    // For testing only
     void setNonce(long nonce) {
         unCacheHeader();
         this.nonce = nonce;
@@ -808,7 +808,7 @@ public class Block extends BaseMessage {
      * 
      * @param height block height, if known, or -1 otherwise.
      */
-    @VisibleForTesting
+    // For testing only
     void addCoinbaseTransaction(byte[] pubKeyTo, Coin value, final int height) {
         unCacheTransactions();
         transactions = new ArrayList<>();
@@ -864,7 +864,7 @@ public class Block extends BaseMessage {
      * @param height        block height if known, or -1 otherwise
      * @return created block
      */
-    @VisibleForTesting
+    // For testing only
     Block createNextBlock(@Nullable Address to, long version, @Nullable TransactionOutPoint prevOut, Instant time,
                           byte[] pubKey, Coin coinbaseValue, int height) {
         Block b = new Block(version);
@@ -974,7 +974,7 @@ public class Block extends BaseMessage {
      * @param height  block height if known, or -1 otherwise
      * @return created block
      */
-    @VisibleForTesting
+    // For testing only
     Block createNextBlockWithCoinbase(long version, byte[] pubKey, int height) {
         return createNextBlock(null, version, (TransactionOutPoint) null, TimeUtils.currentTime(), pubKey,
                 FIFTY_COINS, height);

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -17,7 +17,6 @@
 
 package org.bitcoinj.core;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
@@ -427,7 +426,7 @@ public class PeerGroup implements TransactionBroadcaster {
      * @param chain used to process blocks
      * @param connectionManager used to create new connections and keep track of existing ones.
      */
-    @VisibleForTesting
+    // For testing only
     protected PeerGroup(NetworkParameters params, @Nullable AbstractBlockChain chain, ClientConnectionManager connectionManager) {
         Objects.requireNonNull(params);
         Context.getOrCreate(); // create a context for convenience
@@ -1109,7 +1108,7 @@ public class PeerGroup implements TransactionBroadcaster {
         return addressList.size();
     }
 
-    @VisibleForTesting
+    // For testing only
     void waitForJobQueue() {
         Futures.getUnchecked(executor.submit(Runnables.doNothing()));
     }
@@ -2013,7 +2012,7 @@ public class PeerGroup implements TransactionBroadcaster {
     }
     @Nullable private ChainDownloadSpeedCalculator chainDownloadSpeedCalculator;
 
-    @VisibleForTesting
+    // For testing only
     void startBlockChainDownloadFromPeer(Peer peer) {
         lock.lock();
         try {

--- a/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
@@ -17,7 +17,6 @@
 
 package org.bitcoinj.core;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterators;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.internal.TimeUtils;
@@ -72,7 +71,7 @@ import static org.bitcoinj.base.internal.Preconditions.checkState;
  * To make a copy that won't be changed, use {@link TransactionConfidence#duplicate()}.
  */
 public class TransactionConfidence {
-    @VisibleForTesting
+    // For testing only
     interface Factory {
         TransactionConfidence createConfidence(Sha256Hash hash);
     }

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -17,7 +17,6 @@
 
 package org.bitcoinj.crypto;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
@@ -483,7 +482,7 @@ public class DeterministicKey extends ECKey {
         return key;
     }
 
-    @VisibleForTesting
+    // For testing only
     byte[] serialize(Network network, boolean pub) {
         return serialize(network, pub, ScriptType.P2PKH);
     }
@@ -491,7 +490,6 @@ public class DeterministicKey extends ECKey {
     /**
      * @deprecated Use {@link #serialize(Network, boolean)}
      */
-    @VisibleForTesting
     @Deprecated
     byte[] serialize(NetworkParameters params, boolean pub) {
         return serialize(params.network(), pub);

--- a/core/src/main/java/org/bitcoinj/net/NioServer.java
+++ b/core/src/main/java/org/bitcoinj/net/NioServer.java
@@ -16,7 +16,6 @@
 
 package org.bitcoinj.net;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import org.slf4j.Logger;
@@ -41,7 +40,8 @@ public class NioServer extends AbstractExecutionThreadService {
     private final StreamConnectionFactory connectionFactory;
 
     private final ServerSocketChannel sc;
-    @VisibleForTesting final Selector selector;
+    // For testing only
+    final Selector selector;
 
     // Handle a SelectionKey which was selected
     private void handleKey(Selector selector, SelectionKey key) throws IOException {

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -2020,7 +2020,7 @@ public class Wallet extends BaseTaggableObject
      * If isSpent - check that all my outputs spent, otherwise check that there at least
      * one unspent.
      */
-    @VisibleForTesting
+    // For testing only
     boolean isTxConsistent(final Transaction tx, final boolean isSpent) {
         boolean isActuallySpent = true;
         for (TransactionOutput o : tx.getOutputs()) {
@@ -4694,7 +4694,7 @@ public class Wallet extends BaseTaggableObject
      * @param inputs a list of possibly unconnected/unvalued inputs (e.g. from a spend request)
      * @return a list of the same inputs, but connected/valued if not previously valued and found in wallet
      */
-    @VisibleForTesting
+    // For testing only
     static List<TransactionInput> connectInputs(List<TransactionOutput> candidates, List<TransactionInput> inputs) {
         return inputs.stream()
                 .map(in -> candidates.stream()


### PR DESCRIPTION
Both methods it is used on are already package-private and one is deprecated.