### PR TITLE
README: Official builds with JDK 17

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,7 @@ To get started, it is best to have the latest JDK and Gradle installed. The HEAD
 
 #### Building from the command line
 
-Official builds are currently using JDK 11. Our GitHub Actions build and test with JDK 11, 17 and 21.
+Official builds are currently using JDK 17. Our GitHub Actions build and test with JDK 11, 17 and 21.
 
 To perform a full build (_including_ JavaDocs, unit/integration _tests_, and `wallettemplate`) use JDK 17+.
 


### PR DESCRIPTION
This updates the README to reflect recent changes (21 in CI) and discussions (official builds using 17.)

Note that PR #2814 includes related changes reflecting that `wallettemplate` now requires JDK 17+.
