### PR TITLE
Wallet/InsufficientMoneyException: add more information

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/InsufficientMoneyException.java
+++ b/core/src/main/java/org/bitcoinj/core/InsufficientMoneyException.java
@@ -41,4 +41,19 @@ public class InsufficientMoneyException extends Exception {
         super(message);
         this.missing = Objects.requireNonNull(missing);
     }
+
+    public InsufficientMoneyException(Coin missing, Coin available, Coin outputs, Coin fee) {
+        this(missing, format(missing, available, outputs, fee));
+    }
+
+    /**
+     * @param missing Amount missing
+     * @param available Amount available (e.g. found by CoinSelector)
+     * @param outputs total amount of output requested
+     * @param fee calculated fee required for transaction
+     * @return An exception message
+     */
+    static String format(Coin missing, Coin available, Coin outputs, Coin fee) {
+        return String.format("Insufficient money, missing %s (available: %s, total outputs: %s, fee: %s)", missing.toFriendlyString(), available.toFriendlyString(), outputs.toFriendlyString(), fee.toFriendlyString());
+    }
 }

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -5472,7 +5472,7 @@ public class Wallet extends BaseTaggableObject
             // Can we afford this?
             if (selection.totalValue().compareTo(valueNeeded) < 0) {
                 Coin valueMissing = valueNeeded.subtract(selection.totalValue());
-                throw new InsufficientMoneyException(valueMissing);
+                throw new InsufficientMoneyException(valueMissing, selection.totalValue(), value, fee);
             }
             Coin change = selection.totalValue().subtract(valueNeeded);
             if (change.isGreaterThan(Coin.ZERO)) {


### PR DESCRIPTION
Add a new constructor that provides more information about available funds, total outputs, and fee in addition to amount missing. Use it in `Wallet.calculatFee()` to provide more information when the exception occurs.

When assisting a beginning bitcoinj user, I saw that this could be helpful.