### PR TITLE
SPVBlockStore: deprecate constant `HEADER_MAGIC`

### DIFF
--- a/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
@@ -57,6 +57,7 @@ public class SPVBlockStore implements BlockStore {
 
     /** The default number of headers that will be stored in the ring buffer. */
     public static final int DEFAULT_CAPACITY = 10000;
+    @Deprecated
     public static final String HEADER_MAGIC = "SPVB";
 
     protected volatile MappedByteBuffer buffer;


### PR DESCRIPTION
It's an implementation detail. We should be switching this to private in future.