### PR TITLE
build.Containerfile: update reference build to use JDK 17

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,7 @@ To get started, it is best to have the latest JDK and Gradle installed. The HEAD
 
 #### Building from the command line
 
-Official builds are currently using JDK 11. Our GitHub Actions build and test with JDK 11, 17 and 21.
+Official builds are currently using JDK 17. Our GitHub Actions build and test with JDK 11, 17 and 21.
 
 To perform a full build (_including_ JavaDocs, unit/integration _tests_, and `wallettemplate`) use JDK 17+.
 

--- a/build.Containerfile
+++ b/build.Containerfile
@@ -16,11 +16,11 @@
 #
 
 # stage: set up debian environment
-FROM debian:bullseye-slim AS setup-stage
+FROM debian:bookworm-slim AS setup-stage
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN /usr/bin/apt-get update && \
-    /usr/bin/apt-get --yes install openjdk-11-jdk-headless gradle && \
+    /usr/bin/apt-get --yes install openjdk-17-jdk-headless gradle && \
     /usr/sbin/adduser --disabled-login --gecos "" builder
 
 # stage: build


### PR DESCRIPTION
Also updates the container to Debian Bookworm, because we need its specific Gradle version.

Note this change makes the JavaDoc build artifact reproducible.