### PR TITLE
Refactor length and size checks to isEmpty

### DIFF
--- a/base/src/main/java/org/bitcoinj/base/Base58.java
+++ b/base/src/main/java/org/bitcoinj/base/Base58.java
@@ -123,7 +123,7 @@ public class Base58 {
      * @throws AddressFormatException if the given string is not a valid base58 string
      */
     public static byte[] decode(String input) throws AddressFormatException {
-        if (input.length() == 0) {
+        if (input.isEmpty()) {
             return new byte[0];
         }
         // Convert the base58-encoded ASCII chars to a base58 byte sequence (base58 digits).

--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -1732,7 +1732,7 @@ public class Script {
             p2shStack = new LinkedList<>(stack);
         executeScript(txContainingThis, scriptSigIndex, scriptPubKey, stack, verifyFlags);
         
-        if (stack.size() == 0)
+        if (stack.isEmpty())
             throw new ScriptException(ScriptError.SCRIPT_ERR_EVAL_FALSE, "Stack empty at end of script execution.");
 
         List<byte[]> stackCopy = new LinkedList<>(stack);
@@ -1763,7 +1763,7 @@ public class Script {
             
             executeScript(txContainingThis, scriptSigIndex, scriptPubKeyP2SH, p2shStack, verifyFlags);
             
-            if (p2shStack.size() == 0)
+            if (p2shStack.isEmpty())
                 throw new ScriptException(ScriptError.SCRIPT_ERR_EVAL_FALSE, "P2SH stack empty at end of script execution.");
             
             List<byte[]> p2shStackCopy = new LinkedList<>(p2shStack);

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4842,7 +4842,7 @@ public class Wallet extends BaseTaggableObject
             // because there are so many ways the block can be invalid.
 
             // Avoid spuriously informing the user of wallet/tx confidence changes whilst we're re-organizing.
-            checkState(confidenceChanged.size() == 0);
+            checkState(confidenceChanged.isEmpty());
             checkState(!insideReorg);
             insideReorg = true;
             checkState(onWalletChangedSuppressions == 0);


### PR DESCRIPTION
Refactoring the use of `.length == 0` / `.size() == 0` to `.isEmpty()` will make the code more readable and correct