### PR TITLE
Transaction: cache transaction IDs

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -1034,6 +1034,21 @@ public class Transaction extends BaseMessage {
     }
 
     /**
+     * Replaces an already added output. This is meant to amend a transaction before it's committed to a wallet.
+     *
+     * @param index  index of output to replace
+     * @param output output to replace with
+     */
+    public void replaceOutput(int index, TransactionOutput output) {
+        TransactionOutput oldOutput = outputs.remove(index);
+        checkState(oldOutput.isAvailableForSpending(), () ->
+                "output to be replaced is buried in a wallet: " + oldOutput);
+        oldOutput.setParent(null);
+        output.setParent(this);
+        outputs.add(index, output);
+    }
+
+    /**
      * Creates an output based on the given address and value, adds it to this transaction, and returns the new output.
      */
     public TransactionOutput addOutput(Coin value, Address address) {

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -222,6 +222,10 @@ public class Transaction extends BaseMessage {
     @Nullable
     private String memo;
 
+    // These are in memory helpers only. They contain the transaction hashes without and with witness.
+    private Sha256Hash cachedTxId;
+    private Sha256Hash cachedWTxId;
+
     /**
      * Constructs an incomplete coinbase transaction with a minimal input script and no outputs.
      *
@@ -330,17 +334,26 @@ public class Transaction extends BaseMessage {
     }
 
     /**
-     * Returns the transaction id as you see them in block explorers. It is used as a reference by transaction inputs
+     * Returns the transaction ID as you see them in block explorers. It is used as a reference by transaction inputs
      * via outpoints.
+     *
+     * @return transaction ID
      */
     public Sha256Hash getTxId() {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try {
-            bitcoinSerializeToStream(baos, false);
-        } catch (IOException e) {
-            throw new RuntimeException(e); // cannot happen
+        if (cachedTxId == null) {
+            if (!hasWitnesses() && cachedWTxId != null) {
+                cachedTxId = cachedWTxId;
+            } else {
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                try {
+                    bitcoinSerializeToStream(baos, false);
+                } catch (IOException e) {
+                    throw new RuntimeException(e); // cannot happen
+                }
+                cachedTxId = Sha256Hash.wrapReversed(Sha256Hash.hashTwice(baos.toByteArray()));
+            }
         }
-        return Sha256Hash.wrapReversed(Sha256Hash.hashTwice(baos.toByteArray()));
+        return cachedTxId;
     }
 
     /**
@@ -352,17 +365,32 @@ public class Transaction extends BaseMessage {
     }
 
     /**
-     * Returns the witness transaction id (aka witness id) as per BIP144. For transactions without witness, this is the
+     * Returns the witness transaction ID (aka witness ID) as per BIP144. For transactions without witness, this is the
      * same as {@link #getTxId()}.
+     *
+     * @return witness transaction ID
      */
     public Sha256Hash getWTxId() {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try {
-            bitcoinSerializeToStream(baos, hasWitnesses());
-        } catch (IOException e) {
-            throw new RuntimeException(e); // cannot happen
+        if (cachedWTxId == null) {
+            if (!hasWitnesses() && cachedTxId != null) {
+                cachedWTxId = cachedTxId;
+            } else {
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                try {
+                    bitcoinSerializeToStream(baos, hasWitnesses());
+                } catch (IOException e) {
+                    throw new RuntimeException(e); // cannot happen
+                }
+                cachedWTxId = Sha256Hash.wrapReversed(Sha256Hash.hashTwice(baos.toByteArray()));
+            }
         }
-        return Sha256Hash.wrapReversed(Sha256Hash.hashTwice(baos.toByteArray()));
+        return cachedWTxId;
+    }
+
+    /** invalidates cache for both transaction IDs */
+    private void invalidateCachedTxIds() {
+        cachedTxId = null;
+        cachedWTxId = null;
     }
 
     /** Gets the transaction weight as defined in BIP141. */
@@ -643,6 +671,7 @@ public class Transaction extends BaseMessage {
         for (long i = 0; i < numInputs; i++) {
             inputs.add(TransactionInput.read(payload, this));
         }
+        invalidateCachedTxIds();
     }
 
     private void readOutputs(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
@@ -653,6 +682,7 @@ public class Transaction extends BaseMessage {
         for (long i = 0; i < numOutputs; i++) {
             outputs.add(TransactionOutput.read(payload, this));
         }
+        invalidateCachedTxIds();
     }
 
     private void readWitnesses(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
@@ -864,6 +894,7 @@ public class Transaction extends BaseMessage {
             input.setParent(null);
         }
         inputs.clear();
+        invalidateCachedTxIds();
     }
 
     /**
@@ -874,7 +905,9 @@ public class Transaction extends BaseMessage {
      * @return the newly created input.
      */
     public TransactionInput addInput(TransactionOutput from) {
-        return addInput(new TransactionInput(this, from));
+        TransactionInput input = addInput(new TransactionInput(this, from));
+        invalidateCachedTxIds();
+        return input;
     }
 
     /**
@@ -884,6 +917,7 @@ public class Transaction extends BaseMessage {
     public TransactionInput addInput(TransactionInput input) {
         input.setParent(this);
         inputs.add(input);
+        invalidateCachedTxIds();
         return input;
     }
 
@@ -892,7 +926,10 @@ public class Transaction extends BaseMessage {
      * @return the newly created input.
      */
     public TransactionInput addInput(Sha256Hash spendTxHash, long outputIndex, Script script) {
-        return addInput(new TransactionInput(this, script.program(), new TransactionOutPoint(outputIndex, spendTxHash)));
+        TransactionInput input = addInput(new TransactionInput(this, script.program(),
+                new TransactionOutPoint(outputIndex, spendTxHash)));
+        invalidateCachedTxIds();
+        return input;
     }
 
     /**
@@ -1029,6 +1066,7 @@ public class Transaction extends BaseMessage {
         oldInput.setParent(null);
         input.setParent(this);
         inputs.add(index, input);
+        invalidateCachedTxIds();
     }
 
     /**
@@ -1040,6 +1078,7 @@ public class Transaction extends BaseMessage {
             output.setParent(null);
         }
         outputs.clear();
+        invalidateCachedTxIds();
     }
 
     /**
@@ -1048,6 +1087,7 @@ public class Transaction extends BaseMessage {
     public TransactionOutput addOutput(TransactionOutput to) {
         to.setParent(this);
         outputs.add(to);
+        invalidateCachedTxIds();
         return to;
     }
 
@@ -1064,6 +1104,7 @@ public class Transaction extends BaseMessage {
         oldOutput.setParent(null);
         output.setParent(this);
         outputs.add(index, output);
+        invalidateCachedTxIds();
     }
 
     /**
@@ -1549,6 +1590,7 @@ public class Transaction extends BaseMessage {
             log.warn("You are setting the lock time on a transaction but none of the inputs have non-default sequence numbers. This will not do what you expect!");
         }
         this.vLockTime = LockTime.of(lockTime);
+        invalidateCachedTxIds();
     }
 
     public long getVersion() {
@@ -1557,6 +1599,7 @@ public class Transaction extends BaseMessage {
 
     public void setVersion(int version) {
         this.version = version;
+        invalidateCachedTxIds();
     }
 
     /** Returns an unmodifiable view of all inputs. */

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -656,8 +656,10 @@ public class Transaction extends BaseMessage {
     }
 
     private void readWitnesses(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
-        for (TransactionInput input : inputs) {
-            input.setWitness(TransactionWitness.read(payload));
+        int numInputs = inputs.size();
+        for (int i = 0; i < numInputs; i++) {
+            TransactionWitness witness = TransactionWitness.read(payload);
+            replaceInput(i, getInput(i).withWitness(witness));
         }
     }
 
@@ -923,18 +925,21 @@ public class Transaction extends BaseMessage {
             TransactionSignature signature = calculateSignature(inputIndex, sigKey, scriptPubKey, sigHash,
                     anyoneCanPay);
             input.setScriptSig(ScriptBuilder.createInputScript(signature));
-            input.setWitness(null);
+            input = input.withoutWitness();
+            replaceInput(inputIndex, input);
         } else if (ScriptPattern.isP2PKH(scriptPubKey)) {
             TransactionSignature signature = calculateSignature(inputIndex, sigKey, scriptPubKey, sigHash,
                     anyoneCanPay);
             input.setScriptSig(ScriptBuilder.createInputScript(signature, sigKey));
-            input.setWitness(null);
+            input = input.withoutWitness();
+            replaceInput(inputIndex, input);
         } else if (ScriptPattern.isP2WPKH(scriptPubKey)) {
             Script scriptCode = ScriptBuilder.createP2PKHOutputScript(sigKey);
             TransactionSignature signature = calculateWitnessSignature(inputIndex, sigKey, scriptCode, input.getValue(),
                     sigHash, anyoneCanPay);
             input.setScriptSig(ScriptBuilder.createEmpty());
-            input.setWitness(TransactionWitness.redeemP2WPKH(signature, sigKey));
+            input = input.withWitness(TransactionWitness.redeemP2WPKH(signature, sigKey));
+            replaceInput(inputIndex, input);
         } else {
             throw new ScriptException(ScriptError.SCRIPT_ERR_UNKNOWN_ERROR, "Don't know how to sign for this kind of scriptPubKey: " + scriptPubKey);
         }
@@ -1226,9 +1231,10 @@ public class Transaction extends BaseMessage {
             // transaction that step isn't very helpful, but it doesn't add much cost relative to the actual
             // EC math so we'll do it anyway.
             for (int i = 0; i < tx.inputs.size(); i++) {
-                TransactionInput input = tx.inputs.get(i);
+                TransactionInput input = tx.getInput(i);
                 input.clearScriptBytes();
-                input.setWitness(null);
+                input = input.withoutWitness();
+                tx.replaceInput(i, input);
             }
 
             // This step has no purpose beyond being synchronized with Bitcoin Core's bugs. OP_CODESEPARATOR

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -1387,8 +1387,9 @@ public class Transaction extends BaseMessage {
                             BigInteger.valueOf(output.getValue().getValue()),
                             bosHashOutputs
                     );
-                    bosHashOutputs.write(VarInt.of(output.getScriptBytes().length).serialize());
-                    bosHashOutputs.write(output.getScriptBytes());
+                    byte[] scriptBytes = output.getScriptBytes();
+                    bosHashOutputs.write(VarInt.of(scriptBytes.length).serialize());
+                    bosHashOutputs.write(scriptBytes);
                 }
                 hashOutputs = Sha256Hash.hashTwice(bosHashOutputs.toByteArray());
             } else if (basicSigHashType == SigHash.SINGLE.value && inputIndex < outputs.size()) {
@@ -1397,8 +1398,9 @@ public class Transaction extends BaseMessage {
                         BigInteger.valueOf(this.outputs.get(inputIndex).getValue().getValue()),
                         bosHashOutputs
                 );
-                bosHashOutputs.write(VarInt.of(this.outputs.get(inputIndex).getScriptBytes().length).serialize());
-                bosHashOutputs.write(this.outputs.get(inputIndex).getScriptBytes());
+                byte[] scriptBytes = this.outputs.get(inputIndex).getScriptBytes();
+                bosHashOutputs.write(VarInt.of(scriptBytes.length).serialize());
+                bosHashOutputs.write(scriptBytes);
                 hashOutputs = Sha256Hash.hashTwice(bosHashOutputs.toByteArray());
             }
             writeInt32LE(version, bos);

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -924,20 +924,20 @@ public class Transaction extends BaseMessage {
         if (ScriptPattern.isP2PK(scriptPubKey)) {
             TransactionSignature signature = calculateSignature(inputIndex, sigKey, scriptPubKey, sigHash,
                     anyoneCanPay);
-            input.setScriptSig(ScriptBuilder.createInputScript(signature));
+            input = input.withScriptSig(ScriptBuilder.createInputScript(signature));
             input = input.withoutWitness();
             replaceInput(inputIndex, input);
         } else if (ScriptPattern.isP2PKH(scriptPubKey)) {
             TransactionSignature signature = calculateSignature(inputIndex, sigKey, scriptPubKey, sigHash,
                     anyoneCanPay);
-            input.setScriptSig(ScriptBuilder.createInputScript(signature, sigKey));
+            input = input.withScriptSig(ScriptBuilder.createInputScript(signature, sigKey));
             input = input.withoutWitness();
             replaceInput(inputIndex, input);
         } else if (ScriptPattern.isP2WPKH(scriptPubKey)) {
             Script scriptCode = ScriptBuilder.createP2PKHOutputScript(sigKey);
             TransactionSignature signature = calculateWitnessSignature(inputIndex, sigKey, scriptCode, input.getValue(),
                     sigHash, anyoneCanPay);
-            input.setScriptSig(ScriptBuilder.createEmpty());
+            input = input.withScriptSig(ScriptBuilder.createEmpty());
             input = input.withWitness(TransactionWitness.redeemP2WPKH(signature, sigKey));
             replaceInput(inputIndex, input);
         } else {
@@ -1232,7 +1232,7 @@ public class Transaction extends BaseMessage {
             // EC math so we'll do it anyway.
             for (int i = 0; i < tx.inputs.size(); i++) {
                 TransactionInput input = tx.getInput(i);
-                input.clearScriptBytes();
+                input = input.withoutScriptBytes();
                 input = input.withoutWitness();
                 tx.replaceInput(i, input);
             }
@@ -1249,8 +1249,9 @@ public class Transaction extends BaseMessage {
             // Set the input to the script of its output. Bitcoin Core does this but the step has no obvious purpose as
             // the signature covers the hash of the prevout transaction which obviously includes the output script
             // already. Perhaps it felt safer to him in some way, or is another leftover from how the code was written.
-            TransactionInput input = tx.inputs.get(inputIndex);
-            input.setScriptBytes(connectedScript);
+            TransactionInput input = tx.getInput(inputIndex);
+            input = input.withScriptBytes(connectedScript);
+            tx.replaceInput(inputIndex, input);
 
             if ((sigHashType & 0x1f) == SigHash.NONE.value) {
                 // SIGHASH_NONE means no outputs are signed at all - the signature is effectively for a "blank cheque".

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -1014,6 +1014,19 @@ public class Transaction extends BaseMessage {
     }
 
     /**
+     * Replaces an already added input. This is meant to amend a transaction before it's committed to a wallet.
+     *
+     * @param index index of input to replace
+     * @param input input to replace with
+     */
+    public void replaceInput(int index, TransactionInput input) {
+        TransactionInput oldInput = inputs.remove(index);
+        oldInput.setParent(null);
+        input.setParent(this);
+        inputs.add(index, input);
+    }
+
+    /**
      * Removes all the outputs from this transaction.
      * Note that this also invalidates the length attribute
      */
@@ -1239,7 +1252,7 @@ public class Transaction extends BaseMessage {
                 // The signature isn't broken by new versions of the transaction issued by other parties.
                 for (int i = 0; i < tx.inputs.size(); i++)
                     if (i != inputIndex)
-                        tx.inputs.get(i).setSequenceNumber(0);
+                        tx.replaceInput(i, tx.getInput(i).withSequence(0));
             } else if ((sigHashType & 0x1f) == SigHash.SINGLE.value) {
                 // SIGHASH_SINGLE means only sign the output at the same index as the input (ie, my output).
                 if (inputIndex >= tx.outputs.size()) {
@@ -1261,7 +1274,7 @@ public class Transaction extends BaseMessage {
                 // The signature isn't broken by new versions of the transaction issued by other parties.
                 for (int i = 0; i < tx.inputs.size(); i++)
                     if (i != inputIndex)
-                        tx.inputs.get(i).setSequenceNumber(0);
+                        tx.replaceInput(i, tx.getInput(i).withSequence(0));
             }
 
             if ((sigHashType & SigHash.ANYONECANPAY.value) == SigHash.ANYONECANPAY.value) {

--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -87,7 +87,7 @@ public class TransactionInput {
     @Nullable
     private Coin value;
 
-    private TransactionWitness witness;
+    private final TransactionWitness witness;
 
     /**
      * Creates an input that connects to nothing - used only in creation of coinbase transactions.
@@ -134,9 +134,15 @@ public class TransactionInput {
     }
 
     /** internal use only */
-    public TransactionInput(Transaction parentTransaction, byte[] scriptBytes, TransactionOutPoint outpoint,
-                            long sequence, @Nullable Coin value) {
+    private TransactionInput(@Nullable Transaction parentTransaction, byte[] scriptBytes, TransactionOutPoint outpoint,
+                             long sequence, @Nullable Coin value) {
         this(parentTransaction, null, scriptBytes, outpoint, sequence, value, null);
+    }
+
+    /** internal use only */
+    public TransactionInput(@Nullable Transaction parentTransaction, byte[] scriptBytes, TransactionOutPoint outpoint,
+                            long sequence, @Nullable Coin value, @Nullable TransactionWitness witness) {
+        this(parentTransaction, null, scriptBytes, outpoint, sequence, value, witness);
     }
 
     private TransactionInput(@Nullable Transaction parentTransaction, @Nullable Script scriptSig, byte[] scriptBytes,
@@ -342,10 +348,27 @@ public class TransactionInput {
     }
 
     /**
-     * Set the transaction witness of an input.
+     * Returns a clone of this input, with a given witness. The typical use-case is transaction signing.
+     *
+     * @param witness witness for the clone
+     * @return clone of input, with given witness
      */
-    public void setWitness(TransactionWitness witness) {
-        this.witness = witness;
+    public TransactionInput withWitness(TransactionWitness witness) {
+        Objects.requireNonNull(witness);
+        Script scriptSig = this.scriptSig != null ? this.scriptSig.get() : null;
+        return new TransactionInput(this.parent, scriptSig, this.scriptBytes, this.outpoint, sequence, this.value,
+                witness);
+    }
+
+    /**
+     * Returns a clone of this input, without witness. The typical use-case is transaction signing.
+     *
+     * @return clone of input, without witness
+     */
+    public TransactionInput withoutWitness() {
+        Script scriptSig = this.scriptSig != null ? this.scriptSig.get() : null;
+        return new TransactionInput(this.parent, scriptSig, this.scriptBytes, this.outpoint, sequence, this.value,
+                null);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -57,7 +57,7 @@ public class TransactionOutput {
     @Nullable protected Transaction parent;
 
     // The output's value is kept as a native type in order to save class instances.
-    private long value;
+    private final long value;
 
     // A transaction output has a script used for authenticating that the redeemer is allowed to spend
     // this output.
@@ -189,14 +189,14 @@ public class TransactionOutput {
     }
 
     /**
-     * Sets the value of this output.
+     * Returns a clone of this output, with given value. The typical use case is fee calculation.
+     *
+     * @param value value for the clone
+     * @return clone of output, with given value
      */
-    public void setValue(Coin value) {
+    public TransactionOutput withValue(Coin value) {
         Objects.requireNonNull(value);
-        // Negative values obviously make no sense, except for -1 which is used as a sentinel value when calculating
-        // SIGHASH_SINGLE signatures, so unfortunately we have to allow that here.
-        checkArgument(value.signum() >= 0 || value.equals(Coin.NEGATIVE_SATOSHI), () -> "value out of range: " + value);
-        this.value = value.value;
+        return new TransactionOutput(this.parent, value, this.scriptBytes);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -61,7 +61,7 @@ public class TransactionOutput {
 
     // A transaction output has a script used for authenticating that the redeemer is allowed to spend
     // this output.
-    private byte[] scriptBytes;
+    private final byte[] scriptBytes;
 
     // The script bytes are parsed and turned into a Script on demand.
     private Script scriptPubKey;
@@ -308,7 +308,7 @@ public class TransactionOutput {
      * @return the scriptBytes
     */
     public byte[] getScriptBytes() {
-        return scriptBytes;
+        return Arrays.copyOf(scriptBytes, scriptBytes.length);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/TransactionWitness.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionWitness.java
@@ -37,6 +37,19 @@ import java.util.Objects;
 import static org.bitcoinj.base.internal.Preconditions.check;
 import static org.bitcoinj.base.internal.Preconditions.checkArgument;
 
+/**
+ * This structure contains data required to check transaction validity but not required to determine transaction
+ * effects. It is described as a number of byte vectors called "pushes". Those vectors are pushed to the script stack
+ * before script execution when validating a transaction.
+ * <p>
+ * For example, for inputs spending a P2WPKH output the witness consists of a signature and a public key – the same
+ * data that would have been pushed to the stack via a scriptSig for P2PKH.
+ * <p>
+ * Instances of this class are immutable.
+ *
+ * @see <a href="https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki">BIP 141</a>
+ * @see <a href="https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki">BIP 143</a>
+ */
 public class TransactionWitness {
     public static final TransactionWitness EMPTY = TransactionWitness.of(Collections.emptyList());
 
@@ -66,7 +79,7 @@ public class TransactionWitness {
     }
 
     /**
-     * Construct a transaction witness from a given list of arbitrary pushes.
+     * Construct a transaction witness from a given list of arbitrary stack pushes.
      *
      * @param pushes list of pushes
      * @return constructed transaction witness
@@ -76,7 +89,7 @@ public class TransactionWitness {
     }
 
     /**
-     * Construct a transaction witness from a given list of arbitrary pushes.
+     * Construct a transaction witness from a given list of arbitrary stack pushes.
      *
      * @param pushes list of pushes
      * @return constructed transaction witness
@@ -110,10 +123,21 @@ public class TransactionWitness {
         this.pushes = pushes;
     }
 
+    /**
+     * Get the stack push at a specified index.
+     *
+     * @param i index to get push at
+     * @return stack push
+     */
     public byte[] getPush(int i) {
         return pushes.get(i);
     }
 
+    /**
+     * Gets the number of stack pushes in this witness.
+     *
+     * @return number of pushes
+     */
     public int getPushCount() {
         return pushes.size();
     }

--- a/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
@@ -115,10 +115,7 @@ public class ScriptBuilder {
 
     /** Adds a copy of the given byte array as a data element (i.e. PUSHDATA) at the end of the program. */
     public ScriptBuilder data(byte[] data) {
-        if (data.length == 0)
-            return smallNum(0);
-        else
-            return data(chunks.size(), data);
+        return data(chunks.size(), data);
     }
 
     /** Adds a copy of the given byte array as a data element (i.e. PUSHDATA) at the given index in the program. */

--- a/core/src/main/java/org/bitcoinj/signers/CustomTransactionSigner.java
+++ b/core/src/main/java/org/bitcoinj/signers/CustomTransactionSigner.java
@@ -93,7 +93,8 @@ public abstract class CustomTransactionSigner implements TransactionSigner {
             TransactionSignature txSig = new TransactionSignature(sigKey.sig, Transaction.SigHash.ALL, false);
             int sigIndex = inputScript.getSigInsertionIndex(sighash, sigKey.pubKey);
             inputScript = scriptPubKey.getScriptSigWithSignature(inputScript, txSig.encodeToBitcoin(), sigIndex);
-            txIn.setScriptSig(inputScript);
+            txIn = txIn.withScriptSig(inputScript);
+            tx.replaceInput(i, txIn);
         }
         return true;
     }

--- a/core/src/main/java/org/bitcoinj/signers/LocalTransactionSigner.java
+++ b/core/src/main/java/org/bitcoinj/signers/LocalTransactionSigner.java
@@ -127,14 +127,14 @@ public class LocalTransactionSigner implements TransactionSigner {
                     int sigIndex = 0;
                     inputScript = scriptPubKey.getScriptSigWithSignature(inputScript, signature.encodeToBitcoin(),
                             sigIndex);
-                    txIn.setScriptSig(inputScript);
+                    txIn = txIn.withScriptSig(inputScript);
                     txIn = txIn.withoutWitness();
                 } else if (ScriptPattern.isP2WPKH(scriptPubKey)) {
                     Script scriptCode = ScriptBuilder.createP2PKHOutputScript(key);
                     Coin value = txIn.getValue();
                     TransactionSignature signature = tx.calculateWitnessSignature(i, key, scriptCode, value,
                             Transaction.SigHash.ALL, false);
-                    txIn.setScriptSig(ScriptBuilder.createEmpty());
+                    txIn = txIn.withScriptSig(ScriptBuilder.createEmpty());
                     txIn = txIn.withWitness(TransactionWitness.redeemP2WPKH(signature, key));
                 } else {
                     throw new IllegalStateException(script.toString());

--- a/core/src/main/java/org/bitcoinj/signers/LocalTransactionSigner.java
+++ b/core/src/main/java/org/bitcoinj/signers/LocalTransactionSigner.java
@@ -128,14 +128,14 @@ public class LocalTransactionSigner implements TransactionSigner {
                     inputScript = scriptPubKey.getScriptSigWithSignature(inputScript, signature.encodeToBitcoin(),
                             sigIndex);
                     txIn.setScriptSig(inputScript);
-                    txIn.setWitness(null);
+                    txIn = txIn.withoutWitness();
                 } else if (ScriptPattern.isP2WPKH(scriptPubKey)) {
                     Script scriptCode = ScriptBuilder.createP2PKHOutputScript(key);
                     Coin value = txIn.getValue();
                     TransactionSignature signature = tx.calculateWitnessSignature(i, key, scriptCode, value,
                             Transaction.SigHash.ALL, false);
                     txIn.setScriptSig(ScriptBuilder.createEmpty());
-                    txIn.setWitness(TransactionWitness.redeemP2WPKH(signature, key));
+                    txIn = txIn.withWitness(TransactionWitness.redeemP2WPKH(signature, key));
                 } else {
                     throw new IllegalStateException(script.toString());
                 }
@@ -144,7 +144,7 @@ public class LocalTransactionSigner implements TransactionSigner {
             } catch (ECKey.MissingPrivateKeyException e) {
                 log.warn("No private key in keypair for input {}", i);
             }
-
+            tx.replaceInput(i, txIn);
         }
         return true;
     }

--- a/core/src/main/java/org/bitcoinj/signers/MissingSigResolutionSigner.java
+++ b/core/src/main/java/org/bitcoinj/signers/MissingSigResolutionSigner.java
@@ -100,12 +100,13 @@ public class MissingSigResolutionSigner implements TransactionSigner {
                     } else if (missingSigsMode == Wallet.MissingSigsMode.USE_DUMMY_SIG) {
                         ECKey key = keyBag.findKeyFromPubKeyHash(
                                 ScriptPattern.extractHashFromP2WH(scriptPubKey), ScriptType.P2WPKH);
-                        txIn.setWitness(TransactionWitness.redeemP2WPKH(TransactionSignature.dummy(), key));
+                        txIn = txIn.withWitness(TransactionWitness.redeemP2WPKH(TransactionSignature.dummy(), key));
                     }
                 }
             } else {
                 throw new IllegalStateException("cannot handle: " + scriptPubKey);
             }
+            propTx.partialTx.replaceInput(i, txIn);
         }
         return true;
     }

--- a/core/src/main/java/org/bitcoinj/signers/MissingSigResolutionSigner.java
+++ b/core/src/main/java/org/bitcoinj/signers/MissingSigResolutionSigner.java
@@ -80,7 +80,7 @@ public class MissingSigResolutionSigner implements TransactionSigner {
                         if (missingSigsMode == Wallet.MissingSigsMode.THROW) {
                             throw new MissingSignatureException();
                         } else if (missingSigsMode == Wallet.MissingSigsMode.USE_DUMMY_SIG) {
-                            txIn.setScriptSig(scriptPubKey.getScriptSigWithSignature(inputScript, dummySig, j - 1));
+                            txIn = txIn.withScriptSig(scriptPubKey.getScriptSigWithSignature(inputScript, dummySig, j - 1));
                         }
                     }
                 }
@@ -89,7 +89,7 @@ public class MissingSigResolutionSigner implements TransactionSigner {
                     if (missingSigsMode == Wallet.MissingSigsMode.THROW) {
                         throw new ECKey.MissingPrivateKeyException();
                     } else if (missingSigsMode == Wallet.MissingSigsMode.USE_DUMMY_SIG) {
-                        txIn.setScriptSig(scriptPubKey.getScriptSigWithSignature(inputScript, dummySig, 0));
+                        txIn = txIn.withScriptSig(scriptPubKey.getScriptSigWithSignature(inputScript, dummySig, 0));
                     }
                 }
             } else if (ScriptPattern.isP2WPKH(scriptPubKey)) {

--- a/core/src/main/java/org/bitcoinj/testing/FakeTxBuilder.java
+++ b/core/src/main/java/org/bitcoinj/testing/FakeTxBuilder.java
@@ -107,7 +107,9 @@ public class FakeTxBuilder {
         TransactionOutput prevOut = new TransactionOutput(prevTx, value, to);
         prevTx.addOutput(prevOut);
         // Connect it.
-        t.addInput(prevOut).setScriptSig(ScriptBuilder.createInputScript(TransactionSignature.dummy()));
+        TransactionInput in = t.addInput(prevOut);
+        in = in.withScriptSig(ScriptBuilder.createInputScript(TransactionSignature.dummy()));
+        t.replaceInput(t.getInputs().size() - 1, in);
         // Fake signature.
         // Serialize/deserialize to ensure internal state is stripped, as if it had been read from the wire.
         return roundTripTransaction(t);
@@ -136,14 +138,18 @@ public class FakeTxBuilder {
         TransactionOutput prevOut1 = new TransactionOutput(prevTx1, Coin.valueOf(split), to);
         prevTx1.addOutput(prevOut1);
         // Connect it.
-        t.addInput(prevOut1).setScriptSig(ScriptBuilder.createInputScript(TransactionSignature.dummy()));
+        TransactionInput in1 = t.addInput(prevOut1);
+        in1 = in1.withScriptSig(ScriptBuilder.createInputScript(TransactionSignature.dummy()));
+        t.replaceInput(t.getInputs().size() - 1, in1);
         // Fake signature.
 
         // Do it again
         Transaction prevTx2 = new Transaction();
         TransactionOutput prevOut2 = new TransactionOutput(prevTx2, Coin.valueOf(value.getValue() - split), to);
         prevTx2.addOutput(prevOut2);
-        t.addInput(prevOut2).setScriptSig(ScriptBuilder.createInputScript(TransactionSignature.dummy()));
+        TransactionInput in2 = t.addInput(prevOut2);
+        in2 = in2.withScriptSig(ScriptBuilder.createInputScript(TransactionSignature.dummy()));
+        t.replaceInput(t.getInputs().size() - 1, in2);
 
         // Serialize/deserialize to ensure internal state is stripped, as if it had been read from the wire.
         return roundTripTransaction(t);

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4766,7 +4766,8 @@ public class Wallet extends BaseTaggableObject
                 RedeemData redeemData = txIn.getConnectedRedeemData(maybeDecryptingKeyBag);
                 Objects.requireNonNull(redeemData, () ->
                         "Transaction exists in wallet that we cannot redeem: " + txIn.getOutpoint().hash());
-                txIn.setScriptSig(scriptPubKey.createEmptyInputScript(redeemData.keys.get(0), redeemData.redeemScript));
+                tx.replaceInput(i, txIn.withScriptSig(scriptPubKey.createEmptyInputScript(redeemData.keys.get(0),
+                        redeemData.redeemScript)));
             }
 
             TransactionSigner.ProposedTransaction proposal = new TransactionSigner.ProposedTransaction(tx);

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4641,7 +4641,7 @@ public class Wallet extends BaseTaggableObject
                 CoinSelector selector = req.coinSelector == null ? coinSelector : req.coinSelector;
                 bestCoinSelection = selector.select((Coin) network.maxMoney(), candidates);
                 candidates = null;  // Selector took ownership and might have changed candidates. Don't access again.
-                req.tx.getOutput(0).setValue(bestCoinSelection.totalValue());
+                req.tx.replaceOutput(0, req.tx.getOutput(0).withValue(bestCoinSelection.totalValue()));
                 log.info("  emptying {}", bestCoinSelection.totalValue().toFriendlyString());
             }
 
@@ -4655,7 +4655,7 @@ public class Wallet extends BaseTaggableObject
 
             if (updatedOutputValues != null) {
                 for (int i = 0; i < updatedOutputValues.size(); i++) {
-                    req.tx.getOutput(i).setValue(updatedOutputValues.get(i));
+                    req.tx.replaceOutput(i, req.tx.getOutput(i).withValue(updatedOutputValues.get(i)));
                 }
             }
 
@@ -4793,7 +4793,8 @@ public class Wallet extends BaseTaggableObject
             boolean ensureMinRequiredFee) {
         Coin fee = estimateFees(tx, coinSelection, feePerKb, ensureMinRequiredFee);
         TransactionOutput output = tx.getOutput(0);
-        output.setValue(output.getValue().subtract(fee));
+        output = output.withValue(output.getValue().subtract(fee));
+        tx.replaceOutput(0, output);
         return !output.isDust();
     }
 
@@ -5471,11 +5472,12 @@ public class Wallet extends BaseTaggableObject
                         ByteBuffer.wrap(req.tx.getOutput(i).serialize()), tx);
                 if (req.recipientsPayFees) {
                     // Subtract fee equally from each selected recipient
-                    output.setValue(output.getValue().subtract(fee.divide(req.tx.getOutputs().size())));
+                    output = output.withValue(output.getValue().subtract(fee.divide(req.tx.getOutputs().size())));
                     // first receiver pays the remainder not divisible by output count
                     if (i == 0) {
-                        output.setValue(
-                                output.getValue().subtract(fee.divideAndRemainder(req.tx.getOutputs().size())[1])); // Subtract fee equally from each selected recipient
+                        // Subtract fee equally from each selected recipient
+                        Coin feeRemainder = fee.divideAndRemainder(req.tx.getOutputs().size())[1];
+                        output = output.withValue(output.getValue().subtract(feeRemainder));
                     }
                     result.updatedOutputValues.add(output.getValue());
                     Coin nonDustValue = output.getMinNonDustValue();
@@ -5506,9 +5508,10 @@ public class Wallet extends BaseTaggableObject
                     // This would be against the purpose of the all-inclusive feature.
                     // So instead we raise the change and deduct from the first recipient.
                     Coin missingToNotBeDust = changeOutput.getMinNonDustValue().subtract(changeOutput.getValue());
-                    changeOutput.setValue(changeOutput.getValue().add(missingToNotBeDust));
+                    changeOutput = changeOutput.withValue(changeOutput.getValue().add(missingToNotBeDust));
                     TransactionOutput firstOutput = tx.getOutput(0);
-                    firstOutput.setValue(firstOutput.getValue().subtract(missingToNotBeDust));
+                    firstOutput = firstOutput.withValue(firstOutput.getValue().subtract(missingToNotBeDust));
+                    tx.replaceOutput(0, firstOutput);
                     result.updatedOutputValues.set(0, firstOutput.getValue());
                     if (firstOutput.isDust()) {
                         throw new CouldNotAdjustDownwards();

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -670,9 +670,8 @@ public class WalletProtobufSerializer {
                     byteStringToHash(inputProto.getTransactionOutPointHash())
             );
             Coin value = inputProto.hasValue() ? Coin.valueOf(inputProto.getValue()) : null;
-            TransactionInput input = new TransactionInput(tx, scriptBytes, outpoint, value);
-            if (inputProto.hasSequence())
-                input.setSequenceNumber(0xffffffffL & inputProto.getSequence());
+            long sequence = inputProto.hasSequence() ? 0xffffffffL & inputProto.getSequence() : TransactionInput.NO_SEQUENCE;
+            TransactionInput input = new TransactionInput(tx, scriptBytes, outpoint, sequence, value);
             if (inputProto.hasWitness()) {
                 Protos.ScriptWitness witnessProto = inputProto.getWitness();
                 if (witnessProto.getDataCount() > 0) {

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -671,16 +671,17 @@ public class WalletProtobufSerializer {
             );
             Coin value = inputProto.hasValue() ? Coin.valueOf(inputProto.getValue()) : null;
             long sequence = inputProto.hasSequence() ? 0xffffffffL & inputProto.getSequence() : TransactionInput.NO_SEQUENCE;
-            TransactionInput input = new TransactionInput(tx, scriptBytes, outpoint, sequence, value);
+            TransactionWitness witness = null;
             if (inputProto.hasWitness()) {
                 Protos.ScriptWitness witnessProto = inputProto.getWitness();
                 if (witnessProto.getDataCount() > 0) {
                     List<byte[]> pushes = new ArrayList<>(witnessProto.getDataCount());
                     for (int j = 0; j < witnessProto.getDataCount(); j++)
                         pushes.add(witnessProto.getData(j).toByteArray());
-                    input.setWitness(TransactionWitness.of(pushes));
+                    witness = TransactionWitness.of(pushes);
                 }
             }
+            TransactionInput input = new TransactionInput(tx, scriptBytes, outpoint, sequence, value, witness);
             tx.addInput(input);
         }
 

--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -163,7 +163,8 @@ public abstract class AbstractFullPrunedBlockChainTest {
         t.addOutput(new TransactionOutput(t, FIFTY_COINS, new byte[] {}));
         TransactionInput input = t.addInput(spendableOutput);
         // Invalid script.
-        input.clearScriptBytes();
+        input = input.withoutScriptBytes();
+        t.replaceInput(t.getInputs().size() - 1, input);
         rollingBlock.addTransaction(t);
         rollingBlock.solve();
         chain.setRunScripts(false);

--- a/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
@@ -114,7 +114,7 @@ public class BitcoinSerializerTest {
         transaction = (Transaction) serializer.deserialize(ByteBuffer.wrap(TRANSACTION_MESSAGE_BYTES));
         assertNotNull(transaction);
 
-        transaction.getInput(0).setSequenceNumber(1);
+        transaction.replaceInput(0, transaction.getInput(0).withSequence(1));
 
         bos = new ByteArrayOutputStream();
         serializer.serialize(transaction, bos);
@@ -131,7 +131,8 @@ public class BitcoinSerializerTest {
         transaction = (Transaction) serializer.deserialize(ByteBuffer.wrap(TRANSACTION_MESSAGE_BYTES));
         assertNotNull(transaction);
 
-        transaction.getInput(0).setSequenceNumber(transaction.getInputs().get(0).getSequenceNumber());
+        transaction.replaceInput(0,
+                transaction.getInput(0).withSequence(transaction.getInput(0).getSequenceNumber())); // no-op?
 
         bos = new ByteArrayOutputStream();
         serializer.serialize(transaction, bos);

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -1193,7 +1193,7 @@ public class FullBlockTestGenerator {
         NewBlock b63 = createNextBlock(b60, chainHeadHeight + 19, null, null);
         {
             b63.block.getTransactions().get(0).setLockTime(0xffffffffL);
-            b63.block.getTransactions().get(0).getInput(0).setSequenceNumber(0xdeadbeefL);
+            b63.block.getTransactions().get(0).replaceInput(0, b63.block.getTransactions().get(0).getInput(0).withSequence(0xdeadbeefL));
             checkState(!b63.block.getTransactions().get(0).isFinal(chainHeadHeight + 17, b63.block.time()));
         }
         b63.solve();
@@ -1797,7 +1797,7 @@ public class FullBlockTestGenerator {
 
     private void addOnlyInputToTransaction(Transaction t, TransactionOutPointWithValue prevOut, long sequence) throws ScriptException {
         TransactionInput input = new TransactionInput(t, new byte[]{}, prevOut.outpoint);
-        input.setSequenceNumber(sequence);
+        input = input.withSequence(sequence);
         t.addInput(input);
 
         if (prevOut.scriptPubKey.chunks().get(0).equalsOpCode(OP_TRUE)) {

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -341,7 +341,8 @@ public class TransactionTest {
         assertTrue(correctlySpends(txIn0, scriptPubKey0, 0));
 
         assertFalse(correctlySpends(txIn1, scriptPubKey1, 1));
-        txIn1.setWitness(TransactionWitness.redeemP2WPKH(txSig1, key1));
+        txIn1 = txIn1.withWitness(TransactionWitness.redeemP2WPKH(txSig1, key1));
+        tx.replaceInput(1, txIn1);
         // no redeem script for p2wpkh
         assertTrue(correctlySpends(txIn1, scriptPubKey1, 1));
 
@@ -414,7 +415,8 @@ public class TransactionTest {
                 ByteUtils.formatHex(txSig.encodeToBitcoin()));
 
         assertFalse(correctlySpends(txIn, scriptPubKey, 0));
-        txIn.setWitness(TransactionWitness.redeemP2WPKH(txSig, key));
+        txIn = txIn.withWitness(TransactionWitness.redeemP2WPKH(txSig, key));
+        tx.replaceInput(0, txIn);
         txIn.setScriptSig(new ScriptBuilder().data(redeemScript.program()).build());
         assertTrue(correctlySpends(txIn, scriptPubKey, 0));
 
@@ -714,7 +716,7 @@ public class TransactionTest {
             this.addInput(inputTx.getOutput(0));
             this.getInput(0).disconnect();
             TransactionWitness witness = TransactionWitness.of(new byte[] { 0 });
-            this.getInput(0).setWitness(witness);
+            this.replaceInput(0, this.getInput(0).withWitness(witness));
             this.addOutput(Coin.COIN, new ECKey());
 
             this.hackInputsSize = hackInputsSize;

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -482,8 +482,7 @@ public class TransactionTest {
     @Test
     public void testToStringWhenLockTimeIsSpecifiedInBlockHeight() {
         Transaction tx = FakeTxBuilder.createFakeTx(TESTNET.network());
-        TransactionInput input = tx.getInput(0);
-        input.setSequenceNumber(42);
+        tx.replaceInput(0, tx.getInput(0).withSequence(42));
 
         int TEST_LOCK_TIME = 20;
         tx.setLockTime(TEST_LOCK_TIME);
@@ -609,7 +608,7 @@ public class TransactionTest {
         Transaction tx = FakeTxBuilder.createFakeTx(TESTNET.network());
         assertFalse(tx.isOptInFullRBF());
 
-        tx.getInput(0).setSequenceNumber(TransactionInput.NO_SEQUENCE - 2);
+        tx.replaceInput(0, tx.getInput(0).withSequence(TransactionInput.NO_SEQUENCE - 2));
         assertTrue(tx.isOptInFullRBF());
     }
 

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -117,7 +117,7 @@ public class TransactionTest {
     @Test(expected = VerificationException.NegativeValueOutput.class)
     public void negativeOutput() {
         Transaction tx = FakeTxBuilder.createFakeTx(TESTNET.network());
-        tx.getOutput(0).setValue(Coin.NEGATIVE_SATOSHI);
+        tx.replaceOutput(0, tx.getOutput(0).withValue(Coin.NEGATIVE_SATOSHI));
         Transaction.verify(TESTNET.network(), tx);
     }
 
@@ -125,7 +125,7 @@ public class TransactionTest {
     public void exceedsMaxMoney2() {
         Transaction tx = FakeTxBuilder.createFakeTx(TESTNET.network());
         Coin half = BitcoinNetwork.MAX_MONEY.divide(2).add(Coin.SATOSHI);
-        tx.getOutput(0).setValue(half);
+        tx.replaceOutput(0, tx.getOutput(0).withValue(half));
         tx.addOutput(half, ADDRESS);
         Transaction.verify(TESTNET.network(), tx);
     }

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -101,7 +101,7 @@ public class TransactionTest {
     @Test(expected = VerificationException.LargerThanMaxBlockSize.class)
     public void tooHuge() {
         Transaction tx = FakeTxBuilder.createFakeTx(TESTNET.network());
-        tx.getInput(0).setScriptBytes(new byte[Block.MAX_BLOCK_SIZE]);
+        tx.replaceInput(0, tx.getInput(0).withScriptBytes(new byte[Block.MAX_BLOCK_SIZE]));
         Transaction.verify(TESTNET.network(), tx);
     }
 
@@ -109,7 +109,7 @@ public class TransactionTest {
     public void duplicateOutPoint() {
         Transaction tx = FakeTxBuilder.createFakeTx(TESTNET.network());
         TransactionInput input = tx.getInput(0);
-        input.setScriptBytes(new byte[1]);
+        input = input.withScriptBytes(new byte[1]);
         tx.addInput(input);
         Transaction.verify(TESTNET.network(), tx);
     }
@@ -337,7 +337,8 @@ public class TransactionTest {
                 ByteUtils.formatHex(txSig1.encodeToBitcoin()));
 
         assertFalse(correctlySpends(txIn0, scriptPubKey0, 0));
-        txIn0.setScriptSig(new ScriptBuilder().data(txSig0.encodeToBitcoin()).build());
+        txIn0 = txIn0.withScriptSig(new ScriptBuilder().data(txSig0.encodeToBitcoin()).build());
+	    tx.replaceInput(0, txIn0);
         assertTrue(correctlySpends(txIn0, scriptPubKey0, 0));
 
         assertFalse(correctlySpends(txIn1, scriptPubKey1, 1));
@@ -416,8 +417,8 @@ public class TransactionTest {
 
         assertFalse(correctlySpends(txIn, scriptPubKey, 0));
         txIn = txIn.withWitness(TransactionWitness.redeemP2WPKH(txSig, key));
+        txIn = txIn.withScriptSig(new ScriptBuilder().data(redeemScript.program()).build());
         tx.replaceInput(0, txIn);
-        txIn.setScriptSig(new ScriptBuilder().data(redeemScript.program()).build());
         assertTrue(correctlySpends(txIn, scriptPubKey, 0));
 
         String signedTxHex = "01000000" // version
@@ -572,11 +573,11 @@ public class TransactionTest {
         int size1 = tx1.messageSize();
         int size2 = tx1.getMessageSizeForPriorityCalc();
         assertEquals(113, size1 - size2);
-        tx1.getInput(0).setScriptSig(Script.parse(new byte[109]));
+        tx1.replaceInput(0, tx1.getInput(0).withScriptSig(Script.parse(new byte[109])));
         assertEquals(78, tx1.getMessageSizeForPriorityCalc());
-        tx1.getInput(0).setScriptSig(Script.parse(new byte[110]));
+        tx1.replaceInput(0, tx1.getInput(0).withScriptSig(Script.parse(new byte[110])));
         assertEquals(78, tx1.getMessageSizeForPriorityCalc());
-        tx1.getInput(0).setScriptSig(Script.parse(new byte[111]));
+        tx1.replaceInput(0, tx1.getInput(0).withScriptSig(Script.parse(new byte[111])));
         assertEquals(79, tx1.getMessageSizeForPriorityCalc());
     }
 

--- a/core/src/test/java/org/bitcoinj/script/ScriptBuilderTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptBuilderTest.java
@@ -18,13 +18,35 @@ package org.bitcoinj.script;
 
 import org.junit.Test;
 
+import static org.bitcoinj.script.ScriptOpCodes.OP_0;
 import static org.bitcoinj.script.ScriptOpCodes.OP_FALSE;
 import static org.bitcoinj.script.ScriptOpCodes.OP_TRUE;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class ScriptBuilderTest {
+
+    @Test
+    public void emptyPushData() {
+        Script script = new ScriptBuilder().data(new byte[0]).build();
+        ScriptChunk chunk = script.chunks().get(0);
+        assertEquals(OP_0, chunk.opcode);
+        assertNotNull(chunk.data);
+        assertEquals(0, chunk.data.length);
+
+        byte[] serialized = script.program();
+        assertArrayEquals(new byte[] {
+                0x00         // Pushed data
+        }, serialized);
+
+        Script parsedScript = Script.parse(script.program());
+        ScriptChunk parsedChunk = parsedScript.chunks().get(0);
+        assertEquals(OP_0, parsedChunk.opcode);
+        assertNotNull(parsedChunk.data);
+        assertEquals(0, parsedChunk.data.length);
+    }
 
     @Test
     public void testNumber() {

--- a/core/src/test/java/org/bitcoinj/script/ScriptTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptTest.java
@@ -355,7 +355,7 @@ public class ScriptTest {
 
         TransactionInput txInput = new TransactionInput(null,
                 new ScriptBuilder().number(0).number(0).build().program(), TransactionOutPoint.UNCONNECTED);
-        txInput.setSequenceNumber(TransactionInput.NO_SEQUENCE);
+        txInput = txInput.withSequence(TransactionInput.NO_SEQUENCE);
         tx.addInput(txInput);
 
         TransactionOutput txOutput = new TransactionOutput(tx, Coin.ZERO, scriptPubKey.program());
@@ -371,7 +371,7 @@ public class ScriptTest {
 
         TransactionInput txInput = new TransactionInput(creditingTransaction, scriptSig.program(),
                 TransactionOutPoint.UNCONNECTED);
-        txInput.setSequenceNumber(TransactionInput.NO_SEQUENCE);
+        txInput = txInput.withSequence(TransactionInput.NO_SEQUENCE);
         tx.addInput(txInput);
 
         TransactionOutput txOutput = new TransactionOutput(tx, creditingTransaction.getOutput(0).getValue(),

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -246,10 +246,10 @@ public class WalletProtobufSerializerTest {
     public void testSequenceNumber() throws Exception {
         Wallet wallet = Wallet.createDeterministic(BitcoinNetwork.TESTNET, ScriptType.P2PKH);
         Transaction tx1 = createFakeTx(TESTNET.network(), Coin.COIN, wallet.currentReceiveAddress());
-        tx1.getInput(0).setSequenceNumber(TransactionInput.NO_SEQUENCE);
+        tx1.replaceInput(0, tx1.getInput(0).withSequence(TransactionInput.NO_SEQUENCE));
         wallet.receivePending(tx1, null);
         Transaction tx2 = createFakeTx(TESTNET.network(), Coin.COIN, wallet.currentReceiveAddress());
-        tx2.getInput(0).setSequenceNumber(TransactionInput.NO_SEQUENCE - 1);
+        tx2.replaceInput(0, tx2.getInput(0).withSequence(TransactionInput.NO_SEQUENCE - 1));
         wallet.receivePending(tx2, null);
         Wallet walletCopy = roundTrip(wallet);
         Transaction tx1copy = Objects.requireNonNull(walletCopy.getTransaction(tx1.getTxId()));

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -3459,7 +3459,8 @@ public class WalletTest extends TestWithWallet {
         TransactionSignature txSig1 = sendReq.tx.calculateWitnessSignature(0, sigKey1, scriptCode1,
                 inputW1.getValue(), Transaction.SigHash.ALL, false);
         inputW1.setScriptSig(ScriptBuilder.createEmpty());
-        inputW1.setWitness(TransactionWitness.redeemP2WPKH(txSig1, sigKey1));
+        inputW1 = inputW1.withWitness(TransactionWitness.redeemP2WPKH(txSig1, sigKey1));
+        sendReq.tx.replaceInput(0, inputW1);
 
         // Wallet2 sign input 1
         TransactionInput inputW2 = sendReq.tx.getInput(1);
@@ -3468,7 +3469,8 @@ public class WalletTest extends TestWithWallet {
         TransactionSignature txSig2 = sendReq.tx.calculateWitnessSignature(0, sigKey2, scriptCode2,
                 inputW2.getValue(), Transaction.SigHash.ALL, false);
         inputW2.setScriptSig(ScriptBuilder.createEmpty());
-        inputW2.setWitness(TransactionWitness.redeemP2WPKH(txSig2, sigKey2));
+        inputW2 = inputW2.withWitness(TransactionWitness.redeemP2WPKH(txSig2, sigKey2));
+        sendReq.tx.replaceInput(1, inputW2);
 
         wallet1.commitTx(sendReq.tx);
         wallet2.commitTx(sendReq.tx);

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -3050,8 +3050,10 @@ public class WalletTest extends TestWithWallet {
         SendRequest req = SendRequest.emptyWallet(OTHER_ADDRESS);
         wallet.completeTx(req);
         // Delete the sigs
-        for (TransactionInput input : req.tx.getInputs())
-            input.clearScriptBytes();
+        for (int i = 0; i < req.tx.getInputs().size(); i++) {
+            TransactionInput input = req.tx.getInput(i).withoutScriptBytes();
+            req.tx.replaceInput(i, input);
+        }
         Wallet watching = Wallet.fromWatchingKey(TESTNET, wallet.getWatchingKey().dropParent().dropPrivateBytes(),
                 ScriptType.P2PKH);
         watching.freshReceiveKey();
@@ -3458,7 +3460,7 @@ public class WalletTest extends TestWithWallet {
         Script scriptCode1 = ScriptBuilder.createP2PKHOutputScript(sigKey1);
         TransactionSignature txSig1 = sendReq.tx.calculateWitnessSignature(0, sigKey1, scriptCode1,
                 inputW1.getValue(), Transaction.SigHash.ALL, false);
-        inputW1.setScriptSig(ScriptBuilder.createEmpty());
+        inputW1 = inputW1.withScriptSig(ScriptBuilder.createEmpty());
         inputW1 = inputW1.withWitness(TransactionWitness.redeemP2WPKH(txSig1, sigKey1));
         sendReq.tx.replaceInput(0, inputW1);
 
@@ -3468,7 +3470,7 @@ public class WalletTest extends TestWithWallet {
         Script scriptCode2 = ScriptBuilder.createP2PKHOutputScript(sigKey2);
         TransactionSignature txSig2 = sendReq.tx.calculateWitnessSignature(0, sigKey2, scriptCode2,
                 inputW2.getValue(), Transaction.SigHash.ALL, false);
-        inputW2.setScriptSig(ScriptBuilder.createEmpty());
+        inputW2 = inputW2.withScriptSig(ScriptBuilder.createEmpty());
         inputW2 = inputW2.withWitness(TransactionWitness.redeemP2WPKH(txSig2, sigKey2));
         sendReq.tx.replaceInput(1, inputW2);
 

--- a/examples/src/main/java/org/bitcoinj/examples/GenerateLowSTests.java
+++ b/examples/src/main/java/org/bitcoinj/examples/GenerateLowSTests.java
@@ -96,7 +96,7 @@ public class GenerateLowSTests {
         // Sign the transaction
         final ProposedTransaction proposedTransaction = new ProposedTransaction(outputTransaction);
         signer.signInputs(proposedTransaction, bag);
-        final TransactionInput input = proposedTransaction.partialTx.getInput(0);
+        TransactionInput input = proposedTransaction.partialTx.getInput(0);
 
         input.verify(output);
         input.getScriptSig().correctlySpends(outputTransaction, 0, null, null, output.getScriptPubKey(),
@@ -116,7 +116,7 @@ public class GenerateLowSTests {
 
         final BigInteger highS = HIGH_S_DIFFERENCE.subtract(signature.s);
         final TransactionSignature highSig = new TransactionSignature(signature.r, highS);
-        input.setScriptSig(new ScriptBuilder().data(highSig.encodeToBitcoin()).data(scriptSig.chunks().get(1).data).build());
+        input = input.withScriptSig(new ScriptBuilder().data(highSig.encodeToBitcoin()).data(scriptSig.chunks().get(1).data).build());
         input.getScriptSig().correctlySpends(outputTransaction, 0, null, null, output.getScriptPubKey(),
             EnumSet.of(Script.VerifyFlag.P2SH));
 
@@ -147,7 +147,7 @@ public class GenerateLowSTests {
             RedeemData redeemData = txIn.getConnectedRedeemData(bag);
             Objects.requireNonNull(redeemData, () ->
                     "Transaction exists in wallet that we cannot redeem: " + txIn.getOutpoint().hash());
-            txIn.setScriptSig(scriptPubKey.createEmptyInputScript(redeemData.keys.get(0), redeemData.redeemScript));
+            outputTransaction.replaceInput(i, txIn.withScriptSig(scriptPubKey.createEmptyInputScript(redeemData.keys.get(0), redeemData.redeemScript)));
         }
     }
 

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -732,8 +732,7 @@ public class PeerTest extends TestWithNetworkConnections {
         t2.setLockTime(999999);
         // Add a fake input to t3 that goes nowhere.
         Sha256Hash t3 = Sha256Hash.of("abc".getBytes(StandardCharsets.UTF_8));
-        t2.addInput(new TransactionInput(t2, new byte[]{}, new TransactionOutPoint(0, t3)));
-        t2.getInput(0).setSequenceNumber(0xDEADBEEF);
+        t2.addInput(new TransactionInput(t2, new byte[] {}, new TransactionOutPoint(0, t3), 0xDEADBEEF));
         t2.addOutput(COIN, new ECKey());
         Transaction t1 = new Transaction();
         t1.addInput(t2.getOutput(0));

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -664,7 +664,7 @@ public class WalletTool implements Callable<Integer> {
             if (lockTimeStr != null) {
                 tx.setLockTime(parseLockTimeStr(lockTimeStr));
                 // For lock times to take effect, at least one output must have a non-final sequence number.
-                tx.getInput(0).setSequenceNumber(0);
+                tx.replaceInput(0, tx.getInput(0).withSequence(0));
                 // And because we modified the transaction after it was completed, we must re-sign the inputs.
                 wallet.signTransaction(req);
             }


### PR DESCRIPTION
Without caching, transactions are serialized way too often.

This effectively reverts b8d3c4a641f1d6d7410f7152e5bd383b1f00c9ce, but invalidation is slightly different.

This PR has multiple commits, but **only the last commit is relevant for review**. All previous commits except the last are just backports of recent immutability work from master. We need that because it would be hard to detect mutations of dependant objects in order to properly invalidate caches.

If this is merged, I'll forward-port the relevant commit to master as well.