### PR TITLE
ForwardingService: let main() throw InterruptedException

### DIFF
--- a/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
@@ -56,7 +56,7 @@ public class ForwardingService implements Closeable {
      * Run the forwarding service as a command line tool
      * @param args See {@link #USAGE}
      */
-    public static void main(String[] args) {
+    public static void main(String[] args) throws InterruptedException {
         // This line makes the log output more compact and easily read, especially when using the JDK log adapter.
         BriefLogFormatter.init();
         Context.propagate(new Context());
@@ -70,9 +70,7 @@ public class ForwardingService implements Closeable {
         try (ForwardingService forwardingService = new ForwardingService(args)) {
             forwardingService.run();
             // Wait for Control-C
-            try {
-                Thread.sleep(Long.MAX_VALUE);
-            } catch (InterruptedException ignored) {}
+            Thread.sleep(Long.MAX_VALUE);
         }
     }
 


### PR DESCRIPTION
This simplifies main() and increases readability. And it is fine to terminate the process if the thread is interrupted.