### PR TITLE
migrate script-related address tests to ScriptBuilderTest

### DIFF
--- a/core/src/main/java/org/bitcoinj/base/internal/AddressData.java
+++ b/core/src/main/java/org/bitcoinj/base/internal/AddressData.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.base.internal;
+
+import org.bitcoinj.base.BitcoinNetwork;
+
+import static org.bitcoinj.base.BitcoinNetwork.MAINNET;
+import static org.bitcoinj.base.BitcoinNetwork.TESTNET;
+
+/**
+ * Address test data for internal use in unit tests.
+ */
+public class AddressData {
+    public static final AddressData[] VALID_ADDRESSES = {
+            // from BIP350 (includes the corrected BIP173 vectors):
+            new AddressData("BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4", MAINNET,
+                    "0014751e76e8199196d454941c45d1b3a323f1433bd6", 0),
+            new AddressData("tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7", TESTNET,
+                    "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262", 0),
+            new AddressData("BC1SW50QGDZ25J", MAINNET, "6002751e", 16),
+            new AddressData("bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs", MAINNET, "5210751e76e8199196d454941c45d1b3a323", 2),
+            new AddressData("tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy", TESTNET,
+                    "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433", 0),
+            new AddressData("tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c", TESTNET,
+                    "5120000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433", 1),
+            new AddressData("bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0", MAINNET,
+                    "512079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798", 1),
+    };
+    public static final String[] INVALID_ADDRESSES = {
+            // from BIP173:
+            "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty", // Invalid human-readable part
+            "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5", // Invalid checksum
+            "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2", // Invalid witness version
+            "bc1rw5uspcuh", // Invalid program length
+            "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90", // Invalid program length
+            "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P", // Invalid program length for witness version 0 (per BIP141)
+            "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7", // Mixed case
+            "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du", // Zero padding of more than 4 bits
+            "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv", // Non-zero padding in 8-to-5 conversion
+            "bc1gmk9yu", // Empty data section
+
+            // from BIP350:
+            "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty", // Invalid human-readable part
+            "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5", // Invalid checksum
+            "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2", // Invalid witness version
+            "bc1rw5uspcuh", // Invalid program length
+            "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90", // Invalid program length
+            "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P", // Invalid program length for witness version 0 (per BIP141)
+            "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7", // Mixed case
+            "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du", // zero padding of more than 4 bits
+            "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv", // Non-zero padding in 8-to-5 conversion
+            "bc1gmk9yu", // Empty data section
+    };
+    public final String address;
+    public final BitcoinNetwork expectedNetwork;
+    public final String expectedScriptPubKey;
+    public final int expectedWitnessVersion;
+
+    public AddressData(String address, BitcoinNetwork expectedNetwork, String expectedScriptPubKey,
+                       int expectedWitnessVersion) {
+        this.address = address;
+        this.expectedNetwork = expectedNetwork;
+        this.expectedScriptPubKey = expectedScriptPubKey;
+        this.expectedWitnessVersion = expectedWitnessVersion;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder s = new StringBuilder(this.getClass().getSimpleName()).append('{');
+        s.append("address=").append(address).append(',');
+        s.append("expected=").append(expectedNetwork.id()).append(',').append(expectedScriptPubKey).append(',').append(expectedWitnessVersion);
+        return s.append('}').toString();
+    }
+}

--- a/core/src/test/java/org/bitcoinj/base/SegwitAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/base/SegwitAddressTest.java
@@ -19,6 +19,7 @@ package org.bitcoinj.base;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.bitcoinj.base.exceptions.AddressFormatException;
+import org.bitcoinj.base.internal.AddressData;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
@@ -144,7 +145,7 @@ public class SegwitAddressTest {
 
     @Test
     public void validAddresses() {
-        for (AddressData valid : VALID_ADDRESSES) {
+        for (AddressData valid : AddressData.VALID_ADDRESSES) {
             SegwitAddress address = (SegwitAddress) addressParser.parseAddress(valid.address);
 
             assertEquals(valid.expectedNetwork, address.network());
@@ -160,48 +161,9 @@ public class SegwitAddressTest {
         }
     }
 
-    private static class AddressData {
-        final String address;
-        final BitcoinNetwork expectedNetwork;
-        final String expectedScriptPubKey;
-        final int expectedWitnessVersion;
-
-        AddressData(String address, BitcoinNetwork expectedNetwork, String expectedScriptPubKey,
-                int expectedWitnessVersion) {
-            this.address = address;
-            this.expectedNetwork = expectedNetwork;
-            this.expectedScriptPubKey = expectedScriptPubKey;
-            this.expectedWitnessVersion = expectedWitnessVersion;
-        }
-
-        @Override
-        public String toString() {
-            StringBuilder s = new StringBuilder(this.getClass().getSimpleName()).append('{');
-            s.append("address=").append(address).append(',');
-            s.append("expected=").append(expectedNetwork.id()).append(',').append(expectedScriptPubKey).append(',').append(expectedWitnessVersion);
-            return s.append('}').toString();
-        }
-    }
-
-    private static AddressData[] VALID_ADDRESSES = {
-            // from BIP350 (includes the corrected BIP173 vectors):
-            new AddressData("BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4", MAINNET,
-                    "0014751e76e8199196d454941c45d1b3a323f1433bd6", 0),
-            new AddressData("tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7", TESTNET,
-                    "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262", 0),
-            new AddressData("BC1SW50QGDZ25J", MAINNET, "6002751e", 16),
-            new AddressData("bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs", MAINNET, "5210751e76e8199196d454941c45d1b3a323", 2),
-            new AddressData("tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy", TESTNET,
-                    "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433", 0),
-            new AddressData("tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c", TESTNET,
-                    "5120000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433", 1),
-            new AddressData("bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0", MAINNET,
-                    "512079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798", 1),
-    };
-
     @Test
     public void invalidAddresses() {
-        for (String invalid : INVALID_ADDRESSES) {
+        for (String invalid : AddressData.INVALID_ADDRESSES) {
             try {
                 addressParser.parseAddress(invalid);
                 fail(invalid);
@@ -210,32 +172,6 @@ public class SegwitAddressTest {
             }
         }
     }
-
-    private static String[] INVALID_ADDRESSES = {
-            // from BIP173:
-            "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty", // Invalid human-readable part
-            "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5", // Invalid checksum
-            "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2", // Invalid witness version
-            "bc1rw5uspcuh", // Invalid program length
-            "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90", // Invalid program length
-            "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P", // Invalid program length for witness version 0 (per BIP141)
-            "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7", // Mixed case
-            "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du", // Zero padding of more than 4 bits
-            "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv", // Non-zero padding in 8-to-5 conversion
-            "bc1gmk9yu", // Empty data section
-
-            // from BIP350:
-            "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty", // Invalid human-readable part
-            "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5", // Invalid checksum
-            "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2", // Invalid witness version
-            "bc1rw5uspcuh", // Invalid program length
-            "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90", // Invalid program length
-            "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P", // Invalid program length for witness version 0 (per BIP141)
-            "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7", // Mixed case
-            "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du", // zero padding of more than 4 bits
-            "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv", // Non-zero padding in 8-to-5 conversion
-            "bc1gmk9yu", // Empty data section
-    };
 
     @Test(expected = AddressFormatException.InvalidDataLength.class)
     public void fromBech32_version0_invalidLength() {

--- a/core/src/test/java/org/bitcoinj/base/SegwitAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/base/SegwitAddressTest.java
@@ -20,10 +20,6 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.internal.AddressData;
-import org.bitcoinj.base.internal.ByteUtils;
-import org.bitcoinj.script.Script;
-import org.bitcoinj.script.ScriptBuilder;
-import org.bitcoinj.script.ScriptPattern;
 import org.junit.Test;
 
 import java.util.Locale;
@@ -55,8 +51,6 @@ public class SegwitAddressTest {
         SegwitAddress address = SegwitAddress.fromBech32(bech32, MAINNET);
 
         assertEquals(MAINNET, address.network());
-        assertEquals("0014751e76e8199196d454941c45d1b3a323f1433bd6",
-                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
         assertEquals(ScriptType.P2WPKH, address.getOutputScriptType());
         assertEquals(bech32.toLowerCase(Locale.ROOT), address.toBech32());
         assertEquals(bech32.toLowerCase(Locale.ROOT), address.toString());
@@ -69,8 +63,6 @@ public class SegwitAddressTest {
         SegwitAddress address = SegwitAddress.fromBech32(bech32, MAINNET);
 
         assertEquals(MAINNET, address.network());
-        assertEquals("00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
-                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
         assertEquals(ScriptType.P2WSH, address.getOutputScriptType());
         assertEquals(bech32.toLowerCase(Locale.ROOT), address.toBech32());
         assertEquals(bech32.toLowerCase(Locale.ROOT), address.toString());
@@ -83,8 +75,6 @@ public class SegwitAddressTest {
         SegwitAddress address = SegwitAddress.fromBech32(bech32, TESTNET);
 
         assertEquals(TESTNET, address.network());
-        assertEquals("0014751e76e8199196d454941c45d1b3a323f1433bd6",
-                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
         assertEquals(ScriptType.P2WPKH, address.getOutputScriptType());
         assertEquals(bech32.toLowerCase(Locale.ROOT), address.toBech32());
         assertEquals(bech32.toLowerCase(Locale.ROOT), address.toString());
@@ -108,8 +98,6 @@ public class SegwitAddressTest {
         SegwitAddress address = SegwitAddress.fromBech32(bcrt1_bech32, REGTEST);
 
         assertEquals(REGTEST, address.network());
-        assertEquals("00148053ccf51e4b164f6cf75f05d1e62681ca7132f1",
-                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
         assertEquals(ScriptType.P2WPKH, address.getOutputScriptType());
         assertEquals(bcrt1_bech32.toLowerCase(Locale.ROOT), address.toBech32());
         assertEquals(bcrt1_bech32.toLowerCase(Locale.ROOT), address.toString());
@@ -122,8 +110,6 @@ public class SegwitAddressTest {
         Address address = addressParser.parseAddress(bcrt1_bech32);
 
         assertEquals(REGTEST, address.network());
-        assertEquals("00148053ccf51e4b164f6cf75f05d1e62681ca7132f1",
-                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
         assertEquals(ScriptType.P2WPKH, address.getOutputScriptType());
         assertEquals(bcrt1_bech32.toLowerCase(Locale.ROOT), ((SegwitAddress)address).toBech32());
         assertEquals(bcrt1_bech32.toLowerCase(Locale.ROOT), address.toString());
@@ -136,8 +122,6 @@ public class SegwitAddressTest {
         SegwitAddress address = SegwitAddress.fromBech32(bech32, TESTNET);
 
         assertEquals(TESTNET, address.network());
-        assertEquals("00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
-                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
         assertEquals(ScriptType.P2WSH, address.getOutputScriptType());
         assertEquals(bech32.toLowerCase(Locale.ROOT), address.toBech32());
         assertEquals(bech32.toLowerCase(Locale.ROOT), address.toString());
@@ -149,14 +133,7 @@ public class SegwitAddressTest {
             SegwitAddress address = (SegwitAddress) addressParser.parseAddress(valid.address);
 
             assertEquals(valid.expectedNetwork, address.network());
-            assertEquals(valid.expectedScriptPubKey,
-                    ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
             assertEquals(valid.address.toLowerCase(Locale.ROOT), address.toBech32());
-            if (valid.expectedWitnessVersion == 0) {
-                Script expectedScriptPubKey = Script.parse(ByteUtils.parseHex(valid.expectedScriptPubKey));
-                assertEquals(address, SegwitAddress.fromHash(valid.expectedNetwork,
-                        ScriptPattern.extractHashFromP2WH(expectedScriptPubKey)));
-            }
             assertEquals(valid.expectedWitnessVersion, address.getWitnessVersion());
         }
     }

--- a/core/src/test/java/org/bitcoinj/script/ScriptBuilderTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptBuilderTest.java
@@ -16,8 +16,18 @@
 
 package org.bitcoinj.script;
 
+import org.bitcoinj.base.Address;
+import org.bitcoinj.base.AddressParser;
+import org.bitcoinj.base.SegwitAddress;
+import org.bitcoinj.base.internal.AddressData;
+import org.bitcoinj.base.internal.ByteUtils;
 import org.junit.Test;
 
+import java.util.Locale;
+
+import static org.bitcoinj.base.BitcoinNetwork.MAINNET;
+import static org.bitcoinj.base.BitcoinNetwork.REGTEST;
+import static org.bitcoinj.base.BitcoinNetwork.TESTNET;
 import static org.bitcoinj.script.ScriptOpCodes.OP_FALSE;
 import static org.bitcoinj.script.ScriptOpCodes.OP_TRUE;
 import static org.junit.Assert.assertArrayEquals;
@@ -120,4 +130,84 @@ public class ScriptBuilderTest {
         byte[] s = new ScriptBuilder().opFalse().build().program();
         assertArrayEquals(expected, s);
     }
+
+    @Test
+    public void example_p2wpkh_mainnet() {
+        String bech32 = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+
+        SegwitAddress address = SegwitAddress.fromBech32(bech32, MAINNET);
+
+        assertEquals("0014751e76e8199196d454941c45d1b3a323f1433bd6",
+                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
+    }
+
+    @Test
+    public void example_p2wsh_mainnet() {
+        String bech32 = "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3";
+
+        SegwitAddress address = SegwitAddress.fromBech32(bech32, MAINNET);
+
+        assertEquals("00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
+                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
+    }
+
+    @Test
+    public void example_p2wpkh_testnet() {
+        String bech32 = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx";
+
+        SegwitAddress address = SegwitAddress.fromBech32(bech32, TESTNET);
+
+        assertEquals("0014751e76e8199196d454941c45d1b3a323f1433bd6",
+                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
+    }
+
+    @Test
+    public void example_p2wpkh_regtest() {
+        String bcrt1_bech32 = "bcrt1qspfueag7fvty7m8htuzare3xs898zvh30fttu2";
+
+        SegwitAddress address = SegwitAddress.fromBech32(bcrt1_bech32, REGTEST);
+
+        assertEquals("00148053ccf51e4b164f6cf75f05d1e62681ca7132f1",
+                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
+    }
+
+    @Test
+    public void example_p2wpkh_regtest_any_network() {
+        AddressParser addressParser = AddressParser.getDefault();
+
+        String bcrt1_bech32 = "bcrt1qspfueag7fvty7m8htuzare3xs898zvh30fttu2";
+
+        Address address = addressParser.parseAddress(bcrt1_bech32);
+
+        assertEquals("00148053ccf51e4b164f6cf75f05d1e62681ca7132f1",
+                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
+    }
+
+    @Test
+    public void example_p2wsh_testnet() {
+        String bech32 = "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7";
+
+        SegwitAddress address = SegwitAddress.fromBech32(bech32, TESTNET);
+
+        assertEquals("00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
+                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
+    }
+
+    @Test
+    public void validAddresses() {
+        AddressParser addressParser = AddressParser.getDefault();
+
+        for (AddressData valid : AddressData.VALID_ADDRESSES) {
+            SegwitAddress address = (SegwitAddress) addressParser.parseAddress(valid.address);
+
+            assertEquals(valid.expectedScriptPubKey,
+                    ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
+            if (valid.expectedWitnessVersion == 0) {
+                Script expectedScriptPubKey = Script.parse(ByteUtils.parseHex(valid.expectedScriptPubKey));
+                assertEquals(address, SegwitAddress.fromHash(valid.expectedNetwork,
+                        ScriptPattern.extractHashFromP2WH(expectedScriptPubKey)));
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
This removes dependencies on o.b.script from SegwitAddressTest

This is a child of PR #3474 