### PR TITLE
Block: remove reference to deprecated getTimeSeconds()

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
@@ -600,7 +600,7 @@ public abstract class AbstractBlockChain {
                         block.getHashAsString(), filteredTxHashList.size(), filteredTxn.size());
                 for (Sha256Hash hash : filteredTxHashList) log.debug("  matched tx {}", hash);
             }
-            if (expensiveChecks && block.getTimeSeconds() <= getMedianTimestampOfRecentBlocks(head, blockStore))
+            if (expensiveChecks && block.time().getEpochSecond() <= getMedianTimestampOfRecentBlocks(head, blockStore))
                 throw new VerificationException("Block's timestamp is too early");
 
             // BIP 66 & 65: Enforce block version 3/4 once they are a supermajority of blocks
@@ -774,9 +774,9 @@ public abstract class AbstractBlockChain {
                                                          BlockStore store) throws BlockStoreException {
         long[] timestamps = new long[11];
         int unused = 9;
-        timestamps[10] = storedBlock.getHeader().getTimeSeconds();
+        timestamps[10] = storedBlock.getHeader().time().getEpochSecond();
         while (unused >= 0 && (storedBlock = storedBlock.getPrev(store)) != null)
-            timestamps[unused--] = storedBlock.getHeader().getTimeSeconds();
+            timestamps[unused--] = storedBlock.getHeader().time().getEpochSecond();
         
         Arrays.sort(timestamps, unused+1, 11);
         return timestamps[unused + (11-unused)/2];
@@ -832,7 +832,7 @@ public abstract class AbstractBlockChain {
             for (Iterator<StoredBlock> it = newBlocks.descendingIterator(); it.hasNext();) {
                 cursor = it.next();
                 Block cursorBlock = cursor.getHeader();
-                if (expensiveChecks && cursorBlock.getTimeSeconds() <= getMedianTimestampOfRecentBlocks(cursor.getPrev(blockStore), blockStore))
+                if (expensiveChecks && cursorBlock.time().getEpochSecond() <= getMedianTimestampOfRecentBlocks(cursor.getPrev(blockStore), blockStore))
                     throw new VerificationException("Block's timestamp is too early during reorg");
                 TransactionOutputChanges txOutChanges;
                 if (cursor != newChainHead || block == null)

--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -524,7 +524,7 @@ public abstract class NetworkParameters {
     public EnumSet<Script.VerifyFlag> getTransactionVerificationFlags(final Block block,
             final Transaction transaction, final VersionTally tally, final Integer height) {
         final EnumSet<Script.VerifyFlag> verifyFlags = EnumSet.noneOf(Script.VerifyFlag.class);
-        if (block.getTimeSeconds() >= NetworkParameters.BIP16_ENFORCE_TIME)
+        if (block.time().getEpochSecond() >= NetworkParameters.BIP16_ENFORCE_TIME)
             verifyFlags.add(Script.VerifyFlag.P2SH);
 
         // Start enforcing CHECKLOCKTIMEVERIFY, (BIP65) for block.nVersion=4

--- a/core/src/main/java/org/bitcoinj/params/BitcoinNetworkParams.java
+++ b/core/src/main/java/org/bitcoinj/params/BitcoinNetworkParams.java
@@ -197,7 +197,7 @@ public abstract class BitcoinNetworkParams extends NetworkParameters {
             log.info("Difficulty transition traversal took {}", watch);
 
         Block blockIntervalAgo = cursor.getHeader();
-        int timespan = (int) (prev.getTimeSeconds() - blockIntervalAgo.getTimeSeconds());
+        int timespan = (int) (prev.time().getEpochSecond() - blockIntervalAgo.time().getEpochSecond());
         // Limit the adjustment step.
         final int targetTimespan = this.getTargetTimespan();
         if (timespan < targetTimespan / 4)

--- a/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
@@ -108,7 +108,7 @@ public class TestNet3Params extends BitcoinNetworkParams {
             // After 15th February 2012 the rules on the testnet change to avoid people running up the difficulty
             // and then leaving, making it too hard to mine a block. On non-difficulty transition points, easy
             // blocks are allowed if there has been a span of 20 minutes without one.
-            final long timeDelta = nextBlock.getTimeSeconds() - prev.getTimeSeconds();
+            final long timeDelta = nextBlock.time().getEpochSecond() - prev.time().getEpochSecond();
             // There is an integer underflow bug in bitcoin-qt that means mindiff blocks are accepted when time
             // goes backwards.
             if (timeDelta >= 0 && timeDelta <= NetworkParameters.TARGET_SPACING * 2) {

--- a/core/src/test/java/org/bitcoinj/core/BlockTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockTest.java
@@ -319,7 +319,7 @@ public class BlockTest {
                 ByteUtils.writeInt32LE(getVersion(), stream);
                 stream.write(getPrevBlockHash().serialize());
                 stream.write(getMerkleRoot().serialize());
-                ByteUtils.writeInt32LE(getTimeSeconds(), stream);
+                ByteUtils.writeInt32LE(time().getEpochSecond(), stream);
                 ByteUtils.writeInt32LE(getDifficultyTarget(), stream);
                 ByteUtils.writeInt32LE(getNonce(), stream);
 


### PR DESCRIPTION
If approved, I'll merge this to 0.17 as well.