### PR TITLE
Wallet: wrap more exceptions as "failedFuture"

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4473,7 +4473,7 @@ public class Wallet extends BaseTaggableObject
         try {
             // Complete successfully when the transaction has been sent (or buffered, at least) to peers.
             return sendCoins(sendRequest).broadcast.awaitSent();
-        } catch (KeyCrypterException | InsufficientMoneyException e) {
+        } catch (KeyCrypterException | InsufficientMoneyException | CompletionException | IllegalStateException | IllegalArgumentException e) {
             // We should never try to send more coins than we have, if we do we get an InsufficientMoneyException
             return FutureUtils.failedFuture(e);
         }


### PR DESCRIPTION
I'm pretty sure this is the right thing to do for `CompletionException`. I'm less sure for `IllegalArgumentException` and `IllegalStateException`.

The `CompletionExceptions` cases need to be handled at runtime by wallet implementations and should show up as failed futures (so that callers don't have to test whether the future failed _and_ do a try-catch) for the "fatal" exceptions I'm not as sure.