### PR TITLE
ECKey: make constructor based on `ECPoint` private

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -94,7 +94,7 @@ public class DeterministicKey extends ECKey {
                             byte[] chainCode,
                             BigInteger priv,
                             @Nullable DeterministicKey parent) {
-        super(priv, ECKey.publicPointFromPrivate(priv), true);
+        super(priv, new LazyECPoint(ECKey.publicPointFromPrivate(priv), true));
         checkArgument(chainCode.length == 32);
         this.parent = parent;
         this.childNumberPath = Objects.requireNonNull(hdPath);
@@ -160,7 +160,7 @@ public class DeterministicKey extends ECKey {
                             @Nullable DeterministicKey parent,
                             int depth,
                             int parentFingerprint) {
-        super(priv, ECKey.publicPointFromPrivate(priv), true);
+        super(priv, new LazyECPoint(ECKey.publicPointFromPrivate(priv), true));
         checkArgument(chainCode.length == 32);
         this.parent = parent;
         this.childNumberPath = HDPath.M(Objects.requireNonNull(childNumberPath));

--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -220,7 +220,7 @@ public class ECKey implements EncryptableItem {
         creationTime = TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS);
     }
 
-    protected ECKey(@Nullable BigInteger priv, ECPoint pub, boolean compressed) {
+    private ECKey(@Nullable BigInteger priv, ECPoint pub, boolean compressed) {
         this(priv, new LazyECPoint(Objects.requireNonNull(pub), compressed));
     }
 


### PR DESCRIPTION
Change two usages to construct the `LazyECPoint` themselves.

This is a child of #3700.