### PR TITLE
TxConfidenceTable.WeakConfidenceReference: make hash final, remove unneeded public modifier

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TxConfidenceTable.java
+++ b/core/src/main/java/org/bitcoinj/core/TxConfidenceTable.java
@@ -43,8 +43,8 @@ public class TxConfidenceTable {
     protected final ReentrantLock lock = Threading.lock(TxConfidenceTable.class);
 
     private static class WeakConfidenceReference extends WeakReference<TransactionConfidence> {
-        public Sha256Hash hash;
-        public WeakConfidenceReference(TransactionConfidence confidence, ReferenceQueue<TransactionConfidence> queue) {
+        final Sha256Hash hash;
+        WeakConfidenceReference(TransactionConfidence confidence, ReferenceQueue<TransactionConfidence> queue) {
             super(confidence, queue);
             hash = confidence.getTransactionHash();
         }


### PR DESCRIPTION
... from hash member and constructor.