### PR TITLE
Transaction: don't wrap Coin values in BigInteger

### DIFF
--- a/base/src/main/java/org/bitcoinj/base/internal/ByteUtils.java
+++ b/base/src/main/java/org/bitcoinj/base/internal/ByteUtils.java
@@ -327,28 +327,6 @@ public class ByteUtils {
     }
 
     /**
-     * Write a 64-bit integer to a given output stream in little-endian format.
-     * <p>
-     * The value is expected as an unsigned {@link BigInteger}.
-     *
-     * @param val    value to be written
-     * @param stream stream to be written into
-     * @throws IOException if an I/O error occurs
-     */
-    public static void writeInt64LE(BigInteger val, OutputStream stream) throws IOException {
-        byte[] bytes = val.toByteArray();
-        if (bytes.length > 8) {
-            throw new RuntimeException("Input too large to encode into a uint64");
-        }
-        bytes = reverseBytes(bytes);
-        stream.write(bytes);
-        if (bytes.length < 8) {
-            for (int i = 0; i < 8 - bytes.length; i++)
-                stream.write(0);
-        }
-    }
-
-    /**
      * Read 2 bytes from the buffer as unsigned 16-bit integer in little endian format.
      * @param buf buffer to be read from
      * @throws BufferUnderflowException if the read value extends beyond the remaining bytes of the buffer

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -51,7 +51,6 @@ import javax.annotation.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
@@ -1444,10 +1443,7 @@ public class Transaction extends BaseMessage {
             if (signAll) {
                 ByteArrayOutputStream bosHashOutputs = new ByteArrayOutputStream(256);
                 for (TransactionOutput output : this.outputs) {
-                    writeInt64LE(
-                            BigInteger.valueOf(output.getValue().getValue()),
-                            bosHashOutputs
-                    );
+                    writeInt64LE(output.getValue().getValue(), bosHashOutputs);
                     byte[] scriptBytes = output.getScriptBytes();
                     bosHashOutputs.write(VarInt.of(scriptBytes.length).serialize());
                     bosHashOutputs.write(scriptBytes);
@@ -1455,10 +1451,7 @@ public class Transaction extends BaseMessage {
                 hashOutputs = Sha256Hash.hashTwice(bosHashOutputs.toByteArray());
             } else if (basicSigHashType == SigHash.SINGLE.value && inputIndex < outputs.size()) {
                 ByteArrayOutputStream bosHashOutputs = new ByteArrayOutputStream(256);
-                writeInt64LE(
-                        BigInteger.valueOf(this.outputs.get(inputIndex).getValue().getValue()),
-                        bosHashOutputs
-                );
+                writeInt64LE(this.outputs.get(inputIndex).getValue().getValue(), bosHashOutputs);
                 byte[] scriptBytes = this.outputs.get(inputIndex).getScriptBytes();
                 bosHashOutputs.write(VarInt.of(scriptBytes.length).serialize());
                 bosHashOutputs.write(scriptBytes);
@@ -1471,7 +1464,7 @@ public class Transaction extends BaseMessage {
             writeInt32LE(inputs.get(inputIndex).getOutpoint().index(), bos);
             bos.write(VarInt.of(scriptCode.length).serialize());
             bos.write(scriptCode);
-            writeInt64LE(BigInteger.valueOf(prevValue.getValue()), bos);
+            writeInt64LE(prevValue.getValue(), bos);
             writeInt32LE(inputs.get(inputIndex).getSequenceNumber(), bos);
             bos.write(hashOutputs);
             writeInt32LE(this.vLockTime.rawValue(), bos);


### PR DESCRIPTION
This is likely a remnant from the past when we expressed Coin values as BigInteger.

As a side effect, we can get rid of a ByteUtils helper.