### PR TITLE
Transaction: include coinbase input in toString()

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -768,7 +768,8 @@ public class Transaction extends BaseMessage {
             s.append(indent).append("purpose: ").append(purpose).append('\n');
         if (isCoinBase()) {
             s.append(indent).append("coinbase\n");
-        } else if (!inputs.isEmpty()) {
+        }
+        if (!inputs.isEmpty()) {
             for (TransactionInput in : inputs) {
                 s.append(indent).append("   ");
                 s.append("in   ");


### PR DESCRIPTION
This is a child of #3621 and #3622, but could be merged individually.

It used to be suppressed, presumably because coinbase scriptSigs may contain arbitrary bytes which could confuse our script parser.
