### PR TITLE
gradle.yml, graalvm.yml: fix Gradle Action deprecation warning

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -23,11 +23,12 @@ jobs:
           java-version: ${{ matrix.java-version }}
           distribution: ${{ matrix.distribution }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build with Gradle
+      - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: ${{ matrix.gradle }}
-          arguments: test nativeCompile --init-script build-scan-agree.gradle --scan --info --stacktrace
+      - name: Run Gradle
+        run: gradle test nativeCompile --init-script build-scan-agree.gradle --scan --info --stacktrace
       - name: Upload wallet-tool as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,11 +28,12 @@ jobs:
         with:
           distribution: ${{ matrix.distribution }}
           java-version: ${{ matrix.java }}
-      - name: Build with Gradle
+      - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: ${{ matrix.gradle }}
-          arguments: -PtestJdk8=true build --init-script build-scan-agree.gradle --scan --info --stacktrace
+      - name: Run Gradle
+        run: gradle -PtestJdk8=true build --init-script build-scan-agree.gradle --scan --info --stacktrace
       - name: Upload Test Results and Reports
         uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
Remove `arguments` parameter from `setup-gradle` and add add a basic `run` step with the actual `gradle` command.

This fixes a deprecation warning.