### PR TITLE
WalletTool, BitcoinURITest: update fictious example URLs

### DIFF
--- a/core/src/test/java/org/bitcoinj/uri/BitcoinURITest.java
+++ b/core/src/test/java/org/bitcoinj/uri/BitcoinURITest.java
@@ -455,9 +455,9 @@ public class BitcoinURITest {
 
     @Test
     public void testUnescapedPaymentProtocolReq() throws Exception {
-        BitcoinURI uri = BitcoinURI.of("bitcoin:?r=https://merchant.com/pay.php?h%3D2a8628fc2fbe", TESTNET);
-        assertEquals("https://merchant.com/pay.php?h=2a8628fc2fbe", uri.getPaymentRequestUrl());
-        assertEquals(Collections.singletonList("https://merchant.com/pay.php?h=2a8628fc2fbe"), uri.getPaymentRequestUrls());
+        BitcoinURI uri = BitcoinURI.of("bitcoin:?r=https://merchant.example.com/pay?h%3D2a8628fc2fbe", TESTNET);
+        assertEquals("https://merchant.example.com/pay?h=2a8628fc2fbe", uri.getPaymentRequestUrl());
+        assertEquals(Collections.singletonList("https://merchant.example.com/pay?h=2a8628fc2fbe"), uri.getPaymentRequestUrls());
         assertNull(uri.getAddress());
     }
 }

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -143,8 +143,8 @@ public class WalletTool implements Callable<Integer> {
             "                       <key> CHECKSIG as the script.%n" +
             "                       If --payment-request is specified, a transaction will be created using the provided payment request. A payment request can be a local file, a bitcoin uri, or url to download the payment request, e.g.:%n" +
             "                         --payment-request=/path/to/my.bitcoinpaymentrequest%n" +
-            "                         --payment-request=bitcoin:?r=http://merchant.com/pay.php?123%n" +
-            "                         --payment-request=http://merchant.com/pay.php?123%n" +
+            "                         --payment-request=bitcoin:?r=https://merchant.example.com/pay?123%n" +
+            "                         --payment-request=https://merchant.example.com/pay?123%n" +
             "                       Other options include:%n" +
             "                         --fee-per-vkb or --fee-sat-per-vbyte sets the network fee, see below%n" +
             "                         --select-addr or --select-output to select specific outputs%n" +


### PR DESCRIPTION
- Use a subdomain of `example.com`
- Use HTTPS, though not strictly necessary with BIP-70
- Strip the `.php` suffix