### PR TITLE
gradle.yml: update JDK to 21-ea in the build matrix

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        java: ['11', '17', '20']
+        java: ['11', '17', '21-ea']
         distribution: ['temurin']
         gradle: ['8.3']
         include:


### PR DESCRIPTION
We could merge this now or wait a few weeks until Java 21 is final.