### PR TITLE
TransactionOutPoint: when constructing with known fromTx, do more integrity checks

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -91,6 +91,13 @@ public class TransactionOutPoint {
         checkArgument(index >= 0 && index <= ByteUtils.MAX_UNSIGNED_INTEGER, () ->
                 "index out of range: " + index);
         this.index = index;
+        if (fromTx != null) {
+            TransactionOutput outputFromTx = fromTx.getOutput(index);
+            Objects.requireNonNull(outputFromTx);
+            if (connectedOutput != null) {
+                checkArgument(connectedOutput.equals(outputFromTx), () -> "mismatched connected output");
+            }
+        }
         this.fromTx = fromTx;
         this.connectedOutput = connectedOutput;
     }

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -1134,7 +1134,7 @@ public class FullBlockTestGenerator {
             Transaction tx = new Transaction();
             tx.addOutput(new TransactionOutput(tx, ZERO, new byte[] {}));
             // Replace the TransactionOutPoint with an out-of-range OutPoint
-            b58.getSpendableOutput().outpoint = new TransactionOutPoint(42, tx);
+            b58.getSpendableOutput().outpoint = new TransactionOutPoint(42, tx.getTxId());
             addOnlyInputToTransaction(tx, b58);
             b58.addTransaction(tx);
         }


### PR DESCRIPTION
- the output with given index has to exist in fromTx, and
- that output needs to match connectedOutput if given
    
This restriction causes a test to be unconstructable. It is replaced by the next best thing, but it's unclear if the test remains meaningful at all.

Child of #3636.