### PR TITLE
DefaultCoinSelector: extract compareByDepth comparator

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/DefaultCoinSelector.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DefaultCoinSelector.java
@@ -101,7 +101,7 @@ public class DefaultCoinSelector implements CoinSelector {
      */
     @Deprecated
     static void sortOutputs(ArrayList<TransactionOutput> outputs) {
-        Collections.sort(outputs, DefaultCoinSelector::compareByDepth);
+        outputs.sort(DefaultCoinSelector::compareByDepth);
     }
 
     /** Sub-classes can override this to just customize whether transactions are usable, but keep age sorting. */

--- a/core/src/test/java/org/bitcoinj/wallet/DefaultCoinSelectorTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DefaultCoinSelectorTest.java
@@ -96,7 +96,7 @@ public class DefaultCoinSelectorTest extends TestWithWallet {
         ArrayList<TransactionOutput> candidates = new ArrayList<>();
         candidates.add(t2.getOutput(0));
         candidates.add(t1.getOutput(0));
-        DefaultCoinSelector.sortOutputs(candidates);
+        candidates.sort(DefaultCoinSelector::compareByDepth);
         assertEquals(t1.getOutput(0), candidates.get(0));
         assertEquals(t2.getOutput(0), candidates.get(1));
     }
@@ -117,7 +117,7 @@ public class DefaultCoinSelectorTest extends TestWithWallet {
         candidates.add(t3.getOutput(0));
         candidates.add(t2.getOutput(0));
         candidates.add(t1.getOutput(0));
-        DefaultCoinSelector.sortOutputs(candidates);
+        candidates.sort(DefaultCoinSelector::compareByDepth);
         assertEquals(t2.getOutput(0), candidates.get(0));
         assertEquals(t1.getOutput(0), candidates.get(1));
         assertEquals(t3.getOutput(0), candidates.get(2));


### PR DESCRIPTION
This is actually split into two commits, the first is the extract method. The second updates the deprecated `sortOutputs` method to use `List.sort` instead of `Collections.sort` as suggested by the IDE (and the `@deprecation` comment.)