### PR TITLE
TestFeeLevel, WalletTest: use wallet.waitForConfirmations()

### DIFF
--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -419,7 +419,7 @@ public class WalletTest extends TestWithWallet {
         // Send some pending coins to the wallet.
         Transaction t1 = sendMoneyToWallet(wallet, null, amount, toAddress);
         Threading.waitForUserCode();
-        final CompletableFuture<TransactionConfidence> depthFuture = t1.getConfidence().getDepthFuture(1);
+        final CompletableFuture<TransactionConfidence> depthFuture = wallet.waitForConfirmations(t1, 1);
         assertFalse(depthFuture.isDone());
         assertEquals(ZERO, wallet.getBalance(Wallet.BalanceType.AVAILABLE));
         assertEquals(amount, wallet.getBalance(Wallet.BalanceType.ESTIMATED));

--- a/tools/src/main/java/org/bitcoinj/tools/TestFeeLevel.java
+++ b/tools/src/main/java/org/bitcoinj/tools/TestFeeLevel.java
@@ -95,7 +95,7 @@ public class TestFeeLevel {
                 " peers connected"));
         kit.peerGroup().broadcastTransaction(request.tx).awaitRelayed().get();
         System.out.println("Send complete, waiting for confirmation");
-        request.tx.getConfidence().getDepthFuture(1).get();
+        kit.wallet().waitForConfirmations(request.tx, 1).get();
 
         int heightNow = kit.chain().getBestChainHeight();
         System.out.println("Height after confirmation is " + heightNow);


### PR DESCRIPTION
... instead of tx.getConfidence.getDepthFuture()