### PR TITLE
KeyDerivationTasks: replace wildcard import

### DIFF
--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/utils/KeyDerivationTasks.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/utils/KeyDerivationTasks.java
@@ -23,7 +23,7 @@ import javafx.concurrent.Task;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import jakarta.annotation.*;
+import jakarta.annotation.Nullable;
 import java.time.Duration;
 
 import static org.bitcoinj.walletfx.utils.GuiUtils.checkGuiThread;


### PR DESCRIPTION
Replace import of `jakarta.annotation.*` with `jakarta.annotation.Nullable`