### PR TITLE
gradle.yml: explicitly use ubuntu-22.04, macos-12, windows-2019

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-22.04, macOS-12, windows-2019]
         java: ['8', '11', '17']
         distribution: ['temurin']
         gradle: ['7.2']
         include:
           # Special case to test something close to Debian config with the oldest supported (standard) Gradle on Ubuntu
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             java: '11'
             distribution: 'temurin'
             gradle: '4.10.3'


### PR DESCRIPTION
This is a backport of a similar change made on `master`.