### PR TITLE
NetworkParameters: convert spacing and timespans to `java.time.Duration`

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -30,6 +30,7 @@ import org.bitcoinj.base.utils.MonetaryFormat;
 import org.bitcoinj.utils.VersionTally;
 
 import java.math.BigInteger;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -52,7 +53,7 @@ public abstract class NetworkParameters {
     protected int packetMagic;  // Indicates message origin network and is used to seek to the next message when stream state is unknown.
     protected int dumpedPrivateKeyHeader;
     protected int interval;
-    protected int targetTimespan;
+    protected Duration targetTimespan;
     protected int bip32HeaderP2PKHpub;
     protected int bip32HeaderP2PKHpriv;
     protected int bip32HeaderP2WPKHpub;
@@ -87,10 +88,10 @@ public abstract class NetworkParameters {
 
     /** @deprecated use {@link BitcoinNetworkParams#TARGET_TIMESPAN} */
     @Deprecated
-    public static final int TARGET_TIMESPAN = BitcoinNetworkParams.TARGET_TIMESPAN;
+    public static final int TARGET_TIMESPAN = (int) BitcoinNetworkParams.TARGET_TIMESPAN.getSeconds();
     /** @deprecated use {@link BitcoinNetworkParams#TARGET_SPACING} */
     @Deprecated
-    public static final int TARGET_SPACING = BitcoinNetworkParams.TARGET_SPACING;
+    public static final int TARGET_SPACING = (int) BitcoinNetworkParams.TARGET_SPACING.getSeconds();
     /** @deprecated use {@link BitcoinNetworkParams#INTERVAL_BLOCKS} */
     @Deprecated
     public static final int INTERVAL = BitcoinNetworkParams.INTERVAL_BLOCKS;
@@ -238,13 +239,20 @@ public abstract class NetworkParameters {
     }
 
     /**
-     * How much time in seconds is supposed to pass between "interval" blocks. If the actual elapsed time is
+     * How much time is supposed to pass between "interval" blocks. If the actual elapsed time is
      * significantly different from this value, the network difficulty formula will produce a different value. Both
      * test and main Bitcoin networks use 2 weeks (1209600 seconds).
-     * @return target timespan in seconds
+     *
+     * @return target timespan
      */
-    public int getTargetTimespan() {
+    public Duration targetTimespan() {
         return targetTimespan;
+    }
+
+    /** @deprecated use {@link #targetTimespan()} */
+    @Deprecated
+    public int getTargetTimespan() {
+        return (int) (targetTimespan.getSeconds());
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -85,10 +85,16 @@ public abstract class NetworkParameters {
         this.id = network.id();
     }
 
-    public static final int TARGET_TIMESPAN = 14 * 24 * 60 * 60;  // 2 weeks per difficulty cycle, on average.
-    public static final int TARGET_SPACING = 10 * 60;  // 10 minutes per block.
-    public static final int INTERVAL = TARGET_TIMESPAN / TARGET_SPACING;
-    
+    /** @deprecated use {@link BitcoinNetworkParams#TARGET_TIMESPAN} */
+    @Deprecated
+    public static final int TARGET_TIMESPAN = BitcoinNetworkParams.TARGET_TIMESPAN;
+    /** @deprecated use {@link BitcoinNetworkParams#TARGET_SPACING} */
+    @Deprecated
+    public static final int TARGET_SPACING = BitcoinNetworkParams.TARGET_SPACING;
+    /** @deprecated use {@link BitcoinNetworkParams#INTERVAL_BLOCKS} */
+    @Deprecated
+    public static final int INTERVAL = BitcoinNetworkParams.INTERVAL_BLOCKS;
+
     /**
      * Blocks with a timestamp after this should enforce BIP 16, aka "Pay to script hash". This BIP changed the
      * network rules in a soft-forking manner, that is, blocks that don't follow the rules are accepted but not

--- a/core/src/main/java/org/bitcoinj/params/BitcoinNetworkParams.java
+++ b/core/src/main/java/org/bitcoinj/params/BitcoinNetworkParams.java
@@ -48,6 +48,12 @@ public abstract class BitcoinNetworkParams extends NetworkParameters {
      * Block reward halving interval (number of blocks)
      */
     public static final int REWARD_HALVING_INTERVAL = 210_000;
+    /** Desired average time between consecutive blocks */
+    public static final int TARGET_SPACING = 10 * 60;  // 10 minutes per block.
+    /** Desired average time for each difficulty cycle */
+    public static final int TARGET_TIMESPAN = 14 * 24 * 60 * 60;  // 2 weeks per difficulty cycle.
+    /** A difficulty cycle has this many blocks */
+    public static final int INTERVAL_BLOCKS = TARGET_TIMESPAN / TARGET_SPACING;
 
     private static final Logger log = LoggerFactory.getLogger(BitcoinNetworkParams.class);
 
@@ -59,7 +65,7 @@ public abstract class BitcoinNetworkParams extends NetworkParameters {
      */
     public BitcoinNetworkParams(BitcoinNetwork network) {
         super(network);
-        interval = INTERVAL;
+        interval = INTERVAL_BLOCKS;
         subsidyDecreaseBlockCount = REWARD_HALVING_INTERVAL;
     }
 

--- a/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
@@ -20,7 +20,6 @@ package org.bitcoinj.params;
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.core.Block;
-import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.core.StoredBlock;
 import org.bitcoinj.core.VerificationException;
@@ -44,7 +43,7 @@ public class TestNet3Params extends BitcoinNetworkParams {
     private static final long GENESIS_NONCE = 414098458;
     private static final Sha256Hash GENESIS_HASH = Sha256Hash.wrap("000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943");
     /** Spacing for the 20-minute difficulty exception. */
-    private static final int TESTNET_DIFFICULTY_EXCEPTION_SPACING = NetworkParameters.TARGET_SPACING * 2;
+    private static final int TESTNET_DIFFICULTY_EXCEPTION_SPACING = TARGET_SPACING * 2;
 
     public TestNet3Params() {
         super(BitcoinNetwork.TESTNET);

--- a/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
@@ -22,6 +22,8 @@ import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.core.Block;
 
+import java.time.Duration;
+
 /**
  * Network parameters used by the bitcoinj unit tests (and potentially your own). This lets you solve a block using
  * {@link Block#solve()} by setting difficulty to the easiest possible.
@@ -36,7 +38,7 @@ public class UnitTestParams extends BitcoinNetworkParams {
         // This means that tests that run against UnitTestParams expect TEST network behavior.
         super(BitcoinNetwork.TESTNET);
 
-        targetTimespan = 200000000;  // 6 years. Just a very big number.
+        targetTimespan = Duration.ofSeconds(200000000);  // 6 years. Just a very big number.
         maxTarget = ByteUtils.decodeCompactBits(Block.EASIEST_DIFFICULTY_TARGET);
         interval = 10;
         subsidyDecreaseBlockCount = 100;


### PR DESCRIPTION
This is two commits:

* BitcoinNetworkParams: move spacing, timespan, interval constants from NetworkParameters
  Also rename `INTERVAL` to `INTERVAL_BLOCKS`.

* NetworkParameters: convert spacing and timespans to `java.time.Duration`
