### PR TITLE
FilteringCoinSelector: use stream in select

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/FilteringCoinSelector.java
+++ b/core/src/main/java/org/bitcoinj/wallet/FilteringCoinSelector.java
@@ -17,12 +17,12 @@
 package org.bitcoinj.wallet;
 
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.internal.StreamUtils;
 import org.bitcoinj.core.TransactionOutPoint;
 import org.bitcoinj.core.TransactionOutput;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -40,11 +40,9 @@ public class FilteringCoinSelector implements CoinSelector {
 
     @Override
     public CoinSelection select(Coin target, List<TransactionOutput> candidates) {
-        Iterator<TransactionOutput> iter = candidates.iterator();
-        while (iter.hasNext()) {
-            TransactionOutput output = iter.next();
-            if (spent.contains(output.getOutPointFor())) iter.remove();
-        }
-        return delegate.select(target, candidates);
+        List<TransactionOutput> filtered = candidates.stream()
+                .filter(output -> !spent.contains(output.getOutPointFor()))
+                .collect(StreamUtils.toUnmodifiableList());
+        return delegate.select(target, filtered);
     }
 }


### PR DESCRIPTION
Note: this also prevents mutation of the candidate List which isn't
a problem as used within bitcoinj, but could be a problem if used
externally.

This is accidentally a child of PR #3226 (I marked as DRAFT and will rebase after that one is merged.)
