### PR TITLE
HDPath: implement `equals()` and `hashCode()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/HDPath.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDPath.java
@@ -169,6 +169,20 @@ public abstract class HDPath extends AbstractList<ChildNumber> {
         public HDPartialPath asPartial() {
             return new HDPartialPath(this.childNumbers);
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if ((o == null) || getClass() != o.getClass()) return false;
+            HDFullPath other = (HDFullPath) o;
+            return Objects.equals(this.hasPrivateKey, other.hasPrivateKey) &&
+                    super.equals(other);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.hasPrivateKey, super.hashCode());
+        }
     }
 
     public static class HDPartialPath extends HDPath {
@@ -540,7 +554,7 @@ public abstract class HDPath extends AbstractList<ChildNumber> {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if ((o == null) || !(o instanceof HDPath)) return false;
+        if ((o == null) || getClass() != o.getClass()) return false;
         HDPath other = (HDPath) o;
         return Objects.equals(this.childNumbers, other.childNumbers);
     }

--- a/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
@@ -278,7 +278,6 @@ public class HDPathTest {
     }
 
     @Test
-    @Ignore("Ignored until we have a correct implementation of equals that compares the prefix")
     public void equals_not_M_m() {
         assertNotEquals(HDPath.M(), HDPath.m());
     }


### PR DESCRIPTION
Take the `hasPrivateKey` (prefix) into account.

Also add a test, and change some that don't work any more.