### PR TITLE
Transaction: optimize `getWeight()` to skip serialization

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -399,16 +399,9 @@ public class Transaction extends BaseMessage {
     public int getWeight() {
         if (!hasWitnesses())
             return this.messageSize() * 4;
-        try (final ByteArrayOutputStream stream = new ByteArrayOutputStream(255)) { // just a guess at an average tx length
-            bitcoinSerializeToStream(stream, false);
-            final int baseSize = stream.size();
-            stream.reset();
-            bitcoinSerializeToStream(stream, true);
-            final int totalSize = stream.size();
-            return baseSize * 3 + totalSize;
-        } catch (IOException e) {
-            throw new RuntimeException(e); // cannot happen
-        }
+        int baseSize = messageSize(false);
+        int totalSize = messageSize(true);
+        return baseSize * 3 + totalSize;
     }
 
     /** Gets the virtual transaction size as defined in BIP141. */
@@ -1488,7 +1481,10 @@ public class Transaction extends BaseMessage {
 
     @Override
     public int messageSize() {
-        boolean useSegwitSerialization = useSegwitSerialization();
+        return messageSize(useSegwitSerialization());
+    }
+
+    private int messageSize(boolean useSegwitSerialization) {
         int size = 4; // version
         if (useSegwitSerialization)
             size += 2; // marker, flag

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -727,11 +727,11 @@ public class TransactionTest {
         }
 
         @Override
-        protected void bitcoinSerializeToStream(OutputStream stream, boolean useSegwit) throws IOException {
+        protected void bitcoinSerializeToStream(OutputStream stream, boolean useSegwitSerialization) throws IOException {
             // version
             writeInt32LE(getVersion(), stream);
             // marker, flag
-            if (useSegwit) {
+            if (useSegwitSerialization) {
                 stream.write(0);
                 stream.write(1);
             }
@@ -746,7 +746,7 @@ public class TransactionTest {
             for (TransactionOutput out : getOutputs())
                 stream.write(out.serialize());
             // script_witnisses
-            if (useSegwit) {
+            if (useSegwitSerialization) {
                 for (TransactionInput in : getInputs()) {
                     TransactionWitness witness = in.getWitness();
                     long pushCount = hackWitnessPushCountSize ? Integer.MAX_VALUE : witness.getPushCount();


### PR DESCRIPTION
Now that we have accurate messageSize(), why not use it? We need to distinguish between segwit and non-segwit message sizes though.