### PR TITLE
Wallettool modularize `call()` method

### DIFF
--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -332,10 +332,7 @@ public class WalletTool implements Callable<Integer> {
 
         setupLogging(debugLog);
         params = NetworkParameters.of(net);
-        String fileName = String.format("%s.chain", net);
-        if (chainFile == null) {
-            chainFile = new File(fileName);
-        }
+        setDefaultChainFile(net);
         Context.propagate(new Context());
 
         if (conditionStr != null) {
@@ -465,6 +462,12 @@ public class WalletTool implements Callable<Integer> {
         shutdown();
 
         return 0;
+    }
+
+    private void setDefaultChainFile(BitcoinNetwork net) {
+        if (chainFile == null) {
+            chainFile = new File(String.format("%s.chain", net));
+        }
     }
 
     private void setupLogging(boolean debugLog){

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -332,7 +332,11 @@ public class WalletTool implements Callable<Integer> {
 
         setupLogging(debugLog);
         params = NetworkParameters.of(net);
-        setDefaultChainFile(net);
+
+        if(chainFile == null){
+            chainFile = getDefaultChainFile(net);
+        }
+        getDefaultChainFile(net);
         Context.propagate(new Context());
 
         if (conditionStr != null) {
@@ -464,13 +468,11 @@ public class WalletTool implements Callable<Integer> {
         return 0;
     }
 
-    private void setDefaultChainFile(BitcoinNetwork net) {
-        if (chainFile == null) {
-            chainFile = new File(String.format("%s.chain", net));
-        }
+    private static File getDefaultChainFile(BitcoinNetwork net) {
+            return new File(String.format("%s.chain", net));
     }
 
-    private void setupLogging(boolean debugLog){
+    private static void setupLogging(boolean debugLog){
         if (debugLog) {
             BriefLogFormatter.init();
             log.info("Starting up ...");

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -330,14 +330,7 @@ public class WalletTool implements Callable<Integer> {
             return 1;
         }
 
-        if (debugLog) {
-            BriefLogFormatter.init();
-            log.info("Starting up ...");
-        } else {
-            // Disable logspam unless there is a flag.
-            java.util.logging.Logger logger = LogManager.getLogManager().getLogger("");
-            logger.setLevel(Level.SEVERE);
-        }
+        setupLogging(debugLog);
         params = NetworkParameters.of(net);
         String fileName = String.format("%s.chain", net);
         if (chainFile == null) {
@@ -472,6 +465,17 @@ public class WalletTool implements Callable<Integer> {
         shutdown();
 
         return 0;
+    }
+
+    private void setupLogging(boolean debugLog){
+        if (debugLog) {
+            BriefLogFormatter.init();
+            log.info("Starting up ...");
+        } else {
+            // Disable logspam unless there is a flag.
+            java.util.logging.Logger logger = LogManager.getLogManager().getLogger("");
+            logger.setLevel(Level.SEVERE);
+        }
     }
 
     private static Protos.Wallet attemptHexConversion(Protos.Wallet proto) {


### PR DESCRIPTION
This pr is based on feedback [here ](https://github.com/bitcoinj/bitcoinj/pull/3667#discussion_r2019570790)in PR #3667

This contains 2 commits that
- Moves log setup to its own method
- Moves default chain setup to its own method