### PR TITLE
WIP: Comment out use of TxConfidenceTable in Block.readTransactions()

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -173,7 +173,9 @@ public class Block extends BaseMessage {
         for (int i = 0; i < numTransactions; i++) {
             Transaction tx = Transaction.read(payload);
             // Label the transaction as coming from the P2P network, so code that cares where we first saw it knows.
-            tx.getConfidence().setSource(TransactionConfidence.Source.NETWORK);
+            // TODO: Either remove this or add equivalent functionality in a way that doesn't
+            // require a dependency on TxConfidenceTable or slow multi-threaded apps
+            // tx.getConfidence().setSource(TransactionConfidence.Source.NETWORK);
             transactions.add(tx);
         }
         return transactions;


### PR DESCRIPTION
This change speeds up an integration test that I am writing by a factor of 15x (from 30 minutes to 2 minutes)  When I am deserializing `Block` s on different threads it seems the contention for the `TxConfidenceTable` lock is preventing effective concurrency.

Removing this line doesn't affect the unit tests, but I don't know what the best solution is for removing this. I don't think that `Block` or `Transaction` should have dependencies on the `TxConfidenceTable`, though.