### PR TITLE
Message: remove references to deprecated bitcoinSerialize()

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/BaseMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/BaseMessage.java
@@ -53,7 +53,7 @@ public abstract class BaseMessage implements Message {
     }
 
     /**
-     * Serializes this message to the provided stream. If you just want the raw bytes use bitcoinSerialize().
+     * Serializes this message to the provided stream. If you just want the raw bytes use {@link #serialize()}.
      */
     protected abstract void bitcoinSerializeToStream(OutputStream stream) throws IOException;
 

--- a/core/src/main/java/org/bitcoinj/core/BloomFilter.java
+++ b/core/src/main/java/org/bitcoinj/core/BloomFilter.java
@@ -168,7 +168,7 @@ public class BloomFilter extends BaseMessage {
     }
 
     /**
-     * Serializes this message to the provided stream. If you just want the raw bytes use bitcoinSerialize().
+     * Serializes this message to the provided stream. If you just want the raw bytes use {@link #serialize()}.
      */
     @Override
     protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -5350,7 +5350,7 @@ public class Wallet extends BaseTaggableObject
 
     private void addSuppliedInputs(Transaction tx, List<TransactionInput> originalInputs) {
         for (TransactionInput input : originalInputs)
-            tx.addInput(TransactionInput.read(ByteBuffer.wrap(input.bitcoinSerialize()), tx));
+            tx.addInput(TransactionInput.read(ByteBuffer.wrap(input.serialize()), tx));
     }
 
     private Coin estimateFees(Transaction tx, CoinSelection coinSelection, Coin requestedFeePerKb, boolean ensureMinRequiredFee) {

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -1234,7 +1234,7 @@ public class FullBlockTestGenerator {
             // This check fails because it was created for "retain mode" and the likely encoding is not "optimal".
             // We since removed this capability retain the original encoding, but could not rewrite this test data.
             // checkState(stream.size() == b64.getMessageSize());
-            // checkState(Arrays.equals(stream.toByteArray(), b64.bitcoinSerialize()));
+            // checkState(Arrays.equals(stream.toByteArray(), b64.serialize()));
             // checkState(b64.getOptimalEncodingMessageSize() == b64Original.block.getMessageSize());
         }
         blocks.add(new BlockAndValidity(b64, true, false, b64.getHash(), chainHeadHeight + 19, "b64"));


### PR DESCRIPTION
If this is approved, I'll merge it to 0.17 as well.