### PR TITLE
remove all references to `java.util.Date`

### DIFF
--- a/base/src/test/java/org/bitcoinj/base/internal/TimeUtilsTest.java
+++ b/base/src/test/java/org/bitcoinj/base/internal/TimeUtilsTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
-import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
@@ -42,7 +42,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -1064,12 +1063,6 @@ public abstract class AbstractBlockChain {
             Instant headTime = chainHead.getHeader().time();
             return headTime.plus(10 * offset, ChronoUnit.MINUTES);
         }
-    }
-
-    /** @deprecated use {@link #estimateBlockTimeInstant(int)} */
-    @Deprecated
-    public Date estimateBlockTime(int height) {
-        return Date.from(estimateBlockTimeInstant(height));
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -48,7 +48,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
@@ -737,15 +736,6 @@ public class Block extends BaseMessage {
     @Deprecated
     public long getTimeSeconds() {
         return time.getEpochSecond();
-    }
-
-    /**
-     * Returns the time at which the block was solved and broadcast, according to the clock of the solving node.
-     * @deprecated use {@link #time()}
-     */
-    @Deprecated
-    public Date getTime() {
-        return Date.from(time());
     }
 
     // For testing only

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -59,7 +59,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -569,12 +568,6 @@ public class Transaction extends BaseMessage {
         return Optional.ofNullable(updateTime);
     }
 
-    /** @deprecated use {@link #updateTime()} */
-    @Deprecated
-    public Date getUpdateTime() {
-        return Date.from(updateTime().orElse(Instant.EPOCH));
-    }
-
     /**
      * Sets the update time of this transaction.
      * @param updateTime update time
@@ -588,15 +581,6 @@ public class Transaction extends BaseMessage {
      */
     public void clearUpdateTime() {
         this.updateTime = null;
-    }
-
-    /** @deprecated use {@link #setUpdateTime(Instant)} or {@link #clearUpdateTime()} */
-    @Deprecated
-    public void setUpdateTime(Date updateTime) {
-        if (updateTime != null && updateTime.getTime() > 0)
-            setUpdateTime(updateTime.toInstant());
-        else
-            clearUpdateTime();
     }
 
     /**
@@ -1735,12 +1719,6 @@ public class Transaction extends BaseMessage {
         return locktime instanceof HeightLock ?
                 chain.estimateBlockTimeInstant(((HeightLock) locktime).blockHeight()) :
                 ((TimeLock) locktime).timestamp();
-    }
-
-    /** @deprecated use {@link #estimateUnlockTime(AbstractBlockChain)} */
-    @Deprecated
-    public Date estimateLockTime(AbstractBlockChain chain) {
-        return Date.from(estimateUnlockTime(chain));
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
@@ -30,7 +30,6 @@ import org.bitcoinj.wallet.Wallet;
 import javax.annotation.Nullable;
 import java.time.Instant;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Objects;
@@ -347,25 +346,12 @@ public class TransactionConfidence {
         return Optional.ofNullable(lastBroadcastTime);
     }
 
-    /** @deprecated use {@link #getLastBroadcastTime()} */
-    @Deprecated
-    @Nullable
-    public Date getLastBroadcastedAt() {
-        return lastBroadcastTime != null ? Date.from(lastBroadcastTime) : null;
-    }
-
     /**
      * Set the time the transaction was last announced to us.
      * @param lastBroadcastTime time the transaction was last announced to us
      */
     public void setLastBroadcastTime(Instant lastBroadcastTime) {
         this.lastBroadcastTime = Objects.requireNonNull(lastBroadcastTime);
-    }
-
-    /** @deprecated use {@link #setLastBroadcastTime(Instant)} */
-    @Deprecated
-    public void setLastBroadcastedAt(Date lastBroadcastedAt) {
-        setLastBroadcastTime(lastBroadcastedAt.toInstant());
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/core/listeners/DownloadProgressTracker.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/DownloadProgressTracker.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.time.Instant;
-import java.util.Date;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;

--- a/core/src/main/java/org/bitcoinj/protocols/payments/PaymentSession.java
+++ b/core/src/main/java/org/bitcoinj/protocols/payments/PaymentSession.java
@@ -45,7 +45,6 @@ import java.net.URL;
 import java.security.KeyStoreException;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -261,12 +260,6 @@ public class PaymentSession {
         return Instant.ofEpochSecond(paymentDetails.getTime());
     }
 
-    /** @deprecated use {@link #time()} */
-    @Deprecated
-    public Date getDate() {
-        return Date.from(time());
-    }
-
     /**
      * Returns the expires time of the payment request, or empty if none.
      */
@@ -275,15 +268,6 @@ public class PaymentSession {
             return Optional.of(Instant.ofEpochSecond(paymentDetails.getExpires()));
         else
             return Optional.empty();
-    }
-
-    /** @deprecated use {@link #expires()} */
-    @Nullable
-    @Deprecated
-    public Date getExpires() {
-        return expires()
-                .map(Date::from)
-                .orElse(null);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/utils/BriefLogFormatter.java
+++ b/core/src/main/java/org/bitcoinj/utils/BriefLogFormatter.java
@@ -24,7 +24,6 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.Date;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.Level;

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -118,7 +118,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -3885,13 +3884,6 @@ public class Wallet extends BaseTaggableObject
         return lastBlockSeenTime().map(Instant::getEpochSecond).orElse((long) 0);
     }
 
-    /** @deprecated use {@link #lastBlockSeenTime()} */
-    @Deprecated
-    @Nullable
-    public Date getLastBlockSeenTime() {
-        return lastBlockSeenTime().map(Date::from).orElse(null);
-    }
-
     /**
      * Returns the height of the last seen best-chain block. Can be 0 if a wallet is brand new or -1 if the wallet
      * is old and doesn't have that data.
@@ -5684,31 +5676,12 @@ public class Wallet extends BaseTaggableObject
             setKeyRotationTime(Instant.ofEpochSecond(timeSecs));
     }
 
-    /** @deprecated use {@link #setKeyRotationTime(Instant)} */
-    @Deprecated
-    public void setKeyRotationTime(@Nullable Date time) {
-        if (time == null)
-            setKeyRotationTime((Instant) null);
-        else
-            setKeyRotationTime(Instant.ofEpochMilli(time.getTime()));
-    }
-
     /**
      * Returns the key rotation time, or empty if unconfigured. See {@link #setKeyRotationTime(Instant)} for a description
      * of the field.
      */
     public Optional<Instant> keyRotationTime() {
         return Optional.ofNullable(vKeyRotationTime);
-    }
-
-    /** @deprecated use {@link #keyRotationTime()} */
-    @Deprecated
-    public @Nullable Date getKeyRotationTime() {
-        Instant keyRotationTime = vKeyRotationTime;
-        if (keyRotationTime != null)
-            return Date.from(keyRotationTime);
-        else
-            return null;
     }
 
     /** Returns whether the keys creation time is before the key rotation time, if one was set. */

--- a/core/src/main/java/org/bitcoinj/wallet/WalletFiles.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletFiles.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.sql.Time;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Date;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledThreadPoolExecutor;

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -60,7 +60,6 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -47,7 +47,6 @@ import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.SortedSet;

--- a/core/src/test/java/org/bitcoinj/protocols/payments/PaymentSessionTest.java
+++ b/core/src/test/java/org/bitcoinj/protocols/payments/PaymentSessionTest.java
@@ -44,7 +44,6 @@ import java.net.URL;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 

--- a/core/src/test/java/org/bitcoinj/wallet/BasicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/BasicKeyChainTest.java
@@ -35,7 +35,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;


### PR DESCRIPTION
This also removes deprecated members.

We have no hurry merging this.