### PR TITLE
PBKDF2SHA512: remove redundant mac.reset() calls

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/PBKDF2SHA512.java
+++ b/core/src/main/java/org/bitcoinj/crypto/PBKDF2SHA512.java
@@ -89,10 +89,8 @@ public class PBKDF2SHA512 {
 
                 U_XOR = mac.doFinal(baU);
                 U_LAST = U_XOR;
-                mac.reset();
             } else {
                 byte[] baU = mac.doFinal(U_LAST);
-                mac.reset();
 
                 for (int k = 0; k < U_XOR.length; k++) {
                     U_XOR[k] = (byte) (U_XOR[k] ^ baU[k]);


### PR DESCRIPTION
Calls to mac.reset() are not needed after mac.doFinal(input) as stated in the JavaDoc for doFinal:

> A call to this method resets this Mac object to the state it was in when previously initialized