### PR TITLE
.gitlab-ci.yml: remove build with OpenJDK 21 under Debian Trixie

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,17 +37,6 @@ bookworm-jdk17:
     - gradle --version
     - sha256sum core/build/libs/*.jar wallettool/build/install/wallet-tool/bin/*  wallettool/build/install/wallet-tool/lib/*.jar
 
-trixie-jdk21:
-  image: debian:trixie-slim
-  before_script:
-    - apt-get update
-    - apt-get -y install openjdk-21-jdk-headless gradle
-  script:
-    - gradle build :bitcoinj-core:publishToMavenLocal :bitcoinj-wallettool:installDist --init-script build-scan-agree.gradle --scan --stacktrace
-  after_script:
-    - gradle --version
-    - sha256sum core/build/libs/*.jar wallettool/build/install/wallet-tool/bin/*  wallettool/build/install/wallet-tool/lib/*.jar
-
 sast:
   stage: test
 


### PR DESCRIPTION
Trixie doesn't carry OpenJDK 21 any more, so our GitLab CI builds started failing. Because OpenJDK support under Debian is a moving target, it's better to remove it until Trixie is released. Otherwise, CI builds will start failing at any time.