### PR TITLE
WalletTool: use CoinSelector.fromPredicate and related refactoring

### DIFF
--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -445,8 +445,7 @@ public class WalletTool implements Callable<Integer> {
                         final Address validSelectAddr = selectAddr;
                         coinSelector = CoinSelector.fromPredicate(candidate -> {
                             try {
-                                Address candidateAddr = candidate.getScriptPubKey().getToAddress(net);
-                                return validSelectAddr.equals(candidateAddr);
+                                return candidate.getScriptPubKey().getToAddress(net).equals(validSelectAddr);
                             } catch (ScriptException x) {
                                 return false;
                             }
@@ -456,11 +455,9 @@ public class WalletTool implements Callable<Integer> {
                         String[] parts = selectOutputStr.split(":", 2);
                         Sha256Hash selectTransactionHash = Sha256Hash.wrap(parts[0]);
                         int selectIndex = Integer.parseInt(parts[1]);
-                        coinSelector = CoinSelector.fromPredicate(candidate -> {
-                            int candidateIndex = candidate.getIndex();
-                            Sha256Hash candidateTransactionHash = candidate.getParentTransactionHash();
-                            return selectIndex == candidateIndex && selectTransactionHash.equals(candidateTransactionHash);
-                        });
+                        coinSelector = CoinSelector.fromPredicate(candidate ->
+                             candidate.getIndex() == selectIndex && candidate.getParentTransactionHash().equals(selectTransactionHash)
+                        );
                     }
                     send(coinSelector, outputsStr, feePerVkb, lockTimeStr, allowUnconfirmed);
                 } else if (paymentRequestLocationStr != null) {

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -424,11 +424,13 @@ public class WalletTool implements Callable<Integer> {
                     System.err.println("--fee-per-kb and --fee-sat-per-byte cannot be used together.");
                     return 1;
                 } else if (outputsStr != null) {
-                    Coin feePerVkb = null;
+                    Coin feePerVkb;
                     if (feePerVkbStr != null)
                         feePerVkb = parseCoin(feePerVkbStr);
-                    if (feeSatPerVbyteStr != null)
+                    else if (feeSatPerVbyteStr != null)
                         feePerVkb = Coin.valueOf(Long.parseLong(feeSatPerVbyteStr) * 1000);
+                    else
+                        feePerVkb = null;
                     if (selectAddrStr != null && selectOutputStr != null) {
                         System.err.println("--select-addr and --select-output cannot be used together.");
                         return 1;

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -433,7 +433,7 @@ public class WalletTool implements Callable<Integer> {
                         System.err.println("--select-addr and --select-output cannot be used together.");
                         return 1;
                     }
-                    CoinSelector coinSelector = null;
+                    CoinSelector coinSelector;
                     if (selectAddrStr != null) {
                         Address selectAddr;
                         try {
@@ -450,14 +450,15 @@ public class WalletTool implements Callable<Integer> {
                                 return false;
                             }
                         });
-                    }
-                    if (selectOutputStr != null) {
+                    } else if (selectOutputStr != null) {
                         String[] parts = selectOutputStr.split(":", 2);
                         Sha256Hash selectTransactionHash = Sha256Hash.wrap(parts[0]);
                         int selectIndex = Integer.parseInt(parts[1]);
                         coinSelector = CoinSelector.fromPredicate(candidate ->
                              candidate.getIndex() == selectIndex && candidate.getParentTransactionHash().equals(selectTransactionHash)
                         );
+                    } else {
+                        coinSelector = null;
                     }
                     send(coinSelector, outputsStr, feePerVkb, lockTimeStr, allowUnconfirmed);
                 } else if (paymentRequestLocationStr != null) {


### PR DESCRIPTION
This is split into 4 commits, the first being the most significant (using `CoinSelector.fromPredicate`) and the others providing some further simplification/cleanup of surrounding code.