### PR TITLE
Introducing bitcoinj Guru on Gurubase.io

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,6 +3,7 @@ image:https://gitlab.com/bitcoinj/bitcoinj/badges/master/pipeline.svg[GitLab Bui
 image:https://coveralls.io/repos/bitcoinj/bitcoinj/badge.png?branch=master[Coverage Status,link=https://coveralls.io/r/bitcoinj/bitcoinj?branch=master]
 
 image::https://img.shields.io/badge/chat-Join%20bitcoinj--users%20on%20Matrix-blue[Join the bitcoinj-users Matrix room, link=https://matrix.to/#/#bitcoinj-users:matrix.org]
+image::https://img.shields.io/badge/Gurubase-Ask%20bitcoinj%20Guru-006BFF[Ask bitcoinj Guru, link=https://gurubase.io/g/bitcoinj]
 
 ### Welcome to bitcoinj
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [bitcoinj Guru](https://gurubase.io/g/bitcoinj) to Gurubase. bitcoinj Guru uses the data from this repo and data from the [docs](https://bitcoinj.github.io/) to answer questions by leveraging the LLM.

In this PR, I showcased the "bitcoinj Guru", which highlights that bitcoinj now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable bitcoinj Guru in Gurubase, just let me know that's totally fine.
