### PR TITLE
Block: remove exception-safe usage mode from `checkProofOfWork()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Context.java
+++ b/core/src/main/java/org/bitcoinj/core/Context.java
@@ -67,7 +67,7 @@ public class Context {
      * @param eventHorizon Number of blocks after which the library will delete data and be unable to always process reorgs. See {@link #getEventHorizon()}.
      * @param feePerKb The default fee per 1000 virtual bytes of transaction data to pay when completing transactions. For details, see {@link SendRequest#feePerKb}.
      * @param ensureMinRequiredFee Whether to ensure the minimum required fee by default when completing transactions. For details, see {@link SendRequest#ensureMinRequiredFee}.
-     * @param relaxProofOfWork If true, proof of work is not enforced. This is useful for unit-testing. See {@link Block#checkProofOfWork(boolean)}.
+     * @param relaxProofOfWork If true, proof of work is not enforced. This is useful for unit-testing. See {@link Block#checkProofOfWork()}.
      */
     public Context(int eventHorizon, Coin feePerKb, boolean ensureMinRequiredFee, boolean relaxProofOfWork) {
         log.info("Creating bitcoinj {} context.", VersionMessage.BITCOINJ_VERSION);


### PR DESCRIPTION
This removes both the boolean argument and the boolean return type. It always throws if difficulty target is not met. If it returns normally, the target is met.
    
The only consumer of the exception-safe usage mode is switched to using `Difficulty.isMetBy()` directly.
    
Also, this method is switched to private visibility.

This PR is a child of #3631.