### PR TITLE
KeyDerivationTasks: use Thread.sleep instead of Guava Uninterrruptables, define interval with a Duration

### DIFF
--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/utils/KeyDerivationTasks.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/utils/KeyDerivationTasks.java
@@ -18,7 +18,6 @@ package org.bitcoinj.walletfx.utils;
 
 import org.bitcoinj.crypto.AesKey;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
-import com.google.common.util.concurrent.Uninterruptibles;
 import javafx.beans.property.ReadOnlyDoubleProperty;
 import javafx.concurrent.Task;
 import org.slf4j.Logger;
@@ -26,7 +25,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.*;
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 
 import static org.bitcoinj.walletfx.utils.GuiUtils.checkGuiThread;
 
@@ -78,7 +76,7 @@ public class KeyDerivationTasks {
                         double progress = (curTime - startTime) / (double) targetTimeMillis;
                         updateProgress(progress, 1.0);
 
-                        Uninterruptibles.sleepUninterruptibly(PROGRESS_UPDATE_INTERVAL.toMillis(), TimeUnit.MILLISECONDS);
+                        Thread.sleep(PROGRESS_UPDATE_INTERVAL.toMillis());
                     }
                     // Wait for the encryption thread before switching back to main UI.
                     updateProgress(1.0, 1.0);

--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/utils/KeyDerivationTasks.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/utils/KeyDerivationTasks.java
@@ -35,6 +35,8 @@ import static org.bitcoinj.walletfx.utils.GuiUtils.checkGuiThread;
  */
 public class KeyDerivationTasks {
     private static final Logger log = LoggerFactory.getLogger(KeyDerivationTasks.class);
+    // 60fps would require a 16 millisecond value here.
+    private static final Duration PROGRESS_UPDATE_INTERVAL = Duration.ofMillis(20);
 
     public final Task<AesKey> keyDerivationTask;
     public final ReadOnlyDoubleProperty progress;
@@ -76,8 +78,7 @@ public class KeyDerivationTasks {
                         double progress = (curTime - startTime) / (double) targetTimeMillis;
                         updateProgress(progress, 1.0);
 
-                        // 60fps would require 16msec sleep here.
-                        Uninterruptibles.sleepUninterruptibly(20, TimeUnit.MILLISECONDS);
+                        Uninterruptibles.sleepUninterruptibly(PROGRESS_UPDATE_INTERVAL.toMillis(), TimeUnit.MILLISECONDS);
                     }
                     // Wait for the encryption thread before switching back to main UI.
                     updateProgress(1.0, 1.0);


### PR DESCRIPTION
There are two commits:

1. define sleep interval with a `Duration` constant
2. Use `Thread.sleep` directly rather than `Uninterruptables.sleepUninterrruptibly()`

We don't really need to sleep uninterrruptibly here. The code is only displaying a progress indicator and the `call()` method is already throwing `Exception`.