### PR TITLE
TestNet3Params: fix difficulty transition check

### DIFF
--- a/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
@@ -115,12 +115,12 @@ public class TestNet3Params extends BitcoinNetworkParams {
                 // There is an integer underflow bug in bitcoin-qt that means mindiff blocks are accepted when time
                 // goes backwards.
                 return;
-            } else if (timeDelta <= TESTNET_DIFFICULTY_EXCEPTION_SPACING) {
-                Block prevBlock = backwardsSkipMindiffBlocks(storedPrev, blockStore);
-                expectedTarget = prevBlock.getDifficultyTargetAsInteger();
-            } else {
+            } else if (timeDelta > TESTNET_DIFFICULTY_EXCEPTION_SPACING){
                 // 20 minute exception
                 expectedTarget = getMaxTarget();
+            } else {
+                // If no special rule applies, expect the last non-mindiff difficulty.
+                expectedTarget = backwardsSkipMindiffBlocks(storedPrev, blockStore).getDifficultyTargetAsInteger();
             }
             BigInteger newTarget = nextBlock.getDifficultyTargetAsInteger();
             if (!newTarget.equals(expectedTarget))

--- a/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
@@ -110,23 +110,23 @@ public class TestNet3Params extends BitcoinNetworkParams {
             // and then leaving, making it too hard to mine a block. On non-difficulty transition points, easy
             // blocks are allowed if there has been a span of 20 minutes without one.
             final long timeDelta = nextBlock.time().getEpochSecond() - storedPrev.getHeader().time().getEpochSecond();
-            BigInteger expectedTarget;
-            if (timeDelta < 0 && nextBlock.getDifficultyTargetAsInteger().equals(getMaxTarget())) {
-                // There is an integer underflow bug in bitcoin-qt that means mindiff blocks are accepted when time
-                // goes backwards.
-                return;
-            } else if (timeDelta > TESTNET_DIFFICULTY_EXCEPTION_SPACING){
-                // 20 minute exception
-                expectedTarget = getMaxTarget();
-            } else {
-                // If no special rule applies, expect the last non-mindiff difficulty.
-                expectedTarget = backwardsSkipMindiffBlocks(storedPrev, blockStore).getDifficultyTargetAsInteger();
+            // There is an integer underflow bug in bitcoin-qt that means mindiff blocks are accepted when time
+            // goes backwards.
+            if (timeDelta >= 0 || !nextBlock.getDifficultyTargetAsInteger().equals(getMaxTarget())) {
+                BigInteger expectedTarget;
+                if (timeDelta > TESTNET_DIFFICULTY_EXCEPTION_SPACING) {
+                    // 20 minute exception
+                    expectedTarget = getMaxTarget();
+                } else {
+                    // If no special rule applies, expect the last non-mindiff difficulty.
+                    expectedTarget = backwardsSkipMindiffBlocks(storedPrev, blockStore).getDifficultyTargetAsInteger();
+                }
+                BigInteger newTarget = nextBlock.getDifficultyTargetAsInteger();
+                if (!newTarget.equals(expectedTarget))
+                    throw new VerificationException("Testnet block transition that is not allowed: " +
+                            Long.toHexString(ByteUtils.encodeCompactBits(expectedTarget)) + " vs " +
+                            Long.toHexString(nextBlock.getDifficultyTarget()));
             }
-            BigInteger newTarget = nextBlock.getDifficultyTargetAsInteger();
-            if (!newTarget.equals(expectedTarget))
-                throw new VerificationException("Testnet block transition that is not allowed: " +
-                        Long.toHexString(ByteUtils.encodeCompactBits(expectedTarget)) + " vs " +
-                        Long.toHexString(nextBlock.getDifficultyTarget()));
         } else {
             super.checkDifficultyTransitions(storedPrev, nextBlock, blockStore);
         }

--- a/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
@@ -110,9 +110,10 @@ public class TestNet3Params extends BitcoinNetworkParams {
             // and then leaving, making it too hard to mine a block. On non-difficulty transition points, easy
             // blocks are allowed if there has been a span of 20 minutes without one.
             final long timeDelta = nextBlock.time().getEpochSecond() - storedPrev.getHeader().time().getEpochSecond();
-            // There is an integer underflow bug in bitcoin-qt that means mindiff blocks are accepted when time
-            // goes backwards.
-            if (timeDelta >= 0 || !nextBlock.getDifficultyTargetAsInteger().equals(getMaxTarget())) {
+            if (timeDelta < 0 && nextBlock.getDifficultyTargetAsInteger().equals(getMaxTarget())) {
+                // There is an integer underflow bug in bitcoin-qt that means mindiff blocks are accepted when time
+                // goes backwards.
+            } else {
                 BigInteger expectedTarget;
                 if (timeDelta > TESTNET_DIFFICULTY_EXCEPTION_SPACING) {
                     // 20 minute exception

--- a/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
@@ -111,7 +111,7 @@ public class TestNet3Params extends BitcoinNetworkParams {
             // blocks are allowed if there has been a span of 20 minutes without one.
             final long timeDelta = nextBlock.time().getEpochSecond() - storedPrev.getHeader().time().getEpochSecond();
             if (timeDelta < 0 && nextBlock.getDifficultyTargetAsInteger().equals(getMaxTarget())) {
-                // There is an integer underflow bug in bitcoin-qt that means mindiff blocks are accepted when time
+                // There is an integer underflow bug in Bitcoin Core that means mindiff blocks are accepted when time
                 // goes backwards.
             } else {
                 BigInteger expectedTarget;


### PR DESCRIPTION
The difficulty transition check didn't properly account for the "20 minute rule" specific to testnet: if the time delta between a block and its previous block is more than 20 minutes, the block's difficulty target MUST reset to the minimum difficulty.

Before this fix, it did not check the difficulty target at all in this case. So it wrongly assumed the difficulty target can be changed to any value.