### PR TITLE
migrate script-related address tests to ScriptBuilderTest

### DIFF
--- a/core/src/test/java/org/bitcoinj/base/SegwitAddressTest.java
+++ b/core/src/test/java/org/bitcoinj/base/SegwitAddressTest.java
@@ -19,10 +19,6 @@ package org.bitcoinj.base;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.bitcoinj.base.exceptions.AddressFormatException;
-import org.bitcoinj.base.internal.ByteUtils;
-import org.bitcoinj.script.Script;
-import org.bitcoinj.script.ScriptBuilder;
-import org.bitcoinj.script.ScriptPattern;
 import org.bitcoinj.test.support.AddressData;
 import org.junit.Test;
 
@@ -55,8 +51,6 @@ public class SegwitAddressTest {
         SegwitAddress address = SegwitAddress.fromBech32(bech32, MAINNET);
 
         assertEquals(MAINNET, address.network());
-        assertEquals("0014751e76e8199196d454941c45d1b3a323f1433bd6",
-                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
         assertEquals(ScriptType.P2WPKH, address.getOutputScriptType());
         assertEquals(bech32.toLowerCase(Locale.ROOT), address.toBech32());
         assertEquals(bech32.toLowerCase(Locale.ROOT), address.toString());
@@ -69,8 +63,6 @@ public class SegwitAddressTest {
         SegwitAddress address = SegwitAddress.fromBech32(bech32, MAINNET);
 
         assertEquals(MAINNET, address.network());
-        assertEquals("00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
-                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
         assertEquals(ScriptType.P2WSH, address.getOutputScriptType());
         assertEquals(bech32.toLowerCase(Locale.ROOT), address.toBech32());
         assertEquals(bech32.toLowerCase(Locale.ROOT), address.toString());
@@ -83,8 +75,6 @@ public class SegwitAddressTest {
         SegwitAddress address = SegwitAddress.fromBech32(bech32, TESTNET);
 
         assertEquals(TESTNET, address.network());
-        assertEquals("0014751e76e8199196d454941c45d1b3a323f1433bd6",
-                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
         assertEquals(ScriptType.P2WPKH, address.getOutputScriptType());
         assertEquals(bech32.toLowerCase(Locale.ROOT), address.toBech32());
         assertEquals(bech32.toLowerCase(Locale.ROOT), address.toString());
@@ -108,8 +98,6 @@ public class SegwitAddressTest {
         SegwitAddress address = SegwitAddress.fromBech32(bcrt1_bech32, REGTEST);
 
         assertEquals(REGTEST, address.network());
-        assertEquals("00148053ccf51e4b164f6cf75f05d1e62681ca7132f1",
-                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
         assertEquals(ScriptType.P2WPKH, address.getOutputScriptType());
         assertEquals(bcrt1_bech32.toLowerCase(Locale.ROOT), address.toBech32());
         assertEquals(bcrt1_bech32.toLowerCase(Locale.ROOT), address.toString());
@@ -122,8 +110,6 @@ public class SegwitAddressTest {
         Address address = addressParser.parseAddress(bcrt1_bech32);
 
         assertEquals(REGTEST, address.network());
-        assertEquals("00148053ccf51e4b164f6cf75f05d1e62681ca7132f1",
-                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
         assertEquals(ScriptType.P2WPKH, address.getOutputScriptType());
         assertEquals(bcrt1_bech32.toLowerCase(Locale.ROOT), ((SegwitAddress)address).toBech32());
         assertEquals(bcrt1_bech32.toLowerCase(Locale.ROOT), address.toString());
@@ -136,8 +122,6 @@ public class SegwitAddressTest {
         SegwitAddress address = SegwitAddress.fromBech32(bech32, TESTNET);
 
         assertEquals(TESTNET, address.network());
-        assertEquals("00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
-                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
         assertEquals(ScriptType.P2WSH, address.getOutputScriptType());
         assertEquals(bech32.toLowerCase(Locale.ROOT), address.toBech32());
         assertEquals(bech32.toLowerCase(Locale.ROOT), address.toString());
@@ -149,14 +133,7 @@ public class SegwitAddressTest {
             SegwitAddress address = (SegwitAddress) addressParser.parseAddress(valid.address);
 
             assertEquals(valid.expectedNetwork, address.network());
-            assertEquals(valid.expectedScriptPubKey,
-                    ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
             assertEquals(valid.address.toLowerCase(Locale.ROOT), address.toBech32());
-            if (valid.expectedWitnessVersion == 0) {
-                Script expectedScriptPubKey = Script.parse(ByteUtils.parseHex(valid.expectedScriptPubKey));
-                assertEquals(address, SegwitAddress.fromHash(valid.expectedNetwork,
-                        ScriptPattern.extractHashFromP2WH(expectedScriptPubKey)));
-            }
             assertEquals(valid.expectedWitnessVersion, address.getWitnessVersion());
         }
     }

--- a/core/src/test/java/org/bitcoinj/script/ScriptBuilderTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptBuilderTest.java
@@ -16,11 +16,18 @@
 
 package org.bitcoinj.script;
 
+import org.bitcoinj.base.Address;
+import org.bitcoinj.base.AddressParser;
 import org.bitcoinj.base.LegacyAddress;
+import org.bitcoinj.base.SegwitAddress;
 import org.bitcoinj.base.internal.ByteUtils;
+import org.bitcoinj.test.support.AddressData;
+
 import org.junit.Test;
 
 import static org.bitcoinj.base.BitcoinNetwork.MAINNET;
+import static org.bitcoinj.base.BitcoinNetwork.REGTEST;
+import static org.bitcoinj.base.BitcoinNetwork.TESTNET;
 import static org.bitcoinj.script.ScriptOpCodes.OP_FALSE;
 import static org.bitcoinj.script.ScriptOpCodes.OP_TRUE;
 import static org.junit.Assert.assertArrayEquals;
@@ -132,4 +139,84 @@ public class ScriptBuilderTest {
                 ScriptPattern.extractHashFromP2SH(ScriptBuilder.createP2SHOutputScript(redeemScriptHex)));
         assertEquals("35b9vsyH1KoFT5a5KtrKusaCcPLkiSo1tU", c.toString());
     }
+
+    @Test
+    public void example_p2wpkh_mainnet() {
+        String bech32 = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+
+        SegwitAddress address = SegwitAddress.fromBech32(bech32, MAINNET);
+
+        assertEquals("0014751e76e8199196d454941c45d1b3a323f1433bd6",
+                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
+    }
+
+    @Test
+    public void example_p2wsh_mainnet() {
+        String bech32 = "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3";
+
+        SegwitAddress address = SegwitAddress.fromBech32(bech32, MAINNET);
+
+        assertEquals("00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
+                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
+    }
+
+    @Test
+    public void example_p2wpkh_testnet() {
+        String bech32 = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx";
+
+        SegwitAddress address = SegwitAddress.fromBech32(bech32, TESTNET);
+
+        assertEquals("0014751e76e8199196d454941c45d1b3a323f1433bd6",
+                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
+    }
+
+    @Test
+    public void example_p2wpkh_regtest() {
+        String bcrt1_bech32 = "bcrt1qspfueag7fvty7m8htuzare3xs898zvh30fttu2";
+
+        SegwitAddress address = SegwitAddress.fromBech32(bcrt1_bech32, REGTEST);
+
+        assertEquals("00148053ccf51e4b164f6cf75f05d1e62681ca7132f1",
+                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
+    }
+
+    @Test
+    public void example_p2wpkh_regtest_any_network() {
+        AddressParser addressParser = AddressParser.getDefault();
+
+        String bcrt1_bech32 = "bcrt1qspfueag7fvty7m8htuzare3xs898zvh30fttu2";
+
+        Address address = addressParser.parseAddress(bcrt1_bech32);
+
+        assertEquals("00148053ccf51e4b164f6cf75f05d1e62681ca7132f1",
+                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
+    }
+
+    @Test
+    public void example_p2wsh_testnet() {
+        String bech32 = "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7";
+
+        SegwitAddress address = SegwitAddress.fromBech32(bech32, TESTNET);
+
+        assertEquals("00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
+                ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
+    }
+
+    @Test
+    public void validAddresses() {
+        AddressParser addressParser = AddressParser.getDefault();
+
+        for (AddressData valid : AddressData.VALID_ADDRESSES) {
+            SegwitAddress address = (SegwitAddress) addressParser.parseAddress(valid.address);
+
+            assertEquals(valid.expectedScriptPubKey,
+                    ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
+            if (valid.expectedWitnessVersion == 0) {
+                Script expectedScriptPubKey = Script.parse(ByteUtils.parseHex(valid.expectedScriptPubKey));
+                assertEquals(address, SegwitAddress.fromHash(valid.expectedNetwork,
+                        ScriptPattern.extractHashFromP2WH(expectedScriptPubKey)));
+            }
+        }
+    }
 }
+


### PR DESCRIPTION
This removes dependencies on o.b.script from SegwitAddressTest