### PR TITLE
core/build.gradle: Use constraint to enforce Android Guava

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -24,6 +24,22 @@ dependencies {
     testImplementation 'pl.pragmatists:JUnitParams:1.1.1'
 }
 
+// Prevent newer Gradle from switching to JRE version of Guava
+
+def gradleVersionTargetJVM = GradleVersion.version("7.0")
+
+if (GradleVersion.current().compareTo(gradleVersionTargetJVM) > 0) {
+    dependencies.constraints {
+        implementation("com.google.guava:guava") {
+            attributes {
+                attribute(
+                        TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE,
+                        objects.named(TargetJvmEnvironment, TargetJvmEnvironment.ANDROID))
+            }
+        }
+    }
+}
+
 sourceCompatibility = 8
 targetCompatibility = 8
 compileJava.options.encoding = 'UTF-8'


### PR DESCRIPTION
This is a solution to Issue #3262 

I tested this against PR #3246 which was only failing with Gradle 4.10.3 but should have been failing for _all_ builds in the GitHub CI matrix. With this change the build properly fails when JRE-only Guava methods are used.