### PR TITLE
BlockFileLoader: make stream of ByteBuffer available (with test)

### DIFF
--- a/integration-test/src/test/java/org/bitcoinj/util/BlockFileLoaderBitcoindTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/util/BlockFileLoaderBitcoindTest.java
@@ -84,4 +84,14 @@ public class BlockFileLoaderBitcoindTest {
         System.out.println("Final block height: " + (blockCount - 1));
         assertTrue(blockCount > 1);
     }
+
+    @Test
+    public void streamEntireBitcoindBlockchainAsBuffers() {
+        BlockFileLoader loader = new BlockFileLoader(BitcoinNetwork.MAINNET, BlockFileLoader.getReferenceClientBlockFileList());
+
+        long blockCount = loader.streamBuffers().count();
+        System.out.println("Final block height: " + (blockCount - 1));
+        assertTrue(blockCount > 1);
+    }
+
 }


### PR DESCRIPTION
* Inner class BlockFileIterator now iterates ByteBuffer
* stream() method calls makeBlock (deserializer)
* streamBuffers() method makes raw ByteBuffer blocks available
* Add integration test streamEntireBitcoindBlockChainAsBuffers()
