### PR TITLE
settings-debian.gradle: separate out settings for builds on Debian Gradle 4.4

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ bullseye-jdk11:
     - apt-get update
     - apt-get -y install openjdk-11-jdk-headless gradle
   script:
-    - gradle build :bitcoinj-core:publishToMavenLocal :bitcoinj-wallettool:installDist --init-script build-scan-agree.gradle --scan --stacktrace
+    - gradle --settings-file settings-debian.gradle build :bitcoinj-core:publishToMavenLocal :bitcoinj-wallettool:installDist --init-script build-scan-agree.gradle --scan --stacktrace
   after_script:
     - gradle --version
     - sha256sum core/build/libs/*.jar wallettool/build/install/wallet-tool/bin/*  wallettool/build/install/wallet-tool/lib/*.jar
@@ -32,7 +32,7 @@ bookworm-jdk17:
     - apt-get update
     - apt-get -y install openjdk-17-jdk-headless gradle
   script:
-    - gradle build :bitcoinj-core:publishToMavenLocal :bitcoinj-wallettool:installDist --init-script build-scan-agree.gradle --scan --stacktrace
+    - gradle --settings-file settings-debian.gradle build :bitcoinj-core:publishToMavenLocal :bitcoinj-wallettool:installDist --init-script build-scan-agree.gradle --scan --stacktrace
   after_script:
     - gradle --version
     - sha256sum core/build/libs/*.jar wallettool/build/install/wallet-tool/bin/*  wallettool/build/install/wallet-tool/lib/*.jar

--- a/README.adoc
+++ b/README.adoc
@@ -80,6 +80,13 @@ Our reference build (which is also used for our releases) is running within a co
 Buildah 1.26+, Podman 4.1+ and Docker (with BuildKit) are supported. We tested various combinations of host OSes
 (Debian, Ubuntu, macOS, Windows+WSL) and architectures (amd64, arm64). For usage instructions see `build.Containerfile`.
 
+This uses Debian Gradle with the `settings-debian.gradle` settings. If you happen to use Debian and have Gradle
+installed from the Debian repository, you can invoke these settings directly:
+
+```
+gradle --settings-file settings-debian.gradle clean build
+```
+
 ### Example applications
 
 These are found in the `examples` module.

--- a/build.Containerfile
+++ b/build.Containerfile
@@ -38,6 +38,7 @@ COPY --chown=builder / project/
 # build project
 RUN /usr/bin/gradle --project-dir project/ \
     --no-build-cache --no-daemon --no-parallel \
+    --settings-file=settings-debian.gradle \
     -Dmaven.repo.local=repo \
     clean ${ADDITIONAL_GRADLE_TASK} :bitcoinj-core:publishToMavenLocal :bitcoinj-wallettool:installDist
 

--- a/settings-debian.gradle
+++ b/settings-debian.gradle
@@ -1,0 +1,31 @@
+/*
+ * Setting file only for Debian Gradle 4.4.1.
+ * Usage: gradle --settings-file=settings-debian.gradle build
+ */
+
+import org.gradle.util.GradleVersion
+
+// required Gradle version for build
+def gradleVersion = GradleVersion.version("4.4.1")
+
+if (GradleVersion.current().compareTo(gradleVersion) != 0) {
+    throw new GradleScriptException("bitcoinj build requires Debian Gradle ${gradleVersion}", null)
+}
+
+if (!JavaVersion.current().isJava11Compatible()) {
+    throw new GradleScriptException("bitcoinj build requires Java 11 or later", null)
+}
+
+rootProject.name = 'bitcoinj-parent'
+
+include 'core'
+project(':core').name = 'bitcoinj-core'
+
+include 'tools'
+project(':tools').name = 'bitcoinj-tools'
+
+include 'wallettool'
+project(':wallettool').name = 'bitcoinj-wallettool'
+
+include 'examples'
+project(':examples').name = 'bitcoinj-examples'


### PR DESCRIPTION
This is meant to prepare for improvements to the regular `settings.gradle` file.

GitLab pipeline, which is affected by these changes, succeeds: https://gitlab.com/bitcoinj/bitcoinj/-/pipelines/1427520217

