### PR TITLE
wallettemplate: use jakarta.annotations (instead of javax)

### DIFF
--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation 'de.jensd:fontawesomefx:8.0.0'
     implementation 'com.google.zxing:core:3.5.1'
     implementation 'org.slf4j:slf4j-jdk14:2.0.9'
+    implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.0"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.0"

--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/application/WalletApplication.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/application/WalletApplication.java
@@ -34,7 +34,7 @@ import org.bitcoinj.wallet.KeyChainGroupStructure;
 import org.bitcoinj.walletfx.utils.GuiUtils;
 import wallettemplate.WalletSetPasswordController;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 

--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/controls/NotificationBarPane.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/controls/NotificationBarPane.java
@@ -36,7 +36,7 @@ import org.bitcoinj.walletfx.utils.GuiUtils;
 import org.bitcoinj.walletfx.utils.easing.EasingMode;
 import org.bitcoinj.walletfx.utils.easing.ElasticInterpolator;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 /**
  * Wraps the given Node in a BorderPane and allows a thin bar to slide in from the bottom or top, squeezing the content

--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/overlay/OverlayableStackPaneController.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/overlay/OverlayableStackPaneController.java
@@ -21,7 +21,7 @@ import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 import org.bitcoinj.walletfx.utils.GuiUtils;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 
 import java.io.IOException;
 import java.net.URL;

--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/utils/KeyDerivationTasks.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/utils/KeyDerivationTasks.java
@@ -23,7 +23,7 @@ import javafx.concurrent.Task;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.*;
+import jakarta.annotation.*;
 import java.time.Duration;
 
 import static org.bitcoinj.walletfx.utils.GuiUtils.checkGuiThread;

--- a/wallettemplate/src/main/java/wallettemplate/WalletSettingsController.java
+++ b/wallettemplate/src/main/java/wallettemplate/WalletSettingsController.java
@@ -35,7 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.bitcoinj.walletfx.utils.TextFieldValidator;
 
-import javax.annotation.Nullable;
+import jakarta.annotation.Nullable;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;


### PR DESCRIPTION
jakarta.annotations supports Java Modules, so this is necessary to migrate to running wallettemplate on the module path.