### PR TITLE
Transaction: add a constructor as deprecated

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -323,7 +323,7 @@ public class Transaction extends BaseMessage {
         vLockTime = LockTime.unset();
     }
 
-    /** @deprecated */
+    /** @deprecated use {@link #Transaction()} */
     @Deprecated
     public Transaction(NetworkParameters params) {
         this();

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -323,6 +323,12 @@ public class Transaction extends BaseMessage {
         vLockTime = LockTime.unset();
     }
 
+    /** @deprecated */
+    @Deprecated
+    public Transaction(NetworkParameters params) {
+        this();
+    }
+
     /**
      * Returns the transaction id as you see them in block explorers. It is used as a reference by transaction inputs
      * via outpoints.


### PR DESCRIPTION
Problem: At the moment, we don't have a replacement for the removed `new Transaction(NetworkParameters)`.

Workaround: Add back `new Transaction(NetworkParameters)` or a *previously not existing* `new Transaction()` as deprecated, so there is at least something apps can use.

Context: My code constructs an empty transaction and then adds inputs and outputs as needed. So it's basically using it as a builder.