### PR TITLE
BlockImporter: remove unsupported "Disk" option from usage

### DIFF
--- a/tools/src/main/java/org/bitcoinj/tools/BlockImporter.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BlockImporter.java
@@ -29,7 +29,7 @@ import static org.bitcoinj.base.internal.Preconditions.checkArgument;
 /** Very thin wrapper around {@link BlockFileLoader} */
 public class BlockImporter {
     public static void main(String[] args) throws BlockStoreException, VerificationException, PrunedException {
-        System.out.println("USAGE: BlockImporter (prod|test) (Disk|MemFull|Mem|SPV) [blockStore]");
+        System.out.println("USAGE: BlockImporter (prod|test) (MemFull|Mem|SPV) [blockStore]");
         System.out.println("       blockStore is required unless type is Mem or MemFull");
         System.out.println("       Does full verification if the store supports it");
         checkArgument(args.length == 2 || args.length == 3);


### PR DESCRIPTION
"Disk" is listed in USAGE but will result in an "Unknown store" message. Remove it from USAGE.