### PR TITLE
gradle.yml: add Gradle 7.3 to the build matrix

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,11 @@ jobs:
         os: [ubuntu-22.04, macOS-12, windows-2022]
         java: ['17', '21']
         distribution: ['temurin']
-        gradle: ['8.10']
+        gradle: ['7.3', '8.10']
+        exclude:
+          # Java 21+ requires Gradle 8.5+
+          - java: '21'
+            gradle: '7.3'
       fail-fast: false
     name: JAVA ${{ matrix.distribution }} ${{ matrix.java }} OS ${{ matrix.os }} Gradle ${{ matrix.gradle }}
     steps:


### PR DESCRIPTION
This is the lowest version we support at the moment (apart from Debian Gradle). We should prevent it regressing without us noticing.