### PR TITLE
gradle.yml: use JDK `21` in the matrix

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        java: ['11', '17', '21-ea']
+        java: ['11', '17', '21']
         distribution: ['temurin']
         gradle: ['8.4']
         include:


### PR DESCRIPTION
Upgrade from `21-ea` to `21`.

~~This is a DRAFT PR because `21` isn't available on GitHub yet and the build is failing. When `21` is available we can re-run tests on this PR and then merge.~~