### PR TITLE
PeerGroup: remove redundant log message when download peer dies

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -1773,7 +1773,6 @@ public class PeerGroup implements TransactionBroadcaster {
 
             log.info("{}: Peer died      ({} connected, {} pending, {} max)", address, peers.size(), pendingPeers.size(), maxConnections);
             if (peer == downloadPeer) {
-                log.info("Download peer died. Picking a new one.");
                 setDownloadPeer(null);
                 // Pick a new one and possibly tell it to download the chain.
                 final Peer newDownloadPeer = selectDownloadPeer(peers);


### PR DESCRIPTION
It's always

```
Download peer died. Picking a new one.
Unsetting download peer: <peer>
Setting download peer: <peer>
```

So the first message can go away.