### PR TITLE
GitHub Actions: Use build-scan-agree.gradle init script

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -27,7 +27,7 @@ jobs:
         uses: gradle/gradle-build-action@v2.8.0
         with:
           gradle-version: ${{ matrix.gradle }}
-          arguments: test nativeCompile --info --stacktrace
+          arguments: test nativeCompile --init-script build-scan-agree.gradle --scan --info --stacktrace
       - name: Upload wallet-tool as artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,7 +32,7 @@ jobs:
         uses: gradle/gradle-build-action@v2.8.0
         with:
           gradle-version: ${{ matrix.gradle }}
-          arguments: -PtestJdk8=true build --info --stacktrace
+          arguments: -PtestJdk8=true build --init-script build-scan-agree.gradle --scan --info --stacktrace
       - name: Upload Test Results and Reports
         uses: actions/upload-artifact@v3
         if: always()

--- a/build-scan-agree.gradle
+++ b/build-scan-agree.gradle
@@ -1,0 +1,37 @@
+/* Gradle Init Script to non-interactively agree to the Gradle Build Scan terms of service
+ * Provided by Stefan Wolf via GitHub Issues
+ * See: https://github.com/gradle/gradle/issues/26316#issuecomment-1739245349
+ * To use add `--scan --init-script build-scan-agree.gradle` to your Gradle command-line
+ * Works with Gradle 4.4 - Gradle 8.4 (at least)
+ */
+def isTopLevelBuild = gradle.getParent() == null
+
+if (isTopLevelBuild) {
+    def gradleVersion = GradleVersion.current().baseVersion
+    def atLeastGradle6 = gradleVersion >= GradleVersion.version("6.0")
+    if (atLeastGradle6) {
+        settingsEvaluated { settings ->
+            settings.pluginManager.withPlugin("com.gradle.enterprise") {
+                configureExtension(settings.extensions["gradleEnterprise"].buildScan)
+            }
+        }
+    } else {
+        rootProject { root ->
+            root.pluginManager.withPlugin("com.gradle.build-scan") {
+                configureExtension(root.extensions["buildScan"])
+            }
+        }
+    }
+}
+
+void configureExtension(extension) {
+    extension.with {
+        if (delegate.metaClass.respondsTo(delegate, 'setTermsOfServiceUrl')) {
+            termsOfServiceUrl = "https://gradle.com/terms-of-service"
+            termsOfServiceAgree = "yes"
+        } else {
+            licenseAgreementUrl = "https://gradle.com/terms-of-service"
+            licenseAgree = "yes"
+        }
+    }
+}


### PR DESCRIPTION
Add a Gradle initialization script to non-interactively agree to the Gradle Build Scan terms of service. Provided by Stefan Wolf via GitHub Issues.

Works with Gradle 4.4 - Gradle 8.4 (at least)

See:

https://github.com/gradle/gradle/issues/26316#issuecomment-1739245349


`--scan --init-script build-scan-agree.gradle` added to gradle.yml and graalvm.yml GitHub workflows.

(If we decide to add to GitLab CI that can be in a separate PR)