### PR TITLE
README: Use double-dash to fix the label "bitcoinj-users" in the Matrix badge

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@ image:https://github.com/bitcoinj/bitcoinj/workflows/Java%20CI/badge.svg[GitHub 
 image:https://gitlab.com/bitcoinj/bitcoinj/badges/master/pipeline.svg[GitLab Build Status,link=https://gitlab.com/bitcoinj/bitcoinj/-/pipelines]
 image:https://coveralls.io/repos/bitcoinj/bitcoinj/badge.png?branch=master[Coverage Status,link=https://coveralls.io/r/bitcoinj/bitcoinj?branch=master]
 
-image::https://img.shields.io/badge/chat-Join%20bitcoinj%20users%20on%20Matrix-blue[Join the bitcoinj-users Matrix room, link=https://matrix.to/#/#bitcoinj-users:matrix.org]
+image::https://img.shields.io/badge/chat-Join%20bitcoinj--users%20on%20Matrix-blue[Join the bitcoinj-users Matrix room, link=https://matrix.to/#/#bitcoinj-users:matrix.org]
 
 ### Welcome to bitcoinj
 


### PR DESCRIPTION
We were incorrectly (and mostly unnoticed) displaying a space where we should be displaying a single-dash.

See: https://shields.io/badges