### PR TITLE
GHA gradle.yml: job name conform with graalvm.yml

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,7 +17,7 @@ jobs:
           - java: '21'
             gradle: '7.3'
       fail-fast: false
-    name: JAVA ${{ matrix.distribution }} ${{ matrix.java }} OS ${{ matrix.os }} Gradle ${{ matrix.gradle }}
+    name: ${{ matrix.os }} JDK ${{ matrix.java }}.${{ matrix.distribution }} Gradle ${{ matrix.gradle }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
(The graalvm name is a little more compact and we should harmonize the two to make it easier to compare these files)