### PR TITLE
DeterministicKey: add `depth` to `equals()` and `hashCode()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -700,6 +700,7 @@ public class DeterministicKey extends ECKey {
         helper.add("pub", ByteUtils.formatHex(pub.getEncoded()));
         helper.add("chainCode", ByteUtils.formatHex(chainCode));
         helper.add("path", getPathAsString());
+        helper.add("depth", depth);
         Optional<Instant> creationTime = this.getCreationTime();
         if (!creationTime.isPresent())
             helper.add("creationTimeSeconds", "unknown");

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -686,12 +686,13 @@ public class DeterministicKey extends ECKey {
         DeterministicKey other = (DeterministicKey) o;
         return super.equals(other)
                 && Arrays.equals(this.chainCode, other.chainCode)
-                && Objects.equals(this.childNumberPath, other.childNumberPath);
+                && Objects.equals(this.childNumberPath, other.childNumberPath)
+                && Objects.equals(this.depth, other.depth);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), Arrays.hashCode(chainCode), childNumberPath);
+        return Objects.hash(super.hashCode(), Arrays.hashCode(chainCode), childNumberPath, depth);
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -431,9 +431,11 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
         basicKeyChain.importKey(rootKey);
 
         for (HDPath path : getAccountPath().ancestors()) {
-            encryptNonLeaf(aesKey, chain, rootKey, path);
+            DeterministicKey parent = this.getKeyByPath(path.parent());
+            encryptNonLeaf(aesKey, chain, parent, path);
         }
-        DeterministicKey account = encryptNonLeaf(aesKey, chain, rootKey, getAccountPath());
+        DeterministicKey accountParent = this.getKeyByPath(getAccountPath().parent());
+        DeterministicKey account = encryptNonLeaf(aesKey, chain, accountParent, getAccountPath());
         externalParentKey = encryptNonLeaf(aesKey, chain, account, getAccountPath().extend(EXTERNAL_SUBPATH));
         internalParentKey = encryptNonLeaf(aesKey, chain, account, getAccountPath().extend(INTERNAL_SUBPATH));
 


### PR DESCRIPTION
This breaks a test, so for now marked as draft.

org.bitcoinj.wallet.WalletTest#encryptDecryptWalletWithArbitraryPathAndScriptType