### PR TITLE
ECKey: Make HALF_CURVE_ORDER package private

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -132,7 +132,7 @@ public class ECKey implements EncryptableItem {
      * Equal to CURVE.getN().shiftRight(1), used for canonicalising the S value of a signature. If you aren't
      * sure what this is about, you can ignore it.
      */
-    public static final BigInteger HALF_CURVE_ORDER;
+    static final BigInteger HALF_CURVE_ORDER;
 
     private static final SecureRandom secureRandom;
 


### PR DESCRIPTION
This isn't a Bouncy Castle type, but it isn't currently being used publicly and can and should be made package private.

If anyone needs the constant, they can still get it via `ECDomainParameters` (BC) or `ECParameterSpec` (`java.security`)
