### PR TITLE
BaseMessage: remove default implementation of `messageSize()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AddressV1Message.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressV1Message.java
@@ -54,6 +54,16 @@ public class AddressV1Message extends AddressMessage {
     }
 
     @Override
+    public int messageSize() {
+        if (addresses == null)
+            return 0;
+        return VarInt.sizeOf(addresses.size()) +
+                addresses.stream()
+                        .mapToInt(addr -> addr.getMessageSize(1))
+                        .sum();
+    }
+
+    @Override
     protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         if (addresses == null)
             return;

--- a/core/src/main/java/org/bitcoinj/core/AddressV2Message.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressV2Message.java
@@ -55,6 +55,16 @@ public class AddressV2Message extends AddressMessage {
     }
 
     @Override
+    public int messageSize() {
+        if (addresses == null)
+            return 0;
+        return VarInt.sizeOf(addresses.size()) +
+                addresses.stream()
+                        .mapToInt(addr -> addr.getMessageSize(2))
+                        .sum();
+    }
+
+    @Override
     protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         if (addresses == null)
             return;

--- a/core/src/main/java/org/bitcoinj/core/BaseMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/BaseMessage.java
@@ -51,14 +51,4 @@ public abstract class BaseMessage implements Message {
      * Serializes this message to the provided stream. If you just want the raw bytes use {@link #serialize()}.
      */
     protected abstract void bitcoinSerializeToStream(OutputStream stream) throws IOException;
-
-    /**
-     * Return the size of the serialized message. Note that if the message was deserialized from a payload, this
-     * size can differ from the size of the original payload.
-     * @return size of this object when serialized (in bytes)
-     */
-    @Override
-    public int messageSize() {
-        return serialize().length;
-    }
 }

--- a/core/src/main/java/org/bitcoinj/core/BloomFilter.java
+++ b/core/src/main/java/org/bitcoinj/core/BloomFilter.java
@@ -167,6 +167,14 @@ public class BloomFilter extends BaseMessage {
         return helper.toString();
     }
 
+    @Override
+    public int messageSize() {
+        return Buffers.lengthPrefixedBytesSize(data) +
+                4 + // hashFuncs
+                4 + // nTweak
+                1; // nFlags
+    }
+
     /**
      * Serializes this message to the provided stream. If you just want the raw bytes use {@link #serialize()}.
      */

--- a/core/src/main/java/org/bitcoinj/core/FeeFilterMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/FeeFilterMessage.java
@@ -64,6 +64,11 @@ public class FeeFilterMessage extends BaseMessage {
     }
 
     @Override
+    public int messageSize() {
+        return Coin.BYTES;
+    }
+
+    @Override
     protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         stream.write(feeRate.serialize());
     }

--- a/core/src/main/java/org/bitcoinj/core/FilteredBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/FilteredBlock.java
@@ -68,6 +68,12 @@ public class FilteredBlock extends BaseMessage {
     }
 
     @Override
+    public int messageSize() {
+        return Block.HEADER_SIZE +
+                merkleTree.messageSize();
+    }
+
+    @Override
     public void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         if (header.getTransactions() == null)
             header.bitcoinSerializeToStream(stream);

--- a/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
@@ -84,6 +84,14 @@ public class GetBlocksMessage extends BaseMessage {
     }
 
     @Override
+    public int messageSize() {
+        return 4 + // version
+                VarInt.sizeOf(locator.size()) +
+                locator.size() * Sha256Hash.LENGTH + // hashes
+                Sha256Hash.LENGTH; // stopHash
+    }
+
+    @Override
     protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         // Version, for some reason.
         ByteUtils.writeInt32LE(version, stream);

--- a/core/src/main/java/org/bitcoinj/core/HeadersMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/HeadersMessage.java
@@ -89,6 +89,12 @@ public class HeadersMessage extends BaseMessage {
     }
 
     @Override
+    public int messageSize() {
+        return VarInt.sizeOf(blockHeaders.size()) +
+                blockHeaders.size() * (Block.HEADER_SIZE + 1);
+    }
+
+    @Override
     public void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         stream.write(VarInt.of(blockHeaders.size()).serialize());
         for (Block header : blockHeaders) {

--- a/core/src/main/java/org/bitcoinj/core/ListMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/ListMessage.java
@@ -77,6 +77,12 @@ public abstract class ListMessage extends BaseMessage {
     }
 
     @Override
+    public int messageSize() {
+        return VarInt.sizeOf(items.size()) +
+                items.size() * (4 + Sha256Hash.LENGTH);
+    }
+
+    @Override
     public void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         stream.write(VarInt.of(items.size()).serialize());
         for (InventoryItem i : items) {

--- a/core/src/main/java/org/bitcoinj/core/Ping.java
+++ b/core/src/main/java/org/bitcoinj/core/Ping.java
@@ -70,6 +70,11 @@ public class Ping extends BaseMessage {
     }
 
     @Override
+    public int messageSize() {
+        return Long.BYTES;
+    }
+
+    @Override
     public void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         ByteUtils.writeInt64LE(nonce, stream);
     }

--- a/core/src/main/java/org/bitcoinj/core/Pong.java
+++ b/core/src/main/java/org/bitcoinj/core/Pong.java
@@ -57,6 +57,11 @@ public class Pong extends BaseMessage {
     }
 
     @Override
+    public int messageSize() {
+        return Long.BYTES;
+    }
+
+    @Override
     public void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         ByteUtils.writeInt64LE(nonce, stream);
     }

--- a/core/src/main/java/org/bitcoinj/core/RejectMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/RejectMessage.java
@@ -113,6 +113,16 @@ public class RejectMessage extends BaseMessage {
     }
 
     @Override
+    public int messageSize() {
+        int size = Buffers.lengthPrefixedStringSize(rejectedMessage) +
+                1 + // code
+                Buffers.lengthPrefixedStringSize(reason);
+        if ("block".equals(rejectedMessage) || "tx".equals(rejectedMessage))
+            size += Sha256Hash.LENGTH;
+        return size;
+    }
+
+    @Override
     public void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         byte[] messageBytes = rejectedMessage.getBytes(StandardCharsets.UTF_8);
         stream.write(VarInt.of(messageBytes.length).serialize());

--- a/core/src/main/java/org/bitcoinj/core/VersionMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionMessage.java
@@ -192,6 +192,20 @@ public class VersionMessage extends BaseMessage {
     }
 
     @Override
+    public int messageSize() {
+        return Integer.BYTES + // clientVersion
+                Services.BYTES + // localServices
+                Long.BYTES + // time
+                Services.BYTES + // receivingServices
+                16 + 2 + // receivingAddr
+                NETADDR_BYTES +
+                4 + 4 + // local host nonce
+                Buffers.lengthPrefixedStringSize(subVer) +
+                4 + // height
+                1; // relayTxesBeforeFilter
+    }
+
+    @Override
     public void bitcoinSerializeToStream(OutputStream buf) throws IOException {
         ByteUtils.writeInt32LE(clientVersion, buf);
         buf.write(localServices.serialize());

--- a/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
@@ -238,6 +238,9 @@ public class BitcoinSerializerTest {
 
         Message unknownMessage = new BaseMessage() {
             @Override
+            public int messageSize() { return 0; }
+
+            @Override
             protected void bitcoinSerializeToStream(OutputStream stream) {}
         };
         ByteArrayOutputStream bos = new ByteArrayOutputStream(ADDRESS_MESSAGE_BYTES.length);


### PR DESCRIPTION
Implement it in the concrete implementations. This avoids needless serialization and instantiation of buffers.