### PR TITLE
gitlab-ci.yml: add trixie build for jdk 21

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,20 @@ bookworm-jdk17:
     paths:
       - core/build/libs/*.jar
 
+trixie-jdk21:
+  image: debian:trixie-slim
+  before_script:
+    - apt-get update
+    - apt-get -y install openjdk-21-jdk-headless gradle
+  script:
+    - gradle build --stacktrace
+  after_script:
+    - gradle --version
+  artifacts:
+    name: bitcoinj-$CI_JOB_NAME-$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHORT_SHA
+    paths:
+      - core/build/libs/*.jar
+
 sast:
   stage: test
 


### PR DESCRIPTION
@schildbach I'm not sure if you want to add trixie builds for both 17 & 21. If you want I can resubmit with just 21.