### PR TITLE
gradle.yml, graalvm.yml: explicitly use macos-12

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-12]
         java-version: [ '17', '21' ]
         distribution: [ 'graalvm-community' ]
         gradle: ['8.7']

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-12, windows-latest]
         java: ['11', '17', '21']
         distribution: ['temurin']
         gradle: ['8.7']


### PR DESCRIPTION
GitHub has bumped macos-latest to be macos-14 (and ARM) so our tests are currently broken. This PR is a short-term fix to restore the status quo and makes the minimum change to fix the broken build.

See https://github.com/bitcoinj/bitcoinj/pull/3345 for more discussion.