### PR TITLE
core/build.gradle,gradle.yml remove test(On)Jdk8

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           gradle-version: ${{ matrix.gradle }}
       - name: Run Gradle
-        run: gradle -PtestJdk8=true build --init-script build-scan-agree.gradle --scan --info --stacktrace
+        run: gradle build --init-script build-scan-agree.gradle --scan --info --stacktrace
       - name: Upload Test Results and Reports
         uses: actions/upload-artifact@v4
         if: always()

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -80,26 +80,6 @@ test {
     }
 }
 
-def gradleVersionToolchains = GradleVersion.version("6.7")
-
-if (GradleVersion.current().compareTo(gradleVersionToolchains) > 0) {
-    // If the Gradle Java Toolchains feature is available, run tests on older JDKs
-    System.err.println "Adding 'testOnJdk8' task, because ${GradleVersion.current()}"
-
-    task('testOnJdk8', type: Test) {
-        doFirst {
-            logger.lifecycle("Testing with JDK ${javaLauncher.get().metadata.javaRuntimeVersion}")
-        }
-        javaLauncher = javaToolchains.launcherFor {
-            languageVersion = JavaLanguageVersion.of(8)
-        }
-    }
-    // Activate if `testJdk8` is `true` in `gradle.properties` or `-PtestJdk8=true` is on command-line
-    if (Boolean.valueOf(findProperty('testJdk8'))) {
-        check.dependsOn testOnJdk8
-    }
-}
-
 ext.moduleName = 'org.bitcoinj.core'
 
 jar {


### PR DESCRIPTION
Since we are planning on dropping support for Jdk8 in the next release and the current implementation of this in GitHub Actions is blocking us from testing on macos-14 (ARM64), let's just remove this.