### PR TITLE
LegacyAddressTest: remove unused import

### DIFF
--- a/core/src/test/java/org/bitcoinj/base/LegacyAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/base/LegacyAddressTest.java
@@ -22,7 +22,6 @@ import nl.jqno.equalsverifier.Warning;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.base.internal.MockAltNetwork;
-import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptPattern;
 import org.junit.Test;


### PR DESCRIPTION
NetworkParameters is no longer used after the last rebase.