### PR TITLE
Use Transaction.messageSize() instead of serialize().length

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4659,7 +4659,7 @@ public class Wallet extends BaseTaggableObject
                 signTransaction(req);
 
             // Check size.
-            final int size = req.tx.serialize().length;
+            final int size = req.tx.messageSize();
             if (size > Transaction.MAX_STANDARD_TX_SIZE)
                 throw new ExceededMaxTransactionSize();
 
@@ -5892,7 +5892,7 @@ public class Wallet extends BaseTaggableObject
             if (sign)
                 signTransaction(req);
             // KeyTimeCoinSelector should never select enough inputs to push us oversize.
-            checkState(rekeyTx.serialize().length < Transaction.MAX_STANDARD_TX_SIZE);
+            checkState(rekeyTx.messageSize() < Transaction.MAX_STANDARD_TX_SIZE);
             return rekeyTx;
         } catch (VerificationException e) {
             throw new RuntimeException(e);  // Cannot happen.

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -2331,14 +2331,14 @@ public class WalletTest extends TestWithWallet {
         assertEquals(Coin.valueOf(99900), request17.tx.getFee());
         assertEquals(1, request17.tx.getInputs().size());
         // Calculate its max length to make sure it is indeed 999
-        int theoreticalMaxLength17 = request17.tx.serialize().length + myKey.getPubKey().length + 75;
+        int theoreticalMaxLength17 = request17.tx.messageSize() + myKey.getPubKey().length + 75;
         for (TransactionInput in : request17.tx.getInputs())
             theoreticalMaxLength17 -= in.getScriptBytes().length;
         assertEquals(999, theoreticalMaxLength17);
         Transaction spend17 = request17.tx;
         {
             // Its actual size must be between 996 and 999 (inclusive) as signatures have a 3-byte size range (almost always)
-            final int length = spend17.serialize().length;
+            final int length = spend17.messageSize();
             assertTrue(Integer.toString(length), length >= 996 && length <= 999);
         }
         // Now check that it got a fee of 1 since its max size is 999 (1kb).
@@ -2359,7 +2359,7 @@ public class WalletTest extends TestWithWallet {
         assertEquals(1, request18.tx.getInputs().size());
         // Calculate its max length to make sure it is indeed 1001
         Transaction spend18 = request18.tx;
-        int theoreticalMaxLength18 = spend18.serialize().length + myKey.getPubKey().length + 75;
+        int theoreticalMaxLength18 = spend18.messageSize() + myKey.getPubKey().length + 75;
         for (TransactionInput in : spend18.getInputs())
             theoreticalMaxLength18 -= in.getScriptBytes().length;
         assertEquals(1001, theoreticalMaxLength18);

--- a/tools/src/main/java/org/bitcoinj/tools/TestFeeLevel.java
+++ b/tools/src/main/java/org/bitcoinj/tools/TestFeeLevel.java
@@ -86,7 +86,7 @@ public class TestFeeLevel {
         request.feePerKb = feeRateToTest;
         request.ensureMinRequiredFee = false;
         kit.wallet().completeTx(request);
-        System.out.println("Size in bytes is " + request.tx.serialize().length);
+        System.out.println("Size in bytes is " + request.tx.messageSize());
         System.out.println("TX is " + request.tx);
         System.out.println("Waiting for " + kit.peerGroup().getMaxConnections() + " connected peers");
         kit.peerGroup().addDisconnectedEventListener((peer, peerCount) -> System.out.println(peerCount +


### PR DESCRIPTION
(Except in asserts in tests)