### PR TITLE
DeterministicKey: add makeHDPath() static helper 

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -73,7 +73,7 @@ public class DeterministicKey extends ECKey {
         super(priv, publicAsPoint.compress());
         checkArgument(chainCode.length == 32);
         this.parent = parent;
-        this.childNumberPath = HDPath.M(Objects.requireNonNull(childNumberPath));
+        this.childNumberPath = makeHDPath(Objects.requireNonNull(childNumberPath), priv);
         this.chainCode = Arrays.copyOf(chainCode, chainCode.length);
         this.depth = parent == null ? 0 : parent.depth + 1;
         this.parentFingerprint = (parent != null) ? parent.getFingerprint() : 0;
@@ -167,12 +167,19 @@ public class DeterministicKey extends ECKey {
         super(priv, pub);
         checkArgument(chainCode.length == 32);
         this.parent = parent;
-        this.childNumberPath = HDPath.M(Objects.requireNonNull(childNumberPath));
+        this.childNumberPath = makeHDPath(Objects.requireNonNull(childNumberPath), priv);
         this.chainCode = Arrays.copyOf(chainCode, chainCode.length);
         this.depth = depth;
         this.parentFingerprint = ascertainParentFingerprint(parentFingerprint);
     }
 
+    // If we don't already have an HDPath, this method will create
+    // and return an HDPath.M or HDPath.m as appropriate based on whether `priv` is non-null
+    private static HDPath makeHDPath(List<ChildNumber> childNumberPath, @Nullable BigInteger priv) {
+        return childNumberPath instanceof HDPath
+                ? (HDPath) childNumberPath
+                : HDPath.of(priv != null ? HDPath.Prefix.PRIVATE : HDPath.Prefix.PUBLIC, childNumberPath);
+    }
     
     /** Clones the key */
     public DeterministicKey(DeterministicKey keyToClone, DeterministicKey newParent) {

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -59,7 +59,7 @@ public class DeterministicKey extends ECKey {
     private final DeterministicKey parent;
     private final HDPath childNumberPath;
     private final int depth;
-    private int parentFingerprint; // 0 if this key is root node of key hierarchy
+    private final int parentFingerprint; // 0 if this key is root node of key hierarchy
 
     /** 32 bytes */
     private final byte[] chainCode;
@@ -140,13 +140,7 @@ public class DeterministicKey extends ECKey {
                             @Nullable DeterministicKey parent,
                             int depth,
                             int parentFingerprint) {
-        super(null, publicAsPoint.compress());
-        checkArgument(chainCode.length == 32);
-        this.parent = parent;
-        this.childNumberPath = HDPath.M(Objects.requireNonNull(childNumberPath));
-        this.chainCode = Arrays.copyOf(chainCode, chainCode.length);
-        this.depth = depth;
-        this.parentFingerprint = ascertainParentFingerprint(parentFingerprint);
+        this(childNumberPath, chainCode, publicAsPoint, null, parent, depth, parentFingerprint);
     }
 
     /**
@@ -160,7 +154,17 @@ public class DeterministicKey extends ECKey {
                             @Nullable DeterministicKey parent,
                             int depth,
                             int parentFingerprint) {
-        super(priv, ECKey.publicPointFromPrivate(priv), true);
+        this(childNumberPath, chainCode, new LazyECPoint(ECKey.publicPointFromPrivate(priv), true), priv, parent, depth, parentFingerprint);
+    }
+
+    private DeterministicKey(List<ChildNumber> childNumberPath,
+                             byte[] chainCode,
+                             LazyECPoint pub,
+                             @Nullable BigInteger priv,
+                             @Nullable DeterministicKey parent,
+                             int depth,
+                             int parentFingerprint) {
+        super(priv, pub);
         checkArgument(chainCode.length == 32);
         this.parent = parent;
         this.childNumberPath = HDPath.M(Objects.requireNonNull(childNumberPath));
@@ -278,8 +282,7 @@ public class DeterministicKey extends ECKey {
      * private key at all.</p>
      */
     public DeterministicKey dropParent() {
-        DeterministicKey key = new DeterministicKey(getPath(), getChainCode(), pub, priv, null);
-        key.parentFingerprint = parentFingerprint;
+        DeterministicKey key = new DeterministicKey(getPath(), getChainCode(), pub, priv, null, depth, parentFingerprint);
         return key;
     }
 


### PR DESCRIPTION
Add a static helper method for use in constructors (and elsewhere)
that takes a List<ChildNumber> (which could already be an HDPath) and
returns it unmodified if it's an instance of HDPath. Otherwise it
creates one of the correct prefix based upon whether `priv != null`.

Child of PR #3707 