### PR TITLE
Block: add a test helper `replaceTransactions()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -678,23 +678,25 @@ public class Block implements Message {
 
     /** Adds a transaction to this block. The nonce and merkle root are invalid after this. */
     public void addTransaction(Transaction t) {
-        addTransaction(t, true);
-    }
-
-    /** Adds a transaction to this block, with or without checking the sanity of doing so */
-    void addTransaction(Transaction t, boolean runSanityChecks) {
         unCacheTransactions();
         if (transactions == null) {
             transactions = new ArrayList<>();
         }
-        if (runSanityChecks && transactions.size() == 0 && !t.isCoinBase())
+        if (transactions.isEmpty() && !t.isCoinBase())
             throw new RuntimeException("Attempted to add a non-coinbase transaction as the first transaction: " + t);
-        else if (runSanityChecks && transactions.size() > 0 && t.isCoinBase())
+        else if (!transactions.isEmpty() && t.isCoinBase())
             throw new RuntimeException("Attempted to add a coinbase transaction when there already is one: " + t);
         transactions.add(t);
         // Force a recalculation next time the values are needed.
         merkleRoot = null;
         hash = null;
+    }
+
+    /** For testing only. */
+    @VisibleForTesting
+    void replaceTransactions(List<Transaction> transactions) {
+        unCacheTransactions();
+        this.transactions = new ArrayList<>(transactions);
     }
 
     /**

--- a/core/src/test/java/org/bitcoinj/core/BlockTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockTest.java
@@ -43,7 +43,7 @@ import java.nio.Buffer;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.time.Instant;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -130,10 +130,12 @@ public class BlockTest {
     @Test
     public void testBadTransactions() {
         // Re-arrange so the coinbase transaction is not first.
-        Transaction tx1 = block700000.transactions.get(0);
-        Transaction tx2 = block700000.transactions.get(1);
-        block700000.transactions.set(0, tx2);
-        block700000.transactions.set(1, tx1);
+        List<Transaction> transactions = new ArrayList<>(block700000.getTransactions());
+        Transaction tx1 = transactions.get(0);
+        Transaction tx2 = transactions.get(1);
+        transactions.set(0, tx2);
+        transactions.set(1, tx1);
+        block700000.replaceTransactions(transactions);
         try {
             Block.verify(TESTNET, block700000, Block.BLOCK_HEIGHT_GENESIS, EnumSet.noneOf(Block.VerifyFlag.class));
             fail();

--- a/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
@@ -43,6 +43,7 @@ import java.math.BigInteger;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -252,9 +253,7 @@ public class ChainSplitTest {
         //         -> b2
         Block b2 = TESTNET.getGenesisBlock().createNextBlock(coinsTo);
         Transaction b2coinbase = b2.transactions.get(0);
-        b2.transactions.clear();
-        b2.addTransaction(b2coinbase);
-        b2.addTransaction(t);
+        b2.replaceTransactions(Arrays.asList(b2coinbase, t));
         chain.add(roundtrip(b2));
         assertEquals(FIFTY_COINS, wallet.getBalance());
         assertTrue(wallet.isConsistent());

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -943,7 +943,7 @@ public class FullBlockTestGenerator {
             } catch (RuntimeException e) { } // Should happen
             if (b45.getTransactions().size() > 0)
                 throw new RuntimeException("addTransaction doesn't properly check for adding a non-coinbase as first tx");
-            b45.addTransaction(t, false);
+            b45.replaceTransactions(Arrays.asList(t));
 
             b45.setTime(b44.time().plusSeconds(1));
         }
@@ -953,7 +953,6 @@ public class FullBlockTestGenerator {
         // A block with no txn
         Block b46 = new Block(Block.BLOCK_VERSION_GENESIS, b44.getHash());
         {
-            b46.transactions = new ArrayList<>();
             b46.setDifficultyTarget(b44.difficultyTarget());
             b46.setMerkleRoot(Sha256Hash.ZERO_HASH);
 
@@ -1010,7 +1009,9 @@ public class FullBlockTestGenerator {
             Transaction coinbase = new Transaction();
             coinbase.addInput(TransactionInput.coinbaseInput(coinbase, new byte[]{(byte) 0xff, 110, 1}));
             coinbase.addOutput(new TransactionOutput(coinbase, SATOSHI, outScriptBytes));
-            b51.block.addTransaction(coinbase, false);
+            List<Transaction> transactions = new ArrayList<>(b51.block.getTransactions());
+            transactions.add(coinbase);
+            b51.block.replaceTransactions(transactions);
         }
         b51.solve();
         blocks.add(new BlockAndValidity(b51, false, true, b44.getHash(), chainHeadHeight + 15, "b51"));


### PR DESCRIPTION
This is a more powerful replacement to the former helper `addTransaction(tx, runSanityChecks)`. Use it to get rid of direct mutations of the `transactions` field.