### PR TITLE
GitLab CI: Add build scans using init script to agree to TOS

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ bullseye-jdk11:
     - apt-get update
     - apt-get -y install openjdk-11-jdk-headless gradle
   script:
-    - gradle build :bitcoinj-core:publishToMavenLocal :bitcoinj-wallettool:installDist --stacktrace
+    - gradle build :bitcoinj-core:publishToMavenLocal :bitcoinj-wallettool:installDist --init-script build-scan-agree.gradle --scan --stacktrace
   after_script:
     - gradle --version
     - sha256sum core/build/libs/*.jar wallettool/build/install/wallet-tool/bin/*  wallettool/build/install/wallet-tool/lib/*.jar
@@ -32,7 +32,7 @@ bookworm-jdk17:
     - apt-get update
     - apt-get -y install openjdk-17-jdk-headless gradle
   script:
-    - gradle build :bitcoinj-core:publishToMavenLocal :bitcoinj-wallettool:installDist --stacktrace
+    - gradle build :bitcoinj-core:publishToMavenLocal :bitcoinj-wallettool:installDist --init-script build-scan-agree.gradle --scan --stacktrace
   after_script:
     - gradle --version
     - sha256sum core/build/libs/*.jar wallettool/build/install/wallet-tool/bin/*  wallettool/build/install/wallet-tool/lib/*.jar
@@ -43,7 +43,7 @@ trixie-jdk21:
     - apt-get update
     - apt-get -y install openjdk-21-jdk-headless gradle
   script:
-    - gradle build :bitcoinj-core:publishToMavenLocal :bitcoinj-wallettool:installDist --stacktrace
+    - gradle build :bitcoinj-core:publishToMavenLocal :bitcoinj-wallettool:installDist --init-script build-scan-agree.gradle --scan --stacktrace
   after_script:
     - gradle --version
     - sha256sum core/build/libs/*.jar wallettool/build/install/wallet-tool/bin/*  wallettool/build/install/wallet-tool/lib/*.jar


### PR DESCRIPTION
Add `--init-script build-scan-agree.gradle --scan` to the Gradle command-line of the three non-reference builds.

~~This is a child of PR #3289~~ (Has now been rebased on `master`) 
