### PR TITLE
LegacyAddressTest: Use MockAltNetwork directly 

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/internal/MockAltNetwork.java
+++ b/core/src/main/java/org/bitcoinj/base/internal/MockAltNetwork.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.testing;
+package org.bitcoinj.base.internal;
 
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Monetary;

--- a/core/src/main/java/org/bitcoinj/testing/MockAltNetworkParams.java
+++ b/core/src/main/java/org/bitcoinj/testing/MockAltNetworkParams.java
@@ -17,6 +17,7 @@
 package org.bitcoinj.testing;
 
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.internal.MockAltNetwork;
 import org.bitcoinj.base.utils.MonetaryFormat;
 import org.bitcoinj.core.BitcoinSerializer;
 import org.bitcoinj.core.Block;


### PR DESCRIPTION
This simplifies the test, removes a dependency on core.NetworkParameters,
and also demonstrates using an Alt Network using only `base` classes.

This is child of PR #3469 