### PR TITLE
Gradle build: support "reproducible" and "modern" variants

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -81,9 +81,9 @@ test {
     }
 }
 
-def gradleVersionToolchains = GradleVersion.version("6.7")
+def minModernGradleVersion = GradleVersion.version("7.4")
 
-if (GradleVersion.current().compareTo(gradleVersionToolchains) > 0) {
+if (GradleVersion.current().compareTo(minModernGradleVersion) > 0) {
     // If the Gradle Java Toolchains feature is available, run tests on older JDKs
     System.err.println "Adding 'testOnJdk8' task, because ${GradleVersion.current()}"
 
@@ -110,10 +110,8 @@ jar {
     }
 }
 
-def minGradleArchiveClassifierVersion = GradleVersion.version("5.0")
-
 task javadocJar(type: Jar, dependsOn: javadoc) {
-    if (GradleVersion.current().compareTo(minGradleArchiveClassifierVersion) > 0) {
+    if (GradleVersion.current().compareTo(minModernGradleVersion) > 0) {
         archiveClassifier.set('javadoc')
     } else {
         classifier = 'javadoc'
@@ -122,7 +120,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {
-    if (GradleVersion.current().compareTo(minGradleArchiveClassifierVersion) > 0) {
+    if (GradleVersion.current().compareTo(minModernGradleVersion) > 0) {
         archiveClassifier.set('sources')
     } else {
         classifier = 'sources'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,17 +1,18 @@
 import org.gradle.util.GradleVersion
 import org.gradle.api.GradleScriptException
 
-// Minimum Gradle version for build
-def minGradleVersion = GradleVersion.version("4.4")
-// Minimum Gradle version for JUnit5
-def minJunit5GradleVersion = GradleVersion.version("4.6")
-// Minimum Gradle version for builds of JavaFX 17 module using JDK 17
-def minFxGradleVersion = GradleVersion.version("7.3")
+// Minimum and Maximum Gradle versions for reproducible Debian-based build
+def minReproducibleGradleVersion = GradleVersion.version("4.4")
+def maxReproducibleGradleVersion = GradleVersion.version("4.11")
+// Minimum Gradle version for modern Gradle builds (JUnit 5, GraalVM, JavaFX support, etc.)
+def minModernGradleVersion = GradleVersion.version("7.4")
 
 rootProject.name = 'bitcoinj-parent'
 
-if (GradleVersion.current().compareTo(minGradleVersion) < 0) {
-    throw new GradleScriptException("bitcoinj build requires Gradle ${minGradleVersion} or later", null)
+if (GradleVersion.current().compareTo(minReproducibleGradleVersion) < 0  ||
+        (GradleVersion.current().compareTo(maxReproducibleGradleVersion) > 0) &&
+        GradleVersion.current().compareTo(minModernGradleVersion) < 0) {
+    throw new GradleScriptException("bitcoinj build requires Gradle ${minReproducibleGradleVersion} - ${maxReproducibleGradleVersion} or ${minModernGradleVersion}+", null)
 }
 
 if (!JavaVersion.current().isJava11Compatible()) {
@@ -30,18 +31,18 @@ project(':wallettool').name = 'bitcoinj-wallettool'
 include 'examples'
 project(':examples').name = 'bitcoinj-examples'
 
-if (GradleVersion.current().compareTo(minFxGradleVersion) > 0 && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+if (GradleVersion.current().compareTo(minModernGradleVersion) > 0 && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
     System.err.println "Including wallettemplate because ${GradleVersion.current()}"
     include 'wallettemplate'
     project(':wallettemplate').name = 'bitcoinj-wallettemplate'
 } else {
-    System.err.println "Skipping wallettemplate, requires Gradle ${minFxGradleVersion}+ and Java 17+, currently running Gradle: ${GradleVersion.current()}, Java ${JavaVersion.current()}"
+    System.err.println "Skipping wallettemplate, requires Gradle ${minModernGradleVersion}+ and Java 17+, currently running Gradle: ${GradleVersion.current()}, Java ${JavaVersion.current()}"
 }
 
-if (GradleVersion.current().compareTo(minJunit5GradleVersion) >= 0) {
+if (GradleVersion.current().compareTo(minModernGradleVersion) >= 0) {
     System.err.println "Including integration-test because ${GradleVersion.current()}"
     include 'integration-test'
     project(':integration-test').name = 'bitcoinj-integration-test'
 } else {
-    System.err.println "Skipping integration-test, requires Gradle ${minJunit5GradleVersion}+, currently running: ${GradleVersion.current()}"
+    System.err.println "Skipping integration-test, requires Gradle ${minModernGradleVersion}+, currently running: ${GradleVersion.current()}"
 }

--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -8,19 +8,14 @@ plugins {
     id 'org.graalvm.buildtools.native' version '0.9.27' apply false
 }
 
-def annotationProcessorMinVersion = GradleVersion.version("4.6")
-boolean hasAnnotationProcessor = (GradleVersion.current().compareTo(annotationProcessorMinVersion) >= 0)
-def junit5MinVersion = GradleVersion.version("4.6")
-boolean hasJunit5 = (GradleVersion.current().compareTo(junit5MinVersion) >= 0)
-
-def graalVMMinVersion = GradleVersion.version("7.4")     // Toolchains with selection by vendor
-boolean hasGraalVM = (GradleVersion.current().compareTo(graalVMMinVersion) >= 0)
+def minModernGradleVersion = GradleVersion.version("7.4")
+boolean isModernGradle = (GradleVersion.current().compareTo(minModernGradleVersion) >= 0)
 
 dependencies {
     implementation project(':bitcoinj-core')
     implementation 'info.picocli:picocli:4.7.4'
     implementation 'org.slf4j:slf4j-jdk14:2.0.7'
-    if (hasAnnotationProcessor) {
+    if (isModernGradle) {
         annotationProcessor 'info.picocli:picocli-codegen:4.7.4'
     } else {
         compileOnly 'info.picocli:picocli-codegen:4.7.4'
@@ -46,7 +41,7 @@ mainClassName = "org.bitcoinj.wallettool.WalletTool"
 applicationName = "wallet-tool"
 
 // wallettool is using JUnit 5 for testing, if it's not available no tests will be run
-if (hasJunit5) {
+if (isModernGradle) {
     test {
         useJUnitPlatform()
     }
@@ -56,7 +51,7 @@ task generateManpageAsciiDoc(type: JavaExec) {
     dependsOn(classes)
     group = "Documentation"
     description = "Generate AsciiDoc manpage"
-    if (hasAnnotationProcessor) {
+    if (isModernGradle) {
         classpath(sourceSets.main.compileClasspath, configurations.annotationProcessor, sourceSets.main.runtimeClasspath)
     } else {
         classpath(sourceSets.main.compileClasspath, sourceSets.main.runtimeClasspath)
@@ -76,7 +71,7 @@ asciidoctor {
     }
 }
 
-if (hasGraalVM) {
+if (isModernGradle) {
 
     apply plugin: 'org.graalvm.buildtools.native'
 


### PR DESCRIPTION
Simplify Gradle feature testing and reduce the number of versions of Gradle that the build supports.

* support Gradle 4.4 - 4.11 and Gradle 7.5+
* simplify feature testing to use minModernGradleVersion