### PR TITLE
GitHub Actions, README: add wallettemplate installDist target

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           gradle-version: ${{ matrix.gradle }}
       - name: Run Gradle
-        run: gradle -PtestJdk8=true build --init-script build-scan-agree.gradle --scan --info --stacktrace
+        run: gradle -PtestJdk8=true build bitcoinj-wallettemplate:installDist --init-script build-scan-agree.gradle --scan --info --stacktrace
       - name: Upload Test Results and Reports
         uses: actions/upload-artifact@v4
         if: always()

--- a/README.adoc
+++ b/README.adoc
@@ -73,6 +73,22 @@ To dump the state of the wallet in `~/bitcoinj/bitcoinj-test.wallet` with the te
 
 NOTE: These instructions are for macOS/Linux, for Windows use the `wallettool/build/install/wallet-tool/bin/wallet-tool.bat` batch file with the equivalent Windows command-line commands and options.
 
+### Building and Running the Wallet Template
+
+The *bitcoinj* `wallettemplate` subproject includes a template JavaFX wallet application (`bitcoinj-wallettemplate`) that can be used as a starting point for building a JavaFX-based *bitcoinj* wallet application.
+
+To build an executable shell script that runs the wallettemplate, use:
+```
+gradle bitcoinj-wallettemplate:installDist
+```
+
+You can now run the `bitcoinj-wallettemplate` to launch the application:
+```
+./wallettemplate/build/install/bitcoinj-wallettemplate/bin/bitcoinj-wallettemplate
+```
+
+NOTE: These instructions are for macOS/Linux, for Windows use the `wallettemplate/build/install/bitcoinj-wallettemplate/bin/bitcoinj-wallettemplate.bat` batch file to start the application.
+
 ### Building the reference build
 
 Our reference build (which is also used for our releases) is running within a container to provide good reproducibility.


### PR DESCRIPTION
Now that this target is working correctly, we should include it in the GitHub Actions build.