### PR TITLE
WIP: Add wallettemplate build to GitLab CI 

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           gradle-version: ${{ matrix.gradle }}
       - name: Run Gradle
-        run: gradle -PtestJdk8=true build --init-script build-scan-agree.gradle --scan --info --stacktrace
+        run: gradle -PtestJdk8=true build bitcoinj-wallettemplate:installDist --init-script build-scan-agree.gradle --scan --info --stacktrace
       - name: Upload Test Results and Reports
         uses: actions/upload-artifact@v4
         if: always()

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,14 @@ bookworm-jdk17:
     - apt-get update
     - apt-get -y install openjdk-17-jdk-headless gradle
   script:
-    - gradle --settings-file settings-debian.gradle build :bitcoinj-base:publishToMavenLocal :bitcoinj-core:publishToMavenLocal :bitcoinj-wallettool:installDist --init-script build-scan-agree.gradle --scan --stacktrace
+    - >
+      gradle --settings-file settings-debian.gradle
+      build
+      :bitcoinj-base:publishToMavenLocal
+      :bitcoinj-core:publishToMavenLocal
+      :bitcoinj-wallettemplate:installDist
+      :bitcoinj-wallettool:installDist
+      --init-script build-scan-agree.gradle --scan --stacktrace
   after_script:
     - gradle --version
     - sha256sum core/build/libs/*.jar wallettool/build/install/wallet-tool/bin/*  wallettool/build/install/wallet-tool/lib/*.jar

--- a/README.adoc
+++ b/README.adoc
@@ -73,6 +73,22 @@ To dump the state of the wallet in `~/bitcoinj/bitcoinj-test.wallet` with the te
 
 NOTE: These instructions are for macOS/Linux, for Windows use the `wallettool/build/install/wallet-tool/bin/wallet-tool.bat` batch file with the equivalent Windows command-line commands and options.
 
+### Building and Running the Wallet Template
+
+The *bitcoinj* `wallettemplate` subproject includes a template JavaFX wallet application (`bitcoinj-wallettemplate`) that can be used as a starting point for building a JavaFX-based *bitcoinj* wallet application.
+
+To build an executable shell script that runs the wallettemplate, use:
+```
+gradle bitcoinj-wallettemplate:installDist
+```
+
+You can now run the `bitcoinj-wallettemplate` to launch the application:
+```
+./wallettemplate/build/install/bitcoinj-wallettemplate/bin/bitcoinj-wallettemplate
+```
+
+NOTE: These instructions are for macOS/Linux, for Windows use the `wallettemplate/build/install/bitcoinj-wallettemplate/bin/bitcoinj-wallettemplate.bat` batch file to start the application.
+
 ### Building the reference build
 
 Our reference build (which is also used for our releases) is running within a container to provide good reproducibility.

--- a/build.Containerfile
+++ b/build.Containerfile
@@ -40,7 +40,8 @@ RUN /usr/bin/gradle --project-dir project/ \
     --no-build-cache --no-daemon --no-parallel \
     --settings-file=settings-debian.gradle \
     -Dmaven.repo.local=repo \
-    clean ${ADDITIONAL_GRADLE_TASK} :bitcoinj-base:publishToMavenLocal :bitcoinj-core:publishToMavenLocal :bitcoinj-wallettool:installDist
+    clean ${ADDITIONAL_GRADLE_TASK} :bitcoinj-base:publishToMavenLocal :bitcoinj-core:publishToMavenLocal \
+    :bitcoinj-wallettool:installDist :bitcoinj-wallettemplate:installDist
 
 # stage: export build output
 FROM scratch AS export-stage
@@ -55,3 +56,6 @@ COPY --from=build-stage \
 COPY --from=build-stage \
     /home/builder/project/wallettool/build/install/wallet-tool/ \
     /wallettool/
+COPY --from=build-stage \
+    /home/builder/project/wallettemplate/build/install/bitcoinj-wallettemplate/ \
+    /wallettemplate/


### PR DESCRIPTION
(This currently doesn't work because these builds are using
Debian Gradle 4.4.1 which doesn't support the JavaFX-related
plugins we are using)