### PR TITLE
BitcoinNetwork.strings() lists all networks as strings, use it to create usage message in ForwardingService

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/BitcoinNetwork.java
+++ b/core/src/main/java/org/bitcoinj/base/BitcoinNetwork.java
@@ -197,17 +197,24 @@ public enum BitcoinNetwork implements Network {
      * @return An {@code Optional} containing the matching enum or empty
      */
     public static Optional<BitcoinNetwork> fromIdString(String idString) {
-        return Arrays.stream(values())
+        return stream()
                 .filter(n -> n.id.equals(idString))
                 .findFirst();
+    }
+    
+    /**
+     * @return stream of all instances of this enum
+     */
+    private static Stream<BitcoinNetwork> stream() {
+        return Arrays.stream(values());
     }
 
     // Create a Map that maps name Strings to networks for all instances
     private static Map<String, BitcoinNetwork> mergedNameMap() {
-        return Stream.of(values())
-                    .collect(HashMap::new,                  // Supply HashMaps as mutable containers
-                        BitcoinNetwork::accumulateNames,    // Accumulate one network into hashmap
-                        Map::putAll);                       // Combine two containers
+        return stream()
+                .collect(HashMap::new,                  // Supply HashMaps as mutable containers
+                    BitcoinNetwork::accumulateNames,    // Accumulate one network into hashmap
+                    Map::putAll);                       // Combine two containers
     }
 
     // Add allNames for this Network as keys to a map that can be used to find it

--- a/core/src/main/java/org/bitcoinj/base/BitcoinNetwork.java
+++ b/core/src/main/java/org/bitcoinj/base/BitcoinNetwork.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.bitcoinj.base.Coin.COIN;
@@ -200,6 +201,15 @@ public enum BitcoinNetwork implements Network {
         return stream()
                 .filter(n -> n.id.equals(idString))
                 .findFirst();
+    }
+
+    /**
+     * @return list of the names of all instances of this enum
+     */
+    public static List<String> strings() {
+        return stream()
+                .map(BitcoinNetwork::toString)
+                .collect(Collectors.toList());
     }
     
     /**

--- a/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
@@ -36,6 +36,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toList;
@@ -45,7 +46,8 @@ import static java.util.stream.Collectors.toList;
  * and when it receives coins, simply sends them onwards to the address given on the command line.
  */
 public class ForwardingService implements Closeable {
-    static final String USAGE = "Usage: address-to-forward-to [mainnet|testnet|signet|regtest]";
+    static private final String NETS = String.join("|", BitcoinNetwork.strings());
+    static final String USAGE = String.format("Usage: address-to-forward-to [%s]", NETS);
     static final int REQUIRED_CONFIRMATIONS = 1;
     static final int MAX_CONNECTIONS = 4;
     private final BitcoinNetwork network;


### PR DESCRIPTION
This PR contains two commits:

* Add `strings()` to `BitcoinNetwork` (also internal stream() method to avoid duplication)
* Use it in `ForwardingService`

The `strings()` method should also make it easier to add a network parameter to other examples.