### PR TITLE
StoredBlock: use Utils.bigIntegerToBytes to convert chainWork (Backport)

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/StoredBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/StoredBlock.java
@@ -124,8 +124,7 @@ public class StoredBlock {
 
     /** Serializes the stored block to a custom packed format. Used by {@link CheckpointManager}. */
     public void serializeCompact(ByteBuffer buffer) {
-        byte[] chainWorkBytes = getChainWork().toByteArray();
-        checkState(chainWorkBytes.length <= CHAIN_WORK_BYTES, "Ran out of space to store chain work!");
+        byte[] chainWorkBytes = Utils.bigIntegerToBytes(getChainWork(), CHAIN_WORK_BYTES);
         if (chainWorkBytes.length < CHAIN_WORK_BYTES) {
             // Pad to the right size.
             buffer.put(EMPTY_BYTES, 0, CHAIN_WORK_BYTES - chainWorkBytes.length);


### PR DESCRIPTION
This is a fix for Issue #3410 that will allow main net blocks above 849,137 to be processed. As of block 849,138 we can no longer fit total chainwork in a 12-byte *signed* field. This fix "kicks the can down the road" by making the field 12-bytes *unsigned*.

We should open a new issue to address the long term need for bigger values. Note that converting the field to 12-byte unsigned precludes us from using the most-significant bit as a flag for a new format, but we should be able to pick some arbitrary value, say 0xA0 as a version flag and declare that values less than 0xA0 are "unversioned".

This is a **BACKPORT** to the 0.16 branch. In the master/0.17 branch the bigIntegerToBytes method has been moved to base.internal.BytUtils, so this commit differs in that one respect.