### PR TITLE
build.gradle: strip various timestamps from build artifacts

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -57,6 +57,10 @@ tasks.withType(AbstractArchiveTask) {
     reproducibleFileOrder = true
 }
 
+tasks.withType(Javadoc) {
+    options.noTimestamp = true
+}
+
 tasks.withType(Test) {
     exclude 'org/bitcoinj/net/discovery/DnsDiscoveryTest*'
     testLogging {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -52,6 +52,11 @@ protobuf {
     }
 }
 
+tasks.withType(AbstractArchiveTask) {
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+}
+
 tasks.withType(Test) {
     exclude 'org/bitcoinj/net/discovery/DnsDiscoveryTest*'
     testLogging {


### PR DESCRIPTION
This aims to make our build reprodicible.