### PR TITLE
build.gradle: update Bouncy Castle to 1.79

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,7 +10,7 @@ version = '0.18-SNAPSHOT'
 
 dependencies {
     api project(':bitcoinj-base')
-    api 'org.bouncycastle:bcprov-jdk15to18:1.78.1'
+    api 'org.bouncycastle:bcprov-jdk15to18:1.79'
     api 'com.google.guava:guava:33.3.0-android'
     api 'com.google.protobuf:protobuf-javalite:4.27.3'
     implementation 'org.slf4j:slf4j-api:2.0.13'


### PR DESCRIPTION
Consider backporting this to 0.17.