### PR TITLE
WIP: Keychain support for Taproot P2TR addresses

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -470,6 +470,12 @@ public class ECKey implements EncryptableItem {
             checkArgument(this.isCompressed(), () ->
                     "only compressed keys allowed");
             return SegwitAddress.fromHash(network, this.getPubKeyHash());
+        } else if (scriptType == ScriptType.P2TR) {
+            checkArgument(this.isCompressed(), () ->
+                    "only compressed keys allowed");
+            // TODO: Fix this once we have support for calculating a P2TR program
+            // byte[] witnessProgram = maker.calcWitnessProgram(this);
+            return SegwitAddress.fromProgram(network, 1, Sha256Hash.hash("BROKEN!".getBytes(StandardCharsets.UTF_8)));
         } else {
             throw new IllegalArgumentException(scriptType.toString());
         }

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -377,8 +377,9 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
      */
     protected DeterministicKeyChain(DeterministicSeed seed, @Nullable KeyCrypter crypter,
                                     ScriptType outputScriptType, HDPath.HDPartialPath accountPath) {
-        checkArgument(outputScriptType == null || outputScriptType == ScriptType.P2PKH || outputScriptType == ScriptType.P2WPKH, () ->
-                "only P2PKH or P2WPKH allowed");
+        checkArgument(outputScriptType == null || outputScriptType == ScriptType.P2PKH ||
+                outputScriptType == ScriptType.P2WPKH || outputScriptType == ScriptType.P2TR, () ->
+                "only P2PKH, P2WPKH, or P2TR allowed");
         this.outputScriptType = outputScriptType != null ? outputScriptType : ScriptType.P2PKH;
         this.accountPath = accountPath;
         this.seed = seed;

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
@@ -147,6 +147,12 @@ public class KeyChainGroup implements KeyBag {
                 this.chains.clear();
                 this.chains.add(fallbackChain);
                 this.chains.add(defaultChain);
+            } else if (outputScriptType == ScriptType.P2TR) {
+                DeterministicKeyChain defaultChain = DeterministicKeyChain.builder().seed(seed)
+                        .outputScriptType(ScriptType.P2TR)
+                        .accountPath(structure.accountPathFor(ScriptType.P2TR, network)).build();
+                this.chains.clear();
+                this.chains.add(defaultChain);
             } else {
                 throw new IllegalArgumentException(outputScriptType.toString());
             }
@@ -351,7 +357,7 @@ public class KeyChainGroup implements KeyBag {
     public Address currentAddress(KeyChain.KeyPurpose purpose) {
         DeterministicKeyChain chain = getActiveKeyChain();
         ScriptType outputScriptType = chain.getOutputScriptType();
-        if (outputScriptType == ScriptType.P2PKH || outputScriptType == ScriptType.P2WPKH) {
+        if (outputScriptType == ScriptType.P2PKH || outputScriptType == ScriptType.P2WPKH || outputScriptType == ScriptType.P2TR) {
             return currentKey(purpose).toAddress(outputScriptType, network);
         } else {
             throw new IllegalStateException(chain.getOutputScriptType().toString());

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroupStructure.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroupStructure.java
@@ -94,6 +94,8 @@ public interface KeyChainGroupStructure {
             return HDPath.BIP44_PARENT;
         } else if (scriptType == ScriptType.P2WPKH) {
             return HDPath.BIP84_PARENT;
+        } else if (scriptType == ScriptType.P2TR) {
+            return HDPath.BIP86_PARENT;
         } else {
             throw new IllegalArgumentException(scriptType.toString());
         }

--- a/core/src/main/proto/wallet.proto
+++ b/core/src/main/proto/wallet.proto
@@ -149,6 +149,7 @@ message Key {
   enum OutputScriptType {
     P2PKH = 1;
     P2WPKH = 2;
+    P2TR = 3;
   }
   // Type of addresses (aka output scripts) to generate for receiving.
   optional OutputScriptType output_script_type = 11;

--- a/integration-test/src/test/java/org/bitcoinj/test/integration/wallet/WalletAccountPathTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/test/integration/wallet/WalletAccountPathTest.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.test.integration.wallet;
 
+import org.bitcoinj.base.Address;
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
@@ -39,10 +40,12 @@ import java.util.List;
 import static org.bitcoinj.base.BitcoinNetwork.MAINNET;
 import static org.bitcoinj.base.BitcoinNetwork.TESTNET;
 import static org.bitcoinj.base.ScriptType.P2PKH;
+import static org.bitcoinj.base.ScriptType.P2TR;
 import static org.bitcoinj.base.ScriptType.P2WPKH;
 import static org.bitcoinj.wallet.KeyChainGroupStructure.BIP32;
 import static org.bitcoinj.wallet.KeyChainGroupStructure.BIP43;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Create new Wallets in a temp directory and make sure their account paths are correct.
@@ -67,6 +70,10 @@ public class WalletAccountPathTest {
 
         // Then the account path is as expected
         assertEquals(expectedPath, wallet.getActiveKeyChain().accountFullPath());
+
+        // We can get the first receive address
+        Address address = wallet.currentReceiveAddress();
+        assertNotNull(address);
     }
 
     static final List<Arguments> walletStructureParams = List.of(
@@ -78,7 +85,9 @@ public class WalletAccountPathTest {
             Arguments.of(BIP43, "m/44H/0H/0H", P2PKH, MAINNET),
             Arguments.of(BIP43, "m/44H/1H/0H", P2PKH, TESTNET),
             Arguments.of(BIP43, "m/84H/0H/0H", P2WPKH, MAINNET),
-            Arguments.of(BIP43, "m/84H/1H/0H", P2WPKH, TESTNET)
+            Arguments.of(BIP43, "m/84H/1H/0H", P2WPKH, TESTNET),
+            Arguments.of(BIP43, "m/86H/0H/0H", P2TR, MAINNET),
+            Arguments.of(BIP43, "m/86H/1H/0H", P2TR, TESTNET)
         );
 
     // Create a wallet, save it to a file, then reload from a file


### PR DESCRIPTION
* Add ScriptType.P2TR to various checks and if/else blocks
* Add P2TR and HDPath.BIP86_PARENT to KeyChainGroupStructure
* Add OutputScriptType of `P2TR = 3` to wallet.proto
* Add BIP-86 paths and address != null tests to WalletAccountPathTest

Remaining issues with this PR:

1. ECKey.toAddress(): Needs to call `calcWitnessProgram` (see TODO on line 431)
2. KeyChainGroup: decision/implementation needed for fallbackChain support.
3. More tests should be added.

Remaining issues for full P2TR support:

1. Need Taproot ECC support (for address generation, tx verification, tx signing)
2. Need to implement TX verification support for P2TR in bitcoinj
3. Need to implement TX signing support for P2TR in bitcoinj

~~I tagged this as for milestone 0.17, because I think we should at least consider the possibility of trying to get P2TR into 0.17. Though I think it make make more sense to wait for 0.18 for this feature.~~ 