### PR TITLE
Wallet: use getAbsoluteFile() when checking parent directory exists

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -1700,11 +1700,11 @@ public class Wallet extends BaseTaggableObject
      * @throws IOException           if an error occurs while saving
      */
     public void saveToFile(File tempFile, File destFile) throws IOException {
-        File tempParentFile = tempFile.getParentFile();
+        File tempParentFile = tempFile.getAbsoluteFile().getParentFile();
         if (!tempParentFile.exists()) {
             throw new FileNotFoundException(tempParentFile.getPath() + " (wallet directory not found)");
         }
-        File destParentFile = destFile.getParentFile();
+        File destParentFile = destFile.getAbsoluteFile().getParentFile();
         if (!destParentFile.exists()) {
             throw new FileNotFoundException(destParentFile.getPath() + " (wallet directory not found)");
         }


### PR DESCRIPTION
This fixes Issue #3239 that shows up in WalletTool.