### PR TITLE
gradle.yml, graalvm.yml: gradle/actions/setup-gradle@v3

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -24,7 +24,7 @@ jobs:
           distribution: ${{ matrix.distribution }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2.8.0
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: ${{ matrix.gradle }}
           arguments: test nativeCompile --init-script build-scan-agree.gradle --scan --info --stacktrace

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,7 +29,7 @@ jobs:
           distribution: ${{ matrix.distribution }}
           java-version: ${{ matrix.java }}
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2.8.0
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: ${{ matrix.gradle }}
           arguments: -PtestJdk8=true build --init-script build-scan-agree.gradle --scan --info --stacktrace


### PR DESCRIPTION
Upgrade to gradle/actions/setup-gradle@v3, which claims to be backward-compatible with v2 (with the exception of requiring node 20)

The `arguments` parameter is now
deprecated (it is recommended to "setup" in one step and to use the standard "run" action in a separate step), see:


See: https://github.com/gradle/gradle-build-action/issues/996

However, for this PR we'll just upgrade to the latest version. We'll deal with the deprecation in a separate PR.