### PR TITLE
ECKey: make `CURVE` package private, provide accessor

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -126,7 +126,17 @@ public class ECKey implements EncryptableItem {
     private static final X9ECParameters CURVE_PARAMS = CustomNamedCurves.getByName("secp256k1");
 
     /** The parameters of the secp256k1 curve that Bitcoin uses. */
-    public static final ECDomainParameters CURVE;
+    static final ECDomainParameters CURVE;
+
+    /**
+     * Return EC parameters for the SECP256K1 curve, in a Bouncy Castle type.
+     * Note that we are migrating to using the build in JDK types for EC parameters,
+     * so we anticipate this method will be deprecated in the near future.
+     * @return Elliptic Curve Domain Parameters (Bouncy Castle)
+     */
+    public static ECDomainParameters ecDomainParameters() {
+        return CURVE;
+    }
 
     /**
      * Equal to CURVE.getN().shiftRight(1), used for canonicalising the S value of a signature. If you aren't

--- a/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
@@ -192,7 +192,7 @@ public class DefaultRiskAnalysisTest {
         // First, a synthetic test.
         TransactionSignature sig = TransactionSignature.dummy();
         Script scriptHighS = ScriptBuilder
-                .createInputScript(new TransactionSignature(sig.r, ECKey.CURVE.getN().subtract(sig.s)));
+                .createInputScript(new TransactionSignature(sig.r, ECKey.ecDomainParameters().getN().subtract(sig.s)));
         assertEquals(RuleViolation.SIGNATURE_CANONICAL_ENCODING, DefaultRiskAnalysis.isInputStandard(
                 new TransactionInput(null, scriptHighS.program(), TransactionOutPoint.UNCONNECTED)));
 


### PR DESCRIPTION
* Make the static field ECKey.CURVE (which is a Bouncy Castle type) package private and provide the ecDomainParameters() accessor for those who really need it.

* Use the accessor in `DefaultRiskAnalysisTest`

* We will not update code within the `o.b.crytpo` package to use the accessor, since we intend to migrate all/most of those usages to the `java.security` types.