### PR TITLE
gradle.yml, graalvm.yml: explicitly use ubuntu-22.04, windows-2022

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-12]
+        os: [ubuntu-22.04, macOS-12]
         java-version: [ '17', '21' ]
         distribution: [ 'graalvm-community' ]
         gradle: ['8.7']

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-12, windows-latest]
+        os: [ubuntu-22.04, macOS-12, windows-2022]
         java: ['11', '17', '21']
         distribution: ['temurin']
         gradle: ['8.7']


### PR DESCRIPTION
This makes explicit which versions of which OSs are used in CI. After this is merged, we will need to manually update to newer OS versions.