### PR TITLE
SegwitAddress: allow instantiation of P2A (pay-to-anchor) address

### DIFF
--- a/test-support/src/main/java/org/bitcoinj/test/support/AddressData.java
+++ b/test-support/src/main/java/org/bitcoinj/test/support/AddressData.java
@@ -20,6 +20,7 @@ import org.bitcoinj.base.BitcoinNetwork;
 
 import static org.bitcoinj.base.BitcoinNetwork.MAINNET;
 import static org.bitcoinj.base.BitcoinNetwork.TESTNET;
+import static org.bitcoinj.base.BitcoinNetwork.REGTEST;
 
 /**
  * AddressData wrapper class with valid and invalid address test vectors.
@@ -39,6 +40,10 @@ public class AddressData {
                     "5120000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433", 1),
             new AddressData("bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0", MAINNET,
                     "512079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798", 1),
+            // P2A (pay-to-anchor) output script address representations (see https://delvingbitcoin.org/t/segwit-ephemeral-anchors/160/2)
+            new AddressData("bc1pfeessrawgf", MAINNET, "51024e73", 1), // pay-2-anchor (P2A) mainnet address
+            new AddressData("tb1pfees9rn5nz", TESTNET, "51024e73", 1), // pay-2-anchor (P2A) testnet address
+            new AddressData("bcrt1pfeesnyr2tx", REGTEST, "51024e73", 1), // pay-2-anchor (P2A) regtest address
     };
     public static String[] INVALID_ADDRESSES = {
             // from BIP173:


### PR DESCRIPTION
Hi! 🙂 

## Overview

As you may remember, in pullrequest #2663, I introduced a length check for the witness programs of v1 addresses, allowing only 32-byte long programs. Reviewing our discussion from back then, we decided to merge this check even though, according to [BIP 341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#script-validation-rules), such v1 witness programs aren’t prohibited. Instead, they produce "anyone-can-spend" outputs (per consensus rules).

Additionally spending from these outputs is disallowed by policy (non-standard), so we came to the conclusion that it probably might not make sense to instantiate such `SegwitAddress` (especially when bitcoinJ is used in the context of a client).

## Change in this PR

In this PR, I’ve relaxed the restriction slightly to permit one specific v1 witness program shorter than 32 bytes: the P2A (pay-to-anchor) output script.

A P2A output script is a segwit output with a witness version of `1` and a hardcoded witness program of `[0x4e, 0x73]`.

You can find the definition of this output type [here in Bitcoin Core](https://github.com/bitcoin/bitcoin/blob/455fca86cfada1823aa28615b5683f9dc73dbb9a/src/script/script.cpp#L216-L222). Since the merge of https://github.com/bitcoin/bitcoin/pull/30352 ([released in 28.0](https://bitcoincore.org/en/releases/28.0/)) spending from this specific output script is now allowed by policy.


## Rationale

Following our discussion when we introduced the taproot witness program length check in #2663, where we talked that bitcoinJ should follow policy, and the fact that spending from P2A is now allowed by policy, I allowed creation of this address. 

## References

- Discussion about ephemeral anchor outputs on delving: https://delvingbitcoin.org/t/segwit-ephemeral-anchors/160
- The P2A address on mempool.space: [bc1pfeessrawgf](https://mempool.space/address/bc1pfeessrawgf)
