### PR TITLE
Block, Transaction, TransactionInput, TransactionOutput, TransactionWitness: make `messageSize()` more functional

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -278,10 +278,10 @@ public class Block extends BaseMessage {
         int size = HEADER_SIZE;
         List<Transaction> transactions = getTransactions();
         if (transactions != null) {
-            size += VarInt.sizeOf(transactions.size());
-            for (Transaction tx : transactions) {
-                size += tx.messageSize();
-            }
+            size += VarInt.sizeOf(transactions.size()) +
+                    transactions.stream()
+                            .mapToInt(Transaction::messageSize)
+                            .sum();
         }
         return size;
     }

--- a/core/src/main/java/org/bitcoinj/core/PartialMerkleTree.java
+++ b/core/src/main/java/org/bitcoinj/core/PartialMerkleTree.java
@@ -154,11 +154,10 @@ public class PartialMerkleTree {
      * @return size of the serialized message in bytes
      */
     public int messageSize() {
-        int size = Integer.BYTES; // transactionCount
-        size += VarInt.sizeOf(hashes.size());
-        size += hashes.size() * Sha256Hash.LENGTH;
-        size += Buffers.lengthPrefixedBytesSize(matchedChildBits);
-        return size;
+        return Integer.BYTES + // transactionCount
+                VarInt.sizeOf(hashes.size()) +
+                hashes.size() * Sha256Hash.LENGTH +
+                Buffers.lengthPrefixedBytesSize(matchedChildBits);
     }
 
     // Based on CPartialMerkleTree::TraverseAndBuild in Bitcoin Core.

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -1489,15 +1489,18 @@ public class Transaction extends BaseMessage {
         int size = 4; // version
         if (useSegwit)
             size += 2; // marker, flag
-        size += VarInt.sizeOf(inputs.size());
-        for (TransactionInput in : inputs)
-            size += in.messageSize();
-        size += VarInt.sizeOf(outputs.size());
-        for (TransactionOutput out : outputs)
-            size += out.messageSize();
+        size += VarInt.sizeOf(inputs.size()) +
+                inputs.stream()
+                        .mapToInt(TransactionInput::messageSize)
+                        .sum() +
+                VarInt.sizeOf(outputs.size()) +
+                outputs.stream()
+                        .mapToInt(TransactionOutput::messageSize)
+                        .sum();
         if (useSegwit)
-            for (TransactionInput in : inputs)
-                size += in.getWitness().messageSize();
+            size += inputs.stream()
+                    .mapToInt(in -> in.getWitness().messageSize())
+                    .sum();
         size += 4; // locktime
         return size;
     }

--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -213,10 +213,9 @@ public class TransactionInput {
      * @return size of the serialized message in bytes
      */
     public int messageSize() {
-        int size = TransactionOutPoint.BYTES;
-        size += Buffers.lengthPrefixedBytesSize(scriptBytes);
-        size += 4; // sequence
-        return size;
+        return TransactionOutPoint.BYTES +
+                Buffers.lengthPrefixedBytesSize(scriptBytes) +
+                4; // sequence
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -155,9 +155,8 @@ public class TransactionOutput {
      * @return size of the serialized message in bytes
      */
     public int messageSize() {
-        int size = Coin.BYTES; // value
-        size += Buffers.lengthPrefixedBytesSize(scriptBytes);
-        return size;
+        return Coin.BYTES + // value
+                Buffers.lengthPrefixedBytesSize(scriptBytes);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/TransactionWitness.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionWitness.java
@@ -172,10 +172,10 @@ public class TransactionWitness {
      * @return size of the serialized message in bytes
      */
     public int messageSize() {
-        int size = VarInt.sizeOf(pushes.size());
-        for (byte[] push : pushes)
-            size += Buffers.lengthPrefixedBytesSize(push);
-        return size;
+        return VarInt.sizeOf(pushes.size()) +
+                pushes.stream()
+                        .mapToInt(Buffers::lengthPrefixedBytesSize)
+                        .sum();
     }
 
     @Override


### PR DESCRIPTION
* replace variable re-assignments by concatenating additions
* use streams to walk and sum the various lists
    
Note: conditionals could be replaced with terniary expressions, but the resulting expression seems too difficult to understand as a whole.

This is another child of #3664.