### PR TITLE
WTUtils: fix warning about raw generic

### DIFF
--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/utils/WTUtils.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/utils/WTUtils.java
@@ -66,7 +66,7 @@ public class WTUtils {
         }
     }
 
-    public static boolean didThrow(UncheckedRun run) {
+    public static boolean didThrow(UncheckedRun<?> run) {
         try {
             run.run();
             return false;


### PR DESCRIPTION
Add a `<?>` to fix a warning about a raw generic type.