### PR TITLE
GitHub gradle.yml/graalvm.yml: Use Gradle 8.5

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
         java-version: [ '17', '21' ]
         distribution: [ 'graalvm-community' ]
-        gradle: ['8.4']
+        gradle: ['8.5']
       fail-fast: false
     name: ${{ matrix.os }} JDK ${{ matrix.java-version }}.${{ matrix.distribution }}
     steps:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         java: ['11', '17', '21']
         distribution: ['temurin']
-        gradle: ['8.4']
+        gradle: ['8.5']
         include:
           # Special case to test something close to Debian config with the oldest supported (standard) Gradle on Ubuntu
           - os: ubuntu-latest


### PR DESCRIPTION
Gradle 8.5 brings official ("full") JDK 21 support. See the [Gradle 8.5 Release Notes](https://docs.gradle.org/8.5/release-notes.html). 