### PR TITLE
build.gradle: update Gradle plugin for GraalVM to 0.10.2

### DIFF
--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'java'
     id 'application'
     id 'org.asciidoctor.jvm.convert' version '3.3.2' apply false
-    id 'org.graalvm.buildtools.native' version '0.9.27' apply false
+    id 'org.graalvm.buildtools.native' version '0.10.2' apply false
 }
 
 def annotationProcessorMinVersion = GradleVersion.version("4.6")


### PR DESCRIPTION
I assume updating to most recent 0.10.2 would also bump our GraalVM requirement to 22 – seems excessive as our highest Java version is currently 21.

https://graalvm.github.io/native-build-tools/latest/index.html#changelog