### PR TITLE
TransactionTest: fix testWitnessSignatureP2WPKH() connected output

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -312,7 +312,9 @@ public class TransactionTest {
         assertEquals("025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee6357", key1.getPublicKeyAsHex());
         Script scriptPubKey1 = ScriptBuilder.createP2WPKHOutputScript(key1);
         assertEquals("00141d0f172a0ecb48aee1be1f2687d2963ae33f71a1", ByteUtils.formatHex(scriptPubKey1.program()));
-        txIn1.connect(new Transaction().addOutput(Coin.COIN.multiply(6), scriptPubKey1));
+        Transaction tx2 = new Transaction();
+        tx2.addOutput(new TransactionOutput(tx2, Coin.SATOSHI, new byte[0])); // dummy output to fill index 0
+        txIn1.connect(tx2.addOutput(Coin.COIN.multiply(6), scriptPubKey1)); // so that this connected output gets correct index 1
 
         assertEquals("63cec688ee06a91e913875356dd4dea2f8e0f2a2659885372da2a37e32c7532e",
                 tx.hashForSignature(0, scriptPubKey0, Transaction.SigHash.ALL, false).toString());


### PR DESCRIPTION
txIn1 is referencing an output at index 1, but when we're creating a mock for the connected transaction the output was inadvertently at index 0. This is fixed by inserting a dummy output before the referenced one.