### PR TITLE
.gitlab-ci.yml: Add :bitcoinj-wallettool:installDist Gradle targets

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ bullseye-jdk11:
     - apt-get update
     - apt-get -y install openjdk-11-jdk-headless gradle
   script:
-    - gradle build --stacktrace
+    - gradle build :bitcoinj-wallettool:installDist --stacktrace
   after_script:
     - gradle --version
   artifacts:
@@ -18,7 +18,7 @@ bookworm-jdk17:
     - apt-get update
     - apt-get -y install openjdk-17-jdk-headless gradle
   script:
-    - gradle build --stacktrace
+    - gradle build :bitcoinj-wallettool:installDist --stacktrace
   after_script:
     - gradle --version
   artifacts:
@@ -32,7 +32,7 @@ trixie-jdk21:
     - apt-get update
     - apt-get -y install openjdk-21-jdk-headless gradle
   script:
-    - gradle build --stacktrace
+    - gradle build :bitcoinj-wallettool:installDist --stacktrace
   after_script:
     - gradle --version
   artifacts:


### PR DESCRIPTION
Add it to all three build jobs.

The full build of wallet-tool should be part of regular CI.