### PR TITLE
ForwardingService: print network, not network.id()

### DIFF
--- a/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
@@ -95,7 +95,7 @@ public class ForwardingService implements Closeable {
      * Start the wallet and register the coin-forwarding listener.
      */
     public void run() {
-        System.out.println("Network: " + network.id());
+        System.out.println("Network: " + network);
         System.out.println("Forwarding address: " + forwardingAddress);
 
         // Create and start the WalletKit


### PR DESCRIPTION
Both the code and the output is simpler this way.