### PR TITLE
BlockFileLoader: stream() call streamBuffers()

### DIFF
--- a/core/src/main/java/org/bitcoinj/utils/BlockFileLoader.java
+++ b/core/src/main/java/org/bitcoinj/utils/BlockFileLoader.java
@@ -204,8 +204,7 @@ public class BlockFileLoader implements Iterable<Block> {
     }
 
     public Stream<Block> stream() {
-        return files.stream()
-                .flatMap(this::fileBlockStream)
+        return streamBuffers()
                 .map(serializer::makeBlock);
     }
 


### PR DESCRIPTION
stream() is streamBuffers() with a map() operation to read a buffer into a Block. Make this more clear by removing duplicated code.