### PR TITLE
TransactionInput: make field `witness` immutable

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -87,7 +87,7 @@ public class TransactionInput {
     @Nullable
     private Coin value;
 
-    private TransactionWitness witness;
+    private final TransactionWitness witness;
 
     /**
      * Creates an input that connects to nothing - used only in creation of coinbase transactions.
@@ -134,9 +134,15 @@ public class TransactionInput {
     }
 
     /** internal use only */
-    public TransactionInput(Transaction parentTransaction, byte[] scriptBytes, TransactionOutPoint outpoint,
-                            long sequence, @Nullable Coin value) {
+    private TransactionInput(@Nullable Transaction parentTransaction, byte[] scriptBytes, TransactionOutPoint outpoint,
+                             long sequence, @Nullable Coin value) {
         this(parentTransaction, null, scriptBytes, outpoint, sequence, value, null);
+    }
+
+    /** internal use only */
+    public TransactionInput(@Nullable Transaction parentTransaction, byte[] scriptBytes, TransactionOutPoint outpoint,
+                            long sequence, @Nullable Coin value, @Nullable TransactionWitness witness) {
+        this(parentTransaction, null, scriptBytes, outpoint, sequence, value, witness);
     }
 
     private TransactionInput(@Nullable Transaction parentTransaction, @Nullable Script scriptSig, byte[] scriptBytes,
@@ -328,10 +334,27 @@ public class TransactionInput {
     }
 
     /**
-     * Set the transaction witness of an input.
+     * Returns a clone of this input, with a given witness. The typical use-case is transaction signing.
+     *
+     * @param witness witness for the clone
+     * @return clone of input, with given witness
      */
-    public void setWitness(TransactionWitness witness) {
-        this.witness = witness;
+    public TransactionInput withWitness(TransactionWitness witness) {
+        Objects.requireNonNull(witness);
+        Script scriptSig = this.scriptSig != null ? this.scriptSig.get() : null;
+        return new TransactionInput(this.parent, scriptSig, this.scriptBytes, this.outpoint, sequence, this.value,
+                witness);
+    }
+
+    /**
+     * Returns a clone of this input, without witness. The typical use-case is transaction signing.
+     *
+     * @return clone of input, without witness
+     */
+    public TransactionInput withoutWitness() {
+        Script scriptSig = this.scriptSig != null ? this.scriptSig.get() : null;
+        return new TransactionInput(this.parent, scriptSig, this.scriptBytes, this.outpoint, sequence, this.value,
+                null);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/signers/LocalTransactionSigner.java
+++ b/core/src/main/java/org/bitcoinj/signers/LocalTransactionSigner.java
@@ -128,14 +128,14 @@ public class LocalTransactionSigner implements TransactionSigner {
                     inputScript = scriptPubKey.getScriptSigWithSignature(inputScript, signature.encodeToBitcoin(),
                             sigIndex);
                     txIn.setScriptSig(inputScript);
-                    txIn.setWitness(null);
+                    txIn = txIn.withoutWitness();
                 } else if (ScriptPattern.isP2WPKH(scriptPubKey)) {
                     Script scriptCode = ScriptBuilder.createP2PKHOutputScript(key);
                     Coin value = txIn.getValue();
                     TransactionSignature signature = tx.calculateWitnessSignature(i, key, scriptCode, value,
                             Transaction.SigHash.ALL, false);
                     txIn.setScriptSig(ScriptBuilder.createEmpty());
-                    txIn.setWitness(TransactionWitness.redeemP2WPKH(signature, key));
+                    txIn = txIn.withWitness(TransactionWitness.redeemP2WPKH(signature, key));
                 } else {
                     throw new IllegalStateException(script.toString());
                 }
@@ -144,7 +144,7 @@ public class LocalTransactionSigner implements TransactionSigner {
             } catch (ECKey.MissingPrivateKeyException e) {
                 log.warn("No private key in keypair for input {}", i);
             }
-
+            tx.replaceInput(i, txIn);
         }
         return true;
     }

--- a/core/src/main/java/org/bitcoinj/signers/MissingSigResolutionSigner.java
+++ b/core/src/main/java/org/bitcoinj/signers/MissingSigResolutionSigner.java
@@ -100,12 +100,13 @@ public class MissingSigResolutionSigner implements TransactionSigner {
                     } else if (missingSigsMode == Wallet.MissingSigsMode.USE_DUMMY_SIG) {
                         ECKey key = keyBag.findKeyFromPubKeyHash(
                                 ScriptPattern.extractHashFromP2WH(scriptPubKey), ScriptType.P2WPKH);
-                        txIn.setWitness(TransactionWitness.redeemP2WPKH(TransactionSignature.dummy(), key));
+                        txIn = txIn.withWitness(TransactionWitness.redeemP2WPKH(TransactionSignature.dummy(), key));
                     }
                 }
             } else {
                 throw new IllegalStateException("cannot handle: " + scriptPubKey);
             }
+            propTx.partialTx.replaceInput(i, txIn);
         }
         return true;
     }

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -656,16 +656,17 @@ public class WalletProtobufSerializer {
             );
             Coin value = inputProto.hasValue() ? Coin.valueOf(inputProto.getValue()) : null;
             long sequence = inputProto.hasSequence() ? 0xffffffffL & inputProto.getSequence() : TransactionInput.NO_SEQUENCE;
-            TransactionInput input = new TransactionInput(tx, scriptBytes, outpoint, sequence, value);
+            TransactionWitness witness = null;
             if (inputProto.hasWitness()) {
                 Protos.ScriptWitness witnessProto = inputProto.getWitness();
                 if (witnessProto.getDataCount() > 0) {
                     List<byte[]> pushes = new ArrayList<>(witnessProto.getDataCount());
                     for (int j = 0; j < witnessProto.getDataCount(); j++)
                         pushes.add(witnessProto.getData(j).toByteArray());
-                    input.setWitness(TransactionWitness.of(pushes));
+                    witness = TransactionWitness.of(pushes);
                 }
             }
+            TransactionInput input = new TransactionInput(tx, scriptBytes, outpoint, sequence, value, witness);
             tx.addInput(input);
         }
 

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -340,7 +340,8 @@ public class TransactionTest {
         assertTrue(correctlySpends(txIn0, scriptPubKey0, 0));
 
         assertFalse(correctlySpends(txIn1, scriptPubKey1, 1));
-        txIn1.setWitness(TransactionWitness.redeemP2WPKH(txSig1, key1));
+        txIn1 = txIn1.withWitness(TransactionWitness.redeemP2WPKH(txSig1, key1));
+        tx.replaceInput(1, txIn1);
         // no redeem script for p2wpkh
         assertTrue(correctlySpends(txIn1, scriptPubKey1, 1));
 
@@ -413,7 +414,8 @@ public class TransactionTest {
                 ByteUtils.formatHex(txSig.encodeToBitcoin()));
 
         assertFalse(correctlySpends(txIn, scriptPubKey, 0));
-        txIn.setWitness(TransactionWitness.redeemP2WPKH(txSig, key));
+        txIn = txIn.withWitness(TransactionWitness.redeemP2WPKH(txSig, key));
+        tx.replaceInput(0, txIn);
         txIn.setScriptSig(new ScriptBuilder().data(redeemScript.program()).build());
         assertTrue(correctlySpends(txIn, scriptPubKey, 0));
 
@@ -713,7 +715,7 @@ public class TransactionTest {
             this.addInput(inputTx.getOutput(0));
             this.getInput(0).disconnect();
             TransactionWitness witness = TransactionWitness.of(new byte[] { 0 });
-            this.getInput(0).setWitness(witness);
+            this.replaceInput(0, this.getInput(0).withWitness(witness));
             this.addOutput(Coin.COIN, new ECKey());
 
             this.hackInputsSize = hackInputsSize;

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -3459,7 +3459,8 @@ public class WalletTest extends TestWithWallet {
         TransactionSignature txSig1 = sendReq.tx.calculateWitnessSignature(0, sigKey1, scriptCode1,
                 inputW1.getValue(), Transaction.SigHash.ALL, false);
         inputW1.setScriptSig(ScriptBuilder.createEmpty());
-        inputW1.setWitness(TransactionWitness.redeemP2WPKH(txSig1, sigKey1));
+        inputW1 = inputW1.withWitness(TransactionWitness.redeemP2WPKH(txSig1, sigKey1));
+        sendReq.tx.replaceInput(0, inputW1);
 
         // Wallet2 sign input 1
         TransactionInput inputW2 = sendReq.tx.getInput(1);
@@ -3468,7 +3469,8 @@ public class WalletTest extends TestWithWallet {
         TransactionSignature txSig2 = sendReq.tx.calculateWitnessSignature(0, sigKey2, scriptCode2,
                 inputW2.getValue(), Transaction.SigHash.ALL, false);
         inputW2.setScriptSig(ScriptBuilder.createEmpty());
-        inputW2.setWitness(TransactionWitness.redeemP2WPKH(txSig2, sigKey2));
+        inputW2 = inputW2.withWitness(TransactionWitness.redeemP2WPKH(txSig2, sigKey2));
+        sendReq.tx.replaceInput(1, inputW2);
 
         wallet1.commitTx(sendReq.tx);
         wallet2.commitTx(sendReq.tx);


### PR DESCRIPTION
Because tweaking is necessary for transaction signing, these usages
have been changed to produce new inputs instead and replace them in
transactions as needed.

This is a child of #3579, but could be made to merge independently.