### PR TITLE
Transaction: add helper `useSegwitSerialization()`

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -727,11 +727,11 @@ public class TransactionTest {
         }
 
         @Override
-        protected void bitcoinSerializeToStream(OutputStream stream, boolean useSegwit) throws IOException {
+        protected void bitcoinSerializeToStream(OutputStream stream, boolean useSegwitSerialization) throws IOException {
             // version
             writeInt32LE(getVersion(), stream);
             // marker, flag
-            if (useSegwit) {
+            if (useSegwitSerialization) {
                 stream.write(0);
                 stream.write(1);
             }
@@ -746,7 +746,7 @@ public class TransactionTest {
             for (TransactionOutput out : getOutputs())
                 stream.write(out.serialize());
             // script_witnisses
-            if (useSegwit) {
+            if (useSegwitSerialization) {
                 for (TransactionInput in : getInputs()) {
                     TransactionWitness witness = in.getWitness();
                     long pushCount = hackWitnessPushCountSize ? Integer.MAX_VALUE : witness.getPushCount();


### PR DESCRIPTION
It determines if segwit serialization should be used for this transaction, based on whether it has any witnesses and on protocol version.

Also renames variables/parameters to `useSegwitSerialization` to make clear it's about the serialization format.