### PR TITLE
BlockFileLoaderBitcoindTest: add streamEntireBitcoindBlockchainAsBlocks()

### DIFF
--- a/integration-test/src/test/java/org/bitcoinj/util/BlockFileLoaderBitcoindTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/util/BlockFileLoaderBitcoindTest.java
@@ -94,4 +94,12 @@ public class BlockFileLoaderBitcoindTest {
         assertTrue(blockCount > 1);
     }
 
+    @Test
+    public void streamEntireBitcoindBlockchainAsBlocks() {
+        BlockFileLoader loader = new BlockFileLoader(BitcoinNetwork.MAINNET, BlockFileLoader.getReferenceClientBlockFileList());
+
+        long blockCount = loader.stream().count();
+        System.out.println("Final block height: " + (blockCount - 1));
+        assertTrue(blockCount > 1);
+    }
 }


### PR DESCRIPTION
This test is useful for performance comparisons with streamEntireBitcoindBlockchainAsBuffers().

With adding to the TxConfidenceTable removed from Block.read() and on a fast, modern laptop, streamEntireBitcoindBlockchainAsBuffers() currently takes under 2 minutes while streamEntireBitcoindBlockchainAsBlocks() takes over 5 minutes.