### PR TITLE
settings.gradle: require Gradle 7.3 or later

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,12 +12,6 @@ jobs:
         java: ['11', '17', '21']
         distribution: ['temurin']
         gradle: ['8.10']
-        include:
-          # Special case to test something close to Debian config with the oldest supported (standard) Gradle on Ubuntu
-          - os: ubuntu-22.04
-            java: '11'
-            distribution: 'temurin'
-            gradle: '4.10.3'
       fail-fast: false
     name: JAVA ${{ matrix.distribution }} ${{ matrix.java }} OS ${{ matrix.os }} Gradle ${{ matrix.gradle }}
     steps:

--- a/README.adoc
+++ b/README.adoc
@@ -10,10 +10,11 @@ The bitcoinj library is a Java implementation of the Bitcoin protocol, which all
 
 ### Technologies
 
-* Java 8+ (needs Java 8 API or Android 8.0 API, compiles to Java 8 bytecode) and Gradle 4.4+ for the `core` module
-* Java 11+ and Gradle 4.4+ for `tools`, `wallettool` and `examples`
-* Java 17+ and Gradle 7.3+ for the JavaFX-based `wallettemplate`
-* https://gradle.org/[Gradle] - for building the project
+* Java 8+ (needs Java 8 API or Android 8.0 API, compiles to Java 8 bytecode) for the `core` module
+* Java 11+ for `tools`, `wallettool` and `examples`
+* Java 17+ for the JavaFX-based `wallettemplate`
+* https://gradle.org/[Gradle] 7.3+ for building the whole project or
+* Debian Gradle 4.4 for just the `core`, `tools`, `wallettool` and `examples` modules (see "reference build" below)
 * https://github.com/google/protobuf[Google Protocol Buffers] - for use with serialization and hardware communications
 
 ### Getting started
@@ -29,7 +30,7 @@ To perform a full build (_including_ JavaDocs, unit/integration _tests_, and `wa
 ```
 gradle clean build
 ```
-If you are using JDK 17+ and Gradle 7.3+, the build will automatically include the JavaFX-based `wallettemplate` module. The outputs are under the `build` directory.
+If you are using JDK 17+, the build will automatically include the JavaFX-based `wallettemplate` module. The outputs are under the `build` directory.
 
 To perform a full build _without_ unit/integration _tests_ use:
 ```

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,13 +1,12 @@
+/*
+ * Settings file for Gradle 7.3 or later.
+ * For building with Debian Gradle 4.4, use the settings-debian.gradle settings.
+ */
+
 import org.gradle.util.GradleVersion
 
 // Minimum Gradle version for build
-def minGradleVersion = GradleVersion.version("4.4")
-// Minimum Gradle version for JUnit5
-def minJunit5GradleVersion = GradleVersion.version("4.6")
-// Minimum Gradle version for builds of JavaFX 17 module using JDK 17
-def minFxGradleVersion = GradleVersion.version("7.3")
-// Minimum Gradle version for kotlin
-def minKotlinGradleVersion = GradleVersion.version("6.8.3")
+def minGradleVersion = GradleVersion.version("7.3")
 
 rootProject.name = 'bitcoinj-parent'
 
@@ -31,23 +30,16 @@ project(':wallettool').name = 'bitcoinj-wallettool'
 include 'examples'
 project(':examples').name = 'bitcoinj-examples'
 
-if (GradleVersion.current().compareTo(minFxGradleVersion) > 0 && JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
-    System.err.println "Including wallettemplate because ${GradleVersion.current()}"
+if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
+    System.err.println "Including wallettemplate because ${JavaVersion.current()}"
     include 'wallettemplate'
     project(':wallettemplate').name = 'bitcoinj-wallettemplate'
 } else {
-    System.err.println "Skipping wallettemplate, requires Gradle ${minFxGradleVersion}+ and Java 17+, currently running Gradle: ${GradleVersion.current()}, Java ${JavaVersion.current()}"
+    System.err.println "Skipping wallettemplate, requires Java 17+, currently running Java ${JavaVersion.current()}"
 }
 
-if (GradleVersion.current().compareTo(minJunit5GradleVersion) >= 0) {
-    System.err.println "Including integration-test because ${GradleVersion.current()}"
-    include 'integration-test'
-    project(':integration-test').name = 'bitcoinj-integration-test'
-} else {
-    System.err.println "Skipping integration-test, requires Gradle ${minJunit5GradleVersion}+, currently running: ${GradleVersion.current()}"
-}
+include 'integration-test'
+project(':integration-test').name = 'bitcoinj-integration-test'
 
-if (GradleVersion.current().compareTo(minKotlinGradleVersion) >= 0) {
-    include 'examples-kotlin'
-    project(':examples-kotlin').name = 'bitcoinj-examples-kotlin'
-}
+include 'examples-kotlin'
+project(':examples-kotlin').name = 'bitcoinj-examples-kotlin'


### PR DESCRIPTION
Two reasons for picking that particular version:
* it enables us to replace all previous Gradle-related conditionals in this file
* it's required for official support of Java 17

Gitlab pipeline is fine: https://gitlab.com/bitcoinj/bitcoinj/-/pipelines/1428473105