### PR TITLE
TransactionOutput: make field `value` immutable

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -1365,8 +1365,9 @@ public class Transaction extends BaseMessage {
                             BigInteger.valueOf(output.getValue().getValue()),
                             bosHashOutputs
                     );
-                    bosHashOutputs.write(VarInt.of(output.getScriptBytes().length).serialize());
-                    bosHashOutputs.write(output.getScriptBytes());
+                    byte[] scriptBytes = output.getScriptBytes();
+                    bosHashOutputs.write(VarInt.of(scriptBytes.length).serialize());
+                    bosHashOutputs.write(scriptBytes);
                 }
                 hashOutputs = Sha256Hash.hashTwice(bosHashOutputs.toByteArray());
             } else if (basicSigHashType == SigHash.SINGLE.value && inputIndex < outputs.size()) {
@@ -1375,8 +1376,9 @@ public class Transaction extends BaseMessage {
                         BigInteger.valueOf(this.outputs.get(inputIndex).getValue().getValue()),
                         bosHashOutputs
                 );
-                bosHashOutputs.write(VarInt.of(this.outputs.get(inputIndex).getScriptBytes().length).serialize());
-                bosHashOutputs.write(this.outputs.get(inputIndex).getScriptBytes());
+                byte[] scriptBytes = this.outputs.get(inputIndex).getScriptBytes();
+                bosHashOutputs.write(VarInt.of(scriptBytes.length).serialize());
+                bosHashOutputs.write(scriptBytes);
                 hashOutputs = Sha256Hash.hashTwice(bosHashOutputs.toByteArray());
             }
             writeInt32LE(version, bos);

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -1012,6 +1012,21 @@ public class Transaction extends BaseMessage {
     }
 
     /**
+     * Replaces an already added output. This is meant to amend a transaction before it's committed to a wallet.
+     *
+     * @param index  index of output to replace
+     * @param output output to replace with
+     */
+    public void replaceOutput(int index, TransactionOutput output) {
+        TransactionOutput oldOutput = outputs.remove(index);
+        checkState(oldOutput.isAvailableForSpending(), () ->
+                "output to be replaced is buried in a wallet: " + oldOutput);
+        oldOutput.setParent(null);
+        output.setParent(this);
+        outputs.add(index, output);
+    }
+
+    /**
      * Creates an output based on the given address and value, adds it to this transaction, and returns the new output.
      */
     public TransactionOutput addOutput(Coin value, Address address) {

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -57,7 +57,7 @@ public class TransactionOutput {
     @Nullable protected Transaction parent;
 
     // The output's value is kept as a native type in order to save class instances.
-    private long value;
+    private final long value;
 
     // A transaction output has a script used for authenticating that the redeemer is allowed to spend
     // this output.
@@ -169,14 +169,14 @@ public class TransactionOutput {
     }
 
     /**
-     * Sets the value of this output.
+     * Returns a clone of this output, with given value. The typical use case is fee calculation.
+     *
+     * @param value value for the clone
+     * @return clone of output, with given value
      */
-    public void setValue(Coin value) {
+    public TransactionOutput withValue(Coin value) {
         Objects.requireNonNull(value);
-        // Negative values obviously make no sense, except for -1 which is used as a sentinel value when calculating
-        // SIGHASH_SINGLE signatures, so unfortunately we have to allow that here.
-        checkArgument(value.signum() >= 0 || value.equals(Coin.NEGATIVE_SATOSHI), () -> "value out of range: " + value);
-        this.value = value.value;
+        return new TransactionOutput(this.parent, value, this.scriptBytes);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -61,7 +61,7 @@ public class TransactionOutput {
 
     // A transaction output has a script used for authenticating that the redeemer is allowed to spend
     // this output.
-    private byte[] scriptBytes;
+    private final byte[] scriptBytes;
 
     // The script bytes are parsed and turned into a Script on demand.
     private Script scriptPubKey;
@@ -288,7 +288,7 @@ public class TransactionOutput {
      * @return the scriptBytes
     */
     public byte[] getScriptBytes() {
-        return scriptBytes;
+        return Arrays.copyOf(scriptBytes, scriptBytes.length);
     }
 
     /**

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -116,7 +116,7 @@ public class TransactionTest {
     @Test(expected = VerificationException.NegativeValueOutput.class)
     public void negativeOutput() {
         Transaction tx = FakeTxBuilder.createFakeTx(TESTNET.network());
-        tx.getOutput(0).setValue(Coin.NEGATIVE_SATOSHI);
+        tx.replaceOutput(0, tx.getOutput(0).withValue(Coin.NEGATIVE_SATOSHI));
         Transaction.verify(TESTNET.network(), tx);
     }
 
@@ -124,7 +124,7 @@ public class TransactionTest {
     public void exceedsMaxMoney2() {
         Transaction tx = FakeTxBuilder.createFakeTx(TESTNET.network());
         Coin half = BitcoinNetwork.MAX_MONEY.divide(2).add(Coin.SATOSHI);
-        tx.getOutput(0).setValue(half);
+        tx.replaceOutput(0, tx.getOutput(0).withValue(half));
         tx.addOutput(half, ADDRESS);
         Transaction.verify(TESTNET.network(), tx);
     }


### PR DESCRIPTION
Because tweaking is necessary for fee calculation logic, these usages
have been changed to produce new TransactionOutputs instead and
replace them in transactions as needed.

This PR is a child of #3577, but could be changed to merge individually.