### PR TITLE
StoredBlock: if getPrev() called on a genesis block, cut short

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/StoredBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/StoredBlock.java
@@ -129,7 +129,9 @@ public class StoredBlock {
      * @return the previous block in the chain or null if it was not found in the store.
      */
     public StoredBlock getPrev(BlockStore store) throws BlockStoreException {
-        return store.get(getHeader().getPrevBlockHash());
+        return height > 0 ?
+                store.get(header.getPrevBlockHash()) :
+                null; // Genesis blocks have no previous block.
     }
 
     /**


### PR DESCRIPTION
Don't try to locate a previous block of the genesis block, using an arbitrary "previous block hash".

This could be backported to 0.17.