### PR TITLE
.gitlab-ci.yml: remove publishing of artifacts for CI builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,10 +22,6 @@ bullseye-jdk11:
     - gradle build --stacktrace
   after_script:
     - gradle --version
-  artifacts:
-    name: bitcoinj-$CI_JOB_NAME-$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHORT_SHA
-    paths:
-      - core/build/libs/*.jar
 
 bookworm-jdk17:
   image: debian:bookworm-slim
@@ -36,10 +32,6 @@ bookworm-jdk17:
     - gradle build --stacktrace
   after_script:
     - gradle --version
-  artifacts:
-    name: bitcoinj-$CI_JOB_NAME-$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHORT_SHA
-    paths:
-      - core/build/libs/*.jar
 
 trixie-jdk21:
   image: debian:trixie-slim
@@ -50,10 +42,6 @@ trixie-jdk21:
     - gradle build --stacktrace
   after_script:
     - gradle --version
-  artifacts:
-    name: bitcoinj-$CI_JOB_NAME-$CI_COMMIT_REF_SLUG-$CI_COMMIT_SHORT_SHA
-    paths:
-      - core/build/libs/*.jar
 
 sast:
   stage: test


### PR DESCRIPTION
We have our reference build now and all published artifacts go through that one.

Example of an entire build (all jobs):

https://gitlab.com/bitcoinj/bitcoinj/-/pipelines/1012760479/builds
