### PR TITLE
WIP: Add flake.nix for a Nix build

### DIFF
--- a/README_NIX.adoc
+++ b/README_NIX.adoc
@@ -1,0 +1,56 @@
+= bitcoinj Nix ReadMe
+
+These instructions are for a work-in-progress `flake.nix` file. They assume you have `experimental-features = nix-command flakes` enabled. For information about **Nix** see the https://nixos.org[Nix & NixOS] website.
+
+Known issues:
+
+1. The builds are currently using the "escape hatch" method and should be using something like `gradle2nix`.
+2. There should be a separate target to install `bitcoinj-core` and possibly for some of the other module and dependency JARs.
+3. As a result of the above two issues there is a conflict if you install both applications. It can be resolved with the `--priority` option see the note below.
+
+== To start and use a development shell
+
+From the project root directory type:
+
+* `nix develop`
+
+From within the launched shell, you can use commands like:
+
+* `gradle build`
+* `gradle bitcoinj-wallettool:run --help`
+* `gradle bitcoinj-wallettemplate:run`
+
+
+== To run applications directly
+
+From the project root directory type:
+
+* `nix run .#wallettool -- --help`
+* `nix run .#wallettemplate`
+
+== To install and run applications
+
+From the project root directory type:
+
+. `nix profile install .#wallettool`
+. `wallet-tool --help`
+
+and/or
+
+. `nix profile install .#wallettemplate --priority 4`
+. `bitcoinj-wallettemplate`
+
+NOTE:: The `--priority 4` option above is to avoid the following known issue:
++
+```
+error: An existing package already provides the following file:
+
+         /nix/store/kgchs2a7g0ik2ybwc2v0k9iq4i04sarh-wallettool-0.0.1/share/vanilla/lib/slf4j-jdk14-2.0.9.jar
+
+       This is the conflicting file from the new package:
+
+         /nix/store/9b4517xgawvig9fxyf8vxay2nzbmmvq2-wallettemplate-0.0.1/share/vanilla/lib/slf4j-jdk14-2.0.9.jar
+```
+
+
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,106 @@
+{
+  "nodes": {
+    "devshell": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1700815693,
+        "narHash": "sha256-JtKZEQUzosrCwDsLgm+g6aqbP1aseUl1334OShEAS3s=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "7ad1c417c87e98e56dcef7ecd0e0a2f2e5669d51",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1698882062,
+        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1694102001,
+        "narHash": "sha256-vky6VPK1n1od6vXbqzOXnekrQpTL4hbPAwUhT5J9c9E=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "9e21c80adf67ebcb077d75bd5e7d724d21eeafd6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1701156937,
+        "narHash": "sha256-jpMJOFvOTejx211D8z/gz0ErRtQPy6RXxgD2ZB86mso=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "7c4c20509c4363195841faa6c911777a134acdf3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devshell": "devshell",
+        "flake-parts": "flake-parts",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,162 @@
+{
+  description = "bitcoinj";
+
+  # this allows derivations with `__noChroot = true` and allows us to work around limitations with gradle
+  # see https://zimbatm.com/notes/nix-packaging-the-heretic-way
+  nixConfig.sandbox = "relaxed";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+
+    gitignore = {
+      url = "github:hercules-ci/gitignore.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    devshell = {
+      url = "github:numtide/devshell";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = inputs @ {
+    flake-parts,
+    devshell,
+    gitignore,
+    ...
+  }:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+
+      perSystem = {
+        config,
+        inputs',
+        pkgs,
+        lib,
+        system,
+        ...
+      }: let
+        inherit (pkgs) stdenv;
+
+        # pick our jdk and gradle versions
+        jdk = pkgs.jdk17.override {
+            # enabling JavaFX in the JDK allows `nix run .#wallettemplate`  to work correctly.
+            # This is because the `bitcoinj-wallettemplate:installDist` Gradle task does
+            # not set up the Module Path correctly for JavaFX to be loaded from a Maven JAR.
+            enableJavaFX = true;
+        };
+        gradle = pkgs.gradle;
+
+      in {
+        # define a devshell
+        devShells.default = inputs'.devshell.legacyPackages.mkShell {
+          # setup some environment variables
+          env = with lib;
+            mkMerge [
+              [
+                # Configure nix to use nixpgks
+                {
+                  name = "NIX_PATH";
+                  value = "nixpkgs=${toString pkgs.path}";
+                }
+              ]
+              (mkIf stdenv.isLinux [
+                {
+                  name = "JAVA_HOME";
+                  eval = "$DEVSHELL_DIR/lib/openjdk";
+                }
+              ])
+              (mkIf stdenv.isDarwin [
+                {
+                  name = "JAVA_HOME";
+                  # TODO: Fix this so it isn't hardcoded to "zulu".
+                  # I think it should be computed from `jdk` somehow.
+                  eval = "$DEVSHELL_DIR/zulu-17.jdk/Contents/Home";
+                }
+              ])
+            ];
+
+          # add package dependencies
+          packages = with lib;
+            mkMerge [
+              [
+                jdk
+                gradle
+              ]
+            ];
+        };
+
+        # define flake output packages
+        packages = let
+          # useful for filtering src trees based on gitignore
+          inherit (gitignore.lib) gitignoreSource;
+
+          # common properties across the derivations
+          version = "0.0.1";
+          src = gitignoreSource ./.;
+        in {
+          # This package is an example of an escape hatch
+          wallettool = stdenv.mkDerivation {
+            pname = "wallettool";
+            inherit version src;
+
+            # Disable the Nix build sandbox for this specific build.
+            # This means the build can freely talk to the Internet.
+            __noChroot = true;
+
+            nativeBuildInputs = [gradle pkgs.makeWrapper];
+
+            buildPhase = ''
+              export GRADLE_USER_HOME=$(mktemp -d)
+              gradle --no-daemon bitcoinj-wallettool:installDist
+            '';
+
+            installPhase = ''
+              mkdir -p $out/share/vanilla
+              cp -r wallettool/build/install/wallet-tool/* $out/share/vanilla
+              makeWrapper $out/share/vanilla/bin/wallet-tool $out/bin/wallet-tool \
+                    --set JAVA_HOME ${jdk}
+            '';
+
+            meta.mainProgram = "wallet-tool";
+          };
+
+          # This package is an example of an escape hatch
+          wallettemplate = stdenv.mkDerivation {
+            pname = "wallettemplate";
+            inherit version src;
+
+            # Disable the Nix build sandbox for this specific build.
+            # This means the build can freely talk to the Internet.
+            __noChroot = true;
+
+            nativeBuildInputs = [gradle pkgs.makeWrapper];
+
+            buildPhase = ''
+              export GRADLE_USER_HOME=$(mktemp -d)
+              gradle --no-daemon bitcoinj-wallettemplate:installDist
+            '';
+
+            installPhase = ''
+              mkdir -p $out/share/vanilla
+              cp -r wallettemplate/build/install/bitcoinj-wallettemplate/* $out/share/vanilla
+              makeWrapper $out/share/vanilla/bin/bitcoinj-wallettemplate $out/bin/bitcoinj-wallettemplate \
+                    --set JAVA_HOME ${jdk}
+            '';
+
+            meta.mainProgram = "bitcoinj-wallettemplate";
+          };
+        };
+      };
+    };
+}


### PR DESCRIPTION
You should now be able to use:

* `nix develop` -- to get a development shell
* `nix run .#wallettool` to build and run the wallet-tool
* `nix run .#wallettemplate` to build and run the wallettemplate

see README_NIX.adoc for details.

Known issues:

1. The builds are currently using the "escape hatch" method and should be using something like `gradle2nix`.
2. There should be a separate target to install `bitcoinj-core` and possibly for some of the other module and dependency JARs.
3. As a result of the above two issues there is a conflict if you install both applications. It can be resolved with the `--priority` option see the note below.