### PR TITLE
StoredBlock: remove an outdated comment

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/StoredBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/StoredBlock.java
@@ -133,8 +133,6 @@ public class StoredBlock {
         }
         buffer.put(chainWorkBytes);
         buffer.putInt(getHeight());
-        // Using unsafeBitcoinSerialize here can give us direct access to the same bytes we read off the wire,
-        // avoiding serialization round-trips.
         byte[] bytes = getHeader().serialize();
         buffer.put(bytes, 0, Block.HEADER_SIZE);  // Trim the trailing 00 byte (zero transactions).
     }


### PR DESCRIPTION
We don't have unsafeBitcoinSerialize() any more.