### PR TITLE
Simplify Gradle version comparison in settings.gradle and all build.gradle

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -39,7 +39,7 @@ test {
 
 def gradleVersionToolchains = GradleVersion.version("6.7")
 
-if (GradleVersion.current().compareTo(gradleVersionToolchains) > 0) {
+if (GradleVersion.current() > gradleVersionToolchains) {
     // If the Gradle Java Toolchains feature is available, run tests on older JDKs
     System.err.println "Adding 'testOnJdk8' task, because ${GradleVersion.current()}"
 
@@ -69,7 +69,7 @@ jar {
 def minGradleArchiveClassifierVersion = GradleVersion.version("5.0")
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-    if (GradleVersion.current().compareTo(minGradleArchiveClassifierVersion) > 0) {
+    if (GradleVersion.current() > minGradleArchiveClassifierVersion) {
         archiveClassifier.set('javadoc')
     } else {
         classifier = 'javadoc'
@@ -78,7 +78,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {
-    if (GradleVersion.current().compareTo(minGradleArchiveClassifierVersion) > 0) {
+    if (GradleVersion.current() > minGradleArchiveClassifierVersion) {
         archiveClassifier.set('sources')
     } else {
         classifier = 'sources'

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     // If using Gradle 7, use the compatible protobuf plugin, else use the one that works with oldest supported Gradle
-    boolean isGradle7 = GradleVersion.current().compareTo(GradleVersion.version("7.0")) >= 0
+    boolean isGradle7 = GradleVersion.current() >= GradleVersion.version("7.0")
     def gradleProtobufVersion = isGradle7 ? "0.9.4" : "0.8.10"
     if (isGradle7) {
         System.err.println "Warning: Using com.google.protobuf:protobuf-gradle-plugin:${gradleProtobufVersion} because ${GradleVersion.current()}"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 
 // Prevent newer Gradle from switching to JRE version of Guava
 def gradleVersionTargetJVM = GradleVersion.version("7.0")
-if (GradleVersion.current().compareTo(gradleVersionTargetJVM) > 0) {
+if (GradleVersion.current() > gradleVersionTargetJVM) {
     dependencies.constraints {
         implementation("com.google.guava:guava") {
             attributes {
@@ -82,7 +82,7 @@ test {
 
 def gradleVersionToolchains = GradleVersion.version("6.7")
 
-if (GradleVersion.current().compareTo(gradleVersionToolchains) > 0) {
+if (GradleVersion.current() > gradleVersionToolchains) {
     // If the Gradle Java Toolchains feature is available, run tests on older JDKs
     System.err.println "Adding 'testOnJdk8' task, because ${GradleVersion.current()}"
 
@@ -112,7 +112,7 @@ jar {
 def minGradleArchiveClassifierVersion = GradleVersion.version("5.0")
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-    if (GradleVersion.current().compareTo(minGradleArchiveClassifierVersion) > 0) {
+    if (GradleVersion.current() > minGradleArchiveClassifierVersion) {
         archiveClassifier.set('javadoc')
     } else {
         classifier = 'javadoc'
@@ -121,7 +121,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {
-    if (GradleVersion.current().compareTo(minGradleArchiveClassifierVersion) > 0) {
+    if (GradleVersion.current() > minGradleArchiveClassifierVersion) {
         archiveClassifier.set('sources')
     } else {
         classifier = 'sources'

--- a/settings-debian.gradle
+++ b/settings-debian.gradle
@@ -8,7 +8,7 @@ import org.gradle.util.GradleVersion
 // required Gradle version for build
 def gradleVersion = GradleVersion.version("4.4.1")
 
-if (GradleVersion.current().compareTo(gradleVersion) != 0) {
+if (GradleVersion.current() != gradleVersion) {
     throw new GradleScriptException("bitcoinj build requires Debian Gradle ${gradleVersion.version}", null)
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,7 +10,7 @@ def minGradleVersion = GradleVersion.version("7.3")
 
 rootProject.name = 'bitcoinj-parent'
 
-if (GradleVersion.current().compareTo(minGradleVersion) < 0) {
+if (GradleVersion.current() < minGradleVersion) {
     throw new GradleScriptException("bitcoinj build requires Gradle ${minGradleVersion.version} or later", null)
 }
 if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {

--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -8,12 +8,12 @@ plugins {
 }
 
 def annotationProcessorMinVersion = GradleVersion.version("4.6")
-boolean hasAnnotationProcessor = (GradleVersion.current().compareTo(annotationProcessorMinVersion) >= 0)
+boolean hasAnnotationProcessor = GradleVersion.current() >= annotationProcessorMinVersion
 def junit5MinVersion = GradleVersion.version("4.6")
-boolean hasJunit5 = (GradleVersion.current().compareTo(junit5MinVersion) >= 0)
+boolean hasJunit5 = GradleVersion.current() >= junit5MinVersion
 
 def graalVMMinVersion = GradleVersion.version("7.4")     // Toolchains with selection by vendor
-boolean hasGraalVM = (GradleVersion.current().compareTo(graalVMMinVersion) >= 0)
+boolean hasGraalVM = GradleVersion.current() >= graalVMMinVersion
 
 dependencies {
     implementation project(':bitcoinj-core')


### PR DESCRIPTION
I think we should change the version comparison in Gradle to use the “<” operator, since using the comparison operator in GradleVersion under the hood would result in “compareTo” as it is. Also, the code would look more concise that way, I think.