### PR TITLE
build.gradle: generate protobuf classes into the build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ bin/
 out/
 *.chain
 *.spvchain
-core/src/main/java/org/bitcoinj/protobuf/

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -50,7 +50,6 @@ protobuf {
             }
         }
     }
-    generatedFilesBaseDir = new File(projectDir, '/src') // workaround for '$projectDir/src'
 }
 
 tasks.withType(Test) {


### PR DESCRIPTION
This is extracted from #3059, but also removes the old directory from `.gitignore`.