### PR TITLE
PBKDF2SHA512: remove comment about SHA-1 test vectors

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/PBKDF2SHA512.java
+++ b/core/src/main/java/org/bitcoinj/crypto/PBKDF2SHA512.java
@@ -33,8 +33,6 @@ import java.nio.charset.StandardCharsets;
 /**
  * This is a clean-room implementation of PBKDF2 using RFC 2898 as a reference.
  * Modified to use SHA-512 by Ken Sedgwick (ken@bonsai.com)
- * <p>
- * This code passes all <a href="https://datatracker.ietf.org/doc/html/rfc6070">RFC 6070 test vectors</a>
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc2898#section-5.2">RFC 2898 (Section 5.2)</a>
  * @see <a href="https://cryptofreek.org/2012/11/29/pbkdf2-pure-java-implementation/">PBKDF2 – Pure Java Implementation by Cryptofreek</a>
  */


### PR DESCRIPTION
They won't pass against our SHA-512 based code, and we have our tests now.