### PR TITLE
gradle.yml: Use ubuntu-22.04 for gradle 4.10.3 special case

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,7 +14,7 @@ jobs:
         gradle: ['8.7']
         include:
           # Special case to test something close to Debian config with the oldest supported (standard) Gradle on Ubuntu
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             java: '11'
             distribution: 'temurin'
             gradle: '4.10.3'


### PR DESCRIPTION
I missed this entry in today's earlier (already merged) PR.