### PR TITLE
settings.gradle: require JDK 17 for the build

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, macOS-12, windows-2022]
-        java: ['11', '17', '21']
+        java: ['17', '21']
         distribution: ['temurin']
         gradle: ['8.10']
       fail-fast: false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,17 +15,6 @@ reference:
     paths:
       - build/**
 
-bullseye-jdk11:
-  image: debian:bullseye-slim
-  before_script:
-    - apt-get update
-    - apt-get -y install openjdk-11-jdk-headless gradle
-  script:
-    - gradle --settings-file settings-debian.gradle build :bitcoinj-core:publishToMavenLocal :bitcoinj-wallettool:installDist --init-script build-scan-agree.gradle --scan --stacktrace
-  after_script:
-    - gradle --version
-    - sha256sum core/build/libs/*.jar wallettool/build/install/wallet-tool/bin/*  wallettool/build/install/wallet-tool/lib/*.jar
-
 bookworm-jdk17:
   image: debian:bookworm-slim
   before_script:

--- a/README.adoc
+++ b/README.adoc
@@ -23,14 +23,12 @@ To get started, it is best to have the latest JDK and Gradle installed. The HEAD
 
 #### Building from the command line
 
-Official builds are currently using JDK 17. Our GitHub Actions build and test with JDK 11, 17 and 21.
-
-To perform a full build (_including_ JavaDocs, unit/integration _tests_, and `wallettemplate`) use JDK 17+.
+Official builds are currently using JDK 17. Our GitHub Actions build and test with JDK 17 and 21.
 
 ```
 gradle clean build
 ```
-If you are using JDK 17+, the build will automatically include the JavaFX-based `wallettemplate` module. The outputs are under the `build` directory.
+The outputs are under the `build` directory.
 
 To perform a full build _without_ unit/integration _tests_ use:
 ```

--- a/settings-debian.gradle
+++ b/settings-debian.gradle
@@ -12,8 +12,9 @@ if (GradleVersion.current().compareTo(gradleVersion) != 0) {
     throw new GradleScriptException("bitcoinj build requires Debian Gradle ${gradleVersion}", null)
 }
 
+// we can't test for Java 17 in Gradle 4.4, so at least we test for Java 11
 if (!JavaVersion.current().isJava11Compatible()) {
-    throw new GradleScriptException("bitcoinj build requires Java 11 or later", null)
+    throw new GradleScriptException("bitcoinj build requires Java 17 or later", null)
 }
 
 rootProject.name = 'bitcoinj-parent'

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,9 +13,8 @@ rootProject.name = 'bitcoinj-parent'
 if (GradleVersion.current().compareTo(minGradleVersion) < 0) {
     throw new GradleScriptException("bitcoinj build requires Gradle ${minGradleVersion} or later", null)
 }
-
-if (!JavaVersion.current().isJava11Compatible()) {
-    throw new GradleScriptException("bitcoinj build requires Java 11 or later", null)
+if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+    throw new GradleScriptException("bitcoinj build requires Java 17 or later", null)
 }
 
 include 'core'
@@ -30,13 +29,8 @@ project(':wallettool').name = 'bitcoinj-wallettool'
 include 'examples'
 project(':examples').name = 'bitcoinj-examples'
 
-if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
-    System.err.println "Including wallettemplate because ${JavaVersion.current()}"
-    include 'wallettemplate'
-    project(':wallettemplate').name = 'bitcoinj-wallettemplate'
-} else {
-    System.err.println "Skipping wallettemplate, requires Java 17+, currently running Java ${JavaVersion.current()}"
-}
+include 'wallettemplate'
+project(':wallettemplate').name = 'bitcoinj-wallettemplate'
 
 include 'integration-test'
 project(':integration-test').name = 'bitcoinj-integration-test'


### PR DESCRIPTION
I didn't find a way to query for Java 17 compatibility on Gradle below 6.3, so I had to gate the overall check and our Gradle 4.4 build is unchecked.