### PR TITLE
Block: separate out testing helpers

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -18,18 +18,14 @@
 package org.bitcoinj.core;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.bitcoinj.base.Address;
-import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Difficulty;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.VarInt;
 import org.bitcoinj.base.internal.Buffers;
-import org.bitcoinj.base.internal.Stopwatch;
 import org.bitcoinj.base.internal.StreamUtils;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.base.internal.InternalUtils;
-import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 import org.slf4j.Logger;
@@ -430,35 +426,6 @@ public class Block implements Message {
             }
         }
         return s.toString();
-    }
-
-    /**
-     * <p>Finds a value of nonce that makes the blocks hash lower than the difficulty target. This is called mining, but
-     * solve() is far too slow to do real mining with. It exists only for unit testing purposes.
-     *
-     * <p>This can loop forever if a solution cannot be found solely by incrementing nonce. It doesn't change
-     * extraNonce.</p>
-     */
-    @VisibleForTesting
-    public void solve() {
-        Duration warningThreshold = Duration.ofSeconds(5);
-        Stopwatch watch = Stopwatch.start();
-        while (true) {
-            try {
-                // Is our proof of work valid yet?
-                if (difficultyTarget.isMetByWork(getHash()))
-                    return;
-                // No, so increment the nonce and try again.
-                setNonce(getNonce() + 1);
-
-                if (watch.isRunning() && watch.elapsed().compareTo(warningThreshold) > 0) {
-                    watch.stop();
-                    log.warn("trying to solve block for longer than {} seconds", warningThreshold.getSeconds());
-                }
-            } catch (VerificationException e) {
-                throw new RuntimeException(e); // Cannot happen.
-            }
-        }
     }
 
     /** @deprecated use {@link #difficultyTarget()} then {@link Difficulty#asInteger()} */
@@ -867,181 +834,6 @@ public class Block implements Message {
         return transactions != null
                 ? transactions.stream().filter(predicate)
                 : Stream.empty();
-    }
-
-    // ///////////////////////////////////////////////////////////////////////////////////////////////
-    // Unit testing related methods.
-
-    // Used to make transactions unique.
-    private static int txCounter;
-
-    /** Adds a coinbase transaction to the block. This exists for unit tests.
-     * 
-     * @param height block height, if known, or -1 otherwise.
-     */
-    // For testing only
-    void addCoinbaseTransaction(byte[] pubKeyTo, Coin value, final int height) {
-        checkState(!isHeaderOnly());
-        checkState(transactions.isEmpty(), () -> "block must not contain transactions");
-        Transaction coinbase = new Transaction();
-        final ScriptBuilder inputBuilder = new ScriptBuilder();
-
-        if (height >= Block.BLOCK_HEIGHT_GENESIS) {
-            inputBuilder.number(height);
-        }
-        inputBuilder.data(new byte[]{(byte) txCounter, (byte) (txCounter++ >> 8)});
-
-        // A real coinbase transaction has some stuff in the scriptSig like the extraNonce and difficulty. The
-        // transactions are distinguished by every TX output going to a different key.
-        //
-        // Here we will do things a bit differently so a new address isn't needed every time. We'll put a simple
-        // counter in the scriptSig so every transaction has a different hash.
-        coinbase.addInput(TransactionInput.coinbaseInput(coinbase,
-                inputBuilder.build().program()));
-        coinbase.addOutput(new TransactionOutput(coinbase, value,
-                ScriptBuilder.createP2PKOutputScript(ECKey.fromPublicOnly(pubKeyTo)).program()));
-        addTransaction(coinbase);
-    }
-
-    private static final byte[] EMPTY_BYTES = new byte[32];
-
-    // It's pretty weak to have this around at runtime: fix later.
-    private static final byte[] pubkeyForTesting = ECKey.random().getPubKey();
-
-    /**
-     * Returns an unsolved block that builds on top of this one. This exists for unit tests.
-     *
-     * @param to      if not null, 50 coins are sent to the address
-     * @param version version of the block to create
-     * @param time    time of the block to create
-     * @param height  block height if known, or -1 otherwise
-     * @return created block
-     */
-    @VisibleForTesting
-    public Block createNextBlock(@Nullable Address to, long version, Instant time, int height) {
-        return createNextBlock(to, version, null, time, pubkeyForTesting, FIFTY_COINS, height);
-    }
-
-    /**
-     * Returns an unsolved block that builds on top of this one. This exists for unit tests.
-     * In this variant you can specify a public key (pubkey) for use in generating coinbase blocks.
-     *
-     * @param to            if not null, 50 coins are sent to the address
-     * @param version       version of the block to create
-     * @param prevOut       previous output to spend by the "50 coins transaction"
-     * @param time          time of the block to create
-     * @param pubKey        for the coinbase
-     * @param coinbaseValue for the coinbase
-     * @param height        block height if known, or -1 otherwise
-     * @return created block
-     */
-    // For testing only
-    Block createNextBlock(@Nullable Address to, long version, @Nullable TransactionOutPoint prevOut, Instant time,
-                          byte[] pubKey, Coin coinbaseValue, int height) {
-        Block b = new Block(version, this.getHash());
-        b.setDifficultyTarget(difficultyTarget);
-        b.addCoinbaseTransaction(pubKey, coinbaseValue, height);
-
-        if (to != null) {
-            // Add a transaction paying 50 coins to the "to" address.
-            Transaction t = new Transaction();
-            t.addOutput(new TransactionOutput(t, FIFTY_COINS, to));
-            // The input does not really need to be a valid signature, as long as it has the right general form.
-            TransactionInput input;
-            if (prevOut == null) {
-                prevOut = new TransactionOutPoint(0, nextTestOutPointHash());
-            }
-            input = new TransactionInput(t, Script.createInputScript(EMPTY_BYTES, EMPTY_BYTES), prevOut);
-            t.addInput(input);
-            b.addTransaction(t);
-        }
-
-        // Don't let timestamp go backwards
-        Instant bitcoinTime = time.truncatedTo(ChronoUnit.SECONDS);
-        if (time().compareTo(bitcoinTime) >= 0)
-            b.setTime(time().plusSeconds(1));
-        else
-            b.setTime(bitcoinTime);
-        if (b.version() != version) {
-            throw new RuntimeException();
-        }
-        return b;
-    }
-
-    // Importantly the outpoint hash cannot be zero as that's how we detect a coinbase transaction in isolation
-    // but it must be unique to avoid 'different' transactions looking the same.
-    private Sha256Hash nextTestOutPointHash() {
-        byte[] counter = new byte[32];
-        counter[0] = (byte) txCounter;
-        counter[1] = (byte) (txCounter++ >> 8);
-        return Sha256Hash.wrap(counter);
-    }
-
-    /**
-     * This method is intended for test use only.
-     *
-     * @param to      if not null, 50 coins are sent to the address
-     * @param prevOut previous output to spend by the "50 coins transaction"
-     * @return created block
-     */
-    @VisibleForTesting
-    public Block createNextBlock(@Nullable Address to, TransactionOutPoint prevOut) {
-        return createNextBlock(to, BLOCK_VERSION_GENESIS, prevOut, time().plusSeconds(5), pubkeyForTesting,
-                FIFTY_COINS, BLOCK_HEIGHT_UNKNOWN);
-    }
-
-    /**
-     * This method is intended for test use only.
-     *
-     * @param to            if not null, 50 coins are sent to the address
-     * @param coinbaseValue for the coinbase
-     * @return created block
-     */
-    @VisibleForTesting
-    public Block createNextBlock(@Nullable Address to, Coin coinbaseValue) {
-        return createNextBlock(to, BLOCK_VERSION_GENESIS, null, time().plusSeconds(5), pubkeyForTesting,
-                coinbaseValue, BLOCK_HEIGHT_UNKNOWN);
-    }
-
-    /**
-     * This method is intended for test use only.
-     *
-     * @param to if not null, 50 coins are sent to the address
-     * @return created block
-     */
-    @VisibleForTesting
-    public Block createNextBlock(@Nullable Address to) {
-        return createNextBlock(to, FIFTY_COINS);
-    }
-
-    /**
-     * This method is intended for test use only.
-     *
-     * @param version       version of the block to create
-     * @param pubKey        for the coinbase
-     * @param coinbaseValue for the coinbase
-     * @param height        block height if known, or -1 otherwise
-     * @return created block
-     */
-    @VisibleForTesting
-    public Block createNextBlockWithCoinbase(long version, byte[] pubKey, Coin coinbaseValue, int height) {
-        return createNextBlock(null, version, (TransactionOutPoint) null, TimeUtils.currentTime(), pubKey,
-                coinbaseValue, height);
-    }
-
-    /**
-     * Create a block sending 50BTC as a coinbase transaction to the public key specified.
-     * This method is intended for test use only.
-     *
-     * @param version version of the block to create
-     * @param pubKey  for the coinbase
-     * @param height  block height if known, or -1 otherwise
-     * @return created block
-     */
-    // For testing only
-    Block createNextBlockWithCoinbase(long version, byte[] pubKey, int height) {
-        return createNextBlock(null, version, (TransactionOutPoint) null, TimeUtils.currentTime(), pubKey,
-                FIFTY_COINS, height);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/TestBlocks.java
+++ b/core/src/main/java/org/bitcoinj/core/TestBlocks.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.core;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.bitcoinj.base.Address;
+import org.bitcoinj.base.Coin;
+import org.bitcoinj.base.Sha256Hash;
+import org.bitcoinj.base.internal.Stopwatch;
+import org.bitcoinj.base.internal.TimeUtils;
+import org.bitcoinj.crypto.ECKey;
+import org.bitcoinj.script.Script;
+import org.bitcoinj.script.ScriptBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static org.bitcoinj.base.Coin.FIFTY_COINS;
+import static org.bitcoinj.base.internal.Preconditions.checkState;
+
+/**
+ * Helpers for creating chains of blocks. All these methods are intended for test use only.
+ */
+@VisibleForTesting
+public class TestBlocks {
+    // TODO move to the test classpath, currently blocked by FakeTxBuilder depending on this
+
+    private static final byte[] EMPTY_BYTES = new byte[32];
+    private static final byte[] pubkeyForTesting = ECKey.random().getPubKey();
+
+    private static final Logger log = LoggerFactory.getLogger(TestBlocks.class);
+
+    /**
+     * Returns an unsolved block that builds on top of the previous one.
+     *
+     * @param prev    previous block to build next block on
+     * @param to      if not null, 50 coins are sent to the address
+     * @param version version of the block to create
+     * @param time    time of the block to create
+     * @param height  block height if known, or -1 otherwise
+     * @return created block
+     */
+    public static Block createNextBlock(Block prev, @Nullable Address to, long version, Instant time, int height) {
+        return createNextBlock(prev, to, version, null, time, pubkeyForTesting, FIFTY_COINS, height);
+    }
+
+    /**
+     * Returns an unsolved block that builds on top of the previous one.
+     * In this variant you can specify a public key (pubkey) for use in generating coinbase blocks.
+     *
+     * @param prev          previous block to build next block on
+     * @param to            if not null, 50 coins are sent to the address
+     * @param version       version of the block to create
+     * @param prevOut       previous output to spend by the "50 coins transaction"
+     * @param time          time of the block to create
+     * @param pubKey        for the coinbase
+     * @param coinbaseValue for the coinbase
+     * @param height        block height if known, or -1 otherwise
+     * @return created block
+     */
+    static Block createNextBlock(Block prev, @Nullable Address to, long version,
+                                 @Nullable TransactionOutPoint prevOut, Instant time, byte[] pubKey,
+                                 Coin coinbaseValue, int height) {
+        Block b = new Block(version, prev.getHash());
+        b.setDifficultyTarget(prev.difficultyTarget());
+        addCoinbaseTransaction(b, pubKey, coinbaseValue, height);
+
+        if (to != null) {
+            // Add a transaction paying 50 coins to the "to" address.
+            Transaction t = new Transaction();
+            t.addOutput(new TransactionOutput(t, FIFTY_COINS, to));
+            // The input does not really need to be a valid signature, as long as it has the right general form.
+            TransactionInput input;
+            if (prevOut == null) {
+                prevOut = new TransactionOutPoint(0, nextTestOutPointHash());
+            }
+            input = new TransactionInput(t, Script.createInputScript(EMPTY_BYTES, EMPTY_BYTES), prevOut);
+            t.addInput(input);
+            b.addTransaction(t);
+        }
+
+        // Don't let timestamp go backwards
+        Instant bitcoinTime = time.truncatedTo(ChronoUnit.SECONDS);
+        if (prev.time().compareTo(bitcoinTime) >= 0)
+            b.setTime(prev.time().plusSeconds(1));
+        else
+            b.setTime(bitcoinTime);
+        if (b.version() != version) {
+            throw new RuntimeException();
+        }
+        return b;
+    }
+
+    // Importantly the outpoint hash cannot be zero as that's how we detect a coinbase transaction in isolation
+    // but it must be unique to avoid 'different' transactions looking the same.
+    private static Sha256Hash nextTestOutPointHash() {
+        byte[] counter = new byte[32];
+        counter[0] = (byte) txCounter;
+        counter[1] = (byte) (txCounter++ >> 8);
+        return Sha256Hash.wrap(counter);
+    }
+
+    /**
+     * @param prev    previous block to build next block on
+     * @param to      if not null, 50 coins are sent to the address
+     * @param prevOut previous output to spend by the "50 coins transaction"
+     * @return created block
+     */
+    public static Block createNextBlock(Block prev, @Nullable Address to, TransactionOutPoint prevOut) {
+        return createNextBlock(prev, to, Block.BLOCK_VERSION_GENESIS, prevOut, prev.time().plusSeconds(5), pubkeyForTesting,
+                FIFTY_COINS, Block.BLOCK_HEIGHT_UNKNOWN);
+    }
+
+    /**
+     * @param prev          previous block to build next block on
+     * @param to            if not null, 50 coins are sent to the address
+     * @param coinbaseValue for the coinbase
+     * @return created block
+     */
+    public static Block createNextBlock(Block prev, @Nullable Address to, Coin coinbaseValue) {
+        return createNextBlock(prev, to, Block.BLOCK_VERSION_GENESIS, null, prev.time().plusSeconds(5), pubkeyForTesting,
+                coinbaseValue, Block.BLOCK_HEIGHT_UNKNOWN);
+    }
+
+    /**
+     * @param prev previous block to build next block on
+     * @param to   if not null, 50 coins are sent to the address
+     * @return created block
+     */
+    public static Block createNextBlock(Block prev, @Nullable Address to) {
+        return createNextBlock(prev, to, FIFTY_COINS);
+    }
+
+    /**
+     * @param prev          previous block to build next block on
+     * @param version       version of the block to create
+     * @param pubKey        for the coinbase
+     * @param coinbaseValue for the coinbase
+     * @param height        block height if known, or -1 otherwise
+     * @return created block
+     */
+    public static Block createNextBlockWithCoinbase(Block prev, long version, byte[] pubKey, Coin coinbaseValue,
+                                                    int height) {
+        return createNextBlock(prev, null, version, (TransactionOutPoint) null, TimeUtils.currentTime(), pubKey,
+                coinbaseValue, height);
+    }
+
+    /**
+     * Create a block sending 50BTC as a coinbase transaction to the public key specified.
+     *
+     * @param prev    previous block to build next block on
+     * @param version version of the block to create
+     * @param pubKey  for the coinbase
+     * @param height  block height if known, or -1 otherwise
+     * @return created block
+     */
+    static Block createNextBlockWithCoinbase(Block prev, long version, byte[] pubKey, int height) {
+        return createNextBlock(prev, null, version, (TransactionOutPoint) null, TimeUtils.currentTime(), pubKey,
+                FIFTY_COINS, height);
+    }
+
+    /**
+     * Finds a value of nonce that makes the blocks hash lower than the difficulty target. This is called mining, but
+     * solving with the CPU is far too slow to do real mining with. It exists only for unit testing purposes.
+     * <p>
+     * This can loop forever if a solution cannot be found solely by incrementing nonce. It doesn't change
+     * extraNonce.
+     *
+     * @param block block to solve
+     */
+    public static void solve(Block block) {
+        Duration warningThreshold = Duration.ofSeconds(5);
+        Stopwatch watch = Stopwatch.start();
+        while (true) {
+            try {
+                // Is our proof of work valid yet?
+                if (block.difficultyTarget().isMetByWork(block.getHash()))
+                    return;
+                // No, so increment the nonce and try again.
+                block.setNonce(block.getNonce() + 1);
+
+                if (watch.isRunning() && watch.elapsed().compareTo(warningThreshold) > 0) {
+                    watch.stop();
+                    log.warn("trying to solve block for longer than {} seconds", warningThreshold.getSeconds());
+                }
+            } catch (VerificationException e) {
+                throw new RuntimeException(e); // Cannot happen.
+            }
+        }
+    }
+
+    // Used to make transactions unique.
+    private static int txCounter;
+
+    /**
+     * Adds a coinbase transaction to the given block.
+     *
+     * @param block  block to add coinbase transaction to
+     * @param height block height, if known, or -1 otherwise.
+     */
+    static void addCoinbaseTransaction(Block block, byte[] pubKeyTo, Coin value, final int height) {
+        checkState(!block.isHeaderOnly());
+        checkState(!block.hasTransactions(), () -> "block must not contain transactions");
+        Transaction coinbase = new Transaction();
+        final ScriptBuilder inputBuilder = new ScriptBuilder();
+
+        if (height >= Block.BLOCK_HEIGHT_GENESIS) {
+            inputBuilder.number(height);
+        }
+        inputBuilder.data(new byte[]{(byte) txCounter, (byte) (txCounter++ >> 8)});
+
+        // A real coinbase transaction has some stuff in the scriptSig like the extraNonce and difficulty. The
+        // transactions are distinguished by every TX output going to a different key.
+        //
+        // Here we will do things a bit differently so a new address isn't needed every time. We'll put a simple
+        // counter in the scriptSig so every transaction has a different hash.
+        coinbase.addInput(TransactionInput.coinbaseInput(coinbase,
+                inputBuilder.build().program()));
+        coinbase.addOutput(new TransactionOutput(coinbase, value,
+                ScriptBuilder.createP2PKOutputScript(ECKey.fromPublicOnly(pubKeyTo)).program()));
+        block.addTransaction(coinbase);
+    }
+}

--- a/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
+++ b/core/src/main/java/org/bitcoinj/params/UnitTestParams.java
@@ -21,10 +21,11 @@ import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Difficulty;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.core.Block;
+import org.bitcoinj.core.TestBlocks;
 
 /**
  * Network parameters used by the bitcoinj unit tests (and potentially your own). This lets you solve a block using
- * {@link Block#solve()} by setting difficulty to the easiest possible.
+ * {@link TestBlocks#solve(Block)} by setting difficulty to the easiest possible.
  */
 public class UnitTestParams extends BitcoinNetworkParams {
     public static final int UNITNET_MAJORITY_WINDOW = 8;

--- a/core/src/main/java/org/bitcoinj/testing/FakeTxBuilder.java
+++ b/core/src/main/java/org/bitcoinj/testing/FakeTxBuilder.java
@@ -25,6 +25,7 @@ import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.base.Coin;
+import org.bitcoinj.core.TestBlocks;
 import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.core.ProtocolException;
 import org.bitcoinj.base.Sha256Hash;
@@ -268,7 +269,7 @@ public class FakeTxBuilder {
                                             Instant time, int height, Transaction... transactions) {
         try {
             Block previousBlock = previousStoredBlock.getHeader();
-            Block b = previousBlock.createNextBlock(null, version, time, height);
+            Block b = TestBlocks.createNextBlock(previousBlock,null, version, time, height);
             // Coinbase tx was already added.
             for (Transaction tx : transactions) {
                 tx.getConfidence().maybeSetSourceToNetwork();
@@ -310,7 +311,7 @@ public class FakeTxBuilder {
 
     /** Creates an unsolved, but otherwise valid block that builds on top of the chain. */
     public static Block makeTestBlock(BlockStore blockStore, Address coinsTo) throws BlockStoreException {
-        return blockStore.getChainHead().getHeader().createNextBlock(coinsTo);
+        return TestBlocks.createNextBlock(blockStore.getChainHead().getHeader(), coinsTo);
     }
 
     /** Creates an unsolved, but otherwise valid block that builds on top of the chain. */
@@ -320,7 +321,7 @@ public class FakeTxBuilder {
 
     /** Creates an unsolved, but otherwise valid block that builds on top of the chain. */
     public static Block makeTestBlock(Block prev, @Nullable Address to, Transaction... transactions) throws BlockStoreException {
-        Block b = prev.createNextBlock(to);
+        Block b = TestBlocks.createNextBlock(prev, to);
         // Coinbase tx already exists.
         for (Transaction tx : transactions) {
             b.addTransaction(tx);

--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -150,17 +150,17 @@ public abstract class AbstractFullPrunedBlockChainTest {
         int height = 1;
 
         // Build some blocks on genesis block to create a spendable output
-        Block rollingBlock = PARAMS.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
-        rollingBlock.solve();
+        Block rollingBlock = TestBlocks.createNextBlockWithCoinbase(PARAMS.getGenesisBlock(), Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
+        TestBlocks.solve(rollingBlock);
         chain.add(rollingBlock);
         TransactionOutput spendableOutput = rollingBlock.transaction(0).getOutput(0);
         for (int i = 1; i < PARAMS.getSpendableCoinbaseDepth(); i++) {
-            rollingBlock = rollingBlock.createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
-            rollingBlock.solve();
+            rollingBlock = TestBlocks.createNextBlockWithCoinbase(rollingBlock, Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
+            TestBlocks.solve(rollingBlock);
             chain.add(rollingBlock);
         }
 
-        rollingBlock = rollingBlock.createNextBlock(null);
+        rollingBlock = TestBlocks.createNextBlock(rollingBlock, null);
         Transaction t = new Transaction();
         t.addOutput(new TransactionOutput(t, FIFTY_COINS, new byte[] {}));
         TransactionInput input = t.addInput(spendableOutput);
@@ -168,7 +168,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         input = input.withoutScriptBytes();
         t.replaceInput(t.getInputs().size() - 1, input);
         rollingBlock.addTransaction(t);
-        rollingBlock.solve();
+        TestBlocks.solve(rollingBlock);
         chain.setRunScripts(false);
         try {
             chain.add(rollingBlock);
@@ -193,28 +193,28 @@ public abstract class AbstractFullPrunedBlockChainTest {
         int height = 1;
 
         // Build some blocks on genesis block to create a spendable output
-        Block rollingBlock = PARAMS.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
-        rollingBlock.solve();
+        Block rollingBlock = TestBlocks.createNextBlockWithCoinbase(PARAMS.getGenesisBlock(), Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
+        TestBlocks.solve(rollingBlock);
         chain.add(rollingBlock);
         TransactionOutput spendableOutput = rollingBlock.transaction(0).getOutput(0);
         TransactionOutPoint transactionOutPoint = spendableOutput.getOutPointFor();
         Script spendableOutputScriptPubKey = spendableOutput.getScriptPubKey();
         for (int i = 1; i < PARAMS.getSpendableCoinbaseDepth(); i++) {
-            rollingBlock = rollingBlock.createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
-            rollingBlock.solve();
+            rollingBlock = TestBlocks.createNextBlockWithCoinbase(rollingBlock, Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
+            TestBlocks.solve(rollingBlock);
             chain.add(rollingBlock);
         }
         
         WeakReference<UTXO> out = new WeakReference<>
                 (store.getTransactionOutput(transactionOutPoint.hash(), transactionOutPoint.index()));
-        rollingBlock = rollingBlock.createNextBlock(null);
+        rollingBlock = TestBlocks.createNextBlock(rollingBlock, null);
         
         Transaction t = new Transaction();
         // Entirely invalid scriptPubKey
         t.addOutput(new TransactionOutput(t, FIFTY_COINS, new byte[]{}));
         t.addSignedInput(transactionOutPoint, spendableOutputScriptPubKey, spendableOutput.getValue(), outKey);
         rollingBlock.addTransaction(t);
-        rollingBlock.solve();
+        TestBlocks.solve(rollingBlock);
         
         chain.add(rollingBlock);
         WeakReference<StoredUndoableBlock> undoBlock = new WeakReference<>(store.getUndoBlock(rollingBlock.getHash()));
@@ -228,8 +228,8 @@ public abstract class AbstractFullPrunedBlockChainTest {
         
         // Create a chain longer than UNDOABLE_BLOCKS_STORED
         for (int i = 0; i < UNDOABLE_BLOCKS_STORED; i++) {
-            rollingBlock = rollingBlock.createNextBlock(null);
-            rollingBlock.solve();
+            rollingBlock = TestBlocks.createNextBlock(rollingBlock, null);
+            TestBlocks.solve(rollingBlock);
             chain.add(rollingBlock);
         }
         // Try to get the garbage collector to run
@@ -269,19 +269,19 @@ public abstract class AbstractFullPrunedBlockChainTest {
         int height = 1;
 
         // Build some blocks on genesis block to create a spendable output
-        Block rollingBlock = PARAMS.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
-        rollingBlock.solve();
+        Block rollingBlock = TestBlocks.createNextBlockWithCoinbase(PARAMS.getGenesisBlock(), Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
+        TestBlocks.solve(rollingBlock);
         chain.add(rollingBlock);
         Transaction transaction = rollingBlock.transaction(0);
         TransactionOutput spendableOutput = transaction.getOutput(0);
         TransactionOutPoint spendableOutputPoint = spendableOutput.getOutPointFor();
         Script spendableOutputScriptPubKey = spendableOutput.getScriptPubKey();
         for (int i = 1; i < PARAMS.getSpendableCoinbaseDepth(); i++) {
-            rollingBlock = rollingBlock.createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
-            rollingBlock.solve();
+            rollingBlock = TestBlocks.createNextBlockWithCoinbase(rollingBlock, Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
+            TestBlocks.solve(rollingBlock);
             chain.add(rollingBlock);
         }
-        rollingBlock = rollingBlock.createNextBlock(null);
+        rollingBlock = TestBlocks.createNextBlock(rollingBlock, null);
 
         // Create bitcoin spend of 1 BTC.
         ECKey toKey = ECKey.random();
@@ -293,7 +293,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         t.addOutput(new TransactionOutput(t, amount, toKey));
         t.addSignedInput(spendableOutputPoint, spendableOutputScriptPubKey, spendableOutput.getValue(), outKey);
         rollingBlock.addTransaction(t);
-        rollingBlock.solve();
+        TestBlocks.solve(rollingBlock);
         chain.add(rollingBlock);
         totalAmount = totalAmount.add(amount);
 
@@ -323,19 +323,19 @@ public abstract class AbstractFullPrunedBlockChainTest {
         int height = 1;
 
         // Build some blocks on genesis block to create a spendable output.
-        Block rollingBlock = PARAMS.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
-        rollingBlock.solve();
+        Block rollingBlock = TestBlocks.createNextBlockWithCoinbase(PARAMS.getGenesisBlock(), Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
+        TestBlocks.solve(rollingBlock);
         chain.add(rollingBlock);
         Transaction transaction = rollingBlock.transaction(0);
         TransactionOutput spendableOutput = transaction.getOutput(0);
         TransactionOutPoint spendableOutPoint = new TransactionOutPoint(0, transaction.getTxId());
         Script spendableOutputScriptPubKey = spendableOutput.getScriptPubKey();
         for (int i = 1; i < PARAMS.getSpendableCoinbaseDepth(); i++) {
-            rollingBlock = rollingBlock.createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
-            rollingBlock.solve();
+            rollingBlock = TestBlocks.createNextBlockWithCoinbase(rollingBlock, Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
+            TestBlocks.solve(rollingBlock);
             chain.add(rollingBlock);
         }
-        rollingBlock = rollingBlock.createNextBlock(null);
+        rollingBlock = TestBlocks.createNextBlock(rollingBlock, null);
 
         // Create 1 BTC spend to a key in this wallet (to ourselves).
         Wallet wallet = Wallet.createDeterministic(PARAMS.network(), ScriptType.P2PKH);
@@ -350,7 +350,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         t.addOutput(new TransactionOutput(t, amount, toKey));
         t.addSignedInput(spendableOutPoint, spendableOutputScriptPubKey, spendableOutput.getValue(), outKey);
         rollingBlock.addTransaction(t);
-        rollingBlock.solve();
+        TestBlocks.solve(rollingBlock);
         chain.add(rollingBlock);
 
         // Create another spend of 1/2 the value of BTC we have available using the wallet (store coin selector).
@@ -396,33 +396,33 @@ public abstract class AbstractFullPrunedBlockChainTest {
 
             // Put in just enough v1 blocks to stop the v2 blocks from forming a majority
             for (height = 1; height <= (PARAMS.getMajorityWindow() - PARAMS.getMajorityEnforceBlockUpgrade()); height++) {
-                chainHead = chainHead.createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS,
+                chainHead = TestBlocks.createNextBlockWithCoinbase(chainHead, Block.BLOCK_VERSION_GENESIS,
                     outKey.getPubKey(), height);
-                chainHead.solve();
+                TestBlocks.solve(chainHead);
                 chain.add(chainHead);
             }
 
             // Fill the rest of the window in with v2 blocks
             for (; height < PARAMS.getMajorityWindow(); height++) {
-                chainHead = chainHead.createNextBlockWithCoinbase(Block.BLOCK_VERSION_BIP34,
+                chainHead = TestBlocks.createNextBlockWithCoinbase(chainHead, Block.BLOCK_VERSION_BIP34,
                     outKey.getPubKey(), height);
-                chainHead.solve();
+                TestBlocks.solve(chainHead);
                 chain.add(chainHead);
             }
             // Throw a broken v2 block in before we have a supermajority to enable
             // enforcement, which should validate as-is
-            chainHead = chainHead.createNextBlockWithCoinbase(Block.BLOCK_VERSION_BIP34,
+            chainHead = TestBlocks.createNextBlockWithCoinbase(chainHead, Block.BLOCK_VERSION_BIP34,
                 outKey.getPubKey(), height * 2);
-            chainHead.solve();
+            TestBlocks.solve(chainHead);
             chain.add(chainHead);
             height++;
 
             // Trying to add a broken v2 block should now result in rejection as
             // we have a v2 supermajority
             thrown.expect(VerificationException.CoinbaseHeightMismatch.class);
-            chainHead = chainHead.createNextBlockWithCoinbase(Block.BLOCK_VERSION_BIP34,
+            chainHead = TestBlocks.createNextBlockWithCoinbase(chainHead, Block.BLOCK_VERSION_BIP34,
                 outKey.getPubKey(), height * 2);
-            chainHead.solve();
+            TestBlocks.solve(chainHead);
             chain.add(chainHead);
         }  catch(final VerificationException ex) {
             throw (Exception) ex.getCause();

--- a/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
@@ -127,9 +127,9 @@ public class BlockChainTest {
     @Test
     public void unconnectedBlocks() throws Exception {
         Context.propagate(new Context(100, Coin.ZERO, false, true));
-        Block b1 = TESTNET.getGenesisBlock().createNextBlock(coinbaseTo);
-        Block b2 = b1.createNextBlock(coinbaseTo);
-        Block b3 = b2.createNextBlock(coinbaseTo);
+        Block b1 = TestBlocks.createNextBlock(TESTNET.getGenesisBlock(), coinbaseTo);
+        Block b2 = TestBlocks.createNextBlock(b1, coinbaseTo);
+        Block b3 = TestBlocks.createNextBlock(b2, coinbaseTo);
         // Connected.
         assertTrue(testNetChain.add(b1));
         // Unconnected but stored. The head of the chain is still b1.
@@ -149,7 +149,7 @@ public class BlockChainTest {
         Instant newTime = prev.time().plus(spacing);
         for (int i = 1; i < interval; i++) {
             newTime = newTime.plus(spacing);
-            Block newBlock = prev.createNextBlock(null, 1, newTime, epoch * interval + i);
+            Block newBlock = TestBlocks.createNextBlock(prev, null, 1, newTime, epoch * interval + i);
             assertTrue(chain.add(newBlock));
             prev = newBlock;
         }
@@ -159,7 +159,7 @@ public class BlockChainTest {
         int interval = chain.params.interval;
         Block prev = chain.getChainHead().getHeader();
         Instant newTime = prev.time().plus(spacing);
-        Block newBlock = prev.createNextBlock(null, 1, newTime, epoch * interval);
+        Block newBlock = TestBlocks.createNextBlock(prev, null, 1, newTime, epoch * interval);
         assertTrue(chain.add(newBlock));
     }
 
@@ -208,7 +208,7 @@ public class BlockChainTest {
         // genesis block is already there
         Block prev = chain.getChainHead().getHeader();
         Instant newTime = prev.time().plus(Duration.ofMinutes(10));
-        Block newBlock = prev.createNextBlock(null, 1, newTime, 1);
+        Block newBlock = TestBlocks.createNextBlock(prev, null, 1, newTime, 1);
         newBlock.setDifficultyTarget(Difficulty.ofCompact(newBlock.difficultyTarget().compact() + 10));
         assertTrue(chain.add(newBlock));
     }
@@ -292,9 +292,9 @@ public class BlockChainTest {
     public void duplicates() throws Exception {
         Context.propagate(new Context(100, Coin.ZERO, false, true));
         // Adding a block twice should not have any effect, in particular it should not send the block to the wallet.
-        Block b1 = TESTNET.getGenesisBlock().createNextBlock(coinbaseTo);
-        Block b2 = b1.createNextBlock(coinbaseTo);
-        Block b3 = b2.createNextBlock(coinbaseTo);
+        Block b1 = TestBlocks.createNextBlock(TESTNET.getGenesisBlock(), coinbaseTo);
+        Block b2 = TestBlocks.createNextBlock(b1, coinbaseTo);
+        Block b3 = TestBlocks.createNextBlock(b2, coinbaseTo);
         assertTrue(testNetChain.add(b1));
         assertEquals(b1, testNetChain.getChainHead().getHeader());
         assertTrue(testNetChain.add(b2));
@@ -311,7 +311,7 @@ public class BlockChainTest {
         // Covers issue 166 in which transactions that depend on each other inside a block were not always being
         // considered relevant.
         Address somebodyElse = ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
-        Block b1 = TESTNET.getGenesisBlock().createNextBlock(somebodyElse);
+        Block b1 = TestBlocks.createNextBlock(TESTNET.getGenesisBlock(), somebodyElse);
         ECKey key = testNetWallet.freshReceiveKey();
         Address addr = key.toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
         // Create a tx that gives us some coins, and another that spends it to someone else in the same block.
@@ -339,7 +339,7 @@ public class BlockChainTest {
         Address addressToSendTo = receiveKey.toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
 
         // Create a block, sending the coinbase to the coinbaseTo address (which is in the wallet).
-        Block b1 = TESTNET.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, testNetWallet.currentReceiveKey().getPubKey(), height++);
+        Block b1 = TestBlocks.createNextBlockWithCoinbase(TESTNET.getGenesisBlock(), Block.BLOCK_VERSION_GENESIS, testNetWallet.currentReceiveKey().getPubKey(), height++);
         testNetChain.add(b1);
         final Transaction coinbaseTransaction = b1.transaction(0);
 
@@ -479,8 +479,8 @@ public class BlockChainTest {
         Context.propagate(new Context(100, Coin.ZERO, false, true));
         // This test simulates an issue on Android, that causes the VM to crash while receiving a block, so that the
         // block store is persisted but the wallet is not.
-        Block b1 = TESTNET.getGenesisBlock().createNextBlock(coinbaseTo);
-        Block b2 = b1.createNextBlock(coinbaseTo);
+        Block b1 = TestBlocks.createNextBlock(TESTNET.getGenesisBlock(), coinbaseTo);
+        Block b2 = TestBlocks.createNextBlock(b1, coinbaseTo);
         // Add block 1, no frills.
         assertTrue(testNetChain.add(b1));
         assertEquals(b1.asHeader(), testNetChain.getChainHead().getHeader());

--- a/core/src/test/java/org/bitcoinj/core/BlockTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockTest.java
@@ -123,7 +123,7 @@ public class BlockTest {
             // Expected to fail as the nonce is no longer correct.
         }
         // Should find an acceptable nonce.
-        block.solve();
+        TestBlocks.solve(block);
         Block.verify(TWEAK_TESTNET, block, Block.BLOCK_HEIGHT_GENESIS, EnumSet.noneOf(Block.VerifyFlag.class));
     }
 

--- a/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
@@ -92,8 +92,8 @@ public class ChainSplitTest {
         wallet.addChangeEventListener(wallet -> walletChanged.incrementAndGet());
 
         // Start by building a couple of blocks on top of the genesis block.
-        Block b1 = TESTNET.getGenesisBlock().createNextBlock(coinsTo);
-        Block b2 = b1.createNextBlock(coinsTo);
+        Block b1 = TestBlocks.createNextBlock(TESTNET.getGenesisBlock(), coinsTo);
+        Block b2 = TestBlocks.createNextBlock(b1, coinsTo);
         assertTrue(chain.add(b1));
         assertTrue(chain.add(b2));
         Threading.waitForUserCode();
@@ -110,7 +110,7 @@ public class ChainSplitTest {
         //                  \-> b3
         //
         // Nothing should happen at this point. We saw b2 first so it takes priority.
-        Block b3 = b1.createNextBlock(someOtherGuy);
+        Block b3 = TestBlocks.createNextBlock(b1, someOtherGuy);
         assertTrue(chain.add(b3));
         Threading.waitForUserCode();
         assertFalse(reorgHappened.get());  // No re-org took place.
@@ -122,9 +122,9 @@ public class ChainSplitTest {
         //                  |-> b3
         //                  |-> b7 (x)
         //                  \-> b8 (x)
-        Block b7 = b1.createNextBlock(coinsTo);
+        Block b7 = TestBlocks.createNextBlock(b1, coinsTo);
         assertTrue(chain.add(b7));
-        Block b8 = b1.createNextBlock(coinsTo);
+        Block b8 = TestBlocks.createNextBlock(b1, coinsTo);
         final Transaction t = b7.transaction(1);
         final Sha256Hash tHash = t.getTxId();
         b8.addTransaction(t);
@@ -135,7 +135,7 @@ public class ChainSplitTest {
         assertEquals(5, walletChanged.get());
         assertEquals(Coin.valueOf(100, 0), wallet.getBalance());
         // Now we add another block to make the alternative chain longer.
-        assertTrue(chain.add(b3.createNextBlock(someOtherGuy)));
+        assertTrue(chain.add(TestBlocks.createNextBlock(b3, someOtherGuy)));
         Threading.waitForUserCode();
         assertTrue(reorgHappened.get());  // Re-org took place.
         assertEquals(6, walletChanged.get());
@@ -147,8 +147,8 @@ public class ChainSplitTest {
         // It's now pending reconfirmation.
         assertEquals(FIFTY_COINS, wallet.getBalance());
         // ... and back to the first chain.
-        Block b5 = b2.createNextBlock(coinsTo);
-        Block b6 = b5.createNextBlock(coinsTo);
+        Block b5 = TestBlocks.createNextBlock(b2, coinsTo);
+        Block b6 = TestBlocks.createNextBlock(b5, coinsTo);
         assertTrue(chain.add(b5));
         assertTrue(chain.add(b6));
         //
@@ -165,15 +165,15 @@ public class ChainSplitTest {
     public void testForking2() throws Exception {
         // Check that if the chain forks and new coins are received in the alternate chain our balance goes up
         // after the re-org takes place.
-        Block b1 = TESTNET.getGenesisBlock().createNextBlock(someOtherGuy);
-        Block b2 = b1.createNextBlock(someOtherGuy);
+        Block b1 = TestBlocks.createNextBlock(TESTNET.getGenesisBlock(), someOtherGuy);
+        Block b2 = TestBlocks.createNextBlock(b1, someOtherGuy);
         assertTrue(chain.add(b1));
         assertTrue(chain.add(b2));
         //     genesis -> b1 -> b2
         //                  \-> b3 -> b4
         assertEquals(Coin.ZERO, wallet.getBalance());
-        Block b3 = b1.createNextBlock(coinsTo);
-        Block b4 = b3.createNextBlock(someOtherGuy);
+        Block b3 = TestBlocks.createNextBlock(b1, coinsTo);
+        Block b4 = TestBlocks.createNextBlock(b3, someOtherGuy);
         assertTrue(chain.add(b3));
         assertEquals(Coin.ZERO, wallet.getBalance());
         assertTrue(chain.add(b4));
@@ -183,7 +183,7 @@ public class ChainSplitTest {
     @Test
     public void testForking3() throws Exception {
         // Check that we can handle our own spends being rolled back by a fork.
-        Block b1 = TESTNET.getGenesisBlock().createNextBlock(coinsTo);
+        Block b1 = TestBlocks.createNextBlock(TESTNET.getGenesisBlock(), coinsTo);
         chain.add(b1);
         assertEquals(FIFTY_COINS, wallet.getBalance());
         Address dest = ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
@@ -195,15 +195,15 @@ public class ChainSplitTest {
         spend.getConfidence().markBroadcastBy(PeerAddress.simple(InetAddress.getByAddress(new byte[]{5,6,7,8}), TESTNET.getPort()));
         assertEquals(ConfidenceType.PENDING, spend.getConfidence().getConfidenceType());
         assertEquals(valueOf(40, 0), wallet.getBalance());
-        Block b2 = b1.createNextBlock(someOtherGuy);
+        Block b2 = TestBlocks.createNextBlock(b1, someOtherGuy);
         b2.addTransaction(spend);
         chain.add(roundtrip(b2));
         // We have 40 coins in change.
         assertEquals(ConfidenceType.BUILDING, spend.getConfidence().getConfidenceType());
         // genesis -> b1 (receive coins) -> b2 (spend coins)
         //                               \-> b3 -> b4
-        Block b3 = b1.createNextBlock(someOtherGuy);
-        Block b4 = b3.createNextBlock(someOtherGuy);
+        Block b3 = TestBlocks.createNextBlock(b1, someOtherGuy);
+        Block b4 = TestBlocks.createNextBlock(b3, someOtherGuy);
         chain.add(b3);
         chain.add(b4);
         // b4 causes a re-org that should make our spend go pending again.
@@ -216,7 +216,7 @@ public class ChainSplitTest {
         // Check that we can handle external spends on an inactive chain becoming active. An external spend is where
         // we see a transaction that spends our own coins but we did not broadcast it ourselves. This happens when
         // keys are being shared between wallets.
-        Block b1 = TESTNET.getGenesisBlock().createNextBlock(coinsTo);
+        Block b1 = TestBlocks.createNextBlock(TESTNET.getGenesisBlock(), coinsTo);
         chain.add(b1);
         assertEquals(FIFTY_COINS, wallet.getBalance());
         Address dest = ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
@@ -226,16 +226,16 @@ public class ChainSplitTest {
         //
         // genesis -> b1 (receive 50) --> b2
         //                            \-> b3 (external spend) -> b4
-        Block b2 = b1.createNextBlock(someOtherGuy);
+        Block b2 = TestBlocks.createNextBlock(b1, someOtherGuy);
         chain.add(b2);
-        Block b3 = b1.createNextBlock(someOtherGuy);
+        Block b3 = TestBlocks.createNextBlock(b1, someOtherGuy);
         b3.addTransaction(spend);
         chain.add(roundtrip(b3));
         // The external spend is now pending.
         assertEquals(ZERO, wallet.getBalance());
         Transaction tx = wallet.getTransaction(spend.getTxId());
         assertEquals(ConfidenceType.PENDING, tx.getConfidence().getConfidenceType());
-        Block b4 = b3.createNextBlock(someOtherGuy);
+        Block b4 = TestBlocks.createNextBlock(b3, someOtherGuy);
         chain.add(b4);
         // The external spend is now active.
         assertEquals(ZERO, wallet.getBalance());
@@ -245,13 +245,13 @@ public class ChainSplitTest {
     @Test
     public void testForking5() throws Exception {
         // Test the standard case in which a block containing identical transactions appears on a side chain.
-        Block b1 = TESTNET.getGenesisBlock().createNextBlock(coinsTo);
+        Block b1 = TestBlocks.createNextBlock(TESTNET.getGenesisBlock(), coinsTo);
         chain.add(b1);
         final Transaction t = b1.transaction(1);
         assertEquals(FIFTY_COINS, wallet.getBalance());
         // genesis -> b1
         //         -> b2
-        Block b2 = TESTNET.getGenesisBlock().createNextBlock(coinsTo);
+        Block b2 = TestBlocks.createNextBlock(TESTNET.getGenesisBlock(), coinsTo);
         Transaction b2coinbase = b2.transaction(0);
         b2.replaceTransactions(Arrays.asList(b2coinbase, t));
         chain.add(roundtrip(b2));
@@ -259,7 +259,7 @@ public class ChainSplitTest {
         assertTrue(wallet.isConsistent());
         assertEquals(2, wallet.getTransaction(t.getTxId()).getAppearsInHashes().size());
         //          -> b2 -> b3
-        Block b3 = b2.createNextBlock(someOtherGuy);
+        Block b3 = TestBlocks.createNextBlock(b2, someOtherGuy);
         chain.add(b3);
         assertEquals(FIFTY_COINS, wallet.getBalance());
 
@@ -272,16 +272,16 @@ public class ChainSplitTest {
     @Test
     public void testForking6() throws Exception {
         // Test the case in which a side chain block contains a tx, and then it appears in the best chain too.
-        Block b1 = TESTNET.getGenesisBlock().createNextBlock(someOtherGuy);
+        Block b1 = TestBlocks.createNextBlock(TESTNET.getGenesisBlock(), someOtherGuy);
         chain.add(b1);
         // genesis -> b1
         //         -> b2
-        Block b2 = TESTNET.getGenesisBlock().createNextBlock(coinsTo);
+        Block b2 = TestBlocks.createNextBlock(TESTNET.getGenesisBlock(), coinsTo);
         chain.add(b2);
         assertEquals(Coin.ZERO, wallet.getBalance());
         // genesis -> b1 -> b3
         //         -> b2
-        Block b3 = b1.createNextBlock(someOtherGuy);
+        Block b3 = TestBlocks.createNextBlock(b1, someOtherGuy);
         b3.addTransaction(b2.transaction(1));
         chain.add(roundtrip(b3));
         assertEquals(FIFTY_COINS, wallet.getBalance());
@@ -298,7 +298,7 @@ public class ChainSplitTest {
                 eventCalled[0] = true;
         });
 
-        Block b1 = TESTNET.getGenesisBlock().createNextBlock(coinsTo);
+        Block b1 = TestBlocks.createNextBlock(TESTNET.getGenesisBlock(), coinsTo);
         chain.add(b1);
 
         Transaction t1 = wallet.createSend(someOtherGuy, valueOf(10, 0));
@@ -306,15 +306,15 @@ public class ChainSplitTest {
         Transaction t2 = wallet.createSend(yetAnotherGuy, valueOf(20, 0));
         wallet.commitTx(t1);
         // Receive t1 as confirmed by the network.
-        Block b2 = b1.createNextBlock(ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET));
+        Block b2 = TestBlocks.createNextBlock(b1, ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET));
         b2.addTransaction(t1);
         chain.add(roundtrip(b2));
 
         // Now we make a double spend become active after a re-org.
-        Block b3 = b1.createNextBlock(ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET));
+        Block b3 = TestBlocks.createNextBlock(b1, ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET));
         b3.addTransaction(t2);
         chain.add(roundtrip(b3));  // Side chain.
-        Block b4 = b3.createNextBlock(ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET));
+        Block b4 = TestBlocks.createNextBlock(b3, ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET));
         chain.add(b4);  // New best chain.
         Threading.waitForUserCode();
         // Should have seen a double spend.
@@ -336,7 +336,7 @@ public class ChainSplitTest {
         });
 
         // Start with 50 coins.
-        Block b1 = TESTNET.getGenesisBlock().createNextBlock(coinsTo);
+        Block b1 = TestBlocks.createNextBlock(TESTNET.getGenesisBlock(), coinsTo);
         chain.add(b1);
 
         Transaction t1 = Objects.requireNonNull(wallet.createSend(someOtherGuy, valueOf(10, 0)));
@@ -344,7 +344,7 @@ public class ChainSplitTest {
         Transaction t2 = Objects.requireNonNull(wallet.createSend(yetAnotherGuy, valueOf(20, 0)));
         wallet.commitTx(t1);
         // t1 is still pending ...
-        Block b2 = b1.createNextBlock(ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET));
+        Block b2 = TestBlocks.createNextBlock(b1, ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET));
         chain.add(b2);
         assertEquals(ZERO, wallet.getBalance());
         assertEquals(valueOf(40, 0), wallet.getBalance(Wallet.BalanceType.ESTIMATED));
@@ -352,10 +352,10 @@ public class ChainSplitTest {
         // Now we make a double spend become active after a re-org.
         // genesis -> b1 -> b2 [t1 pending]
         //              \-> b3 (t2) -> b4
-        Block b3 = b1.createNextBlock(ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET));
+        Block b3 = TestBlocks.createNextBlock(b1, ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET));
         b3.addTransaction(t2);
         chain.add(roundtrip(b3));  // Side chain.
-        Block b4 = b3.createNextBlock(ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET));
+        Block b4 = TestBlocks.createNextBlock(b3, ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET));
         chain.add(b4);  // New best chain.
         Threading.waitForUserCode();
         // Should have seen a double spend against the pending pool.
@@ -366,9 +366,9 @@ public class ChainSplitTest {
         assertEquals(valueOf(30, 0), wallet.getBalance());
 
         // ... and back to our own parallel universe.
-        Block b5 = b2.createNextBlock(ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET));
+        Block b5 = TestBlocks.createNextBlock(b2, ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET));
         chain.add(b5);
-        Block b6 = b5.createNextBlock(ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET));
+        Block b6 = TestBlocks.createNextBlock(b5, ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET));
         chain.add(b6);
         // genesis -> b1 -> b2 -> b5 -> b6 [t1 still dead]
         //              \-> b3 [t2 resurrected and now pending] -> b4
@@ -389,11 +389,11 @@ public class ChainSplitTest {
         wallet.addCoinsReceivedEventListener((wallet, tx, prevBalance, newBalance) -> txns.add(tx));
 
         // Start by building three blocks on top of the genesis block. All send to us.
-        Block b1 = TESTNET.getGenesisBlock().createNextBlock(coinsTo);
+        Block b1 = TestBlocks.createNextBlock(TESTNET.getGenesisBlock(), coinsTo);
         BigInteger work1 = b1.getWork();
-        Block b2 = b1.createNextBlock(coinsTo2);
+        Block b2 = TestBlocks.createNextBlock(b1, coinsTo2);
         BigInteger work2 = b2.getWork();
-        Block b3 = b2.createNextBlock(coinsTo2);
+        Block b3 = TestBlocks.createNextBlock(b2, coinsTo2);
         BigInteger work3 = b3.getWork();
 
         assertTrue(chain.add(b1));
@@ -420,10 +420,10 @@ public class ChainSplitTest {
         //                  \-> b4 -> b5
         //
         // Nothing should happen at this point. We saw b2 and b3 first so it takes priority.
-        Block b4 = b1.createNextBlock(someOtherGuy);
+        Block b4 = TestBlocks.createNextBlock(b1, someOtherGuy);
         BigInteger work4 = b4.getWork();
 
-        Block b5 = b4.createNextBlock(someOtherGuy);
+        Block b5 = TestBlocks.createNextBlock(b4, someOtherGuy);
         BigInteger work5 = b5.getWork();
 
         assertTrue(chain.add(b4));
@@ -440,7 +440,7 @@ public class ChainSplitTest {
         assertEquals(1, txns.get(2).getConfidence().getDepthInBlocks());
 
         // Now we add another block to make the alternative chain longer.
-        Block b6 = b5.createNextBlock(someOtherGuy);
+        Block b6 = TestBlocks.createNextBlock(b5, someOtherGuy);
         BigInteger work6 = b6.getWork();
         assertTrue(chain.add(b6));
         //
@@ -461,9 +461,9 @@ public class ChainSplitTest {
         assertEquals(0, txns.get(1).getConfidence().getDepthInBlocks());
 
         // ... and back to the first chain.
-        Block b7 = b3.createNextBlock(coinsTo);
+        Block b7 = TestBlocks.createNextBlock(b3, coinsTo);
         BigInteger work7 = b7.getWork();
-        Block b8 = b7.createNextBlock(coinsTo);
+        Block b8 = TestBlocks.createNextBlock(b7, coinsTo);
         BigInteger work8 = b7.getWork();
 
         assertTrue(chain.add(b7));
@@ -488,8 +488,8 @@ public class ChainSplitTest {
         assertEquals(Coin.valueOf(250, 0), wallet.getBalance());
 
         // Now add two more blocks that don't send coins to us. Despite being irrelevant the wallet should still update.
-        Block b9 = b8.createNextBlock(someOtherGuy);
-        Block b10 = b9.createNextBlock(someOtherGuy);
+        Block b9 = TestBlocks.createNextBlock(b8, someOtherGuy);
+        Block b10 = TestBlocks.createNextBlock(b9, someOtherGuy);
         chain.add(b9);
         chain.add(b10);
         BigInteger extraWork = b9.getWork().add(b10.getWork());
@@ -540,10 +540,10 @@ public class ChainSplitTest {
         final ArrayList<Transaction> txns = new ArrayList<>(3);
         wallet.addCoinsReceivedEventListener(Threading.SAME_THREAD, (wallet, tx, prevBalance, newBalance) -> txns.add(tx));
 
-        Block b1 = TESTNET.getGenesisBlock().createNextBlock(someOtherGuy);
+        Block b1 = TestBlocks.createNextBlock(TESTNET.getGenesisBlock(), someOtherGuy);
         final ECKey coinsTo2 = wallet.freshReceiveKey();
-        Block b2 = b1.createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, coinsTo2.getPubKey(), 2);
-        Block b3 = b2.createNextBlock(someOtherGuy);
+        Block b2 = TestBlocks.createNextBlockWithCoinbase(b1, Block.BLOCK_VERSION_GENESIS, coinsTo2.getPubKey(), 2);
+        Block b3 = TestBlocks.createNextBlock(b2, someOtherGuy);
 
         log.debug("Adding block b1");
         assertTrue(chain.add(b1));
@@ -570,7 +570,7 @@ public class ChainSplitTest {
         // Add blocks to b3 until we can spend the coinbase.
         Block firstTip = b3;
         for (int i = 0; i < TESTNET.getSpendableCoinbaseDepth() - 2; i++) {
-            firstTip = firstTip.createNextBlock(someOtherGuy);
+            firstTip = TestBlocks.createNextBlock(firstTip, someOtherGuy);
             chain.add(firstTip);
         }
         // ... and spend.
@@ -585,9 +585,9 @@ public class ChainSplitTest {
         //                  \-> b4 -> b5 -> b6 -> [...]
         //
         // The b4/ b5/ b6 is now the best chain
-        Block b4 = b1.createNextBlock(someOtherGuy);
-        Block b5 = b4.createNextBlock(someOtherGuy);
-        Block b6 = b5.createNextBlock(someOtherGuy);
+        Block b4 = TestBlocks.createNextBlock(b1, someOtherGuy);
+        Block b5 = TestBlocks.createNextBlock(b4, someOtherGuy);
+        Block b6 = TestBlocks.createNextBlock(b5, someOtherGuy);
 
         log.debug("Adding block b4");
         assertTrue(chain.add(b4));
@@ -598,7 +598,7 @@ public class ChainSplitTest {
 
         Block secondTip = b6;
         for (int i = 0; i < TESTNET.getSpendableCoinbaseDepth() - 2; i++) {
-            secondTip = secondTip.createNextBlock(someOtherGuy);
+            secondTip = TestBlocks.createNextBlock(secondTip, someOtherGuy);
             chain.add(secondTip);
         }
 
@@ -612,8 +612,8 @@ public class ChainSplitTest {
         assertTrue(fodderIsDead.get());
 
         // ... and back to the first chain.
-        Block b7 = firstTip.createNextBlock(someOtherGuy);
-        Block b8 = b7.createNextBlock(someOtherGuy);
+        Block b7 = TestBlocks.createNextBlock(firstTip, someOtherGuy);
+        Block b8 = TestBlocks.createNextBlock(b7, someOtherGuy);
 
         log.debug("Adding block b7");
         assertTrue(chain.add(b7));
@@ -635,8 +635,8 @@ public class ChainSplitTest {
         // valid again later. They are just deleted from the mempool for good.
 
         // ... make the side chain dominant again.
-        Block b9 = secondTip.createNextBlock(someOtherGuy);
-        Block b10 = b9.createNextBlock(someOtherGuy);
+        Block b9 = TestBlocks.createNextBlock(secondTip, someOtherGuy);
+        Block b10 = TestBlocks.createNextBlock(b9, someOtherGuy);
 
         log.debug("Adding block b9");
         assertTrue(chain.add(b9));

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -103,7 +103,7 @@ class NewBlock {
     }
     // Wrappers to make it more block-like
     public Sha256Hash getHash() { return block.getHash(); }
-    public void solve() { block.solve(); }
+    public void solve() { TestBlocks.solve(block); }
     public void addTransaction(Transaction tx) { block.addTransaction(tx); }
 
     public TransactionOutPointWithValue getCoinbaseOutput() {
@@ -212,16 +212,16 @@ public class FullBlockTestGenerator {
         Queue<TransactionOutPointWithValue> spendableOutputs = new LinkedList<>();
 
         int chainHeadHeight = 1;
-        Block chainHead = params.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, coinbaseOutKeyPubKey, chainHeadHeight);
-        chainHead.solve();
+        Block chainHead = TestBlocks.createNextBlockWithCoinbase(params.getGenesisBlock(), Block.BLOCK_VERSION_GENESIS, coinbaseOutKeyPubKey, chainHeadHeight);
+        TestBlocks.solve(chainHead);
         blocks.add(new BlockAndValidity(chainHead, true, false, chainHead.getHash(), 1, "Initial Block"));
         spendableOutputs.offer(new TransactionOutPointWithValue(
                 new TransactionOutPoint(0, chainHead.transaction(0).getTxId()),
                 FIFTY_COINS, chainHead.transaction(0).getOutput(0).getScriptPubKey()));
         for (int i = 1; i < params.getSpendableCoinbaseDepth(); i++) {
-            chainHead = chainHead.createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, coinbaseOutKeyPubKey, chainHeadHeight);
+            chainHead = TestBlocks.createNextBlockWithCoinbase(chainHead, Block.BLOCK_VERSION_GENESIS, coinbaseOutKeyPubKey, chainHeadHeight);
             chainHeadHeight++;
-            chainHead.solve();
+            TestBlocks.solve(chainHead);
             blocks.add(new BlockAndValidity(chainHead, true, false, chainHead.getHash(), i+1, "Initial Block chain output generation"));
             spendableOutputs.offer(new TransactionOutPointWithValue(
                     new TransactionOutPoint(0, chainHead.transaction(0).getTxId()),
@@ -872,7 +872,7 @@ public class FullBlockTestGenerator {
         byte[] outScriptBytes = ScriptBuilder.createP2PKOutputScript(ECKey.fromPublicOnly(coinbaseOutKeyPubKey)).program();
         {
             b44.setDifficultyTarget(b43.block.difficultyTarget());
-            b44.addCoinbaseTransaction(coinbaseOutKeyPubKey, ZERO, chainHeadHeight + 15);
+            TestBlocks.addCoinbaseTransaction(b44, coinbaseOutKeyPubKey, ZERO, chainHeadHeight + 15);
 
             Transaction t = new Transaction();
             // Entirely invalid scriptPubKey to ensure we aren't pre-verifying too much
@@ -885,7 +885,7 @@ public class FullBlockTestGenerator {
 
             b44.setTime(b43.block.time().plusSeconds(1));
         }
-        b44.solve();
+        TestBlocks.solve(b44);
         blocks.add(new BlockAndValidity(b44, true, false, b44.getHash(), chainHeadHeight + 15, "b44"));
 
         TransactionOutPointWithValue out15 = spendableOutputs.poll();
@@ -912,7 +912,7 @@ public class FullBlockTestGenerator {
 
             b45.setTime(b44.time().plusSeconds(1));
         }
-        b45.solve();
+        TestBlocks.solve(b45);
         blocks.add(new BlockAndValidity(b45, false, true, b44.getHash(), chainHeadHeight + 15, "b45"));
 
         // A block with no txn
@@ -923,7 +923,7 @@ public class FullBlockTestGenerator {
 
             b46.setTime(b44.time().plusSeconds(1));
         }
-        b46.solve();
+        TestBlocks.solve(b46);
         blocks.add(new BlockAndValidity(b46, false, true, b44.getHash(), chainHeadHeight + 15, "b46"));
 
         // A block with invalid work
@@ -1723,7 +1723,7 @@ public class FullBlockTestGenerator {
         Coin coinbaseValue = FIFTY_COINS.shiftRight(nextBlockHeight / params.getSubsidyDecreaseBlockCount())
                 .add((prevOut != null ? prevOut.value.subtract(SATOSHI) : ZERO))
                 .add(additionalCoinbaseValue == null ? ZERO : additionalCoinbaseValue);
-        Block block = baseBlock.createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, coinbaseOutKeyPubKey, coinbaseValue, nextBlockHeight);
+        Block block = TestBlocks.createNextBlockWithCoinbase(baseBlock, Block.BLOCK_VERSION_GENESIS, coinbaseOutKeyPubKey, coinbaseValue, nextBlockHeight);
         Transaction t = new Transaction();
         if (prevOut != null) {
             // Entirely invalid scriptPubKey to ensure we aren't pre-verifying too much
@@ -1732,7 +1732,7 @@ public class FullBlockTestGenerator {
             t.addOutput(new TransactionOutput(t, SATOSHI, new byte[] {OP_1}));
             addOnlyInputToTransaction(t, prevOut);
             block.addTransaction(t);
-            block.solve();
+            TestBlocks.solve(block);
         }
         return new NewBlock(block, prevOut == null ? null : new TransactionOutPointWithValue(t, 1));
     }

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -623,7 +623,7 @@ public class TransactionTest {
     public void testHashForSignatureThreadSafety() throws Exception {
         Context.propagate(new Context(100, Transaction.DEFAULT_TX_FEE, false, true));
         Block genesis = TESTNET.getGenesisBlock();
-        Block block1 = genesis.createNextBlock(ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET),
+        Block block1 = TestBlocks.createNextBlock(genesis, ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET),
                     genesis.transaction(0).getOutput(0).getOutPointFor());
 
         final Transaction tx = block1.transaction(1);

--- a/core/src/test/java/org/bitcoinj/store/SPVBlockStoreTest.java
+++ b/core/src/test/java/org/bitcoinj/store/SPVBlockStoreTest.java
@@ -25,6 +25,7 @@ import org.bitcoinj.base.internal.PlatformUtils;
 import org.bitcoinj.base.internal.Stopwatch;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.core.Block;
+import org.bitcoinj.core.TestBlocks;
 import org.bitcoinj.core.Context;
 import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.core.NetworkParameters;
@@ -79,7 +80,7 @@ public class SPVBlockStoreTest {
         assertEquals(0, genesis.getHeight());
 
         // Build a new block.
-        StoredBlock b1 = genesis.build(genesis.getHeader().createNextBlock(to).asHeader());
+        StoredBlock b1 = genesis.build(TestBlocks.createNextBlock(genesis.getHeader(), to).asHeader());
         store.put(b1);
         store.setChainHead(b1);
         store.close();
@@ -128,9 +129,9 @@ public class SPVBlockStoreTest {
         Address to = ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
         SPVBlockStore store = new SPVBlockStore(TESTNET, blockStoreFile, 10, true);
         final StoredBlock block0 = store.getChainHead();
-        final StoredBlock block1 = block0.build(block0.getHeader().createNextBlock(to).asHeader());
+        final StoredBlock block1 = block0.build(TestBlocks.createNextBlock(block0.getHeader(), to).asHeader());
         store.put(block1);
-        final StoredBlock block2 = block1.build(block1.getHeader().createNextBlock(to).asHeader());
+        final StoredBlock block2 = block1.build(TestBlocks.createNextBlock(block1.getHeader(), to).asHeader());
         store.put(block2);
         store.setChainHead(block2);
         store.close();
@@ -183,7 +184,7 @@ public class SPVBlockStoreTest {
         // Build a new block.
         Address to = ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
         StoredBlock genesis = store.getChainHead();
-        StoredBlock b1 = genesis.build(genesis.getHeader().createNextBlock(to).asHeader());
+        StoredBlock b1 = genesis.build(TestBlocks.createNextBlock(genesis.getHeader(), to).asHeader());
         store.put(b1);
         store.setChainHead(b1);
         assertEquals(b1.getHeader().getHash(), store.getChainHead().getHeader().getHash());

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -26,6 +26,7 @@ import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.core.BlockChain;
+import org.bitcoinj.core.TestBlocks;
 import org.bitcoinj.core.BlockTest;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.core.Context;
@@ -268,11 +269,11 @@ public class WalletProtobufSerializerTest {
         myWallet.addCoinsReceivedEventListener((wallet, tx, prevBalance, newBalance) -> txns.add(tx));
 
         // Start by building two blocks on top of the genesis block.
-        Block b1 = TESTNET.getGenesisBlock().createNextBlock(myAddress);
+        Block b1 = TestBlocks.createNextBlock(TESTNET.getGenesisBlock(), myAddress);
         BigInteger work1 = b1.getWork();
         assertTrue(work1.signum() > 0);
 
-        Block b2 = b1.createNextBlock(myAddress);
+        Block b2 = TestBlocks.createNextBlock(b1, myAddress);
         BigInteger work2 = b2.getWork();
         assertTrue(work2.signum() > 0);
 
@@ -377,7 +378,7 @@ public class WalletProtobufSerializerTest {
     public void coinbaseTxns() throws Exception {
         // Covers issue 420 where the outpoint index of a coinbase tx input was being mis-serialized.
         Context.propagate(new Context(100, Transaction.DEFAULT_TX_FEE, false, true));
-        Block b = TESTNET.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, myKey.getPubKey(), FIFTY_COINS, Block.BLOCK_HEIGHT_GENESIS);
+        Block b = TestBlocks.createNextBlockWithCoinbase(TESTNET.getGenesisBlock(), Block.BLOCK_VERSION_GENESIS, myKey.getPubKey(), FIFTY_COINS, Block.BLOCK_HEIGHT_GENESIS);
         Transaction coinbase = b.transaction(0);
         assertTrue(coinbase.isCoinBase());
         BlockChain chain = new BlockChain(BitcoinNetwork.TESTNET, myWallet, new MemoryBlockStore(TESTNET.getGenesisBlock()));

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -23,6 +23,7 @@ import junitparams.Parameters;
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.internal.TimeUtils;
+import org.bitcoinj.core.TestBlocks;
 import org.bitcoinj.crypto.AesKey;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.core.AbstractBlockChain;
@@ -2836,7 +2837,7 @@ public class WalletTest extends TestWithWallet {
         assertEquals(CENT, request.tx.getOutput(0).getValue());
 
         // Add an unsendable value
-        block = new StoredBlock(block.getHeader().createNextBlock(OTHER_ADDRESS), BigInteger.ONE, 3);
+        block = new StoredBlock(TestBlocks.createNextBlock(block.getHeader(), OTHER_ADDRESS), BigInteger.ONE, 3);
         Coin dustThresholdMinusOne = new TransactionOutput(null, Coin.COIN, OTHER_ADDRESS).getMinNonDustValue().subtract(SATOSHI);
         tx = createFakeTx(TESTNET, dustThresholdMinusOne, myAddress);
         wallet.receiveFromBlock(tx, block, AbstractBlockChain.NewBlockType.BEST_CHAIN, 0);

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -311,7 +311,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         // Set up a little block chain. We heard about b1 but not b2 (it is pending download). b3 is solved whilst we
         // are downloading the chain.
         Block b1 = FakeTxBuilder.createFakeBlock(blockStore, BLOCK_HEIGHT_GENESIS).block;
-        b1.solve();
+        TestBlocks.solve(b1);
         blockChain.add(b1);
         Block b2 = FakeTxBuilder.makeTestBlock(b1);
         Block b3 = FakeTxBuilder.makeTestBlock(b2);
@@ -813,7 +813,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         for (ECKey key1 : keys) {
             Address addr = key1.toAddress(ScriptType.P2PKH, UNITTEST.network());
             Block next = FakeTxBuilder.makeTestBlock(prev, FakeTxBuilder.createFakeTx(UNITTEST.network(), Coin.FIFTY_COINS, addr));
-            next.solve();
+            TestBlocks.solve(next);
             expectedBalance = expectedBalance.add(next.transaction(1).getOutput(0).getValue());
             blocks.add(next);
             prev = next;


### PR DESCRIPTION
These helpers are moved to new helper `TestBlocks` as static methods:
    
- createNextBlock() and friends
- addCoinbaseTransaction()
- solve()

This is a child of #3650.