### PR TITLE
Convert BaseMessage to StreamSerializedMessage mix-in

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AddressMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressMessage.java
@@ -31,7 +31,7 @@ import static org.bitcoinj.base.internal.Preconditions.check;
  * Abstract superclass for address messages on the P2P network, which contain network addresses of other peers. This is
  * one of the ways peers can find each other without using the {@link PeerDiscovery} mechanism.
  */
-public abstract class AddressMessage extends BaseMessage {
+public abstract class AddressMessage implements Message, StreamSerializedMessage {
 
     protected static final long MAX_ADDRESSES = 1000;
     protected List<PeerAddress> addresses;

--- a/core/src/main/java/org/bitcoinj/core/AddressV1Message.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressV1Message.java
@@ -64,7 +64,7 @@ public class AddressV1Message extends AddressMessage {
     }
 
     @Override
-    protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
+    public void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         if (addresses == null)
             return;
         stream.write(VarInt.of(addresses.size()).serialize());

--- a/core/src/main/java/org/bitcoinj/core/AddressV2Message.java
+++ b/core/src/main/java/org/bitcoinj/core/AddressV2Message.java
@@ -65,7 +65,7 @@ public class AddressV2Message extends AddressMessage {
     }
 
     @Override
-    protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
+    public void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         if (addresses == null)
             return;
         stream.write(VarInt.of(addresses.size()).serialize());

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -71,7 +71,7 @@ import static org.bitcoinj.base.internal.Preconditions.checkState;
  * 
  * <p>Instances of this class are not safe for use by multiple threads.</p>
  */
-public class Block extends BaseMessage {
+public class Block implements Message, StreamSerializedMessage {
     /**
      * Flags used to control which elements of block validation are done on
      * received blocks.
@@ -310,7 +310,7 @@ public class Block extends BaseMessage {
     }
 
     @Override
-    protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
+    public void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         writeHeader(stream);
         writeTransactions(stream);
     }

--- a/core/src/main/java/org/bitcoinj/core/BloomFilter.java
+++ b/core/src/main/java/org/bitcoinj/core/BloomFilter.java
@@ -55,7 +55,7 @@ import static org.bitcoinj.base.internal.Preconditions.checkArgument;
  * 
  * <p>Instances of this class are not safe for use by multiple threads.</p>
  */
-public class BloomFilter extends BaseMessage {
+public class BloomFilter implements Message, StreamSerializedMessage {
     /** The BLOOM_UPDATE_* constants control when the bloom filter is auto-updated by the peer using
         it as a filter, either never, for all outputs or only for P2PK outputs (default) */
     public enum BloomUpdate {
@@ -179,7 +179,7 @@ public class BloomFilter extends BaseMessage {
      * Serializes this message to the provided stream. If you just want the raw bytes use {@link #serialize()}.
      */
     @Override
-    protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
+    public void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         stream.write(VarInt.of(data.length).serialize());
         stream.write(data);
         ByteUtils.writeInt32LE(hashFuncs, stream);

--- a/core/src/main/java/org/bitcoinj/core/EmptyMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/EmptyMessage.java
@@ -26,7 +26,7 @@ import java.io.OutputStream;
  * 
  * <p>Instances of this class are not safe for use by multiple threads.</p>
  */
-public abstract class EmptyMessage extends BaseMessage {
+public abstract class EmptyMessage implements Message, StreamSerializedMessage {
 
     public EmptyMessage() {
         super();
@@ -38,6 +38,6 @@ public abstract class EmptyMessage extends BaseMessage {
     }
 
     @Override
-    protected final void bitcoinSerializeToStream(OutputStream stream) throws IOException {
+    public final void bitcoinSerializeToStream(OutputStream stream) throws IOException {
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/FeeFilterMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/FeeFilterMessage.java
@@ -33,7 +33,7 @@ import static org.bitcoinj.base.internal.Preconditions.check;
  * <p>
  * Instances of this class are immutable.
  */
-public class FeeFilterMessage extends BaseMessage {
+public class FeeFilterMessage implements Message, StreamSerializedMessage {
     private final Coin feeRate;
 
     /**
@@ -69,7 +69,7 @@ public class FeeFilterMessage extends BaseMessage {
     }
 
     @Override
-    protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
+    public void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         stream.write(feeRate.serialize());
     }
 

--- a/core/src/main/java/org/bitcoinj/core/FilteredBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/FilteredBlock.java
@@ -37,7 +37,7 @@ import java.util.Objects;
  * 
  * <p>Instances of this class are not safe for use by multiple threads.</p>
  */
-public class FilteredBlock extends BaseMessage {
+public class FilteredBlock implements Message, StreamSerializedMessage {
     private final Block header;
 
     private final PartialMerkleTree merkleTree;

--- a/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/GetBlocksMessage.java
@@ -36,7 +36,7 @@ import static org.bitcoinj.base.internal.Preconditions.check;
  * 
  * <p>Instances of this class are not safe for use by multiple threads.</p>
  */
-public class GetBlocksMessage extends BaseMessage {
+public class GetBlocksMessage implements Message, StreamSerializedMessage {
 
     protected long version;
     protected BlockLocator locator;
@@ -92,7 +92,7 @@ public class GetBlocksMessage extends BaseMessage {
     }
 
     @Override
-    protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
+    public void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         // Version, for some reason.
         ByteUtils.writeInt32LE(version, stream);
         // Then a vector of block hashes. This is actually a "block locator", a set of block

--- a/core/src/main/java/org/bitcoinj/core/HeadersMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/HeadersMessage.java
@@ -38,7 +38,7 @@ import static org.bitcoinj.base.internal.Preconditions.check;
  * 
  * <p>Instances of this class are not safe for use by multiple threads.</p>
  */
-public class HeadersMessage extends BaseMessage {
+public class HeadersMessage implements Message, StreamSerializedMessage {
     private static final Logger log = LoggerFactory.getLogger(HeadersMessage.class);
 
     // The main client will never send us more than this number of headers.

--- a/core/src/main/java/org/bitcoinj/core/ListMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/ListMessage.java
@@ -37,7 +37,7 @@ import static org.bitcoinj.base.internal.Preconditions.check;
  * 
  * <p>Instances of this class -- that use deprecated methods -- are not safe for use by multiple threads.</p>
  */
-public abstract class ListMessage extends BaseMessage {
+public abstract class ListMessage implements Message, StreamSerializedMessage {
 
     // For some reason the compiler complains if this is inside InventoryItem
     protected final List<InventoryItem> items;

--- a/core/src/main/java/org/bitcoinj/core/Ping.java
+++ b/core/src/main/java/org/bitcoinj/core/Ping.java
@@ -29,7 +29,7 @@ import java.util.Random;
  * <p>
  * Instances of this class are immutable.
  */
-public class Ping extends BaseMessage {
+public class Ping implements Message, StreamSerializedMessage {
     private final long nonce;
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/Pong.java
+++ b/core/src/main/java/org/bitcoinj/core/Pong.java
@@ -28,7 +28,7 @@ import java.nio.ByteBuffer;
  * <p>
  * Instances of this class are immutable.
  */
-public class Pong extends BaseMessage {
+public class Pong implements Message, StreamSerializedMessage {
     private final long nonce;
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/RejectMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/RejectMessage.java
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
  * <p>
  * Instances of this class are immutable.
  */
-public class RejectMessage extends BaseMessage {
+public class RejectMessage implements Message, StreamSerializedMessage {
     public enum RejectCode {
         /** The message was not able to be parsed */
         MALFORMED((byte) 0x01),

--- a/core/src/main/java/org/bitcoinj/core/StreamSerializedMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/StreamSerializedMessage.java
@@ -27,7 +27,7 @@ import java.io.OutputStream;
  * <p>
  * Instances of this class are not safe for use by multiple threads.
  */
-public abstract class BaseMessage implements Message {
+interface StreamSerializedMessage extends Message {
     // These methods handle the serialization/deserialization using the custom Bitcoin protocol.
 
     /**
@@ -36,7 +36,7 @@ public abstract class BaseMessage implements Message {
      * @return serialized data in Bitcoin protocol format
      */
     @Override
-    public final byte[] serialize() {
+    default byte[] serialize() {
         // No cached array available so serialize parts by stream.
         ByteArrayOutputStream stream = new ByteArrayOutputStream(100); // initial size just a guess
         try {
@@ -50,5 +50,5 @@ public abstract class BaseMessage implements Message {
     /**
      * Serializes this message to the provided stream. If you just want the raw bytes use {@link #serialize()}.
      */
-    protected abstract void bitcoinSerializeToStream(OutputStream stream) throws IOException;
+    void bitcoinSerializeToStream(OutputStream stream) throws IOException;
 }

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -91,7 +91,7 @@ import static org.bitcoinj.base.internal.ByteUtils.writeInt64LE;
  * 
  * <p>Instances of this class are not safe for use by multiple threads.</p>
  */
-public class Transaction extends BaseMessage {
+public class Transaction implements Message, StreamSerializedMessage {
     private static final Comparator<Transaction> SORT_TX_BY_ID = Comparator.comparing(Transaction::getTxId);
 
     /**
@@ -1506,7 +1506,7 @@ public class Transaction extends BaseMessage {
     }
 
     @Override
-    protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
+    public void bitcoinSerializeToStream(OutputStream stream) throws IOException {
         boolean useSegwit = hasWitnesses() && allowWitness(protocolVersion);
         bitcoinSerializeToStream(stream, useSegwit);
     }

--- a/core/src/main/java/org/bitcoinj/core/VersionMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionMessage.java
@@ -48,7 +48,7 @@ import static org.bitcoinj.base.internal.Preconditions.check;
  * 
  * <p>Instances of this class are not safe for use by multiple threads.</p>
  */
-public class VersionMessage extends BaseMessage {
+public class VersionMessage implements Message, StreamSerializedMessage {
 
     /** The version of this library release, as a string. */
     public static final String BITCOINJ_VERSION = "0.18-SNAPSHOT";

--- a/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
@@ -236,12 +236,12 @@ public class BitcoinSerializerTest {
     public void testSerializeUnknownMessage() throws Exception {
         MessageSerializer serializer = MAINNET.getDefaultSerializer();
 
-        Message unknownMessage = new BaseMessage() {
+        Message unknownMessage = new StreamSerializedMessage() {
             @Override
             public int messageSize() { return 0; }
 
             @Override
-            protected void bitcoinSerializeToStream(OutputStream stream) {}
+            public void bitcoinSerializeToStream(OutputStream stream) {}
         };
         ByteArrayOutputStream bos = new ByteArrayOutputStream(ADDRESS_MESSAGE_BYTES.length);
         serializer.serialize(unknownMessage, bos);

--- a/core/src/test/java/org/bitcoinj/core/BlockTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockTest.java
@@ -316,7 +316,7 @@ public class BlockTest {
         Block block = new Block(1, Sha256Hash.ZERO_HASH, Sha256Hash.ZERO_HASH, Instant.ofEpochSecond(1),
                 Difficulty.EASIEST_DIFFICULTY_TARGET, 1, new ArrayList<Transaction>()) {
             @Override
-            protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {
+            public void bitcoinSerializeToStream(OutputStream stream) throws IOException {
                 ByteUtils.writeInt32LE(getVersion(), stream);
                 stream.write(getPrevBlockHash().serialize());
                 stream.write(getMerkleRoot().serialize());


### PR DESCRIPTION
This is just a demonstration of the mix-in approach. As previously discussed, exposing `void bitcoinSerializeToStream(OutputStream stream)` is an unfortunate side-effect. And because we're moving to `ByteBuffer`-based serialization this is moot. So after @schildbach looks at this, we'll just close this issue.

