### PR TITLE
Wallet: Declare throws CompletionException where appropriate

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4320,7 +4320,7 @@ public class Wallet extends BaseTaggableObject
      * @throws BadWalletEncryptionKeyException if the supplied {@link SendRequest#aesKey} is wrong.
      */
     public Transaction sendCoinsOffline(SendRequest request)
-            throws InsufficientMoneyException, BadWalletEncryptionKeyException {
+            throws InsufficientMoneyException, CompletionException {
         lock.lock();
         try {
             completeTx(request);
@@ -4359,7 +4359,7 @@ public class Wallet extends BaseTaggableObject
      * @throws BadWalletEncryptionKeyException if the supplied {@link SendRequest#aesKey} is wrong.
      */
     public SendResult sendCoins(TransactionBroadcaster broadcaster, Address to, Coin value)
-            throws InsufficientMoneyException, BadWalletEncryptionKeyException {
+            throws InsufficientMoneyException, CompletionException {
         SendRequest request = SendRequest.to(to, value);
         return sendCoins(broadcaster, request);
     }
@@ -4387,7 +4387,7 @@ public class Wallet extends BaseTaggableObject
      * @throws BadWalletEncryptionKeyException if the supplied {@link SendRequest#aesKey} is wrong.
      */
     public SendResult sendCoins(TransactionBroadcaster broadcaster, SendRequest request)
-            throws InsufficientMoneyException, BadWalletEncryptionKeyException {
+            throws InsufficientMoneyException, CompletionException {
         // Should not be locked here, as we're going to call into the broadcaster and that might want to hold its
         // own lock. sendCoinsOffline handles everything that needs to be locked.
         checkState(!lock.isHeldByCurrentThread());
@@ -4420,7 +4420,7 @@ public class Wallet extends BaseTaggableObject
      * @throws BadWalletEncryptionKeyException if the supplied {@link SendRequest#aesKey} is wrong.
      */
     public SendResult sendCoins(SendRequest request)
-            throws InsufficientMoneyException, BadWalletEncryptionKeyException {
+            throws InsufficientMoneyException, CompletionException {
         TransactionBroadcaster broadcaster = vTransactionBroadcaster;
         checkState(broadcaster != null, () ->
                 "no transaction broadcaster is configured");
@@ -4443,7 +4443,7 @@ public class Wallet extends BaseTaggableObject
      * @throws BadWalletEncryptionKeyException if the supplied {@link SendRequest#aesKey} is wrong.
      */
     public Transaction sendCoins(Peer peer, SendRequest request)
-            throws InsufficientMoneyException, BadWalletEncryptionKeyException {
+            throws InsufficientMoneyException, CompletionException {
         Transaction tx = sendCoinsOffline(request);
         peer.sendMessage(tx);
         return tx;
@@ -4561,7 +4561,7 @@ public class Wallet extends BaseTaggableObject
      * @throws MultipleOpReturnRequested if there is more than one OP_RETURN output for the resultant transaction.
      * @throws BadWalletEncryptionKeyException if the supplied {@link SendRequest#aesKey} is wrong.
      */
-    public void completeTx(SendRequest req) throws InsufficientMoneyException, BadWalletEncryptionKeyException {
+    public void completeTx(SendRequest req) throws InsufficientMoneyException, CompletionException {
         lock.lock();
         try {
             checkArgument(!req.completed, () ->


### PR DESCRIPTION
Adjust the signature of these methods to match the actual behavior and the JavaDoc. (Note: BadWalletEncryptionKeyException is  subclass of CompletionException which is a RuntimeException)