### PR TITLE
WIP secp256k1-jdk feature branch

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           gradle-version: ${{ matrix.gradle }}
       - name: Run Gradle
-        run: gradle -PtestJdk8=true build bitcoinj-wallettemplate:installDist bitcoinj-wallettemplate:jlink --init-script build-scan-agree.gradle --scan --info --stacktrace
+        run: gradle build bitcoinj-wallettemplate:installDist bitcoinj-wallettemplate:jlink --init-script build-scan-agree.gradle --scan --info --stacktrace
       - name: Upload Test Results and Reports
         uses: actions/upload-artifact@v4
         if: always()

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 }
 
 tasks.withType(JavaCompile) {
-    options.compilerArgs.addAll(['--release', '8'])
+    options.compilerArgs.addAll(['--release', '9'])
     options.compilerArgs << '-Xlint:deprecation'
     options.encoding = 'UTF-8'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,9 @@ buildscript {
 allprojects {
     repositories {
         mavenCentral()
+        maven {
+            url 'https://gitlab.com/api/v4/projects/55956336/packages/maven'        // secp256k1-jdk
+        }
     }
 
     group = 'org.bitcoinj'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -13,6 +13,8 @@ dependencies {
     api 'org.bouncycastle:bcprov-jdk15to18:1.80'
     api 'com.google.guava:guava:33.4.0-android'
     api 'com.google.protobuf:protobuf-javalite:4.29.3'
+    api 'org.bitcoinj.secp:secp-api:0.1'
+    implementation 'org.bitcoinj.secp:secp-bouncy:0.1'
     implementation 'org.slf4j:slf4j-api:2.0.16'
 
     testImplementation project(':bitcoinj-test-support')
@@ -40,7 +42,7 @@ if (GradleVersion.current() > gradleVersionTargetJVM) {
 }
 
 tasks.withType(JavaCompile) {
-    options.compilerArgs.addAll(['--release', '8'])
+    options.compilerArgs.addAll(['--release', '9'])
     options.compilerArgs << '-Xlint:deprecation'
     options.encoding = 'UTF-8'
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,7 +10,7 @@ version = '0.18-SNAPSHOT'
 
 dependencies {
     api project(':bitcoinj-base')
-    api 'org.bouncycastle:bcprov-jdk15to18:1.80'
+    //api 'org.bouncycastle:bcprov-jdk15to18:1.80'
     api 'com.google.guava:guava:33.4.0-android'
     api 'com.google.protobuf:protobuf-javalite:4.29.3'
     api 'org.bitcoinj.secp:secp-api:0.1'

--- a/core/src/test/java/org/bitcoinj/crypto/SecpJdkSmokeTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/SecpJdkSmokeTest.java
@@ -1,0 +1,20 @@
+package org.bitcoinj.crypto;
+
+import org.bitcoinj.secp.api.P256K1KeyPair;
+import org.bitcoinj.secp.api.Secp256k1;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * A quick test to make sure we can load and execute the secp-api and secp-bouncy.
+ */
+public class SecpJdkSmokeTest {
+    @Test
+    public void smoke() {
+        try (Secp256k1 secp = Secp256k1.getByName("bouncy-castle")) {
+            P256K1KeyPair keypair = secp.ecKeyPairCreate();
+            assertNotNull(keypair);
+        }
+    }
+}

--- a/test-support/build.gradle
+++ b/test-support/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 }
 
 tasks.withType(JavaCompile) {
-    options.compilerArgs.addAll(['--release', '8'])
+    options.compilerArgs.addAll(['--release', '9'])
     options.compilerArgs << '-Xlint:deprecation'
     options.encoding = 'UTF-8'
 }

--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -36,7 +36,7 @@ application {
 }
 
 jlink {
-    options = ['--add-modules', 'org.slf4j.jul']
+    options = ['--add-modules', 'org.slf4j.jul',  '--ignore-signing-information']
 }
 
 test {


### PR DESCRIPTION
Create a feature branch that requires JDK 17 and uses the secp256k1-jdk proof-of-concept implementation. See Issue #3389.

Because of Issue #3390, we can't build/test with JDK 22, which means we can't use the `secp256k1-foreign` module yet. So instead, this PR/branch uses the (less complete) `secp256k1-bouncy` module.