### PR TITLE
ScriptBuilder: make bigNum() public

### DIFF
--- a/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
@@ -163,7 +163,7 @@ public class ScriptBuilder {
      * 
      * @see #number(long)
      */
-    protected ScriptBuilder bigNum(long num) {
+    public ScriptBuilder bigNum(long num) {
         final byte[] data;
 
         if (num == 0) {


### PR DESCRIPTION
This is a child of #3625, but it could be made to be merged independently if so desired.

We will need this to construct genesis block scriptSigs, which use a pushdata of a small value that would, optimally encoded, be pushed via OP_n.
