### PR TITLE
Buffers: add helpers `lengthPrefixedBytesSize()` and `lengthPrefixedStringSize()`

### DIFF
--- a/base/src/main/java/org/bitcoinj/base/internal/Buffers.java
+++ b/base/src/main/java/org/bitcoinj/base/internal/Buffers.java
@@ -74,6 +74,17 @@ public class Buffers {
     }
 
     /**
+     * Determines the number of bytes written by {@link #writeLengthPrefixedBytes(ByteBuffer, byte[])}. A typical
+     * usage is for allocating a buffer of the right size.
+     *
+     * @param bytes bytes that are about to be written
+     * @return number of bytes required in the buffer, including length
+     */
+    public static int lengthPrefixedBytesSize(byte[] bytes) {
+        return VarInt.sizeOf(bytes.length) + bytes.length;
+    }
+
+    /**
      * First read a {@link VarInt} from the buffer and use it to determine the number of bytes to read. Then read
      * that many bytes and interpret it as an UTF-8 encoded string to be returned. This construct is frequently used
      * by Bitcoin protocols.
@@ -98,6 +109,18 @@ public class Buffers {
     public static ByteBuffer writeLengthPrefixedString(ByteBuffer buf, String str) throws BufferOverflowException {
         byte[] bytes = str.getBytes(StandardCharsets.UTF_8);
         return writeLengthPrefixedBytes(buf, bytes);
+    }
+
+    /**
+     * Determines the number of bytes written by {@link #writeLengthPrefixedString(ByteBuffer, String)}. A typical
+     * usage is for allocating a buffer of the right size.
+     *
+     * @param str string that is about to be written
+     * @return number of bytes required in the buffer, including length
+     */
+    public static int lengthPrefixedStringSize(String str) {
+        byte[] bytes = str.getBytes(StandardCharsets.UTF_8);
+        return lengthPrefixedBytesSize(bytes);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/PartialMerkleTree.java
+++ b/core/src/main/java/org/bitcoinj/core/PartialMerkleTree.java
@@ -157,7 +157,7 @@ public class PartialMerkleTree {
         int size = Integer.BYTES; // transactionCount
         size += VarInt.sizeOf(hashes.size());
         size += hashes.size() * Sha256Hash.LENGTH;
-        size += VarInt.sizeOf(matchedChildBits.length) + matchedChildBits.length;
+        size += Buffers.lengthPrefixedBytesSize(matchedChildBits);
         return size;
     }
 

--- a/core/src/main/java/org/bitcoinj/core/PeerAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerAddress.java
@@ -346,7 +346,7 @@ public class PeerAddress {
             } else if (addr == null && hostname != null && hostname.toLowerCase(Locale.ROOT).endsWith(".onion")) {
                 byte[] onionAddress = TorUtils.decodeOnionUrl(hostname);
                 if (onionAddress.length == 10 || onionAddress.length == 32) {
-                    size += VarInt.sizeOf(onionAddress.length) + onionAddress.length;
+                    size += Buffers.lengthPrefixedBytesSize(onionAddress);
                 } else {
                     throw new IllegalStateException();
                 }

--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -214,7 +214,7 @@ public class TransactionInput {
      */
     public int messageSize() {
         int size = TransactionOutPoint.BYTES;
-        size += VarInt.sizeOf(scriptBytes.length) + scriptBytes.length;
+        size += Buffers.lengthPrefixedBytesSize(scriptBytes);
         size += 4; // sequence
         return size;
     }

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -156,7 +156,7 @@ public class TransactionOutput {
      */
     public int messageSize() {
         int size = Coin.BYTES; // value
-        size += VarInt.sizeOf(scriptBytes.length) + scriptBytes.length;
+        size += Buffers.lengthPrefixedBytesSize(scriptBytes);
         return size;
     }
 

--- a/core/src/main/java/org/bitcoinj/core/TransactionWitness.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionWitness.java
@@ -174,7 +174,7 @@ public class TransactionWitness {
     public int messageSize() {
         int size = VarInt.sizeOf(pushes.size());
         for (byte[] push : pushes)
-            size += VarInt.sizeOf(push.length) + push.length;
+            size += Buffers.lengthPrefixedBytesSize(push);
         return size;
     }
 

--- a/core/src/test/java/org/bitcoinj/core/BuffersTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BuffersTest.java
@@ -38,7 +38,7 @@ public class BuffersTest {
     @Test
     @Parameters(method = "randomBytes")
     public void readAndWrite(byte[] bytes) {
-        ByteBuffer buf = ByteBuffer.allocate(VarInt.sizeOf(bytes.length) + bytes.length);
+        ByteBuffer buf = ByteBuffer.allocate(Buffers.lengthPrefixedBytesSize(bytes));
         Buffers.writeLengthPrefixedBytes(buf, bytes);
         assertFalse(buf.hasRemaining());
         ((Buffer) buf).rewind();


### PR DESCRIPTION
Those determine the number of bytes that are written by `writeLengthPrefixedBytes()` and `writeLengthPrefixedString()`, respectively.

Also use the new helpers where appropriate.