### PR TITLE
TransactionOutput: use messageSize() not serialize().length

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -1425,7 +1425,7 @@ public class Transaction extends BaseMessage {
             size += in.getMessageSize();
         size += VarInt.sizeOf(outputs.size());
         for (TransactionOutput out : outputs)
-            size += out.getMessageSize();
+            size += out.messageSize();
         if (useSegwit)
             for (TransactionInput in : inputs)
                 size += in.getWitness().getMessageSize();

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -240,7 +240,7 @@ public class TransactionOutput {
         // so dust is a spendable txout less than
         // 98*dustRelayFee/1000 (in satoshis).
         // 294 satoshis at the default rate of 3000 sat/kB.
-        long size = this.serialize().length;
+        long size = this.messageSize();
         final Script script = getScriptPubKey();
         if (ScriptPattern.isP2PKH(script) || ScriptPattern.isP2PK(script) || ScriptPattern.isP2SH(script) || ScriptPattern.isSentToMultisig(script))
             size += 32 + 4 + 1 + 107 + 4; // 148

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -145,7 +145,7 @@ public class TransactionOutput {
      * @return byte array containing the transaction output
      */
     public byte[] serialize() {
-        return write(ByteBuffer.allocate(getMessageSize())).array();
+        return write(ByteBuffer.allocate(messageSize())).array();
     }
 
     /** @deprecated use {@link #serialize()} */
@@ -160,10 +160,18 @@ public class TransactionOutput {
      *
      * @return size of the serialized message in bytes
      */
-    public int getMessageSize() {
+    public int messageSize() {
         int size = Coin.BYTES; // value
         size += VarInt.sizeOf(scriptBytes.length) + scriptBytes.length;
         return size;
+    }
+
+    /**
+     * @deprecated Use {@link #messageSize()}
+     */
+    @Deprecated
+    public int getMessageSize() {
+        return messageSize();
     }
 
     /**

--- a/core/src/test/java/org/bitcoinj/core/TransactionOutputTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionOutputTest.java
@@ -129,7 +129,7 @@ public class TransactionOutputTest extends TestWithWallet {
     @Test
     @Parameters(method = "randomOutputs")
     public void write(TransactionOutput output) {
-        ByteBuffer buf = ByteBuffer.allocate(output.getMessageSize());
+        ByteBuffer buf = ByteBuffer.allocate(output.messageSize());
         output.write(buf);
         assertFalse(buf.hasRemaining());
     }

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -184,7 +184,7 @@ public class TransactionTest {
         // add fake transaction output
         TransactionOutput output = new TransactionOutput(null, Coin.COIN, ADDRESS);
         tx.addOutput(output);
-        length += output.getMessageSize();
+        length += output.messageSize();
 
         // message size has now grown
         assertEquals(length, tx.messageSize());


### PR DESCRIPTION
This is a child of PR #3165 