### PR TITLE
StoredBlock: Update comment about CHAIN_WORK_BYTES

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/StoredBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/StoredBlock.java
@@ -39,8 +39,8 @@ import static org.bitcoinj.base.internal.Preconditions.checkState;
  */
 public class StoredBlock {
 
-    // A BigInteger representing the total amount of work done so far on this chain. As of May 2011 it takes 8
-    // bytes to represent this field, so 12 bytes should be plenty for now.
+    // A BigInteger representing the total amount of work done so far on this chain. As of June 22, 2024, it takes 12
+    // unsigned bytes to store this value, so we need to create an updated storage format soon.
     private static final int CHAIN_WORK_BYTES = 12;
     private static final byte[] EMPTY_BYTES = new byte[CHAIN_WORK_BYTES];
     public static final int COMPACT_SERIALIZED_SIZE = Block.HEADER_SIZE + CHAIN_WORK_BYTES + 4;  // for height


### PR DESCRIPTION
The original comment, written in 2011 said "12 bytes should be plenty for now". As of June 2024, we know that 12 bytes is not enough.

See Issue #3415.