### PR TITLE
WIP: Reference build with reusable build container

### DIFF
--- a/bitcoinj-reference-build.sh
+++ b/bitcoinj-reference-build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Run reference-container-build.sh before using this script
+# The output will be produced in the same location as a locally hosted build
+docker run --rm --name bitcoinj-reference-build -v .:/project -it \
+    bitcoinj/reference-build:latest \
+    /usr/bin/gradle --no-build-cache --no-daemon --no-parallel --project-dir /project/ \
+        :bitcoinj-core:build :bitcoinj-wallettool:installDist

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.5"
+
+#
+# Docker Compose File for reproducibly building bitcoinj
+#
+# To build use:
+#     docker compose run --rm build
+#
+# This will create a local image `named bitcoinj-build-tools-image` (if it does
+# not already exist) using `reference-container.ContainerFile`. This is a debian slim image
+# with openjdk and gradle installed via `apt-get`.
+# The `build` "service" will mount this directory in the container as "/project" and run
+# the Gradle build inside the container, writing artifacts to the same locations on your
+# disk as if you had run `gradle` on the host.
+#
+services:
+    build:
+        image: bitcoinj-build-tools-image 
+        depends_on:
+            - build-image-builder
+        volumes:
+            - .:/project
+        command: /usr/bin/gradle --no-build-cache --no-daemon --no-parallel --project-dir /project/ clean :bitcoinj-core:build :bitcoinj-wallettool:installDist
+    build-image-builder:
+        build:
+            context: .
+            dockerfile: reference-container.ContainerFile
+        image: bitcoinj-build-tools-image             # this service builds the image

--- a/reference-container-build.sh
+++ b/reference-container-build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# This script builds a Container image that can be used to run a reference build of bitcoinj.
+# Run this script to build the container and then use bitcoinj-reference-build.sh to
+# make the reference build of bitcoinj.
+# When building the continer `apt-get update` and `apt-get install` are run once and can
+# then be reused for multiple builds of bitcoinj.
+#
+docker build --file reference-container.ContainerFile -t bitcoinj/reference-build .
+

--- a/reference-container.ContainerFile
+++ b/reference-container.ContainerFile
@@ -1,0 +1,6 @@
+FROM debian:bookworm-slim
+
+# prepare debian environment
+ENV DEBIAN_FRONTEND noninteractive
+RUN /usr/bin/apt-get update && \
+    /usr/bin/apt-get --yes install openjdk-17-jdk-headless gradle


### PR DESCRIPTION
This commit splits the reference build into two steps:

1. Build a reference build container with `reference-container-build.sh`
2. Use the container to create a bitcoinj build with `bitcoinj-reference-build.sh` 

`reference-container.ContainerFile` is the ContainerFile for the reusable build container.
