### PR TITLE
build.gradle: drop the Eclipse plugin

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -4,7 +4,6 @@ plugins {
     id 'java-library'
     id 'com.google.protobuf'
     id 'maven-publish'
-    id 'eclipse'
 }
 
 version = '0.17-SNAPSHOT'

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'java'
-    id 'eclipse'
 }
 
 dependencies {

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'java'
     id 'java-library'
-    id 'eclipse'
 }
 
 dependencies {

--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'java'
-    id 'eclipse'
 }
 
 dependencies {

--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'java'
-    id 'eclipse'
     id 'application'
     id 'org.openjfx.javafxplugin' version '0.1.0'
 }

--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -3,7 +3,6 @@ import org.gradle.util.GradleVersion
 plugins {
     id 'java'
     id 'application'
-    id 'eclipse'
     id 'org.asciidoctor.jvm.convert' version '3.3.2' apply false
     id 'org.graalvm.buildtools.native' version '0.9.11' apply false
 }


### PR DESCRIPTION
We assume that these days the plugin isn't needed to set up bitcoinj within Eclipse.

If you feel this is not the case, and/or if you're actually using Eclipse and would like to continued support for it, please comment here.

I'll leave this open for a while deliberately. There is no need to hurry.