### PR TITLE
PBKDF2SHA512: Remove redundant check of max dkLen 

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/PBKDF2SHA512.java
+++ b/core/src/main/java/org/bitcoinj/crypto/PBKDF2SHA512.java
@@ -50,9 +50,6 @@ public class PBKDF2SHA512 {
         Preconditions.checkArgument(dkLen > 0, () -> "derived key length must be greater than zero");
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        if (dkLen > ((Math.pow(2, 32)) - 1) * H_LEN) {
-            throw new IllegalArgumentException("derived key too long");
-        }
         try {
             int l = (dkLen + H_LEN - 1) / H_LEN;    // Divide by H_LEN with rounding up
             // int r = dkLen - (l-1)*hLen;


### PR DESCRIPTION
This PR consists of 5 small refactoring that improve the error-checking and readability of the  `derive` method.

1. Move parameter check of `dkLen` out of try/catch
2. Don't allow negative count or `dkLen`
3. Remove redundant check of exceeded max `dkLen` value
4. Declare/catch specific exceptions thrown by `F` and caught in main `try`
5. Calculate `l` (loop count) with integer math 
