### PR TITLE
Rename Wallet.CompletionException to Wallet.TxCompletionException

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4065,7 +4065,7 @@ public class Wallet extends BaseTaggableObject
      * @throws BadWalletEncryptionKeyException if the supplied {@link SendRequest#aesKey} is wrong.
      */
     public Transaction createSend(Address address, Coin value)
-            throws InsufficientMoneyException, TxCompletionException {
+            throws InsufficientMoneyException, TransactionCompletionException {
         return createSend(address, value, false);
     }
 
@@ -4103,7 +4103,7 @@ public class Wallet extends BaseTaggableObject
      * @throws BadWalletEncryptionKeyException if the supplied {@link SendRequest#aesKey} is wrong.
      */
     public Transaction createSend(Address address, Coin value, boolean allowUnconfirmed)
-            throws InsufficientMoneyException, TxCompletionException {
+            throws InsufficientMoneyException, TransactionCompletionException {
         SendRequest req = SendRequest.to(address, value);
         if (allowUnconfirmed)
             req.allowUnconfirmed();
@@ -4127,7 +4127,7 @@ public class Wallet extends BaseTaggableObject
      * @throws BadWalletEncryptionKeyException if the supplied {@link SendRequest#aesKey} is wrong.
      */
     public Transaction sendCoinsOffline(SendRequest request)
-            throws InsufficientMoneyException, TxCompletionException {
+            throws InsufficientMoneyException, TransactionCompletionException {
         lock.lock();
         try {
             completeTx(request);
@@ -4166,7 +4166,7 @@ public class Wallet extends BaseTaggableObject
      * @throws BadWalletEncryptionKeyException if the supplied {@link SendRequest#aesKey} is wrong.
      */
     public SendResult sendCoins(TransactionBroadcaster broadcaster, Address to, Coin value)
-            throws InsufficientMoneyException, TxCompletionException {
+            throws InsufficientMoneyException, TransactionCompletionException {
         SendRequest request = SendRequest.to(to, value);
         return sendCoins(broadcaster, request);
     }
@@ -4194,7 +4194,7 @@ public class Wallet extends BaseTaggableObject
      * @throws BadWalletEncryptionKeyException if the supplied {@link SendRequest#aesKey} is wrong.
      */
     public SendResult sendCoins(TransactionBroadcaster broadcaster, SendRequest request)
-            throws InsufficientMoneyException, TxCompletionException {
+            throws InsufficientMoneyException, TransactionCompletionException {
         // Should not be locked here, as we're going to call into the broadcaster and that might want to hold its
         // own lock. sendCoinsOffline handles everything that needs to be locked.
         checkState(!lock.isHeldByCurrentThread());
@@ -4227,7 +4227,7 @@ public class Wallet extends BaseTaggableObject
      * @throws BadWalletEncryptionKeyException if the supplied {@link SendRequest#aesKey} is wrong.
      */
     public SendResult sendCoins(SendRequest request)
-            throws InsufficientMoneyException, TxCompletionException {
+            throws InsufficientMoneyException, TransactionCompletionException {
         TransactionBroadcaster broadcaster = vTransactionBroadcaster;
         checkState(broadcaster != null, () ->
                 "no transaction broadcaster is configured");
@@ -4250,7 +4250,7 @@ public class Wallet extends BaseTaggableObject
      * @throws BadWalletEncryptionKeyException if the supplied {@link SendRequest#aesKey} is wrong.
      */
     public Transaction sendCoins(Peer peer, SendRequest request)
-            throws InsufficientMoneyException, TxCompletionException {
+            throws InsufficientMoneyException, TransactionCompletionException {
         Transaction tx = sendCoinsOffline(request);
         peer.sendMessage(tx);
         return tx;
@@ -4313,32 +4313,32 @@ public class Wallet extends BaseTaggableObject
     /**
      * Class of exceptions thrown in {@link Wallet#completeTx(SendRequest)}.
      */
-    public static class TxCompletionException extends RuntimeException {
-        public TxCompletionException() {
+    public static class TransactionCompletionException extends RuntimeException {
+        public TransactionCompletionException() {
             super();
         }
 
-        public TxCompletionException(Throwable throwable) {
+        public TransactionCompletionException(Throwable throwable) {
             super(throwable);
         }
-        public TxCompletionException(String message) {
+        public TransactionCompletionException(String message) {
             super(message);
         }
     }
     /**
      * Thrown if the resultant transaction would violate the dust rules (an output that's too small to be worthwhile).
      */
-    public static class DustySendRequested extends TxCompletionException {}
+    public static class DustySendRequested extends TransactionCompletionException {}
     /**
      * Thrown if there is more than one OP_RETURN output for the resultant transaction.
      */
-    public static class MultipleOpReturnRequested extends TxCompletionException {}
+    public static class MultipleOpReturnRequested extends TransactionCompletionException {}
     /**
      * Thrown when we were trying to empty the wallet, and the total amount of money we were trying to empty after
      * being reduced for the fee was smaller than the min payment. Note that the missing field will be null in this
      * case.
      */
-    public static class CouldNotAdjustDownwards extends TxCompletionException {
+    public static class CouldNotAdjustDownwards extends TransactionCompletionException {
         CouldNotAdjustDownwards() {
             super();
         }
@@ -4349,12 +4349,12 @@ public class Wallet extends BaseTaggableObject
     /**
      * Thrown if the resultant transaction is too big for Bitcoin to process. Try breaking up the amounts of value.
      */
-    public static class ExceededMaxTransactionSize extends TxCompletionException {}
+    public static class ExceededMaxTransactionSize extends TransactionCompletionException {}
     /**
      * Thrown if the private keys and seed of this wallet cannot be decrypted due to the supplied encryption
      * key or password being wrong.
      */
-    public static class BadWalletEncryptionKeyException extends TxCompletionException {
+    public static class BadWalletEncryptionKeyException extends TransactionCompletionException {
         public BadWalletEncryptionKeyException(Throwable throwable) {
             super(throwable);
         }
@@ -4373,7 +4373,7 @@ public class Wallet extends BaseTaggableObject
      * @throws MultipleOpReturnRequested if there is more than one OP_RETURN output for the resultant transaction.
      * @throws BadWalletEncryptionKeyException if the supplied {@link SendRequest#aesKey} is wrong.
      */
-    public void completeTx(SendRequest req) throws InsufficientMoneyException, TxCompletionException {
+    public void completeTx(SendRequest req) throws InsufficientMoneyException, TransactionCompletionException {
         lock.lock();
         try {
             checkArgument(!req.completed, () ->

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4065,7 +4065,7 @@ public class Wallet extends BaseTaggableObject
      * @throws BadWalletEncryptionKeyException if the supplied {@link SendRequest#aesKey} is wrong.
      */
     public Transaction createSend(Address address, Coin value)
-            throws InsufficientMoneyException, CompletionException {
+            throws InsufficientMoneyException, TxCompletionException {
         return createSend(address, value, false);
     }
 
@@ -4103,7 +4103,7 @@ public class Wallet extends BaseTaggableObject
      * @throws BadWalletEncryptionKeyException if the supplied {@link SendRequest#aesKey} is wrong.
      */
     public Transaction createSend(Address address, Coin value, boolean allowUnconfirmed)
-            throws InsufficientMoneyException, CompletionException {
+            throws InsufficientMoneyException, TxCompletionException {
         SendRequest req = SendRequest.to(address, value);
         if (allowUnconfirmed)
             req.allowUnconfirmed();
@@ -4127,7 +4127,7 @@ public class Wallet extends BaseTaggableObject
      * @throws BadWalletEncryptionKeyException if the supplied {@link SendRequest#aesKey} is wrong.
      */
     public Transaction sendCoinsOffline(SendRequest request)
-            throws InsufficientMoneyException, CompletionException {
+            throws InsufficientMoneyException, TxCompletionException {
         lock.lock();
         try {
             completeTx(request);
@@ -4166,7 +4166,7 @@ public class Wallet extends BaseTaggableObject
      * @throws BadWalletEncryptionKeyException if the supplied {@link SendRequest#aesKey} is wrong.
      */
     public SendResult sendCoins(TransactionBroadcaster broadcaster, Address to, Coin value)
-            throws InsufficientMoneyException, CompletionException {
+            throws InsufficientMoneyException, TxCompletionException {
         SendRequest request = SendRequest.to(to, value);
         return sendCoins(broadcaster, request);
     }
@@ -4194,7 +4194,7 @@ public class Wallet extends BaseTaggableObject
      * @throws BadWalletEncryptionKeyException if the supplied {@link SendRequest#aesKey} is wrong.
      */
     public SendResult sendCoins(TransactionBroadcaster broadcaster, SendRequest request)
-            throws InsufficientMoneyException, CompletionException {
+            throws InsufficientMoneyException, TxCompletionException {
         // Should not be locked here, as we're going to call into the broadcaster and that might want to hold its
         // own lock. sendCoinsOffline handles everything that needs to be locked.
         checkState(!lock.isHeldByCurrentThread());
@@ -4227,7 +4227,7 @@ public class Wallet extends BaseTaggableObject
      * @throws BadWalletEncryptionKeyException if the supplied {@link SendRequest#aesKey} is wrong.
      */
     public SendResult sendCoins(SendRequest request)
-            throws InsufficientMoneyException, CompletionException {
+            throws InsufficientMoneyException, TxCompletionException {
         TransactionBroadcaster broadcaster = vTransactionBroadcaster;
         checkState(broadcaster != null, () ->
                 "no transaction broadcaster is configured");
@@ -4250,7 +4250,7 @@ public class Wallet extends BaseTaggableObject
      * @throws BadWalletEncryptionKeyException if the supplied {@link SendRequest#aesKey} is wrong.
      */
     public Transaction sendCoins(Peer peer, SendRequest request)
-            throws InsufficientMoneyException, CompletionException {
+            throws InsufficientMoneyException, TxCompletionException {
         Transaction tx = sendCoinsOffline(request);
         peer.sendMessage(tx);
         return tx;
@@ -4313,32 +4313,32 @@ public class Wallet extends BaseTaggableObject
     /**
      * Class of exceptions thrown in {@link Wallet#completeTx(SendRequest)}.
      */
-    public static class CompletionException extends RuntimeException {
-        public CompletionException() {
+    public static class TxCompletionException extends RuntimeException {
+        public TxCompletionException() {
             super();
         }
 
-        public CompletionException(Throwable throwable) {
+        public TxCompletionException(Throwable throwable) {
             super(throwable);
         }
-        public CompletionException(String message) {
+        public TxCompletionException(String message) {
             super(message);
         }
     }
     /**
      * Thrown if the resultant transaction would violate the dust rules (an output that's too small to be worthwhile).
      */
-    public static class DustySendRequested extends CompletionException {}
+    public static class DustySendRequested extends TxCompletionException {}
     /**
      * Thrown if there is more than one OP_RETURN output for the resultant transaction.
      */
-    public static class MultipleOpReturnRequested extends CompletionException {}
+    public static class MultipleOpReturnRequested extends TxCompletionException {}
     /**
      * Thrown when we were trying to empty the wallet, and the total amount of money we were trying to empty after
      * being reduced for the fee was smaller than the min payment. Note that the missing field will be null in this
      * case.
      */
-    public static class CouldNotAdjustDownwards extends CompletionException {
+    public static class CouldNotAdjustDownwards extends TxCompletionException {
         CouldNotAdjustDownwards() {
             super();
         }
@@ -4349,12 +4349,12 @@ public class Wallet extends BaseTaggableObject
     /**
      * Thrown if the resultant transaction is too big for Bitcoin to process. Try breaking up the amounts of value.
      */
-    public static class ExceededMaxTransactionSize extends CompletionException {}
+    public static class ExceededMaxTransactionSize extends TxCompletionException {}
     /**
      * Thrown if the private keys and seed of this wallet cannot be decrypted due to the supplied encryption
      * key or password being wrong.
      */
-    public static class BadWalletEncryptionKeyException extends CompletionException {
+    public static class BadWalletEncryptionKeyException extends TxCompletionException {
         public BadWalletEncryptionKeyException(Throwable throwable) {
             super(throwable);
         }
@@ -4373,7 +4373,7 @@ public class Wallet extends BaseTaggableObject
      * @throws MultipleOpReturnRequested if there is more than one OP_RETURN output for the resultant transaction.
      * @throws BadWalletEncryptionKeyException if the supplied {@link SendRequest#aesKey} is wrong.
      */
-    public void completeTx(SendRequest req) throws InsufficientMoneyException, CompletionException {
+    public void completeTx(SendRequest req) throws InsufficientMoneyException, TxCompletionException {
         lock.lock();
         try {
             checkArgument(!req.completed, () ->


### PR DESCRIPTION
### Description
This pull request resolves the naming conflict between Wallet.CompletionException and the Java standard java.util.concurrent.CompletionException, as outlined in [issue #3167](https://github.com/bitcoinj/bitcoinj/issues/3167).

###  Changes Made
* Renamed `Wallet.CompletionException` to `Wallet.TxCompletionException`.
* Updated all references to CompletionException within the codebase to use the new name.

### Reason for the Change
The overlapping names caused potential confusion, especially when working with Java 8 features like CompletableFuture, which also utilises CompletionException. This renaming improves code clarity and ensures a better developer experience.

###  Testing
* All unit tests have been run to confirm no regressions were introduced.
* The change was limited to renaming and updating references without altering the logic or functionality.
