### PR TITLE
DnsDiscovery: remove Linux gethostbyname bug workaround from 2015

### DIFF
--- a/core/src/main/java/org/bitcoinj/net/discovery/DnsDiscovery.java
+++ b/core/src/main/java/org/bitcoinj/net/discovery/DnsDiscovery.java
@@ -96,12 +96,7 @@ public class DnsDiscovery extends MultiplexingDiscovery {
 
     @Override
     protected ExecutorService createExecutor() {
-        // Attempted workaround for reported bugs on Linux in which gethostbyname does not appear to be properly
-        // thread safe and can cause segfaults on some libc versions.
-        if (PlatformUtils.isLinux())
-            return Executors.newSingleThreadExecutor(new ContextPropagatingThreadFactory("DNS seed lookups"));
-        else
-            return Executors.newFixedThreadPool(seeds.size(), new DaemonThreadFactory("DNS seed lookups"));
+        return Executors.newFixedThreadPool(seeds.size(), new DaemonThreadFactory("DNS seed lookups"));
     }
 
     /** Implements discovery from a single DNS host. */


### PR DESCRIPTION
This is the commit that introduced the work-around: fe2aff49ae1ab23af9bed01aa131062f47a2e4e7

Note that we could probably remove the override of `createExecutor()` in `DnsDiscovery` but it currently uses different naming and a different `ThreadyFactory`.  I'm not sure at what point this diverged but can probably be simplified.

