### PR TITLE
build.gradle: migrate `--release` compiler option to `compileJava.options.release` for wallettemplate, examples-kotlin

### DIFF
--- a/examples-kotlin/build.gradle
+++ b/examples-kotlin/build.gradle
@@ -12,11 +12,11 @@ compileKotlin {
 }
 
 sourceCompatibility = 17
+compileJava.options.release = 17
 compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
 javadoc.options.encoding = 'UTF-8'
 
 compileJava {
-    options.compilerArgs.addAll(['--release', '17'])
     options.compilerArgs << '-Xlint:deprecation'
 }

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 }
 
 sourceCompatibility = 17
+compileJava.options.release = 17
 compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
 javadoc.options.encoding = 'UTF-8'

--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -21,12 +21,12 @@ javafx {
 }
 
 sourceCompatibility = 17
+compileJava.options.release = 17
 compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
 javadoc.options.encoding = 'UTF-8'
 
 compileJava {
-    options.compilerArgs.addAll(['--release', '17'])
     options.compilerArgs << '-Xlint:deprecation'
 }
 


### PR DESCRIPTION
For the remaining modules, we're still using Gradle 4.4 so we can't do the same.

Removing sourceCompatibility, targetCompatibility is for the next PR.