### PR TITLE
TransactionInput, TransactionOutPoint: in write(), prefer calling write() over serialize()

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -170,7 +170,7 @@ public class TransactionInput {
      * @throws BufferOverflowException if the input doesn't fit the remaining buffer
      */
     public ByteBuffer write(ByteBuffer buf) throws BufferOverflowException {
-        buf.put(outpoint.serialize());
+        outpoint.write(buf);
         Buffers.writeLengthPrefixedBytes(buf, scriptBytes);
         ByteUtils.writeInt32LE(sequence, buf);
         return buf;

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -103,7 +103,7 @@ public class TransactionOutPoint {
      * @throws BufferOverflowException if the outpoint doesn't fit the remaining buffer
      */
     public ByteBuffer write(ByteBuffer buf) throws BufferOverflowException {
-        buf.put(hash.serialize());
+        hash.write(buf);
         ByteUtils.writeInt32LE(index, buf);
         return buf;
     }


### PR DESCRIPTION
The reason is `write()` re-uses the `ByteBuffer`, whereas `serialize()` allocates an intermediate byte array.

If this is merged, I'll backport to 0.17.