### PR TITLE
DeterministicKey: fix depth can overflow byte in `serialize()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -18,6 +18,7 @@
 package org.bitcoinj.crypto;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.primitives.UnsignedBytes;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.internal.ByteUtils;
@@ -498,7 +499,7 @@ public class DeterministicKey extends ECKey {
             ser.putInt(pub ? params.getBip32HeaderP2WPKHpub() : params.getBip32HeaderP2WPKHpriv());
         else
             throw new IllegalStateException(outputScriptType.toString());
-        ser.put((byte) getDepth());
+        ser.put(UnsignedBytes.checkedCast(getDepth()));
         ser.putInt(getParentFingerprint());
         ser.putInt(getChildNumber().i());
         ser.put(getChainCode());
@@ -591,7 +592,7 @@ public class DeterministicKey extends ECKey {
         final boolean priv = header == params.getBip32HeaderP2PKHpriv() || header == params.getBip32HeaderP2WPKHpriv();
         if (!(pub || priv))
             throw new IllegalArgumentException("Unknown header bytes: " + toBase58(serializedKey).substring(0, 4));
-        int depth = buffer.get() & 0xFF; // convert signed byte to positive int since depth cannot be negative
+        int depth = Byte.toUnsignedInt(buffer.get()); // convert signed byte to positive int since depth cannot be negative
         final int parentFingerprint = buffer.getInt();
         final int i = buffer.getInt();
         final ChildNumber childNumber = new ChildNumber(i);

--- a/core/src/test/java/org/bitcoinj/crypto/DeterministicKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/DeterministicKeyTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.crypto;
+
+import org.bitcoinj.base.BitcoinNetwork;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.fail;
+
+public class DeterministicKeyTest {
+    @Test
+    public void serialize_depthOverflow() {
+        DeterministicKey masterPrivateKey = HDKeyDerivation.createMasterPrivateKey(new byte[16]);
+        DeterministicHierarchy dh = new DeterministicHierarchy(masterPrivateKey);
+        HDPath path = new HDPath(false, Collections.nCopies(255, ChildNumber.ZERO));
+        DeterministicKey ehkey = dh.get(path, false, true);
+
+        ehkey.serialize(BitcoinNetwork.MAINNET, false); // still fine at depth 255
+
+        path = path.extend(ChildNumber.ZERO);
+        ehkey = dh.get(path, false, true);
+        try {
+            ehkey.serialize(BitcoinNetwork.MAINNET, false); // throw at depth 256
+            fail();
+        } catch (IllegalArgumentException x) {
+            // expected
+        }
+    }
+}


### PR DESCRIPTION
Also use `Byte.toUnsignedInt()` when deserializing.

Fixes #3683.