### PR TITLE
core/build.gradle,gradle.yml: test(On)Jdk11

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           gradle-version: ${{ matrix.gradle }}
       - name: Run Gradle
-        run: gradle -PtestJdk8=true build --init-script build-scan-agree.gradle --scan --info --stacktrace
+        run: gradle -PtestJdk11=true build --init-script build-scan-agree.gradle --scan --info --stacktrace
       - name: Upload Test Results and Reports
         uses: actions/upload-artifact@v4
         if: always()

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -84,19 +84,19 @@ def gradleVersionToolchains = GradleVersion.version("6.7")
 
 if (GradleVersion.current().compareTo(gradleVersionToolchains) > 0) {
     // If the Gradle Java Toolchains feature is available, run tests on older JDKs
-    System.err.println "Adding 'testOnJdk8' task, because ${GradleVersion.current()}"
+    System.err.println "Adding 'testOnJdk11' task, because ${GradleVersion.current()}"
 
-    task('testOnJdk8', type: Test) {
+    task('testOnJdk11', type: Test) {
         doFirst {
             logger.lifecycle("Testing with JDK ${javaLauncher.get().metadata.javaRuntimeVersion}")
         }
         javaLauncher = javaToolchains.launcherFor {
-            languageVersion = JavaLanguageVersion.of(8)
+            languageVersion = JavaLanguageVersion.of(11)
         }
     }
-    // Activate if `testJdk8` is `true` in `gradle.properties` or `-PtestJdk8=true` is on command-line
-    if (Boolean.valueOf(findProperty('testJdk8'))) {
-        check.dependsOn testOnJdk8
+    // Activate if `testJdk11` is `true` in `gradle.properties` or `-PtestJdk11=true` is on command-line
+    if (Boolean.valueOf(findProperty('testJdk11'))) {
+        check.dependsOn testOnJdk11
     }
 }
 


### PR DESCRIPTION
Continue using Java Toolchain support in Gradle to test on an earlier JDK, but switch from JDK 8 to
JDK 11.