### PR TITLE
Script, ScriptBuilder: don't use current time as a default for creationTime

### DIFF
--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -240,7 +240,7 @@ public class Script {
      * @return script that wraps the chunks
      */
     public static Script of(List<ScriptChunk> chunks) {
-        return of(chunks, TimeUtils.currentTime());
+        return of(chunks, null);
     }
 
     /**
@@ -263,7 +263,7 @@ public class Script {
      * @throws ScriptException if the program could not be parsed
      */
     public static Script parse(byte[] program) throws ScriptException {
-        return parse(program, TimeUtils.currentTime());
+        return parse(program, null);
     }
 
     /**
@@ -343,7 +343,7 @@ public class Script {
      */
     @Deprecated
     public Script(byte[] program) {
-        this(program, TimeUtils.currentTime());
+        this(program, null);
     }
 
     /**
@@ -351,22 +351,20 @@ public class Script {
      */
     @Deprecated
     public Script(byte[] program, long creationTimeInSeconds) {
-        this(program, Instant.ofEpochSecond(creationTimeInSeconds));
+        this(program, creationTimeInSeconds != 0 ? Instant.ofEpochSecond(creationTimeInSeconds) : null);
     }
 
     // When constructing from a program, we store both program and chunks
-    private Script(byte[] program, Instant creationTime) {
+    private Script(byte[] program, @Nullable Instant creationTime) {
         Objects.requireNonNull(program);
-        Objects.requireNonNull(creationTime);
         this.program = Arrays.copyOf(program, program.length); // defensive copy;
         this.chunks = parseIntoChunks(this.program);
         this.creationTime = creationTime;
     }
 
     // When constructing from chunks, we store only chunks, and generate program when getter is called
-    private Script(List<ScriptChunk> chunks, Instant creationTime) {
+    private Script(List<ScriptChunk> chunks, @Nullable Instant creationTime) {
         Objects.requireNonNull(chunks);
-        Objects.requireNonNull(creationTime);
         this.program = null;
         this.chunks = Collections.unmodifiableList(new ArrayList<>(chunks));    // defensive copy
         this.creationTime = creationTime;

--- a/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
@@ -67,7 +67,7 @@ public class ScriptBuilder {
      * their addresses.
      */
     @Nullable
-    private Instant creationTime = TimeUtils.currentTime();
+    private Instant creationTime = null;
 
     /** Creates a fresh ScriptBuilder with an empty program. */
     public ScriptBuilder() {
@@ -82,8 +82,6 @@ public class ScriptBuilder {
     /**
      * Associates this script to be built with a given creation time. This is currently used in the context of
      * watching wallets only, where the scriptPubKeys being watched actually represent public keys and their addresses.
-     * <p>
-     * If this is not set, the current time is used by the builder.
      *
      * @param creationTime creation time to associate the script with
      * @return this builder
@@ -286,7 +284,10 @@ public class ScriptBuilder {
 
     /** Creates a new immutable Script based on the state of the builder. */
     public Script build() {
-        return Script.of(chunks, creationTime);
+        if (creationTime != null)
+            return Script.of(chunks, creationTime);
+        else
+            return Script.of(chunks);
     }
 
     /** Creates an empty script. */
@@ -306,7 +307,7 @@ public class ScriptBuilder {
     }
 
     /**
-     * Creates a scriptPubKey that encodes payment to the given address. The creation time will be the current time.
+     * Creates a scriptPubKey that encodes payment to the given address.
      *
      * @param to address to send payment to
      * @return scriptPubKey


### PR DESCRIPTION
Don't use current time as a default for creationTime. Rather, leave it `null`.

In future, we might get rid of this field in the generic case, and use subclasses just for the watching wallets usecase.

See #3523 and #3541.