### PR TITLE
ForwardingService: Use BitcoinNetwork.strings() to build USAGE string

### DIFF
--- a/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
@@ -44,7 +44,8 @@ import static java.util.stream.Collectors.toList;
  * and when it receives coins, simply sends them onwards to the address given on the command line.
  */
 public class ForwardingService implements Closeable {
-    static final String USAGE = "Usage: address-to-forward-to [mainnet|testnet|signet|regtest]";
+    static private final String NETS = String.join("|", BitcoinNetwork.strings());
+    static final String USAGE = String.format("Usage: address-to-forward-to [%s]", NETS);
     static final int REQUIRED_CONFIRMATIONS = 1;
     static final int MAX_CONNECTIONS = 4;
     private final BitcoinNetwork network;


### PR DESCRIPTION
Use BitcoinNetwork.strings() for the list of valid BitcoinNetwork values included in the USAGE string.

This is a follow-up to PR #3372.