### PR TITLE
Replace put with putAll in MemoryFullPrunedBlockStore

### DIFF
--- a/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
@@ -67,8 +67,7 @@ class TransactionalHashMap<KeyType, ValueType> {
             for(KeyType key : tempSetRemoved.get())
                 map.remove(key);
         if (tempMap.get() != null)
-            for (Map.Entry<KeyType, ValueType> entry : tempMap.get().entrySet())
-                map.put(entry.getKey(), entry.getValue());
+            map.putAll(tempMap.get());
         abortDatabaseBatchWrite();
     }
 


### PR DESCRIPTION
In this way, replacing `.put` with `.putAll` will reduce and simplify the code