### PR TITLE
TorUtils: Move to o.b.core.internal

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerAddress.java
@@ -21,7 +21,7 @@ import org.bitcoinj.base.VarInt;
 import org.bitcoinj.base.internal.Buffers;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.base.internal.ByteUtils;
-import org.bitcoinj.crypto.internal.TorUtils;
+import org.bitcoinj.core.internal.TorUtils;
 
 import javax.annotation.Nullable;
 import java.net.Inet4Address;

--- a/core/src/main/java/org/bitcoinj/core/internal/TorUtils.java
+++ b/core/src/main/java/org/bitcoinj/core/internal/TorUtils.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.crypto.internal;
+package org.bitcoinj.core.internal;
 
 import com.google.common.io.BaseEncoding;
 import org.bouncycastle.jcajce.provider.digest.SHA3;

--- a/core/src/test/java/org/bitcoinj/core/internal/TorUtilsTest.java
+++ b/core/src/test/java/org/bitcoinj/core/internal/TorUtilsTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.crypto.internal;
+package org.bitcoinj.core.internal;
 
 import org.junit.Test;
 


### PR DESCRIPTION
It is only used by PeerAddress, so it makes sense for it to be in the same package as PeerAddress. This removes a Guava dependency from the o.b.crypto package/module.