### PR TITLE
PBKDF2SHA512: Replace unneeded check for max dkLen with comment.

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/PBKDF2SHA512.java
+++ b/core/src/main/java/org/bitcoinj/crypto/PBKDF2SHA512.java
@@ -50,9 +50,8 @@ public class PBKDF2SHA512 {
         Preconditions.checkArgument(dkLen > 0, () -> "derived key length must be greater than zero");
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-        if (dkLen > ((Math.pow(2, 32)) - 1) * H_LEN) {
-            throw new IllegalArgumentException("derived key too long");
-        }
+        // The algorithm in RFC 2898 section 5.2, says to check `dkLen` is not greater than (2^32 - 1) * `H_LEN`
+        // But that is not possible given `dkLen` is an `int` argument, so we omit the check.
         try {
             int l = (dkLen + H_LEN - 1) / H_LEN;    // Divide by H_LEN with rounding up
             // int r = dkLen - (l-1)*hLen;


### PR DESCRIPTION
Since the check for dkLen > (2^32 - 1) * `H_LEN` is effectively a no-op, replace it with a comment.