### PR TITLE
ListMessage & subclasses: make immutable (after deprecations removed)

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/GetDataMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetDataMessage.java
@@ -21,13 +21,14 @@ import org.bitcoinj.base.Sha256Hash;
 
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.List;
 
 /**
  * <p>Represents the "getdata" P2P network message, which requests the contents of blocks or transactions given their
  * hashes.</p>
- * 
- * <p>Instances of this class are not safe for use by multiple threads.</p>
+ *
+ * <p>Instances of this class -- that use deprecated methods -- are not safe for use by multiple threads.</p>
  */
 public class GetDataMessage extends ListMessage {
     /**
@@ -41,23 +42,43 @@ public class GetDataMessage extends ListMessage {
         return new GetDataMessage(readItems(payload));
     }
 
+    @Deprecated
     public GetDataMessage() {
         super();
     }
 
-    private GetDataMessage(List<InventoryItem> items) {
+    GetDataMessage(List<InventoryItem> items) {
         super(items);
     }
 
+    public static GetDataMessage ofBlock(Sha256Hash blockHash, boolean includeWitness) {
+        return new GetDataMessage(Collections.singletonList(
+                    new InventoryItem(includeWitness
+                            ? InventoryItem.Type.WITNESS_BLOCK
+                            : InventoryItem.Type.BLOCK,
+                            blockHash)));
+    }
+
+    public static GetDataMessage ofTransaction(Sha256Hash txId, boolean includeWitness) {
+        return new GetDataMessage(Collections.singletonList(
+                new InventoryItem(includeWitness
+                        ? InventoryItem.Type.WITNESS_TRANSACTION
+                        : InventoryItem.Type.TRANSACTION,
+                        txId)));
+    }
+
+    @Deprecated
     public void addTransaction(Sha256Hash hash, boolean includeWitness) {
         addItem(new InventoryItem(
                 includeWitness ? InventoryItem.Type.WITNESS_TRANSACTION : InventoryItem.Type.TRANSACTION, hash));
     }
 
+    @Deprecated
     public void addBlock(Sha256Hash hash, boolean includeWitness) {
         addItem(new InventoryItem(includeWitness ? InventoryItem.Type.WITNESS_BLOCK : InventoryItem.Type.BLOCK, hash));
     }
 
+    @Deprecated
     public void addFilteredBlock(Sha256Hash hash) {
         addItem(new InventoryItem(InventoryItem.Type.FILTERED_BLOCK, hash));
     }

--- a/core/src/main/java/org/bitcoinj/core/InventoryItem.java
+++ b/core/src/main/java/org/bitcoinj/core/InventoryItem.java
@@ -57,6 +57,16 @@ public class InventoryItem {
         this.hash = hash;
     }
 
+    public InventoryItem(Block block) {
+        this.type = Type.BLOCK;
+        this.hash = block.getHash();
+    }
+
+    public InventoryItem(Transaction tx) {
+        this.type = Type.TRANSACTION;
+        this.hash = tx.getTxId();
+    }
+
     @Override
     public String toString() {
         return type + ": " + hash;

--- a/core/src/main/java/org/bitcoinj/core/InventoryMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/InventoryMessage.java
@@ -18,7 +18,10 @@ package org.bitcoinj.core;
 
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.bitcoinj.base.internal.Preconditions.checkArgument;
 
@@ -27,8 +30,8 @@ import static org.bitcoinj.base.internal.Preconditions.checkArgument;
  * a bandwidth optimization - on receiving some data, a (fully validating) peer sends every connected peer an inv
  * containing the hash of what it saw. It'll only transmit the full thing if a peer asks for it with a
  * {@link GetDataMessage}.</p>
- * 
- * <p>Instances of this class are not safe for use by multiple threads.</p>
+ *
+ * <p>Instances of this class -- that use deprecated methods -- are not safe for use by multiple threads.</p>
  */
 public class InventoryMessage extends ListMessage {
 
@@ -46,7 +49,8 @@ public class InventoryMessage extends ListMessage {
         return new InventoryMessage(readItems(payload));
     }
 
-    public InventoryMessage() {
+    @Deprecated
+    protected InventoryMessage() {
         super();
     }
 
@@ -54,20 +58,50 @@ public class InventoryMessage extends ListMessage {
         super(items);
     }
 
+    public static InventoryMessage ofBlocks(List<Block> blocks) {
+        checkArgument(!blocks.isEmpty());
+        return new InventoryMessage(blocks.stream()
+                .map(InventoryItem::new)
+                .collect(Collectors.toList()));
+    }
+
+    public static InventoryMessage ofBlocks(Block ...blocks) {
+        return ofBlocks(Arrays.asList(blocks));
+    }
+
+    public static InventoryMessage ofTransactions(List<Transaction> transactions) {
+        checkArgument(!transactions.isEmpty());
+        return new InventoryMessage(transactions.stream()
+                .map(InventoryItem::new)
+                .collect(Collectors.toList()));
+    }
+
+    public static InventoryMessage ofTransactions(Transaction ...transactions) {
+        return ofTransactions(Arrays.asList(transactions));
+    }
+
+    /**
+     * @deprecated Use a constructor or factoring
+     */
+    @Deprecated
     public void addBlock(Block block) {
-        addItem(new InventoryItem(InventoryItem.Type.BLOCK, block.getHash()));
+        addItem(new InventoryItem(block));
     }
 
+    /**
+     * @deprecated Use a constructor or factoring
+     */
+    @Deprecated
     public void addTransaction(Transaction tx) {
-        addItem(new InventoryItem(InventoryItem.Type.TRANSACTION, tx.getTxId()));
+        addItem(new InventoryItem(tx));
     }
 
-    /** Creates a new inv message for the given transactions. */
+    /**
+     * Creates a new inv message for the given transactions.
+     * @deprecated Use {@link #ofTransactions(Transaction...)}
+     */
+    @Deprecated
     public static InventoryMessage with(Transaction... txns) {
-        checkArgument(txns.length > 0);
-        InventoryMessage result = new InventoryMessage();
-        for (Transaction tx : txns)
-            result.addTransaction(tx);
-        return result;
+        return ofTransactions(txns);
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/ListMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/ListMessage.java
@@ -35,12 +35,12 @@ import static org.bitcoinj.base.internal.Preconditions.check;
 /**
  * <p>Abstract superclass of classes with list based payload, ie InventoryMessage and GetDataMessage.</p>
  * 
- * <p>Instances of this class are not safe for use by multiple threads.</p>
+ * <p>Instances of this class -- that use deprecated methods -- are not safe for use by multiple threads.</p>
  */
 public abstract class ListMessage extends BaseMessage {
 
     // For some reason the compiler complains if this is inside InventoryItem
-    protected List<InventoryItem> items;
+    protected final List<InventoryItem> items;
 
     public static final int MAX_INVENTORY_ITEMS = 50000;
 
@@ -68,23 +68,26 @@ public abstract class ListMessage extends BaseMessage {
         return items;
     }
 
+    @Deprecated
     public ListMessage() {
         super();
-        items = new ArrayList<>();
+        items = new ArrayList<>(); // TODO: unmodifiable empty list
     }
 
     protected ListMessage(List<InventoryItem> items) {
-        this.items = items;
+        this.items = items;    // TODO: unmodifiable defensive copy
     }
 
     public List<InventoryItem> getItems() {
         return Collections.unmodifiableList(items);
     }
 
+    @Deprecated
     public void addItem(InventoryItem item) {
         items.add(item);
     }
 
+    @Deprecated
     public void removeItem(int index) {
         items.remove(index);
     }

--- a/core/src/main/java/org/bitcoinj/core/NotFoundMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/NotFoundMessage.java
@@ -24,8 +24,8 @@ import java.util.List;
 /**
  * <p>Sent by a peer when a getdata request doesn't find the requested data in the mempool. It has the same format
  * as an inventory message and lists the hashes of the missing items.</p>
- * 
- * <p>Instances of this class are not safe for use by multiple threads.</p>
+ *
+ * <p>Instances of this class -- that use deprecated methods -- are not safe for use by multiple threads.</p>
  */
 public class NotFoundMessage extends InventoryMessage {
     public static int MIN_PROTOCOL_VERSION = 70001;
@@ -41,6 +41,7 @@ public class NotFoundMessage extends InventoryMessage {
         return new NotFoundMessage(readItems(payload));
     }
 
+    @Deprecated
     public NotFoundMessage() {
         super();
     }

--- a/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
@@ -188,9 +188,7 @@ public class BitcoindComparisonTool {
                     if (!found)
                         sendHeaders = headers;
                     bitcoind.sendMessage(new HeadersMessage(sendHeaders));
-                    InventoryMessage i = new InventoryMessage();
-                    for (Block b : sendHeaders)
-                        i.addBlock(b);
+                    InventoryMessage i = InventoryMessage.ofBlocks(sendHeaders);
                     bitcoind.sendMessage(i);
                 } catch (Exception e) {
                     throw new RuntimeException(e);
@@ -271,8 +269,7 @@ public class BitcoindComparisonTool {
                 boolean shouldntRequest = blocksRequested.contains(nextBlock.getHash());
                 if (shouldntRequest)
                     blocksRequested.remove(nextBlock.getHash());
-                InventoryMessage message = new InventoryMessage();
-                message.addBlock(nextBlock);
+                InventoryMessage message = InventoryMessage.ofBlocks(nextBlock);
                 bitcoind.sendMessage(message);
                 log.info("Sent inv with block " + nextBlock.getHashAsString());
                 if (blocksPendingSend.contains(nextBlock.getHash())) {

--- a/integration-test/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTest.java
@@ -188,8 +188,7 @@ public class FilteredBlockAndPartialMerkleTreeTest extends TestWithPeerGroup {
         InboundMessageQueuer p1 = connectPeer(1);
         assertEquals(1, peerGroup.numConnectedPeers());
         // Send an inv for block 100001
-        InventoryMessage inv = new InventoryMessage();
-        inv.addBlock(block);
+        InventoryMessage inv = InventoryMessage.ofBlocks(block);
         inbound(p1, inv);
         
         // Check that we properly requested the correct FilteredBlock

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -247,8 +247,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
 
         Coin value = COIN;
         Transaction t1 = FakeTxBuilder.createFakeTx(UNITTEST.network(), value, address);
-        InventoryMessage inv = new InventoryMessage();
-        inv.addTransaction(t1);
+        InventoryMessage inv = InventoryMessage.ofTransactions(t1);
 
         // Note: we start with p2 here to verify that transactions are downloaded from whichever peer announces first
         // which does not have to be the same as the download peer (which is really the "block download peer").
@@ -287,8 +286,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
 
         Coin value = COIN;
         Transaction t1 = FakeTxBuilder.createFakeTx(UNITTEST.network(), value, address2);
-        InventoryMessage inv = new InventoryMessage();
-        inv.addTransaction(t1);
+        InventoryMessage inv = InventoryMessage.ofTransactions(t1);
 
         inbound(p1, inv);
         assertTrue(outbound(p1) instanceof GetDataMessage);
@@ -319,8 +317,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         Block b3 = FakeTxBuilder.makeSolvedTestBlock(b2);
 
         // Peer 1 and 2 receives an inv advertising a newly solved block.
-        InventoryMessage inv = new InventoryMessage();
-        inv.addBlock(b3);
+        InventoryMessage inv = InventoryMessage.ofBlocks(b3);
         // Only peer 1 tries to download it.
         inbound(p1, inv);
         pingAndWait(p1);
@@ -358,11 +355,8 @@ public class PeerGroupTest extends TestWithPeerGroup {
         GetBlocksMessage getblocks = (GetBlocksMessage) outbound(p1);
         assertEquals(Sha256Hash.ZERO_HASH, getblocks.getStopHash());
         // We give back an inv with some blocks in it.
-        InventoryMessage inv = new InventoryMessage();
-        inv.addBlock(b1);
-        inv.addBlock(b2);
-        inv.addBlock(b3);
-        
+        InventoryMessage inv = InventoryMessage.ofBlocks(b1, b2, b3);
+
         inbound(p1, inv);
         assertTrue(outbound(p1) instanceof GetDataMessage);
         // We hand back the first block.
@@ -388,8 +382,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         InboundMessageQueuer p3 = connectPeer(3);
 
         Transaction tx = FakeTxBuilder.createFakeTx(UNITTEST.network(), valueOf(20, 0), address);
-        InventoryMessage inv = new InventoryMessage();
-        inv.addTransaction(tx);
+        InventoryMessage inv = InventoryMessage.ofTransactions(tx);
 
         assertEquals(0, tx.getConfidence().numBroadcastPeers());
         assertFalse(tx.getConfidence().lastBroadcastTime().isPresent());

--- a/integration-test/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
@@ -110,7 +110,7 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
         Threading.waitForUserCode();
         assertFalse(future.isDone());
         assertEquals(0.0, lastProgress.get(), 0.0);
-        inbound(channels[1], InventoryMessage.with(tx));
+        inbound(channels[1], InventoryMessage.ofTransactions(tx));
         future.get();
         Threading.waitForUserCode();
         assertEquals(1.0, lastProgress.get(), 0.0);
@@ -127,7 +127,7 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
         Transaction tx = FakeTxBuilder.createFakeTx(TESTNET.network(), CENT, address);
         tx.getConfidence().setSource(TransactionConfidence.Source.SELF);
         TransactionBroadcast broadcast = peerGroup.broadcastTransaction(tx);
-        inbound(channels[1], InventoryMessage.with(tx));
+        inbound(channels[1], InventoryMessage.ofTransactions(tx));
         pingAndWait(channels[1]);
         final AtomicDouble p = new AtomicDouble();
         broadcast.setProgressCallback(p::set, Threading.SAME_THREAD);
@@ -234,8 +234,7 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
         // 49 BTC in change.
         assertEquals(valueOf(49, 0), t1.getValueSentToMe(wallet));
         // The future won't complete until it's heard back from the network on p2.
-        InventoryMessage inv = new InventoryMessage();
-        inv.addTransaction(t1);
+        InventoryMessage inv = InventoryMessage.ofTransactions(t1);
         inbound(p2, inv);
         pingAndWait(p2);
         Threading.waitForUserCode();


### PR DESCRIPTION
Make `ListMessage` and its subclasses "almost" immutable. When the deprecated  addItem, removeItem, etc. methods are removed and the constructors are changed to create an ummodifiableList, they will be immutable.