### PR TITLE
Bump equalsverifier to 3.16.1

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testImplementation 'org.easymock:easymock:5.2.0'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.16.0'
     testImplementation 'org.slf4j:slf4j-jdk14:2.0.12'
-    testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.15.2'
+    testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.16.1'
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
     testImplementation 'pl.pragmatists:JUnitParams:1.1.1'
 }

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.0"
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.easymock:easymock:5.2.0'
-    testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.15.2'
+    testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.16.1'
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.0"
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:5.10.0"


### PR DESCRIPTION
This is needed for building with JDK 22.