### PR TITLE
TransactionConfidence: store overriding txId (not Transaction ref) (minor BREAKING)

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -2848,7 +2848,7 @@ public class Wallet extends BaseTaggableObject
                 deadInput.disconnect();
                 maybeMovePool(connected, "kill");
             }
-            tx.getConfidence().setOverridingTransaction(overridingTx);
+            tx.getConfidence().setOverridingTxId(overridingTx != null ? overridingTx.getTxId() : null);
             confidenceChanged.put(tx, TransactionConfidence.Listener.ChangeReason.TYPE);
             // Now kill any transactions we have that depended on this one.
             for (TransactionOutput deadOutput : tx.getOutputs()) {

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -375,8 +375,8 @@ public class WalletProtobufSerializer {
             if (confidence.getConfidenceType() == ConfidenceType.DEAD) {
                 // Copy in the overriding transaction, if available.
                 // (A dead coinbase transaction has no overriding transaction).
-                if (confidence.getOverridingTransaction() != null) {
-                    Sha256Hash overridingHash = confidence.getOverridingTransaction().getTxId();
+                if (confidence.getOverridingTxId() != null) {
+                    Sha256Hash overridingHash = confidence.getOverridingTxId();
                     confidenceBuilder.setOverridingTransaction(hashToByteString(overridingHash));
                 }
             }
@@ -823,7 +823,7 @@ public class WalletProtobufSerializer {
                 log.warn("Have overridingTransaction that is not in wallet for tx {}", tx.getTxId());
                 return;
             }
-            confidence.setOverridingTransaction(overridingTransaction);
+            confidence.setOverridingTxId(overridingTransaction.getTxId());
         }
         for (Protos.PeerAddress proto : confidenceProto.getBroadcastByList()) {
             InetAddress ip;

--- a/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
@@ -335,11 +335,11 @@ public class ChainSplitTest {
         // Check what happens when a re-org happens and one of our unconfirmed transactions becomes invalidated by a
         // double spend on the new best chain.
         final Transaction[] eventDead = new Transaction[1];
-        final Transaction[] eventReplacement = new Transaction[1];
+        final Sha256Hash[] eventReplacement = new Sha256Hash[1];
         wallet.addTransactionConfidenceEventListener((wallet, tx) -> {
             if (tx.getConfidence().getConfidenceType() == ConfidenceType.DEAD) {
                 eventDead[0] = tx;
-                eventReplacement[0] = tx.getConfidence().getOverridingTransaction();
+                eventReplacement[0] = tx.getConfidence().getOverridingTxId();
             }
         });
 
@@ -371,7 +371,7 @@ public class ChainSplitTest {
         // genesis -> b1 -> b2 [t1 dead and exited the miners mempools]
         //              \-> b3 (t2) -> b4
         assertEquals(t1, eventDead[0]);
-        assertEquals(t2, eventReplacement[0]);
+        assertEquals(t2.getTxId(), eventReplacement[0]);
         assertEquals(valueOf(30, 0), wallet.getBalance());
 
         // ... and back to our own parallel universe.


### PR DESCRIPTION
This is a breaking change as `getOverridingTransaction()` has been removed with a replacement of `getOverridingTxId`. All use cases in this repository only need the ID and there are probably very few (if any) external apps that are accessing `TransactionConfidence` directly _and_ using the `getOverridingTransaction()`

Note that ProtoBuf serialization only stores the TxID, so this change does not affect serialization/deserialization.