### PR TITLE
graalvm.yml: Use setup-java GitHub Action

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -9,20 +9,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, macOS-13]
-        java: [ '17', '21' ]
-        distribution: [ 'graalvm-community' ]
+        java: [ '21' ]
+        distribution: [ 'graalvm' ]
         gradle: ['8.12.1']
       fail-fast: false
     name: ${{ matrix.os }} JDK ${{ matrix.java }}.${{ matrix.distribution }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
-      - name: Set up GraalVM
-        uses: graalvm/setup-graalvm@v1
+      - name: Set up JDK (GraalVM)
+        uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.java }}
           distribution: ${{ matrix.distribution }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          java-version: ${{ matrix.java }}
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:


### PR DESCRIPTION
graalvm.yml: Use setup_java GitHub Action

**UPDATED:**

We can now use the same setup_java GitHub Action
in gradle.yml and graalvm.yml. This commit switches
to the setup_java action from the setup-graalvm action
and also changes some variable names to more closely
match gradle.yml.

The setup_java Action at this time only supports _Oracle_ GraalVM which
is licensed under the GFTC license:
https://www.oracle.com/downloads/licenses/graal-free-license.html

See: https://github.com/actions/setup-java/issues/742

So the benefits of using the same action for JDK and GraalVM
have to be weighed against using only a non-FOSS version of GraalVM.

Oracle GraalVM has stopped providing updates under the free-beer license
for JDK 17, so I removed `17` from the matrix. It is also possible
to use the last version: `17.0.12`

The setup_graalvm action supports the Community Edition, Oracle GraalVM,
and some other options.

(It might even be possible/desirable to combine the
two workflows in the future, but let's keep this PR simple)