### PR TITLE
Use 2 Gradle settings files

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,12 +12,14 @@ jobs:
         java: ['11', '17', '19']
         distribution: ['temurin']
         gradle: ['7.6.2']
+        gradle-settings: ['settings.gradle']
         include:
           # Special case to test something close to Debian config with the oldest supported (standard) Gradle on Ubuntu
           - os: ubuntu-latest
             java: '11'
             distribution: 'temurin'
             gradle: '4.10.3'
+            gradle-settings: 'settings-gradle4.gradle'
       fail-fast: false
     name: JAVA ${{ matrix.distribution }} ${{ matrix.java }} OS ${{ matrix.os }} Gradle ${{ matrix.gradle }}
     steps:
@@ -32,7 +34,7 @@ jobs:
         uses: gradle/gradle-build-action@v2.4.2
         with:
           gradle-version: ${{ matrix.gradle }}
-          arguments: -PtestJdk8=true build --info --stacktrace
+          arguments: -c ${{ matrix.gradle-settings }} -PtestJdk8=true build --info --stacktrace
       - name: Upload Test Results and Reports
         uses: actions/upload-artifact@v3
         if: always()

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ bullseye-jdk11:
     - apt-get update
     - apt-get -y install openjdk-11-jdk-headless gradle
   script:
-    - gradle build --stacktrace
+    - gradle -c settings-gradle4.gradle build --stacktrace
   after_script:
     - gradle --version
   artifacts:
@@ -18,7 +18,7 @@ bookworm-jdk17:
     - apt-get update
     - apt-get -y install openjdk-17-jdk-headless gradle
   script:
-    - gradle build --stacktrace
+    - gradle -c settings-gradle4.gradle build --stacktrace
   after_script:
     - gradle --version
   artifacts:

--- a/settings-gradle4.gradle
+++ b/settings-gradle4.gradle
@@ -1,16 +1,12 @@
 import org.gradle.util.GradleVersion
 
 // Minimum Gradle version for build
-def minGradleVersion = GradleVersion.version("6.0")
+def minGradleVersion = GradleVersion.version("4.4")
 
 rootProject.name = 'bitcoinj-parent'
 
 if (GradleVersion.current().compareTo(minGradleVersion) < 0) {
     throw new GradleScriptException("bitcoinj build requires Gradle ${minGradleVersion} or later", null)
-}
-
-if (!JavaVersion.current().isJava11Compatible()) {
-    throw new GradleScriptException("bitcoinj build requires Java 11 or later", null)
 }
 
 include 'core'
@@ -24,9 +20,3 @@ project(':wallettool').name = 'bitcoinj-wallettool'
 
 include 'examples'
 project(':examples').name = 'bitcoinj-examples'
-
-include 'wallettemplate'
-project(':wallettemplate').name = 'bitcoinj-wallettemplate'
-
-include 'integration-test'
-project(':integration-test').name = 'bitcoinj-integration-test'


### PR DESCRIPTION
* settings.gradle: require Gradle 6.0 or later
* settings-gradle4.gradle: work with Gradle 4.4 or later
* GitHub gradle.yml: Parameterize settings file
* GitLab .gitlab_ci.yml: Use settings-gradle4.gradle

My main motivation for creating this was that it is a pre-requisite for adding Gradle Build Scans™ to our CI builds (see PR #3130), but it may have value as a standalone enhancement as well.  See https://github.com/bitcoinj/bitcoinj/pull/3130#issuecomment-1703345198 for an alternate approach for build scans.