### PR TITLE
base: remove last @nonnull annotations & findbugs dependency

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -9,7 +9,6 @@ version = '0.18-SNAPSHOT'
 
 dependencies {
     implementation 'org.slf4j:slf4j-api:2.0.16'
-    implementation 'com.google.code.findbugs:jsr305:3.0.2'
 
     testImplementation project(':bitcoinj-test-support')
     testImplementation 'junit:junit:4.13.2'

--- a/base/src/main/java/org/bitcoinj/base/LegacyAddress.java
+++ b/base/src/main/java/org/bitcoinj/base/LegacyAddress.java
@@ -21,7 +21,6 @@ package org.bitcoinj.base;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.internal.ByteUtils;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumSet;
@@ -113,7 +112,7 @@ public class LegacyAddress implements Address {
      * @throws AddressFormatException              if the given base58 doesn't parse or the checksum is invalid
      * @throws AddressFormatException.WrongNetwork if the given address is valid but for a different chain (e.g. testnet vs mainnet)
      */
-    public static LegacyAddress fromBase58(String base58, @Nonnull Network network)
+    public static LegacyAddress fromBase58(String base58, Network network)
             throws AddressFormatException, AddressFormatException.WrongNetwork {
         byte[] versionAndDataBytes = Base58.decodeChecked(base58);
         int version = versionAndDataBytes[0] & 0xFF;

--- a/base/src/main/java/org/bitcoinj/base/SegwitAddress.java
+++ b/base/src/main/java/org/bitcoinj/base/SegwitAddress.java
@@ -19,7 +19,6 @@ package org.bitcoinj.base;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.internal.ByteUtils;
 
-import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumSet;
@@ -252,7 +251,7 @@ public class SegwitAddress implements Address {
      * @return constructed address
      * @throws AddressFormatException if something about the given bech32 address isn't right
      */
-    public static SegwitAddress fromBech32(String bech32, @Nonnull Network network)
+    public static SegwitAddress fromBech32(String bech32, Network network)
             throws AddressFormatException {
         Bech32.Bech32Data bechData = Bech32.decode(bech32);
         if (bechData.hrp.equals(network.segwitAddressHrp()))
@@ -260,7 +259,7 @@ public class SegwitAddress implements Address {
         throw new AddressFormatException.WrongNetwork(bechData.hrp);
     }
 
-    static SegwitAddress fromBechData(@Nonnull Network network, Bech32.Bech32Data bechData) {
+    static SegwitAddress fromBechData(Network network, Bech32.Bech32Data bechData) {
         if (bechData.bytes().length < 1) {
             throw new AddressFormatException.InvalidDataLength("invalid address length (0)");
         }


### PR DESCRIPTION
A previous PR removed the last @nullable annotation.

This PR removes the @nonnull annotations as we can now assume that
everything in this module is non-nullable. If we discover otherwise
we can add JSpecify and mark them with that. We may want to use
JSpecify anyway, but I'll leave that for a separate PR.

This is a child of PR #3604 