### PR TITLE
MainNetParams, TestNet3Params, SigNetParams: update DNS seeds from Bitcoin Core 28.1

### DIFF
--- a/core/src/main/java/org/bitcoinj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/MainNetParams.java
@@ -72,13 +72,13 @@ public class MainNetParams extends BitcoinNetworkParams {
         dnsSeeds = new String[] {
                 "seed.bitcoin.sipa.be",         // Pieter Wuille
                 "dnsseed.bluematt.me",          // Matt Corallo
-                "dnsseed.bitcoin.dashjr.org",   // Luke Dashjr
-                "seed.bitcoinstats.com",        // Chris Decker
+                "dnsseed.bitcoin.dashjr-list-of-p2p-nodes.us", // Luke Dashjr
                 "seed.bitcoin.jonasschnelli.ch",// Jonas Schnelli
                 "seed.btc.petertodd.net",       // Peter Todd
                 "seed.bitcoin.sprovoost.nl",    // Sjors Provoost
                 "dnsseed.emzy.de",              // Stephan Oeste
                 "seed.bitcoin.wiz.biz",         // Jason Maurice
+                "seed.mainnet.achownodes.xyz",  // Ava Chow
         };
 
         // These are in big-endian format, which is what the SeedPeers code expects.

--- a/core/src/main/java/org/bitcoinj/params/SigNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/SigNetParams.java
@@ -62,7 +62,8 @@ public class SigNetParams extends BitcoinNetworkParams {
         majorityWindow = TESTNET_MAJORITY_WINDOW;
 
         dnsSeeds = new String[] {
-                "seed.signet.bitcoin.sprovoost.nl",
+                "seed.signet.bitcoin.sprovoost.nl", // Sjors Provoost
+                "seed.signet.achownodes.xyz",       // Ava Chow
         };
         addrSeeds = null;
     }

--- a/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
@@ -71,6 +71,7 @@ public class TestNet3Params extends BitcoinNetworkParams {
                 "seed.tbtc.petertodd.net",               // Peter Todd
                 "seed.testnet.bitcoin.sprovoost.nl",     // Sjors Provoost
                 "testnet-seed.bluematt.me",              // Matt Corallo
+                "seed.testnet.achownodes.xyz",           // Ava Chow
         };
         addrSeeds = null;
 


### PR DESCRIPTION
This is a candicate for backport to 0.17, 0.16.