### PR TITLE
Use Duration in 2 calls to sleepUninterruptibly

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -37,7 +38,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import static org.bitcoinj.base.internal.Preconditions.checkState;
@@ -272,7 +272,7 @@ public class TransactionBroadcast {
 
     private static Runnable dropPeerAfterBroadcastHandler(Peer peer) {
         return () ->  {
-            Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+            Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(1));
             peer.close();
         };
     }

--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/utils/KeyDerivationTasks.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/utils/KeyDerivationTasks.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.*;
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 
 import static org.bitcoinj.walletfx.utils.GuiUtils.checkGuiThread;
 
@@ -77,7 +76,7 @@ public class KeyDerivationTasks {
                         updateProgress(progress, 1.0);
 
                         // 60fps would require 16msec sleep here.
-                        Uninterruptibles.sleepUninterruptibly(20, TimeUnit.MILLISECONDS);
+                        Uninterruptibles.sleepUninterruptibly(Duration.ofMillis(20));
                     }
                     // Wait for the encryption thread before switching back to main UI.
                     updateProgress(1.0, 1.0);


### PR DESCRIPTION
Reasons for doing this:
1) We are standardizing on using Duration where possible.
2) Duration values can be a single named constant if desired
3) When we replace this use of Guava, we'll want to use Duration