### PR TITLE
AddressParserProvider: deprecate fromNetworks()

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/DefaultAddressParserProvider.java
+++ b/core/src/main/java/org/bitcoinj/base/DefaultAddressParserProvider.java
@@ -76,10 +76,11 @@ class DefaultAddressParserProvider implements AddressParser.AddressParserProvide
     }
 
     /**
-     * Dynamically create a new AddressParser using a snapshot of currently configured networks
-     * from Networks.get().
+     * Dynamically create a new {@link AddressParser} using a snapshot of currently configured networks
+     * from {@code Networks.get()}. This is only used by deprecated methods in {@link AddressParser}.
      * @return A backward-compatible parser
      */
+    @Deprecated
     static DefaultAddressParserProvider fromNetworks() {
         List<Network> nets = Networks.get().stream()
                 .map(NetworkParameters::network)


### PR DESCRIPTION
It was already package-private and was only used by deprecated methods in `AddressParser`.