### PR TITLE
LazyECPoint: make private `curve` member static

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -685,7 +685,7 @@ public class DeterministicKey extends ECKey {
         checkArgument(!buffer.hasRemaining(), () ->
                 "found unexpected data in key");
         if (pub) {
-            return new DeterministicKey(path, chainCode, new LazyECPoint(ECKey.CURVE.getCurve(), data), parent, depth, parentFingerprint);
+            return new DeterministicKey(path, chainCode, new LazyECPoint(data), parent, depth, parentFingerprint);
         } else {
             return new DeterministicKey(path, chainCode, ByteUtils.bytesToBigInteger(data), parent, depth, parentFingerprint);
         }

--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -259,7 +259,7 @@ public class ECKey implements EncryptableItem {
     public static ECKey fromPrivateAndPrecalculatedPublic(byte[] priv, byte[] pub) {
         Objects.requireNonNull(priv);
         Objects.requireNonNull(pub);
-        return new ECKey(ByteUtils.bytesToBigInteger(priv), new LazyECPoint(CURVE.getCurve(), pub));
+        return new ECKey(ByteUtils.bytesToBigInteger(priv), new LazyECPoint(pub));
     }
 
     /**
@@ -275,7 +275,7 @@ public class ECKey implements EncryptableItem {
      * The compression state of pub will be preserved.
      */
     public static ECKey fromPublicOnly(byte[] pub) {
-        return new ECKey(null, new LazyECPoint(CURVE.getCurve(), pub));
+        return new ECKey(null, new LazyECPoint(pub));
     }
 
     public static ECKey fromPublicOnly(ECKey key) {

--- a/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
@@ -90,7 +90,7 @@ public final class HDKeyDerivation {
     }
 
     public static DeterministicKey createMasterPubKeyFromBytes(byte[] pubKeyBytes, byte[] chainCode) {
-        return new DeterministicKey(HDPath.M(), chainCode, new LazyECPoint(ECKey.CURVE.getCurve(), pubKeyBytes), null, null);
+        return new DeterministicKey(HDPath.M(), chainCode, new LazyECPoint(pubKeyBytes), null, null);
     }
 
     /**
@@ -190,7 +190,7 @@ public final class HDKeyDerivation {
             PublicDeriveMode mode) throws HDDerivationException {
         RawKeyBytes rawKey = deriveChildKeyBytesFromPublic(parent, childNumber, PublicDeriveMode.NORMAL);
         return new DeterministicKey(parent.getPath().extend(childNumber), rawKey.chainCode,
-                new LazyECPoint(ECKey.CURVE.getCurve(), rawKey.keyBytes), null, parent);
+                new LazyECPoint(rawKey.keyBytes), null, parent);
     }
 
     public static RawKeyBytes deriveChildKeyBytesFromPublic(DeterministicKey parent, ChildNumber childNumber, PublicDeriveMode mode) throws HDDerivationException {

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -893,7 +893,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
                     throw new UnreadableWalletException("Deterministic key missing extra data: " + key);
                 byte[] chainCode = key.getDeterministicKey().getChainCode().toByteArray();
                 // Deserialize the public key and path.
-                LazyECPoint pubkey = new LazyECPoint(ECKey.CURVE.getCurve(), key.getPublicKey().toByteArray());
+                LazyECPoint pubkey = new LazyECPoint(key.getPublicKey().toByteArray());
                 // Deserialize the path through the tree.
                 final HDPath path = HDPath.deserialize(key.getDeterministicKey().getPathList());
                 if (key.hasOutputScriptType())


### PR DESCRIPTION
We do not need to specify the curve for each instance as bitcoinj uses SECP256K1 curve exclusively.

This change reduces per instance memory usage, simplifies the API, and reduces public API dependence on Bouncy Castle.

One two-arg constructor is deprecated and replaced with a single-arg constructor that no longer requires the curve parameter.