### PR TITLE
wallettemplate: add Launcher class

### DIFF
--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -28,7 +28,7 @@ tasks.withType(JavaCompile) {
 
 javadoc.options.encoding = 'UTF-8'
 
-mainClassName = 'wallettemplate.Main'
+mainClassName = 'wallettemplate.Launcher'
 
 test {
     useJUnitPlatform()

--- a/wallettemplate/src/main/java/wallettemplate/Launcher.java
+++ b/wallettemplate/src/main/java/wallettemplate/Launcher.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wallettemplate;
+
+/**
+ * A wrapper main class to avoid an issue with launching non-modular JavaFX applications.
+ */
+public class Launcher {
+    public static void main(String[] args) {
+        Main.main(args);
+    }
+}


### PR DESCRIPTION
This works-around a limitation in JavaFX that can prevent non-modular JavaFX classes from launching properly.

With this change the following should work:

```
gradle bitcoinj-wallettemplate:installDist
./wallettemplate/build/install/bitcoinj-wallettemplate/bin/bitcoinj-wallettemplate
```

It will likely also allow running the app in IntelliJ without using Gradle 

This change is unnecessary for a modular JavaFX and can be reversed when/if we upgrade wallettempalte to a modular app.