### PR TITLE
WalletTool: remove unused/obsolete print help code

### DIFF
--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -39,7 +39,6 @@ import org.bitcoinj.wallet.CoinSelector;
 import org.bitcoinj.wallet.DeterministicKeyChain;
 import org.bitcoinj.wallet.DeterministicSeed;
 
-import com.google.common.io.Resources;
 import com.google.protobuf.ByteString;
 
 import org.bitcoinj.core.AbstractBlockChain;
@@ -339,11 +338,6 @@ public class WalletTool implements Callable<Integer> {
 
     @Override
     public Integer call() throws IOException, BlockStoreException {
-        if (help) {
-            System.out.println(Resources.toString(WalletTool.class.getResource("wallet-tool-help.txt"), StandardCharsets.UTF_8));
-            return 0;
-        }
-
         ActionEnum action;
         try {
             action = ActionEnum.valueOf(actionStr.toUpperCase().replace("-", "_"));


### PR DESCRIPTION
This code has been unused since the conversion to picocli. 

picocli generates help text and automatically handles printing it. The `wallet-tool-help.txt` file was deleted in the commit with the picocli implementation. (See 4c094ef193270860e10b14b7bb9dd6e63718dd28 )

Note: this also removes the last usage of Guava in WalletTool.
