### PR TITLE
DeterministicKey: Make parentFingerprint final

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -60,7 +60,7 @@ public class DeterministicKey extends ECKey {
     private final DeterministicKey parent;
     private final HDPath childNumberPath;
     private final int depth;
-    private int parentFingerprint; // 0 if this key is root node of key hierarchy
+    private final int parentFingerprint; // 0 if this key is root node of key hierarchy
 
     /** 32 bytes */
     private final byte[] chainCode;
@@ -140,13 +140,7 @@ public class DeterministicKey extends ECKey {
                             @Nullable DeterministicKey parent,
                             int depth,
                             int parentFingerprint) {
-        super(null, publicAsPoint.compress());
-        checkArgument(chainCode.length == 32);
-        this.parent = parent;
-        this.childNumberPath = HDPath.M(Objects.requireNonNull(childNumberPath));
-        this.chainCode = Arrays.copyOf(chainCode, chainCode.length);
-        this.depth = depth;
-        this.parentFingerprint = ascertainParentFingerprint(parent, parentFingerprint);
+        this(childNumberPath, chainCode, publicAsPoint, null, parent, depth, parentFingerprint);
     }
 
     /**
@@ -160,7 +154,17 @@ public class DeterministicKey extends ECKey {
                             @Nullable DeterministicKey parent,
                             int depth,
                             int parentFingerprint) {
-        super(priv, new LazyECPoint(ECKey.publicPointFromPrivate(priv), true));
+        this(childNumberPath, chainCode, new LazyECPoint(ECKey.publicPointFromPrivate(priv), true), priv, parent, depth, parentFingerprint);
+    }
+
+    private DeterministicKey(List<ChildNumber> childNumberPath,
+                             byte[] chainCode,
+                             LazyECPoint pub,
+                             @Nullable BigInteger priv,
+                             @Nullable DeterministicKey parent,
+                             int depth,
+                             int parentFingerprint) {
+        super(priv, pub);
         checkArgument(chainCode.length == 32);
         this.parent = parent;
         this.childNumberPath = HDPath.M(Objects.requireNonNull(childNumberPath));
@@ -278,8 +282,7 @@ public class DeterministicKey extends ECKey {
      * private key at all.</p>
      */
     public DeterministicKey dropParent() {
-        DeterministicKey key = new DeterministicKey(getPath(), getChainCode(), pub, priv, null);
-        key.parentFingerprint = parentFingerprint;
+        DeterministicKey key = new DeterministicKey(getPath(), getChainCode(), pub, priv, null, depth, parentFingerprint);
         return key;
     }
 


### PR DESCRIPTION
* Make parentFingerprint final
* Create a new private constructor that takes `pub` and `priv` and can be used in dropParent() and can also be called from two similar constructors that take `pub` OR `priv`.

This is similar to PR #3702, but differs in at least two ways:

1. It is a standalone PR that doesn't require any changes to ECKey, etc. as prerequisites
2. It preserves 2 existing constructors that could be marked as @Deprecated in a separate commit.