### PR TITLE
Block: make header-only state immutable

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/FilteredBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/FilteredBlock.java
@@ -73,7 +73,7 @@ public class FilteredBlock implements Message {
 
     @Override
     public ByteBuffer write(ByteBuffer buf) throws BufferOverflowException {
-        if (header.getTransactions() == null)
+        if (header.isHeaderOnly())
             header.write(buf);
         else
             header.cloneAsHeader().write(buf);

--- a/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
@@ -46,6 +46,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 
+import static org.bitcoinj.base.internal.Preconditions.checkArgument;
 import static org.bitcoinj.base.internal.Preconditions.checkState;
 
 /**
@@ -199,8 +200,7 @@ public class FullPrunedBlockChain extends AbstractBlockChain {
     protected TransactionOutputChanges connectTransactions(int height, Block block)
             throws VerificationException, BlockStoreException {
         checkState(lock.isHeldByCurrentThread());
-        if (block.getTransactions() == null)
-            throw new RuntimeException("connectTransactions called with Block that didn't have transactions!");
+        checkArgument(!block.isHeaderOnly(), () -> "block is header-only");
         if (!params.passesCheckpoint(height, block.getHash()))
             throw new VerificationException("Block failed checkpoint lockin at " + height);
 

--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -934,7 +934,7 @@ public class Peer extends PeerSocketHandler {
     protected void processBlock(Block m) {
         if (log.isDebugEnabled())
             log.debug("{}: Received broadcast block {}", getAddress(), m.getHashAsString());
-        if (m.getTransactions() != null) {
+        if (!m.isHeaderOnly()) {
             m.getTransactions().forEach(tx ->
                 tx.getConfidence().maybeSetSourceToNetwork()
             );

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -1878,9 +1878,8 @@ public class PeerGroup implements TransactionBroadcaster {
         public synchronized void onBlocksDownloaded(Peer peer, Block block, @Nullable FilteredBlock filteredBlock, int blocksLeft) {
             blocksInLastSecond++;
             bytesInLastSecond += Block.HEADER_SIZE;
-            List<Transaction> blockTransactions = block.getTransactions();
             // This whole area of the type hierarchy is a mess.
-            int txCount = (blockTransactions != null ? countAndMeasureSize(blockTransactions) : 0) +
+            int txCount = (!block.isHeaderOnly() ? countAndMeasureSize(block.getTransactions()) : 0) +
                           (filteredBlock != null ? countAndMeasureSize(filteredBlock.getAssociatedTransactions().values()) : 0);
             txnsInLastSecond = txnsInLastSecond + txCount;
             if (filteredBlock != null)

--- a/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
@@ -155,7 +155,7 @@ public class BitcoinSerializerTest {
         // http://blockexplorer.com/b/1
         Block block = headersMessage.getBlockHeaders().get(0);
         assertEquals("00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048", block.getHashAsString());
-        assertNotNull(block.transactions);
+        assertFalse(block.isHeaderOnly());
         assertEquals("0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098", ByteUtils.formatHex(block.getMerkleRoot().getBytes()));
 
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();


### PR DESCRIPTION
Blocks can't shapeshift between regular (with transactions) and header-only any more. The `transactions` field is made final.

Add public `isHeaderOnly()` and use it.

Note: there is a difference between header-only, and an empty list of transactions. Headers do not contain the transaction count in its serialized representation.


This is draft because I want to make use of the new method in other classes – currently it's used only internally. Still I'd be interested in early feedback.
