### PR TITLE
wallettemplate/build.gradle: better slf4j dependency declaration

### DIFF
--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -7,8 +7,10 @@ plugins {
 dependencies {
     implementation project(':bitcoinj-core')
     implementation 'com.google.zxing:core:3.5.3'
-    implementation 'org.slf4j:slf4j-jdk14:2.0.16'
+    implementation 'org.slf4j:slf4j-api:2.0.16'
     implementation 'jakarta.annotation:jakarta.annotation-api:3.0.0'
+
+    runtimeOnly 'org.slf4j:slf4j-jdk14:2.0.16'
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.11.4"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.11.4"


### PR DESCRIPTION
There is a compile-time dependency on slf4j-api and a runtimeOnly dependency on slf4j-jdk14. This commit updates Gradle to declare this explicitly.