### PR TITLE
SPVBlockStore: rewind buffer directly before accesses to magic header

### DIFF
--- a/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
@@ -162,6 +162,7 @@ public class SPVBlockStore implements BlockStore {
             // Check or initialize the header bytes to ensure we don't try to open some random file.
             if (exists) {
                 byte[] currentHeader = new byte[4];
+                ((Buffer) buffer).rewind();
                 buffer.get(currentHeader);
                 if (!Arrays.equals(currentHeader, MAGIC_HEADER))
                     throw new BlockStoreException("Magic header expected, got: " + ByteUtils.formatHex(currentHeader));
@@ -179,6 +180,7 @@ public class SPVBlockStore implements BlockStore {
     }
 
     private void initNewStore(Block genesisBlock) throws Exception {
+        ((Buffer) buffer).rewind();
         buffer.put(MAGIC_HEADER);
         // Insert the genesis block.
         lock.lock();
@@ -353,7 +355,6 @@ public class SPVBlockStore implements BlockStore {
                 buffer.put((byte)0);
             }
             // Initialize store again
-            ((Buffer) buffer).position(0);
             initNewStore(params.getGenesisBlock());
         } finally { lock.unlock(); }
     }


### PR DESCRIPTION
This is meant to make sure the buffer position is always right.

Followup to #3432 