### PR TITLE
KeyTimeCoinSelector: refactor for clarity and in preparation to migrate to streams()

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/KeyTimeCoinSelector.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyTimeCoinSelector.java
@@ -98,6 +98,6 @@ public class KeyTimeCoinSelector implements CoinSelector {
 
     private boolean isConfirmed(TransactionOutput output) {
         Transaction parent = Objects.requireNonNull(output.getParentTransaction());
-        return parent.getConfidence().getConfidenceType().equals(TransactionConfidence.ConfidenceType.BUILDING);
+        return wallet.getConfidence(parent).getConfidenceType().equals(TransactionConfidence.ConfidenceType.BUILDING);
     }
 }

--- a/core/src/main/java/org/bitcoinj/wallet/KeyTimeCoinSelector.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyTimeCoinSelector.java
@@ -97,6 +97,7 @@ public class KeyTimeCoinSelector implements CoinSelector {
     }
 
     private boolean isConfirmed(TransactionOutput output) {
-        return output.getParentTransaction().getConfidence().getConfidenceType().equals(TransactionConfidence.ConfidenceType.BUILDING);
+        Transaction parent = Objects.requireNonNull(output.getParentTransaction());
+        return parent.getConfidence().getConfidenceType().equals(TransactionConfidence.ConfidenceType.BUILDING);
     }
 }

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4501,7 +4501,7 @@ public class Wallet extends BaseTaggableObject
         return getConfidence(tx).getDepthFuture(requiredConfirmations);
     }
 
-    private TransactionConfidence getConfidence(Transaction tx) {
+    TransactionConfidence getConfidence(Transaction tx) {
         return Context.get().getConfidenceTable().getConfidence(tx);
     }
 


### PR DESCRIPTION
There are three commits in this refactoring:

1. Explicitly check that parent is nonNull in `isConfirmed()`
2. Use `wallet.getConfidence(parent)` in `isConfirmed()` and make Wallet.getConfidence() package-private.
3. Extract `isKeyBeforeCutoff()` method