### PR TITLE
gradle.yml, graalvm.yml: Upgrade multiple actions

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -16,7 +16,7 @@ jobs:
     name: ${{ matrix.os }} JDK ${{ matrix.java-version }}.${{ matrix.distribution }}
     steps:
       - name: Git checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Set up GraalVM
         uses: graalvm/setup-graalvm@v1
         with:
@@ -29,7 +29,7 @@ jobs:
           gradle-version: ${{ matrix.gradle }}
           arguments: test nativeCompile --init-script build-scan-agree.gradle --scan --info --stacktrace
       - name: Upload wallet-tool as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wallet-tool-${{ matrix.os }}
+          name: wallet-tool-${{ matrix.os }}-${{ matrix.java-version }}
           path: wallettool/build/native/nativeCompile/wallet-tool

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,9 +22,9 @@ jobs:
     name: JAVA ${{ matrix.distribution }} ${{ matrix.java }} OS ${{ matrix.os }} Gradle ${{ matrix.gradle }}
     steps:
       - name: Git checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: ${{ matrix.distribution }}
           java-version: ${{ matrix.java }}
@@ -34,10 +34,10 @@ jobs:
           gradle-version: ${{ matrix.gradle }}
           arguments: -PtestJdk8=true build --init-script build-scan-agree.gradle --scan --info --stacktrace
       - name: Upload Test Results and Reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: bitcoinj-core-test-results-jdk${{ matrix.java }}-${{ matrix.os }}
+          name: bitcoinj-core-test-results-jdk${{ matrix.java }}-${{ matrix.os }}-${{ matrix.gradle }}
           path: |
             core/build/reports/tests/test/
             core/build/test-results/test/


### PR DESCRIPTION
checkout: v1 -> v4
setup-java: v2 -> v4
upload-artifact: v3 -> v4

upload-artifact v4 detects and rejects artifact uploads with duplicate names,
so this PR adjusts artifact names to avoid this error:

gradle.yml: append `-${{ matrix.java-version }}`
graalvm.yml: append `-${{ matrix.gradle }}`
