### PR TITLE
SegwitAddress, LegacyAddress, package-info.java: don't link to classes outside base in JavaDoc

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/Address.java
+++ b/core/src/main/java/org/bitcoinj/base/Address.java
@@ -28,7 +28,7 @@ import java.util.Comparator;
  */
 public interface Address extends Comparable<Address> {
     /**
-     * Construct an {@link Address} that represents the public part of the given {@link ECKey}.
+     * Construct an {@link Address} that represents the public part of the given {@code ECKey}.
      * 
      * @param params
      *            network this address is valid for

--- a/core/src/main/java/org/bitcoinj/base/LegacyAddress.java
+++ b/core/src/main/java/org/bitcoinj/base/LegacyAddress.java
@@ -55,7 +55,7 @@ public class LegacyAddress implements Address {
     /**
      * Private constructor. Use {@link #fromBase58(String, Network)},
      * {@link #fromPubKeyHash(Network, byte[])}, {@link #fromScriptHash(Network, byte[])} or
-     * {@link ECKey#toAddress(ScriptType, Network)}.
+     * {@code ECKey#toAddress(ScriptType, Network)}.
      *
      * @param network
      *            network this address is valid for
@@ -113,7 +113,7 @@ public class LegacyAddress implements Address {
     }
 
     /**
-     * Construct a {@link LegacyAddress} that represents the public part of the given {@link ECKey}. Note that an address is
+     * Construct a {@link LegacyAddress} that represents the public part of the given {@code ECKey}. Note that an address is
      * derived from a hash of the public key and is not the public key itself.
      * 
      * @param params
@@ -121,7 +121,7 @@ public class LegacyAddress implements Address {
      * @param key
      *            only the public part is used
      * @return constructed address
-     * @deprecated Use {@link ECKey#toAddress(ScriptType, Network)}
+     * @deprecated Use {@code ECKey#toAddress(ScriptType, Network)}
      */
     @Deprecated
     public static LegacyAddress fromKey(NetworkParameters params, ECKey key) {
@@ -175,7 +175,7 @@ public class LegacyAddress implements Address {
     }
 
     /**
-     * Get the network this address works on. Use of {@link BitcoinNetwork} is preferred to use of {@link NetworkParameters}
+     * Get the network this address works on. Use of {@link BitcoinNetwork} is preferred to use of {@code NetworkParameters}
      * when you need to know what network an address is for.
      * @return the Network.
      */

--- a/core/src/main/java/org/bitcoinj/base/SegwitAddress.java
+++ b/core/src/main/java/org/bitcoinj/base/SegwitAddress.java
@@ -43,7 +43,7 @@ import java.util.stream.Stream;
  * <a href="https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki">BIP173</a> for details.</p>
  *
  * <p>However, you don't need to care about the internals. Use {@link #fromBech32(String, Network)},
- * {@link #fromHash(org.bitcoinj.base.Network, byte[])} or {@link ECKey#toAddress(ScriptType, Network)}
+ * {@link #fromHash(org.bitcoinj.base.Network, byte[])} or {@code ECKey#toAddress(ScriptType, Network)}
  * to construct a native segwit address.</p>
  */
 public class SegwitAddress implements Address {
@@ -133,7 +133,7 @@ public class SegwitAddress implements Address {
 
     /**
      * Private constructor. Use {@link #fromBech32(String, Network)},
-     * {@link #fromHash(Network, byte[])} or {@link ECKey#toAddress(ScriptType, Network)}.
+     * {@link #fromHash(Network, byte[])} or {@code ECKey#toAddress(ScriptType, Network)}.
      * 
      * @param network
      *            network this address is valid for
@@ -320,7 +320,7 @@ public class SegwitAddress implements Address {
     }
 
     /**
-     * Construct a {@link SegwitAddress} that represents the public part of the given {@link ECKey}. Note that an
+     * Construct a {@link SegwitAddress} that represents the public part of the given {@code ECKey}. Note that an
      * address is derived from a hash of the public key and is not the public key itself.
      * 
      * @param params
@@ -328,7 +328,7 @@ public class SegwitAddress implements Address {
      * @param key
      *            only the public part is used
      * @return constructed address
-     * @deprecated Use {@link ECKey#toAddress(ScriptType, org.bitcoinj.base.Network)}
+     * @deprecated Use {@code ECKey#toAddress(ScriptType, org.bitcoinj.base.Network)}
      */
     @Deprecated
     public static SegwitAddress fromKey(NetworkParameters params, ECKey key) {
@@ -336,7 +336,7 @@ public class SegwitAddress implements Address {
     }
 
     /**
-     * Get the network this address works on. Use of {@link BitcoinNetwork} is preferred to use of {@link NetworkParameters}
+     * Get the network this address works on. Use of {@link BitcoinNetwork} is preferred to use of {@code NetworkParameters}
      * when you need to know what network an address is for.
      * @return the Network.
      */

--- a/core/src/main/java/org/bitcoinj/base/package-info.java
+++ b/core/src/main/java/org/bitcoinj/base/package-info.java
@@ -23,7 +23,7 @@
  * </ul>
  * <p>
  * <b>Temporary exception:</b> In the 0.17 release, we are allowing some dependencies on other packages, e.g. to
- * {@link org.bitcoinj.core.NetworkParameters} or to Guava <i>provided</i> that those references are in <b>deprecated</b> methods.
+ * {@code org.bitcoinj.core.NetworkParameters} or to Guava <i>provided</i> that those references are in <b>deprecated</b> methods.
  * This smooths migration by allowing users to, for example, replace {@code import org.bitcoinj.core.Address} with
  * {@code import org.bitcoinj.base.Address} as first step of conversion and then remove usages of the deprecated methods
  * of {@code Address} in a second step.


### PR DESCRIPTION
Use `@code` rather than `@link` in these cases.