### PR TITLE
ECKey, BtcFormat: fix bad JavaDoc @link tags

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -559,7 +559,7 @@ public class ECKey implements EncryptableItem {
 
     /**
      * Signs the given hash and returns the R and S components as BigIntegers. In the Bitcoin protocol, they are
-     * usually encoded using ASN.1 format, so you want {@link ECKey.ECDSASignature#toASN1()}
+     * usually encoded using ASN.1 format, so you want {@link ECKey#toASN1()}
      * instead. However sometimes the independent components can be useful, for instance, if you're going to do
      * further EC maths on them.
      * @throws KeyCrypterException if this ECKey doesn't have a private part.

--- a/core/src/main/java/org/bitcoinj/utils/BtcFormat.java
+++ b/core/src/main/java/org/bitcoinj/utils/BtcFormat.java
@@ -407,7 +407,7 @@ import static org.bitcoinj.utils.BtcAutoFormat.Style.SYMBOL;
  * interpret every number as being denominated in the units that were specified when
  * constructing the instance doing the parsing.  This default behavior of {@link
  * BtcFixedFormat} can be overridden by setting a parsing pattern that includes a currency sign
- * using the {@link BtcFormat.Builder#pattern()} method.</p>
+ * using the {@link BtcFormat#pattern()} method.</p>
  *
  * <p>The {@link BtcAutoFormat#parse(String)} method of {@link BtcAutoFormat} (and of
  * {@link BtcAutoFormat} configured with applicable non-default pattern) will recognize a


### PR DESCRIPTION
JDK 23 fixes a bug that allowed these invalid links: https://bugs.openjdk.org/browse/JDK-8164094

This PR fixes the invalid links and does not require JDK 23, but does fix our build so it will work with JDK 23.