### PR TITLE
base: remove all (deprecated) usage of Networks.get()

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/Address.java
+++ b/core/src/main/java/org/bitcoinj/base/Address.java
@@ -16,11 +16,9 @@
 
 package org.bitcoinj.base;
 
-import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.core.NetworkParameters;
 
-import javax.annotation.Nullable;
 import java.util.Comparator;
 
 /**
@@ -29,26 +27,6 @@ import java.util.Comparator;
  * Use {@link AddressParser} to construct any kind of address from its textual form.
  */
 public interface Address extends Comparable<Address> {
-    /**
-     * Construct an address from its textual form.
-     * 
-     * @param params the expected network this address is valid for, or null if the network should be derived from the
-     *               textual form
-     * @param str the textual form of the address, such as "17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL" or
-     *            "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
-     * @return constructed address
-     * @throws AddressFormatException
-     *             if the given string doesn't parse or the checksum is invalid
-     * @throws AddressFormatException.WrongNetwork
-     *             if the given string is valid but not for the expected network (e.g. testnet vs mainnet)
-     * @deprecated Use {@link org.bitcoinj.wallet.Wallet#parseAddress(String)} or {@link AddressParser#parseAddress(String)}
-     */
-    @Deprecated
-    static Address fromString(@Nullable NetworkParameters params, String str)
-            throws AddressFormatException {
-        return AddressParser.getLegacy(params).parseAddress(str);
-    }
-
     /**
      * Construct an {@link Address} that represents the public part of the given {@link ECKey}.
      * 

--- a/core/src/main/java/org/bitcoinj/base/AddressParser.java
+++ b/core/src/main/java/org/bitcoinj/base/AddressParser.java
@@ -17,9 +17,6 @@
 package org.bitcoinj.base;
 
 import org.bitcoinj.base.exceptions.AddressFormatException;
-import org.bitcoinj.core.NetworkParameters;
-
-import javax.annotation.Nullable;
 
 /**
  * Functional interface for parsing an {@link Address}. It takes a {@link String} parameter and will parse address
@@ -71,40 +68,4 @@ public interface AddressParser {
          */
         AddressParser forNetwork(Network network);
     }
-
-    /**
-     * Get a <i>legacy</i> address parser that knows about networks that have been
-     * dynamically added to the list maintained by {@link org.bitcoinj.params.Networks}.
-     * @return A parser for all known networks
-     */
-    @Deprecated
-    static AddressParser getLegacy() {
-        return DefaultAddressParserProvider.fromNetworks().forKnownNetworks();
-    }
-
-    /**
-     * Get a <i>legacy</i> address parser that knows about networks that have been
-     * dynamically added to the list maintained by {@link org.bitcoinj.params.Networks}.
-     * @param network the network to parse for
-     * @return A parser that will throw for strings that are not valid for network.
-     */
-    @Deprecated
-    static AddressParser getLegacy(Network network) {
-        return DefaultAddressParserProvider.fromNetworks().forNetwork(network);
-    }
-
-    /**
-     * Get a <i>legacy</i> address parser that knows about networks that have been
-     * dynamically added to the list maintained by {@link org.bitcoinj.params.Networks}.
-     * @param params the network to parser for, or {@code null} for all networks.
-     * @return A parser that will throw for strings that are not valid for network.
-     */
-    @Deprecated
-    static AddressParser getLegacy(@Nullable NetworkParameters params) {
-        AddressParser.AddressParserProvider provider = DefaultAddressParserProvider.fromNetworks();
-        return (params == null)
-                ? provider.forKnownNetworks()
-                : provider.forNetwork(params.network());
-    }
-
 }

--- a/core/src/main/java/org/bitcoinj/base/DefaultAddressParserProvider.java
+++ b/core/src/main/java/org/bitcoinj/base/DefaultAddressParserProvider.java
@@ -17,9 +17,6 @@
 package org.bitcoinj.base;
 
 import org.bitcoinj.base.exceptions.AddressFormatException;
-import org.bitcoinj.base.internal.StreamUtils;
-import org.bitcoinj.core.NetworkParameters;
-import org.bitcoinj.params.Networks;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -73,19 +70,6 @@ class DefaultAddressParserProvider implements AddressParser.AddressParserProvide
     @Override
     public AddressParser forNetwork(Network network) {
         return address -> this.parseAddress(address, network);
-    }
-
-    /**
-     * Dynamically create a new {@link AddressParser} using a snapshot of currently configured networks
-     * from {@code Networks.get()}. This is only used by deprecated methods in {@link AddressParser}.
-     * @return A backward-compatible parser
-     */
-    @Deprecated
-    static DefaultAddressParserProvider fromNetworks() {
-        List<Network> nets = Networks.get().stream()
-                .map(NetworkParameters::network)
-                .collect(StreamUtils.toUnmodifiableList());
-        return new DefaultAddressParserProvider(nets, nets);
     }
 
     private Address parseAddress(String addressString) throws AddressFormatException {

--- a/core/src/main/java/org/bitcoinj/base/LegacyAddress.java
+++ b/core/src/main/java/org/bitcoinj/base/LegacyAddress.java
@@ -18,14 +18,12 @@
 
 package org.bitcoinj.base;
 
-import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.crypto.ECKey;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumSet;
@@ -158,26 +156,6 @@ public class LegacyAddress implements Address {
 
     /**
      * Construct a {@link LegacyAddress} from its base58 form.
-     * 
-     * @param params
-     *            expected network this address is valid for, or null if the network should be derived from the
-     *            base58
-     * @param base58
-     *            base58-encoded textual form of the address
-     * @throws AddressFormatException
-     *             if the given base58 doesn't parse or the checksum is invalid
-     * @throws AddressFormatException.WrongNetwork
-     *             if the given address is valid but for a different chain (e.g. testnet vs mainnet)
-     * @deprecated Use {@link #fromBase58(String, Network)}
-     */
-    @Deprecated
-    public static LegacyAddress fromBase58(@Nullable NetworkParameters params, String base58)
-            throws AddressFormatException, AddressFormatException.WrongNetwork {
-        return (LegacyAddress) AddressParser.getLegacy(params).parseAddress(base58);
-    }
-
-    /**
-     * Construct a {@link LegacyAddress} from its base58 form.
      *
      * @param base58  base58-encoded textual form of the address
      * @param network expected network this address is valid for
@@ -239,19 +217,6 @@ public class LegacyAddress implements Address {
     @Override
     public ScriptType getOutputScriptType() {
         return p2sh ? ScriptType.P2SH : ScriptType.P2PKH;
-    }
-
-    /**
-     * Given an address, examines the version byte and attempts to find a matching NetworkParameters. If you aren't sure
-     * which network the address is intended for (eg, it was provided by a user), you can use this to decide if it is
-     * compatible with the current wallet.
-     * 
-     * @return network the address is valid for
-     * @throws AddressFormatException if the given base58 doesn't parse or the checksum is invalid
-     */
-    @Deprecated
-    public static NetworkParameters getParametersFromAddress(String address) throws AddressFormatException {
-        return NetworkParameters.fromAddress(AddressParser.getLegacy().parseAddress(address));
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/base/SegwitAddress.java
+++ b/core/src/main/java/org/bitcoinj/base/SegwitAddress.java
@@ -16,14 +16,12 @@
 
 package org.bitcoinj.base;
 
-import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.crypto.ECKey;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumSet;
@@ -230,24 +228,6 @@ public class SegwitAddress implements Address {
     @Override
     public String toString() {
         return toBech32();
-    }
-
-    /**
-     * Construct a {@link SegwitAddress} from its textual form.
-     * 
-     * @param params
-     *            expected network this address is valid for, or null if the network should be derived from the bech32
-     * @param bech32
-     *            bech32-encoded textual form of the address
-     * @return constructed address
-     * @throws AddressFormatException
-     *             if something about the given bech32 address isn't right
-     * @deprecated Use {@link AddressParser}
-     */
-    @Deprecated
-    public static SegwitAddress fromBech32(@Nullable NetworkParameters params, String bech32)
-            throws AddressFormatException {
-        return (SegwitAddress) AddressParser.getLegacy(params).parseAddress(bech32);
     }
 
     /**

--- a/core/src/test/java/org/bitcoinj/base/LegacyAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/base/LegacyAddressTest.java
@@ -121,45 +121,12 @@ public class LegacyAddressTest {
     }
 
     @Test
-    @Deprecated
-    // Test a deprecated method just to make sure we didn't break it
-    public void getNetworkViaParameters() {
-        NetworkParameters params = LegacyAddress.getParametersFromAddress("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL");
-        assertEquals(MAINNET.id(), params.getId());
-        params = LegacyAddress.getParametersFromAddress("n4eA2nbYqErp7H6jebchxAN59DmNpksexv");
-        assertEquals(TESTNET.id(), params.getId());
-    }
-
-    @Test
     public void getNetwork() {
         AddressParser parser = AddressParser.getDefault();
         Network mainNet = parser.parseAddress("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL").network();
         assertEquals(MAINNET, mainNet);
         Network testNet = parser.parseAddress("n4eA2nbYqErp7H6jebchxAN59DmNpksexv").network();
         assertEquals(TESTNET, testNet);
-    }
-
-    @Test
-    public void getAltNetworkUsingNetworks() {
-        // An alternative network
-        NetworkParameters altNetParams = new MockAltNetworkParams();
-        // Add new network params, this MODIFIES GLOBAL STATE in `Networks`
-        Networks.register(altNetParams);
-        try {
-            // Check if can parse address
-            Address altAddress = AddressParser.getLegacy().parseAddress("LLxSnHLN2CYyzB5eWTR9K9rS9uWtbTQFb6");
-            assertEquals(altNetParams.getId(), altAddress.network().id());
-            // Check if main network works as before
-            Address mainAddress = AddressParser.getLegacy(MAINNET).parseAddress("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL");
-            assertEquals(MAINNET.id(), mainAddress.network().id());
-        } finally {
-            // Unregister network. Do this in a finally block so other tests don't fail if the try block fails to complete
-            Networks.unregister(altNetParams);
-        }
-        try {
-            AddressParser.getLegacy().parseAddress("LLxSnHLN2CYyzB5eWTR9K9rS9uWtbTQFb6");
-            fail();
-        } catch (AddressFormatException e) { }
     }
 
     @Test
@@ -188,11 +155,6 @@ public class LegacyAddressTest {
             // Unregister network. Do this in a finally block so other tests don't fail if the try block fails to complete
             Networks.unregister(altNetParams);
         }
-
-        try {
-            AddressParser.getLegacy().parseAddress("LLxSnHLN2CYyzB5eWTR9K9rS9uWtbTQFb6");
-            fail();
-        } catch (AddressFormatException e) { }
     }
 
     @Test


### PR DESCRIPTION
Remove `DefaultAddressParserProvder.fromNetworks()` and everything that depends on it. All methods being removed were previously deprecated.

Removing `DefaultAddressParserProvder.fromNetworks()` propagates to the 3 AddressParser getLegacy() methods and several other deprecated methods in Address, LegacyAddress, and Segwit Address.

This change means that nothing in `o.b.base` will use the global list of supported networks stored in `Networks`. This is a mechanism we previously added to support other Bitcoin-compatible networks and their addressing schemes (e.g. LiteCoin.) "Alt networks" are still supported, but applications using them will need to create their own implementations of AddressParser to do it. We hope to eventually remove entirely the global state returned by Networks.get(), but this PR is just about removing its usage from `o.b.base`.

Note: this also removes all uses of javax.annotation.Nullable from o.b.base. There are still instances of @NonNull which we should probably leave in until we move to JSpecify.