### PR TITLE
Wallet: deprecate SendResult

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
@@ -46,8 +46,10 @@ import static org.bitcoinj.base.internal.Preconditions.checkState;
  * defined as seeing the transaction be announced by peers via inv messages, thus indicating their acceptance. A failure
  * is defined as not reaching acceptance within a timeout period, or getting an explicit reject message from a peer
  * indicating that the transaction was not acceptable.
+ * <p>
+ * This class temporarily implements {@link Wallet.SendResult} to allow migration away from that deprecated interface.
  */
-public class TransactionBroadcast {
+public class TransactionBroadcast implements Wallet.SendResult {
     private static final Logger log = LoggerFactory.getLogger(TransactionBroadcast.class);
 
     // This future completes when all broadcast messages were sent (to a buffer)
@@ -82,6 +84,14 @@ public class TransactionBroadcast {
 
     public Transaction transaction() {
         return tx;
+    }
+
+    /**
+     * @deprecated If you are using {@link Wallet.SendResult} switch to {@link TransactionBroadcast}
+     */
+    @Override
+    public TransactionBroadcast getBroadcast() {
+        return this;
     }
 
     @VisibleForTesting

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -3969,36 +3969,12 @@ public class Wallet extends BaseTaggableObject
     /** A SendResult is returned to you as part of sending coins to a recipient. */
     public static class SendResult {
         /**
-         * The Bitcoin transaction message that moves the money.
-         * @deprecated Use {@link #transaction()}
-         */
-        @Deprecated
-        public final Transaction tx;
-        /**
-         * A future that will complete once the tx message has been successfully broadcast to the network. This is just the result of calling broadcast.future()
-         * @deprecated Use {@link #awaitRelayed()}
-         */
-        @Deprecated
-        public final CompletableFuture<Transaction> broadcastComplete;
-        /**
          * The broadcast object returned by the linked TransactionBroadcaster
-         * @deprecated Use {@link #getBroadcast()}
          */
-        @Deprecated
-        public final TransactionBroadcast broadcast;
-
-        /**
-         * @deprecated Use {@link #SendResult(TransactionBroadcast)}
-         */
-        @Deprecated
-        public SendResult(Transaction tx, TransactionBroadcast broadcast) {
-            this(broadcast);
-        }
+        private final TransactionBroadcast broadcast;
 
         public SendResult(TransactionBroadcast broadcast) {
-            this.tx = broadcast.transaction();
             this.broadcast = broadcast;
-            this.broadcastComplete = broadcast.awaitRelayed().thenApply(TransactionBroadcast::transaction);
         }
 
         public Transaction transaction() {

--- a/examples/src/main/java/org/bitcoinj/examples/SendRequest.java
+++ b/examples/src/main/java/org/bitcoinj/examples/SendRequest.java
@@ -20,6 +20,7 @@ import org.bitcoinj.base.Address;
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.core.InsufficientMoneyException;
+import org.bitcoinj.core.TransactionBroadcast;
 import org.bitcoinj.kits.WalletAppKit;
 import org.bitcoinj.wallet.Wallet;
 import org.bitcoinj.wallet.Wallet.BalanceType;
@@ -54,7 +55,7 @@ public class SendRequest {
         // When using the testnet you can use a faucet to get testnet coins.
         // In this example we catch the InsufficientMoneyException and register a BalanceFuture callback that runs once the wallet has enough balance.
         try {
-            Wallet.SendResult result = kit.wallet().sendCoins(kit.peerGroup(), to, value);
+            TransactionBroadcast result = kit.wallet().sendCoins(kit.peerGroup(), to, value);
             System.out.println("coins sent. transaction hash: " + result.transaction().getTxId());
             // you can use a block explorer like https://www.biteasy.com/ to inspect the transaction with the printed transaction hash. 
         } catch (InsufficientMoneyException e) {

--- a/integration-test/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
@@ -171,7 +171,7 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
 
         // Now create a spend, and expect the announcement on p1.
         Address dest = new ECKey().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
-        Wallet.SendResult sendResult = wallet.sendCoins(peerGroup, dest, COIN);
+        TransactionBroadcast sendResult = wallet.sendCoins(peerGroup, dest, COIN);
         assertFalse(sendResult.awaitRelayed().isDone());
         Transaction t1;
         {
@@ -215,7 +215,7 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
 
         // Now create a spend, and expect the announcement on p1.
         Address dest = new ECKey().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
-        Wallet.SendResult sendResult = wallet.sendCoins(peerGroup, dest, COIN);
+        TransactionBroadcast sendResult = wallet.sendCoins(peerGroup, dest, COIN);
         assertNotNull(sendResult.transaction());
         Threading.waitForUserCode();
         assertFalse(sendResult.awaitRelayed().isDone());

--- a/wallettemplate/src/main/java/wallettemplate/SendMoneyController.java
+++ b/wallettemplate/src/main/java/wallettemplate/SendMoneyController.java
@@ -25,6 +25,7 @@ import javafx.scene.layout.HBox;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.core.InsufficientMoneyException;
+import org.bitcoinj.core.TransactionBroadcast;
 import org.bitcoinj.core.TransactionConfidence;
 import org.bitcoinj.crypto.AesKey;
 import org.bitcoinj.crypto.ECKey;
@@ -54,7 +55,7 @@ public class SendMoneyController implements OverlayController<SendMoneyControlle
     private OverlayableStackPaneController rootController;
     private OverlayableStackPaneController.OverlayUI<? extends OverlayController<SendMoneyController>> overlayUI;
 
-    private Wallet.SendResult sendResult;
+    private TransactionBroadcast sendResult;
     private AesKey aesKey;
 
     @Override


### PR DESCRIPTION
* Make `SendResult` an interface
* `TransactionBroadcast` temporarily implements `SendResult`
* Remove all other uses of `SendResult`

Any clients declaring instances of `Wallet.SendResult` must convert to `TransactionBroadcast` before `SendResult` is removed.

Child of PR #3596 