### PR TITLE
ScriptChunk: replace/deprecate write()

### DIFF
--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -341,14 +341,13 @@ public class Script {
         if (program != null)
             // Don't round-trip as Bitcoin Core doesn't and it would introduce a mismatch.
             return Arrays.copyOf(program, program.length);
-        try {
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            for (ScriptChunk chunk : chunks) {
-                chunk.write(bos);
-            }
-            return bos.toByteArray();
-        } catch (IOException e) {
-            throw new RuntimeException(e);  // Cannot happen.
+        else {
+            int size = chunks.stream().mapToInt(ScriptChunk::size).sum();
+            ByteBuffer buf = ByteBuffer.allocate(size);
+            chunks.forEach(chunk ->
+                buf.put(chunk.toByteArray())
+            );
+            return buf.array();
         }
     }
 


### PR DESCRIPTION
Deprecate write(OutputStream) and replace with existing toByteArray() method. Internally implement a write(ByteBuffer) method.

Update Script to use chunk.toByteArray()

We should also consider back-porting this change to 0.17, so we could remove `write(OutputStream)` altogether in 0.18.
