### PR TITLE
Change Key.Type enum from ENCRYPTED_SCRYPT_AES to ENCRYPTED

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/BasicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/BasicKeyChain.java
@@ -361,7 +361,7 @@ public class BasicKeyChain implements EncryptableKeyChain {
                     .setInitialisationVector(ByteString.copyFrom(data.initialisationVector)));
             // We don't allow mixing of encryption types at the moment.
             checkState(item.getEncryptionType() == Protos.Wallet.EncryptionType.ENCRYPTED_SCRYPT_AES);
-            proto.setType(Protos.Key.Type.ENCRYPTED_SCRYPT_AES);
+            proto.setType(Protos.Key.Type.ENCRYPTED);
         } else {
             final byte[] secret = item.getSecretBytes();
             // The secret might be missing in the case of a watching wallet, or a key for which the private key
@@ -401,9 +401,9 @@ public class BasicKeyChain implements EncryptableKeyChain {
             checkState(hashToKeys.isEmpty(), () ->
                     "tried to deserialize into a non-empty chain");
             for (Protos.Key key : keys) {
-                if (key.getType() != Protos.Key.Type.ORIGINAL && key.getType() != Protos.Key.Type.ENCRYPTED_SCRYPT_AES)
+                if (key.getType() != Protos.Key.Type.ORIGINAL && key.getType() != Protos.Key.Type.ENCRYPTED)
                     continue;
-                boolean encrypted = key.getType() == Protos.Key.Type.ENCRYPTED_SCRYPT_AES;
+                boolean encrypted = key.getType() == Protos.Key.Type.ENCRYPTED;
                 byte[] priv = key.hasSecretBytes() ? key.getSecretBytes().toByteArray() : null;
                 if (!key.hasPublicKey())
                     throw new UnreadableWalletException("Public key missing");

--- a/core/src/main/proto/wallet.proto
+++ b/core/src/main/proto/wallet.proto
@@ -86,11 +86,18 @@ message DeterministicKey {
  */
 message Key {
   enum Type {
+    option allow_alias = true;
     /** Unencrypted - Original bitcoin secp256k1 curve */
     ORIGINAL = 1;
 
-    /** Encrypted with Scrypt and AES - Original bitcoin secp256k1 curve */
+    /**
+    * Encrypted - Original bitcoin secp256k1 curve
+    * Details of the encryption are declared via Wallet.EncryptionType enum
+    */
     ENCRYPTED = 2;
+
+    /** Encrypted with Scrypt and AES - Original bitcoin secp256k1 curve */
+    ENCRYPTED_SCRYPT_AES = 2 [deprecated = true];
 
     /**
     * Not really a key, but rather contains the mnemonic phrase for a deterministic key hierarchy in the private_key field.

--- a/core/src/main/proto/wallet.proto
+++ b/core/src/main/proto/wallet.proto
@@ -90,7 +90,7 @@ message Key {
     ORIGINAL = 1;
 
     /** Encrypted with Scrypt and AES - Original bitcoin secp256k1 curve */
-    ENCRYPTED_SCRYPT_AES = 2;
+    ENCRYPTED = 2;
 
     /**
     * Not really a key, but rather contains the mnemonic phrase for a deterministic key hierarchy in the private_key field.


### PR DESCRIPTION
The protobuf Key.Type enum ENRCRYPTED_SCRYPT_AES can be simplified to ENCRYPTED since the encryption type can already be defined with Wallet.EncryptionType.

This is a separate PR for a small change from a different PR: https://github.com/bitcoinj/bitcoinj/pull/3362 

Mentioned in this comment: https://github.com/bitcoinj/bitcoinj/pull/3362#discussion_r1565746921