### PR TITLE
graalvm.yml: Add GraalVM CE 21 to the Matrix

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           java-version: ${{ matrix.java-version }}
           distribution: ${{ matrix.distribution }}
-          components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2.8.0

--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        java-version: [ '17' ]
+        java-version: [ '17', '21' ]
         distribution: [ 'graalvm-community' ]
         gradle: ['8.3']
       fail-fast: false

--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'application'
     id 'eclipse'
     id 'org.asciidoctor.jvm.convert' version '3.3.2' apply false
-    id 'org.graalvm.buildtools.native' version '0.9.11' apply false
+    id 'org.graalvm.buildtools.native' version '0.9.27' apply false
 }
 
 def annotationProcessorMinVersion = GradleVersion.version("4.6")
@@ -13,8 +13,8 @@ boolean hasAnnotationProcessor = (GradleVersion.current().compareTo(annotationPr
 def junit5MinVersion = GradleVersion.version("4.6")
 boolean hasJunit5 = (GradleVersion.current().compareTo(junit5MinVersion) >= 0)
 
-def toolchainsMinVersion = GradleVersion.version("6.8")     // Toolchains with selection by vendor
-boolean hasToolchains = (GradleVersion.current().compareTo(toolchainsMinVersion) >= 0)
+def graalVMMinVersion = GradleVersion.version("7.4")     // Toolchains with selection by vendor
+boolean hasGraalVM = (GradleVersion.current().compareTo(graalVMMinVersion) >= 0)
 
 dependencies {
     implementation project(':bitcoinj-core')
@@ -76,7 +76,7 @@ asciidoctor {
     }
 }
 
-if (hasToolchains) {
+if (hasGraalVM) {
 
     apply plugin: 'org.graalvm.buildtools.native'
 
@@ -86,10 +86,6 @@ if (hasToolchains) {
                 imageName = applicationName
                 configurationFileDirectories.from(file('src/main/graal'))
                 buildArgs.add('--allow-incomplete-classpath')
-                javaLauncher = javaToolchains.launcherFor {
-                    languageVersion = JavaLanguageVersion.of(17)
-                    vendor = JvmVendorSpec.matching("GraalVM Community")
-                }
             }
         }
     }


### PR DESCRIPTION
This consists of 2 commits:

1. Remove unneeded declaration of native-image component (This is not needed with GraalVM 17 and will cause an error with GraalVM 21)
2. Add GraalVM 21 to the Matrix

 