### PR TITLE
TxConfidenceTable: add getConfidence(), reduce visibility of 2 methods in Transaction

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -1584,14 +1584,14 @@ public class Transaction extends BaseMessage {
      * Returns the confidence object for this transaction from the {@link TxConfidenceTable}
      * referenced by the given {@link Context}.
      */
-    public TransactionConfidence getConfidence(Context context) {
+    TransactionConfidence getConfidence(Context context) {
         return getConfidence(context.getConfidenceTable());
     }
 
     /**
      * Returns the confidence object for this transaction from the {@link TxConfidenceTable}
      */
-    public TransactionConfidence getConfidence(TxConfidenceTable table) {
+    TransactionConfidence getConfidence(TxConfidenceTable table) {
         if (confidence == null)
             confidence = table.getOrCreate(getTxId()) ;
         return confidence;

--- a/core/src/main/java/org/bitcoinj/core/TxConfidenceTable.java
+++ b/core/src/main/java/org/bitcoinj/core/TxConfidenceTable.java
@@ -93,6 +93,15 @@ public class TxConfidenceTable {
     }
 
     /**
+     * Get the confidence object for a transaction
+     * @param tx the transaction
+     * @return the corresponding confidence object
+     */
+    public TransactionConfidence getConfidence(Transaction tx) {
+        return tx.getConfidence(this);
+    }
+
+    /**
      * If any transactions have expired due to being only weakly reachable through us, go ahead and delete their
      * table entries - it means we downloaded the transaction and sent it to various event listeners, none of
      * which bothered to keep a reference. Typically, this is because the transaction does not involve any keys that

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4502,7 +4502,7 @@ public class Wallet extends BaseTaggableObject
     }
 
     private TransactionConfidence getConfidence(Transaction tx) {
-        return tx.getConfidence(Context.get().getConfidenceTable());
+        return Context.get().getConfidenceTable().getConfidence(tx);
     }
 
     /**


### PR DESCRIPTION
* TxConfidenceTable: add getConfidence(Transaction)
* Wallet: Use TxConfidenceTable.getConfidence(Transaction)
* Transaction: Reduce visibility of Transaction.getConfidence(TxConfidenceTable) and Transaction.getConfidence(Context) to package-private.

This is a minor breaking change to anything relying on the methods in Transaction that now have package visibility, but that should be very rare.

This is a child of PR #3208.
