### PR TITLE
FakeTxBuilder: do not solve fake blocks

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -820,7 +820,7 @@ public class Block implements Message {
     private static final byte[] pubkeyForTesting = new ECKey().getPubKey();
 
     /**
-     * Returns a solved block that builds on top of this one. This exists for unit tests.
+     * Returns an unsolved block that builds on top of this one. This exists for unit tests.
      *
      * @param to      if not null, 50 coins are sent to the address
      * @param version version of the block to create
@@ -834,7 +834,7 @@ public class Block implements Message {
     }
 
     /**
-     * Returns a solved block that builds on top of this one. This exists for unit tests.
+     * Returns an unsolved block that builds on top of this one. This exists for unit tests.
      * In this variant you can specify a public key (pubkey) for use in generating coinbase blocks.
      *
      * @param to            if not null, 50 coins are sent to the address
@@ -874,12 +874,6 @@ public class Block implements Message {
             b.setTime(time().plusSeconds(1));
         else
             b.setTime(bitcoinTime);
-        b.solve();
-        try {
-            Block.verifyHeader(b);
-        } catch (VerificationException e) {
-            throw new RuntimeException(e); // Cannot happen.
-        }
         if (b.getVersion() != version) {
             throw new RuntimeException();
         }

--- a/core/src/main/java/org/bitcoinj/testing/FakeTxBuilder.java
+++ b/core/src/main/java/org/bitcoinj/testing/FakeTxBuilder.java
@@ -257,13 +257,13 @@ public class FakeTxBuilder {
         }
     }
 
-    /** Emulates receiving a valid block that builds on top of the chain. */
+    /** Creates an unsolved, but otherwise valid block that builds on top of the chain. */
     public static BlockPair createFakeBlock(BlockStore blockStore, long version,
                                             Instant time, Transaction... transactions) {
         return createFakeBlock(blockStore, version, time, 0, transactions);
     }
 
-    /** Emulates receiving a valid block */
+    /** Creates an unsolved, but otherwise valid block that builds on top of the chain. */
     public static BlockPair createFakeBlock(BlockStore blockStore, StoredBlock previousStoredBlock, long version,
                                             Instant time, int height, Transaction... transactions) {
         try {
@@ -274,7 +274,6 @@ public class FakeTxBuilder {
                 tx.getConfidence().maybeSetSourceToNetwork();
                 b.addTransaction(tx);
             }
-            b.solve();
             BlockPair pair = new BlockPair(b, previousStoredBlock.build(b));
             blockStore.put(pair.storedBlock);
             blockStore.setChainHead(pair.storedBlock);
@@ -284,11 +283,12 @@ public class FakeTxBuilder {
         }
     }
 
+    /** Creates an unsolved, but otherwise valid block that builds on top of the chain. */
     public static BlockPair createFakeBlock(BlockStore blockStore, StoredBlock previousStoredBlock, int height, Transaction... transactions) {
         return createFakeBlock(blockStore, previousStoredBlock, Block.BLOCK_VERSION_BIP66, TimeUtils.currentTime(), height, transactions);
     }
 
-    /** Emulates receiving a valid block that builds on top of the chain. */
+    /** Creates an unsolved, but otherwise valid block that builds on top of the chain. */
     public static BlockPair createFakeBlock(BlockStore blockStore, long version, Instant time, int height, Transaction... transactions) {
         try {
             return createFakeBlock(blockStore, blockStore.getChainHead(), version, time, height, transactions);
@@ -297,34 +297,34 @@ public class FakeTxBuilder {
         }
     }
 
-    /** Emulates receiving a valid block that builds on top of the chain. */
+    /** Creates an unsolved, but otherwise valid block that builds on top of the chain. */
     public static BlockPair createFakeBlock(BlockStore blockStore, int height,
                                             Transaction... transactions) {
         return createFakeBlock(blockStore, Block.BLOCK_VERSION_GENESIS, TimeUtils.currentTime(), height, transactions);
     }
 
-    /** Emulates receiving a valid block that builds on top of the chain. */
+    /** Creates an unsolved, but otherwise valid block that builds on top of the chain. */
     public static BlockPair createFakeBlock(BlockStore blockStore, Transaction... transactions) {
         return createFakeBlock(blockStore, Block.BLOCK_VERSION_GENESIS, TimeUtils.currentTime(), 0, transactions);
     }
 
-    public static Block makeSolvedTestBlock(BlockStore blockStore, Address coinsTo) throws BlockStoreException {
-        Block b = blockStore.getChainHead().getHeader().createNextBlock(coinsTo);
-        b.solve();
-        return b;
+    /** Creates an unsolved, but otherwise valid block that builds on top of the chain. */
+    public static Block makeTestBlock(BlockStore blockStore, Address coinsTo) throws BlockStoreException {
+        return blockStore.getChainHead().getHeader().createNextBlock(coinsTo);
     }
 
-    public static Block makeSolvedTestBlock(Block prev, Transaction... transactions) throws BlockStoreException {
-        return makeSolvedTestBlock(prev, null, transactions);
+    /** Creates an unsolved, but otherwise valid block that builds on top of the chain. */
+    public static Block makeTestBlock(Block prev, Transaction... transactions) throws BlockStoreException {
+        return makeTestBlock(prev, null, transactions);
     }
 
-    public static Block makeSolvedTestBlock(Block prev, @Nullable Address to, Transaction... transactions) throws BlockStoreException {
+    /** Creates an unsolved, but otherwise valid block that builds on top of the chain. */
+    public static Block makeTestBlock(Block prev, @Nullable Address to, Transaction... transactions) throws BlockStoreException {
         Block b = prev.createNextBlock(to);
         // Coinbase tx already exists.
         for (Transaction tx : transactions) {
             b.addTransaction(tx);
         }
-        b.solve();
         return b;
     }
 

--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -151,10 +151,12 @@ public abstract class AbstractFullPrunedBlockChainTest {
 
         // Build some blocks on genesis block to create a spendable output
         Block rollingBlock = PARAMS.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
+        rollingBlock.solve();
         chain.add(rollingBlock);
         TransactionOutput spendableOutput = rollingBlock.getTransactions().get(0).getOutput(0);
         for (int i = 1; i < PARAMS.getSpendableCoinbaseDepth(); i++) {
             rollingBlock = rollingBlock.createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
+            rollingBlock.solve();
             chain.add(rollingBlock);
         }
 
@@ -192,12 +194,14 @@ public abstract class AbstractFullPrunedBlockChainTest {
 
         // Build some blocks on genesis block to create a spendable output
         Block rollingBlock = PARAMS.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
+        rollingBlock.solve();
         chain.add(rollingBlock);
         TransactionOutput spendableOutput = rollingBlock.getTransactions().get(0).getOutput(0);
         TransactionOutPoint transactionOutPoint = spendableOutput.getOutPointFor();
         Script spendableOutputScriptPubKey = spendableOutput.getScriptPubKey();
         for (int i = 1; i < PARAMS.getSpendableCoinbaseDepth(); i++) {
             rollingBlock = rollingBlock.createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
+            rollingBlock.solve();
             chain.add(rollingBlock);
         }
         
@@ -225,6 +229,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         // Create a chain longer than UNDOABLE_BLOCKS_STORED
         for (int i = 0; i < UNDOABLE_BLOCKS_STORED; i++) {
             rollingBlock = rollingBlock.createNextBlock(null);
+            rollingBlock.solve();
             chain.add(rollingBlock);
         }
         // Try to get the garbage collector to run
@@ -265,6 +270,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
 
         // Build some blocks on genesis block to create a spendable output
         Block rollingBlock = PARAMS.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
+        rollingBlock.solve();
         chain.add(rollingBlock);
         Transaction transaction = rollingBlock.getTransactions().get(0);
         TransactionOutput spendableOutput = transaction.getOutput(0);
@@ -272,6 +278,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         Script spendableOutputScriptPubKey = spendableOutput.getScriptPubKey();
         for (int i = 1; i < PARAMS.getSpendableCoinbaseDepth(); i++) {
             rollingBlock = rollingBlock.createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
+            rollingBlock.solve();
             chain.add(rollingBlock);
         }
         rollingBlock = rollingBlock.createNextBlock(null);
@@ -317,6 +324,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
 
         // Build some blocks on genesis block to create a spendable output.
         Block rollingBlock = PARAMS.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
+        rollingBlock.solve();
         chain.add(rollingBlock);
         Transaction transaction = rollingBlock.getTransactions().get(0);
         TransactionOutput spendableOutput = transaction.getOutput(0);
@@ -324,6 +332,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         Script spendableOutputScriptPubKey = spendableOutput.getScriptPubKey();
         for (int i = 1; i < PARAMS.getSpendableCoinbaseDepth(); i++) {
             rollingBlock = rollingBlock.createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
+            rollingBlock.solve();
             chain.add(rollingBlock);
         }
         rollingBlock = rollingBlock.createNextBlock(null);
@@ -389,6 +398,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
             for (height = 1; height <= (PARAMS.getMajorityWindow() - PARAMS.getMajorityEnforceBlockUpgrade()); height++) {
                 chainHead = chainHead.createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS,
                     outKey.getPubKey(), height);
+                chainHead.solve();
                 chain.add(chainHead);
             }
 
@@ -396,12 +406,14 @@ public abstract class AbstractFullPrunedBlockChainTest {
             for (; height < PARAMS.getMajorityWindow(); height++) {
                 chainHead = chainHead.createNextBlockWithCoinbase(Block.BLOCK_VERSION_BIP34,
                     outKey.getPubKey(), height);
+                chainHead.solve();
                 chain.add(chainHead);
             }
             // Throw a broken v2 block in before we have a supermajority to enable
             // enforcement, which should validate as-is
             chainHead = chainHead.createNextBlockWithCoinbase(Block.BLOCK_VERSION_BIP34,
                 outKey.getPubKey(), height * 2);
+            chainHead.solve();
             chain.add(chainHead);
             height++;
 
@@ -410,6 +422,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
             thrown.expect(VerificationException.CoinbaseHeightMismatch.class);
             chainHead = chainHead.createNextBlockWithCoinbase(Block.BLOCK_VERSION_BIP34,
                 outKey.getPubKey(), height * 2);
+            chainHead.solve();
             chain.add(chainHead);
         }  catch(final VerificationException ex) {
             throw (Exception) ex.getCause();

--- a/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
@@ -514,7 +514,7 @@ public class ChainSplitTest {
 
         // Receive some money to the wallet.
         Transaction t1 = FakeTxBuilder.createFakeTx(TESTNET.network(), COIN, coinsTo);
-        final Block b1 = FakeTxBuilder.makeSolvedTestBlock(TESTNET.getGenesisBlock(), t1);
+        final Block b1 = FakeTxBuilder.makeTestBlock(TESTNET.getGenesisBlock(), t1);
         chain.add(b1);
 
         // Send a couple of payments one after the other (so the second depends on the change output of the first).
@@ -522,7 +522,7 @@ public class ChainSplitTest {
         wallet.commitTx(t2);
         Transaction t3 = Objects.requireNonNull(wallet.createSend(new ECKey().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET), CENT, true));
         wallet.commitTx(t3);
-        chain.add(FakeTxBuilder.makeSolvedTestBlock(b1, t2, t3));
+        chain.add(FakeTxBuilder.makeTestBlock(b1, t2, t3));
 
         final Coin coins0point98 = COIN.subtract(CENT).subtract(CENT);
         assertEquals(coins0point98, wallet.getBalance());
@@ -531,8 +531,8 @@ public class ChainSplitTest {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         wallet.saveToFileStream(bos);
         wallet = Wallet.loadFromFileStream(new ByteArrayInputStream(bos.toByteArray()));
-        final Block b2 = FakeTxBuilder.makeSolvedTestBlock(b1, t2, t3);
-        final Block b3 = FakeTxBuilder.makeSolvedTestBlock(b2);
+        final Block b2 = FakeTxBuilder.makeTestBlock(b1, t2, t3);
+        final Block b3 = FakeTxBuilder.makeTestBlock(b2);
         chain.add(b2);
         chain.add(b3);
 

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -213,6 +213,7 @@ public class FullBlockTestGenerator {
 
         int chainHeadHeight = 1;
         Block chainHead = params.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, coinbaseOutKeyPubKey, chainHeadHeight);
+        chainHead.solve();
         blocks.add(new BlockAndValidity(chainHead, true, false, chainHead.getHash(), 1, "Initial Block"));
         spendableOutputs.offer(new TransactionOutPointWithValue(
                 new TransactionOutPoint(0, chainHead.getTransactions().get(0).getTxId()),
@@ -220,6 +221,7 @@ public class FullBlockTestGenerator {
         for (int i = 1; i < params.getSpendableCoinbaseDepth(); i++) {
             chainHead = chainHead.createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, coinbaseOutKeyPubKey, chainHeadHeight);
             chainHeadHeight++;
+            chainHead.solve();
             blocks.add(new BlockAndValidity(chainHead, true, false, chainHead.getHash(), i+1, "Initial Block chain output generation"));
             spendableOutputs.offer(new TransactionOutPointWithValue(
                     new TransactionOutPoint(0, chainHead.getTransactions().get(0).getTxId()),

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -114,7 +114,7 @@ import static org.bitcoinj.base.Coin.valueOf;
 import static org.bitcoinj.testing.FakeTxBuilder.createFakeBlock;
 import static org.bitcoinj.testing.FakeTxBuilder.createFakeTx;
 import static org.bitcoinj.testing.FakeTxBuilder.createFakeTxWithoutChangeAddress;
-import static org.bitcoinj.testing.FakeTxBuilder.makeSolvedTestBlock;
+import static org.bitcoinj.testing.FakeTxBuilder.makeTestBlock;
 import static org.bitcoinj.testing.FakeTxBuilder.roundTripTransaction;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.replay;
@@ -1493,10 +1493,10 @@ public class WalletTest extends TestWithWallet {
         Transaction t3 = createFakeTx(TESTNET, v3, myAddress);
 
         Block genesis = blockStore.getChainHead().getHeader();
-        Block b10 = makeSolvedTestBlock(genesis, t1);
-        Block b11 = makeSolvedTestBlock(genesis, t2);
-        Block b2 = makeSolvedTestBlock(b10, t3);
-        Block b3 = makeSolvedTestBlock(b2);
+        Block b10 = FakeTxBuilder.makeTestBlock(genesis, t1);
+        Block b11 = FakeTxBuilder.makeTestBlock(genesis, t2);
+        Block b2 = FakeTxBuilder.makeTestBlock(b10, t3);
+        Block b3 = FakeTxBuilder.makeTestBlock(b2);
 
         // Receive a block on the best chain - this should set the last block seen hash.
         chain.add(b10);
@@ -2607,7 +2607,7 @@ public class WalletTest extends TestWithWallet {
     @Test
     public void transactionGetFeeTest() throws Exception {
         // Prepare wallet to spend
-        StoredBlock block = new StoredBlock(makeSolvedTestBlock(blockStore, OTHER_ADDRESS), BigInteger.ONE, 1);
+        StoredBlock block = new StoredBlock(FakeTxBuilder.makeTestBlock(blockStore, OTHER_ADDRESS), BigInteger.ONE, 1);
         Transaction tx = createFakeTx(TESTNET, COIN, myAddress);
         wallet.receiveFromBlock(tx, block, AbstractBlockChain.NewBlockType.BEST_CHAIN, 0);
 
@@ -2624,7 +2624,7 @@ public class WalletTest extends TestWithWallet {
         Address mySegwitAddress = mySegwitWallet.freshReceiveAddress(ScriptType.P2WPKH);
 
         // Prepare wallet to spend
-        StoredBlock block = new StoredBlock(makeSolvedTestBlock(blockStore, OTHER_SEGWIT_ADDRESS), BigInteger.ONE, 1);
+        StoredBlock block = new StoredBlock(FakeTxBuilder.makeTestBlock(blockStore, OTHER_SEGWIT_ADDRESS), BigInteger.ONE, 1);
         Transaction tx = createFakeTx(TESTNET, COIN, mySegwitAddress);
         mySegwitWallet.receiveFromBlock(tx, block, AbstractBlockChain.NewBlockType.BEST_CHAIN, 0);
 
@@ -2688,7 +2688,7 @@ public class WalletTest extends TestWithWallet {
         // Tests calling completeTx with a SendRequest that already has a few inputs in it
 
         // Generate a few outputs to us
-        StoredBlock block = new StoredBlock(makeSolvedTestBlock(blockStore, OTHER_ADDRESS), BigInteger.ONE, 1);
+        StoredBlock block = new StoredBlock(FakeTxBuilder.makeTestBlock(blockStore, OTHER_ADDRESS), BigInteger.ONE, 1);
         Transaction tx1 = createFakeTx(TESTNET, COIN, myAddress);
         wallet.receiveFromBlock(tx1, block, AbstractBlockChain.NewBlockType.BEST_CHAIN, 0);
         Transaction tx2 = createFakeTx(TESTNET, COIN, myAddress);
@@ -2746,7 +2746,7 @@ public class WalletTest extends TestWithWallet {
         // Test calling completeTx with a SendRequest that has an unconnected input (i.e. an input with an unconnected outpoint)
 
         // Generate an output to us
-        StoredBlock block = new StoredBlock(makeSolvedTestBlock(blockStore, OTHER_ADDRESS), BigInteger.ONE, 1);
+        StoredBlock block = new StoredBlock(FakeTxBuilder.makeTestBlock(blockStore, OTHER_ADDRESS), BigInteger.ONE, 1);
         Transaction tx = createFakeTx(TESTNET, COIN, myAddress);
         wallet.receiveFromBlock(tx, block, AbstractBlockChain.NewBlockType.BEST_CHAIN, 0);
 
@@ -2796,7 +2796,7 @@ public class WalletTest extends TestWithWallet {
     @Test
     public void testEmptyRandomWallet() throws Exception {
         // Add a random set of outputs
-        StoredBlock block = new StoredBlock(makeSolvedTestBlock(blockStore, OTHER_ADDRESS), BigInteger.ONE, 1);
+        StoredBlock block = new StoredBlock(FakeTxBuilder.makeTestBlock(blockStore, OTHER_ADDRESS), BigInteger.ONE, 1);
         Random rng = new Random();
         for (int i = 0; i < rng.nextInt(100) + 1; i++) {
             Transaction tx = createFakeTx(TESTNET, Coin.valueOf(rng.nextInt((int) COIN.value)), myAddress);
@@ -2811,7 +2811,7 @@ public class WalletTest extends TestWithWallet {
     @Test
     public void testEmptyWallet() throws Exception {
         // Add exactly 0.01
-        StoredBlock block = new StoredBlock(makeSolvedTestBlock(blockStore, OTHER_ADDRESS), BigInteger.ONE, 1);
+        StoredBlock block = new StoredBlock(FakeTxBuilder.makeTestBlock(blockStore, OTHER_ADDRESS), BigInteger.ONE, 1);
         Transaction tx = createFakeTx(TESTNET, CENT, myAddress);
         wallet.receiveFromBlock(tx, block, AbstractBlockChain.NewBlockType.BEST_CHAIN, 0);
         SendRequest request = SendRequest.emptyWallet(OTHER_ADDRESS);
@@ -2823,7 +2823,7 @@ public class WalletTest extends TestWithWallet {
 
         // Add 1 confirmed cent and 1 unconfirmed cent. Verify only one cent is emptied because of the coin selection
         // policies that are in use by default.
-        block = new StoredBlock(makeSolvedTestBlock(blockStore, OTHER_ADDRESS), BigInteger.ONE, 2);
+        block = new StoredBlock(FakeTxBuilder.makeTestBlock(blockStore, OTHER_ADDRESS), BigInteger.ONE, 2);
         tx = createFakeTx(TESTNET, CENT, myAddress);
         wallet.receiveFromBlock(tx, block, AbstractBlockChain.NewBlockType.BEST_CHAIN, 0);
         tx = createFakeTx(TESTNET, CENT, myAddress);

--- a/integration-test/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTest.java
@@ -117,7 +117,7 @@ public class FilteredBlockAndPartialMerkleTreeTest extends TestWithPeerGroup {
         Transaction tx1 = FakeTxBuilder.createFakeTx(Coin.COIN,  key1);
         Transaction tx2 = FakeTxBuilder.createFakeTx(TESTNET.network(), Coin.FIFTY_COINS, key2.toAddress(ScriptType.P2PKH,
                 BitcoinNetwork.TESTNET));
-        Block block = FakeTxBuilder.makeSolvedTestBlock(TESTNET.getGenesisBlock(), LegacyAddress.fromBase58("msg2t2V2sWNd85LccoddtWysBTR8oPnkzW", BitcoinNetwork.TESTNET), tx1, tx2);
+        Block block = FakeTxBuilder.makeTestBlock(TESTNET.getGenesisBlock(), LegacyAddress.fromBase58("msg2t2V2sWNd85LccoddtWysBTR8oPnkzW", BitcoinNetwork.TESTNET), tx1, tx2);
         BloomFilter filter = new BloomFilter(4, 0.1, 1);
         filter.insert(key1);
         filter.insert(key2);

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -312,8 +312,8 @@ public class PeerGroupTest extends TestWithPeerGroup {
         // are downloading the chain.
         Block b1 = FakeTxBuilder.createFakeBlock(blockStore, BLOCK_HEIGHT_GENESIS).block;
         blockChain.add(b1);
-        Block b2 = FakeTxBuilder.makeSolvedTestBlock(b1);
-        Block b3 = FakeTxBuilder.makeSolvedTestBlock(b2);
+        Block b2 = FakeTxBuilder.makeTestBlock(b1);
+        Block b3 = FakeTxBuilder.makeTestBlock(b2);
 
         // Peer 1 and 2 receives an inv advertising a newly solved block.
         InventoryMessage inv = InventoryMessage.ofBlocks(b3);
@@ -345,8 +345,8 @@ public class PeerGroupTest extends TestWithPeerGroup {
 
         // Set up a little block chain.
         Block b1 = FakeTxBuilder.createFakeBlock(blockStore, BLOCK_HEIGHT_GENESIS).block;
-        Block b2 = FakeTxBuilder.makeSolvedTestBlock(b1);
-        Block b3 = FakeTxBuilder.makeSolvedTestBlock(b2);
+        Block b2 = FakeTxBuilder.makeTestBlock(b1);
+        Block b3 = FakeTxBuilder.makeTestBlock(b2);
 
         // Expect a zero hash getblocks on p1. This is how the process starts.
         peerGroup.startBlockChainDownload(new DownloadProgressTracker());
@@ -811,7 +811,8 @@ public class PeerGroupTest extends TestWithPeerGroup {
         Block prev = blockStore.getChainHead().getHeader();
         for (ECKey key1 : keys) {
             Address addr = key1.toAddress(ScriptType.P2PKH, UNITTEST.network());
-            Block next = FakeTxBuilder.makeSolvedTestBlock(prev, FakeTxBuilder.createFakeTx(UNITTEST.network(), Coin.FIFTY_COINS, addr));
+            Block next = FakeTxBuilder.makeTestBlock(prev, FakeTxBuilder.createFakeTx(UNITTEST.network(), Coin.FIFTY_COINS, addr));
+            next.solve();
             expectedBalance = expectedBalance.add(next.getTransactions().get(1).getOutput(0).getValue());
             blocks.add(next);
             prev = next;

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -311,6 +311,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         // Set up a little block chain. We heard about b1 but not b2 (it is pending download). b3 is solved whilst we
         // are downloading the chain.
         Block b1 = FakeTxBuilder.createFakeBlock(blockStore, BLOCK_HEIGHT_GENESIS).block;
+        b1.solve();
         blockChain.add(b1);
         Block b2 = FakeTxBuilder.makeTestBlock(b1);
         Block b3 = FakeTxBuilder.makeTestBlock(b2);

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -25,6 +25,7 @@ import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.core.listeners.BlocksDownloadedEventListener;
 import org.bitcoinj.core.listeners.PreMessageReceivedEventListener;
 import org.bitcoinj.crypto.ECKey;
+import org.bitcoinj.testing.FakeTxBuilder;
 import org.bitcoinj.testing.InboundMessageQueuer;
 import org.bitcoinj.testing.TestWithNetworkConnections;
 import org.bitcoinj.utils.Threading;
@@ -59,7 +60,7 @@ import static org.bitcoinj.base.Coin.COIN;
 import static org.bitcoinj.base.Coin.valueOf;
 import static org.bitcoinj.testing.FakeTxBuilder.createFakeBlock;
 import static org.bitcoinj.testing.FakeTxBuilder.createFakeTx;
-import static org.bitcoinj.testing.FakeTxBuilder.makeSolvedTestBlock;
+import static org.bitcoinj.testing.FakeTxBuilder.makeTestBlock;
 import static org.bitcoinj.testing.FakeTxBuilder.roundTripTransaction;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -128,10 +129,10 @@ public class PeerTest extends TestWithNetworkConnections {
         Context.propagate(new Context(100, Transaction.DEFAULT_TX_FEE, false, true));
         Block b1 = createFakeBlock(blockStore, Block.BLOCK_HEIGHT_GENESIS).block;
         blockChain.add(b1);
-        Block b2 = makeSolvedTestBlock(b1);
-        Block b3 = makeSolvedTestBlock(b2);
-        Block b4 = makeSolvedTestBlock(b3);
-        Block b5 = makeSolvedTestBlock(b4);
+        Block b2 = makeTestBlock(b1);
+        Block b3 = makeTestBlock(b2);
+        Block b4 = makeTestBlock(b3);
+        Block b5 = makeTestBlock(b4);
 
         connect();
         
@@ -169,7 +170,7 @@ public class PeerTest extends TestWithNetworkConnections {
         // timewaste. The getblocks message that would have been generated is set to be the same as the previous
         // because we walk backwards down the orphan chain and then discover we already asked for those blocks, so
         // nothing is done.
-        Block b6 = makeSolvedTestBlock(b5);
+        Block b6 = makeTestBlock(b5);
         inv = InventoryMessage.ofBlocks(b6);
         inbound(writeTarget, inv);
         getdata = (GetDataMessage)outbound(writeTarget);
@@ -199,8 +200,8 @@ public class PeerTest extends TestWithNetworkConnections {
         Block b1 = createFakeBlock(blockStore, Block.BLOCK_HEIGHT_GENESIS).block;
         blockChain.add(b1);
         // Make a missing block.
-        Block b2 = makeSolvedTestBlock(b1);
-        Block b3 = makeSolvedTestBlock(b2);
+        Block b2 = makeTestBlock(b1);
+        Block b3 = makeTestBlock(b2);
         inbound(writeTarget, b3);
         InventoryMessage inv = InventoryMessage.ofBlocks(b3);
         inbound(writeTarget, inv);
@@ -226,7 +227,7 @@ public class PeerTest extends TestWithNetworkConnections {
         // Make a missing block that we receive.
         Block b1 = createFakeBlock(blockStore, Block.BLOCK_HEIGHT_GENESIS).block;
         blockChain.add(b1);
-        Block b2 = makeSolvedTestBlock(b1);
+        Block b2 = makeTestBlock(b1);
 
         // Receive an inv.
         InventoryMessage inv = InventoryMessage.ofBlocks(b2);
@@ -297,7 +298,7 @@ public class PeerTest extends TestWithNetworkConnections {
         Context.propagate(new Context(100, Transaction.DEFAULT_TX_FEE, false, true));
         Block b1 = createFakeBlock(blockStore, Block.BLOCK_HEIGHT_GENESIS).block;
         blockChain.add(b1);
-        final Block b2 = makeSolvedTestBlock(b1);
+        final Block b2 = makeTestBlock(b1);
         // Receive notification of a new block.
         final InventoryMessage inv = InventoryMessage.ofBlocks(b2);
 
@@ -357,7 +358,7 @@ public class PeerTest extends TestWithNetworkConnections {
         Context.propagate(new Context(100, Transaction.DEFAULT_TX_FEE, false, true));
         Block b1 = createFakeBlock(blockStore, Block.BLOCK_HEIGHT_GENESIS).block;
         blockChain.add(b1);
-        Block b2 = makeSolvedTestBlock(b1);
+        Block b2 = makeTestBlock(b1);
         blockChain.add(b2);
 
         connect();
@@ -385,8 +386,8 @@ public class PeerTest extends TestWithNetworkConnections {
 
         Block b1 = createFakeBlock(blockStore, Block.BLOCK_HEIGHT_GENESIS).block;
         blockChain.add(b1);
-        Block b2 = makeSolvedTestBlock(b1);
-        Block b3 = makeSolvedTestBlock(b2);
+        Block b2 = makeTestBlock(b1);
+        Block b3 = makeTestBlock(b2);
 
         // Request the block.
         Future<Block> resultFuture = peer.getBlock(b3.getHash());
@@ -408,7 +409,7 @@ public class PeerTest extends TestWithNetworkConnections {
 
         Block b1 = createFakeBlock(blockStore, Block.BLOCK_HEIGHT_GENESIS).block;
         blockChain.add(b1);
-        Block b2 = makeSolvedTestBlock(b1);
+        Block b2 = makeTestBlock(b1);
         Transaction t = new Transaction();
         t.addInput(b1.getTransactions().get(0).getOutput(0));
         t.addOutput(new TransactionOutput(t, Coin.ZERO, new byte[Block.MAX_BLOCK_SIZE - 1000]));
@@ -437,15 +438,15 @@ public class PeerTest extends TestWithNetworkConnections {
         Block b1 = createFakeBlock(blockStore, Block.BLOCK_HEIGHT_GENESIS).block;
         blockChain.add(b1);
         TimeUtils.rollMockClock(Duration.ofMinutes(10));  // 10 minutes later.
-        Block b2 = makeSolvedTestBlock(b1);
+        Block b2 = makeTestBlock(b1);
         b2.setTime(TimeUtils.currentTime());
         b2.solve();
         TimeUtils.rollMockClock(Duration.ofMinutes(10));  // 10 minutes later.
-        Block b3 = makeSolvedTestBlock(b2);
+        Block b3 = makeTestBlock(b2);
         b3.setTime(TimeUtils.currentTime());
         b3.solve();
         TimeUtils.rollMockClock(Duration.ofMinutes(10));
-        Block b4 = makeSolvedTestBlock(b3);
+        Block b4 = makeTestBlock(b3);
         b4.setTime(TimeUtils.currentTime());
         b4.solve();
 

--- a/integration-test/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
@@ -164,7 +164,7 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
         connectPeer(2);
 
         // Send ourselves a bit of money.
-        Block b1 = FakeTxBuilder.makeSolvedTestBlock(blockStore, address);
+        Block b1 = FakeTxBuilder.makeTestBlock(blockStore, address);
         inbound(p1, b1);
         assertNull(outbound(p1));
         assertEquals(FIFTY_COINS, wallet.getBalance());
@@ -203,7 +203,7 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
         InboundMessageQueuer p2 = connectPeer(2);
 
         // Send ourselves a bit of money.
-        Block b1 = FakeTxBuilder.makeSolvedTestBlock(blockStore, address);
+        Block b1 = FakeTxBuilder.makeTestBlock(blockStore, address);
         inbound(p1, b1);
         pingAndWait(p1);
         assertNull(outbound(p1));


### PR DESCRIPTION
Because `solve()` in almost all cases requires too much work, in future it should be called explicitly by the tests that depend on proper proof of work.

Most tests already use `Context.relaxProofOfWork` to skip the check. Only PeerTest depends on it, so it is changed to solve one block manually (on easiest difficulty).

Some method names were stripped of the adjective "solved" and the JavaDocs amended appropriately.
