### PR TITLE
Add InternalUtils.sleepUninterruptibly, replacing Guava equivalent

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/internal/InternalUtils.java
+++ b/core/src/main/java/org/bitcoinj/base/internal/InternalUtils.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.base.internal;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -102,10 +103,9 @@ public class InternalUtils {
      * sure we re-set the thread's interrupt status, so higher-level code on the thread can handle the
      * interruption properly. Based upon the Guava implementation.
      * @param timeout duration to sleep for
-     * @param unit time unit for {@code timeout}
      */
-    public static void sleepUninterruptibly(long timeout, TimeUnit unit) {
-        long end = System.nanoTime() + unit.toNanos(timeout);
+    public static void sleepUninterruptibly(Duration timeout) {
+        long end = System.nanoTime() + timeout.toNanos();
         boolean interrupted = false;
         try {
             while (true) {

--- a/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
@@ -17,7 +17,6 @@
 package org.bitcoinj.core;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.util.concurrent.Uninterruptibles;
 import org.bitcoinj.base.internal.FutureUtils;
 import org.bitcoinj.base.internal.StreamUtils;
 import org.bitcoinj.base.internal.InternalUtils;
@@ -272,7 +271,7 @@ public class TransactionBroadcast {
 
     private static Runnable dropPeerAfterBroadcastHandler(Peer peer) {
         return () ->  {
-            Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+            InternalUtils.sleepUninterruptibly(1, TimeUnit.SECONDS);
             peer.close();
         };
     }

--- a/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -271,7 +272,7 @@ public class TransactionBroadcast {
 
     private static Runnable dropPeerAfterBroadcastHandler(Peer peer) {
         return () ->  {
-            InternalUtils.sleepUninterruptibly(1, TimeUnit.SECONDS);
+            InternalUtils.sleepUninterruptibly(Duration.ofSeconds(1));
             peer.close();
         };
     }


### PR DESCRIPTION
There are two commits:
1. Add `InternalUtils.sleepUninterruptibly()` with the same 2 parameters as currently used.
2. Change to a single `Duration` parameter implementation.

Since this is an internal utility class and it is not strictly needed in `walletemplate`, there is a separate PR to migrate away from the Guava versions for `wallettemplate` here: PR #3293.
