### PR TITLE
Block: add `transaction(index)` accessor

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -497,14 +497,19 @@ public class Block implements Message {
                     TimeUtils.dateTimeFormat(allowedTime), allowedTime.toEpochMilli()));
     }
 
+    /**
+     * Sums up all SigOps in all transactions of this block.
+     *
+     * @return sum of SigOps
+     */
+    public int sigOpCount() {
+        return transactions.stream().mapToInt(Transaction::getSigOpCount).sum();
+    }
+
     private void checkSigOps() throws VerificationException {
         // Check there aren't too many signature verifications in the block. This is an anti-DoS measure, see the
         // comments for MAX_BLOCK_SIGOPS.
-        int sigOps = 0;
-        for (Transaction tx : transactions) {
-            sigOps += tx.getSigOpCount();
-        }
-        if (sigOps > MAX_BLOCK_SIGOPS)
+        if (sigOpCount() > MAX_BLOCK_SIGOPS)
             throw new VerificationException("Block had too many Signature Operations");
     }
 

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -807,6 +807,17 @@ public class Block implements Message {
         return transactions == null ? null : Collections.unmodifiableList(transactions);
     }
 
+    /**
+     * Gets the transaction at the given index.
+     *
+     * @param index index of the transaction to get
+     * @return transaction
+     * @throws IndexOutOfBoundsException if the given index is out of bounds
+     */
+    public Transaction transaction(int index) {
+        return transactions.get(index);
+    }
+
     // ///////////////////////////////////////////////////////////////////////////////////////////////
     // Unit testing related methods.
 

--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -153,7 +153,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         Block rollingBlock = PARAMS.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
         rollingBlock.solve();
         chain.add(rollingBlock);
-        TransactionOutput spendableOutput = rollingBlock.getTransactions().get(0).getOutput(0);
+        TransactionOutput spendableOutput = rollingBlock.transaction(0).getOutput(0);
         for (int i = 1; i < PARAMS.getSpendableCoinbaseDepth(); i++) {
             rollingBlock = rollingBlock.createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
             rollingBlock.solve();
@@ -196,7 +196,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         Block rollingBlock = PARAMS.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
         rollingBlock.solve();
         chain.add(rollingBlock);
-        TransactionOutput spendableOutput = rollingBlock.getTransactions().get(0).getOutput(0);
+        TransactionOutput spendableOutput = rollingBlock.transaction(0).getOutput(0);
         TransactionOutPoint transactionOutPoint = spendableOutput.getOutPointFor();
         Script spendableOutputScriptPubKey = spendableOutput.getScriptPubKey();
         for (int i = 1; i < PARAMS.getSpendableCoinbaseDepth(); i++) {
@@ -272,7 +272,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         Block rollingBlock = PARAMS.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
         rollingBlock.solve();
         chain.add(rollingBlock);
-        Transaction transaction = rollingBlock.getTransactions().get(0);
+        Transaction transaction = rollingBlock.transaction(0);
         TransactionOutput spendableOutput = transaction.getOutput(0);
         TransactionOutPoint spendableOutputPoint = spendableOutput.getOutPointFor();
         Script spendableOutputScriptPubKey = spendableOutput.getScriptPubKey();
@@ -326,7 +326,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         Block rollingBlock = PARAMS.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
         rollingBlock.solve();
         chain.add(rollingBlock);
-        Transaction transaction = rollingBlock.getTransactions().get(0);
+        Transaction transaction = rollingBlock.transaction(0);
         TransactionOutput spendableOutput = transaction.getOutput(0);
         TransactionOutPoint spendableOutPoint = new TransactionOutPoint(0, transaction.getTxId());
         Script spendableOutputScriptPubKey = spendableOutput.getScriptPubKey();

--- a/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
@@ -341,7 +341,7 @@ public class BlockChainTest {
         // Create a block, sending the coinbase to the coinbaseTo address (which is in the wallet).
         Block b1 = TESTNET.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, testNetWallet.currentReceiveKey().getPubKey(), height++);
         testNetChain.add(b1);
-        final Transaction coinbaseTransaction = b1.getTransactions().get(0);
+        final Transaction coinbaseTransaction = b1.transaction(0);
 
         // Check a transaction has been received.
         assertNotNull(coinbaseTransaction);

--- a/core/src/test/java/org/bitcoinj/core/BlockTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockTest.java
@@ -239,7 +239,7 @@ public class BlockTest {
             assertFalse(tx.hasWitnesses());
 
         // Nevertheless, there is a witness commitment (but no witness reserved).
-        Transaction coinbase = block481815.getTransactions().get(0);
+        Transaction coinbase = block481815.transaction(0);
         assertEquals("919a0df2253172a55bebcb9002dbe775b8511f84955b282ca6dae826fdd94f90", coinbase.getTxId().toString());
         assertEquals("919a0df2253172a55bebcb9002dbe775b8511f84955b282ca6dae826fdd94f90",
                 coinbase.getWTxId().toString());
@@ -257,7 +257,7 @@ public class BlockTest {
         assertEquals("0a02ddb2f86a14051294f8d98dd6959dd12bf3d016ca816c3db9b32d3e24fc2d",
                 block481829.getWitnessRoot().toString());
 
-        Transaction coinbase = block481829.getTransactions().get(0);
+        Transaction coinbase = block481829.transaction(0);
         assertEquals("9c1ab453283035800c43eb6461eb46682b81be110a0cb89ee923882a5fd9daa4", coinbase.getTxId().toString());
         assertEquals("2bbda73aa4e561e7f849703994cc5e563e4bcf103fb0f6fef5ae44c95c7b83a6",
                 coinbase.getWTxId().toString());

--- a/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ChainSplitTest.java
@@ -125,7 +125,7 @@ public class ChainSplitTest {
         Block b7 = b1.createNextBlock(coinsTo);
         assertTrue(chain.add(b7));
         Block b8 = b1.createNextBlock(coinsTo);
-        final Transaction t = b7.getTransactions().get(1);
+        final Transaction t = b7.transaction(1);
         final Sha256Hash tHash = t.getTxId();
         b8.addTransaction(t);
         assertTrue(chain.add(roundtrip(b8)));
@@ -247,12 +247,12 @@ public class ChainSplitTest {
         // Test the standard case in which a block containing identical transactions appears on a side chain.
         Block b1 = TESTNET.getGenesisBlock().createNextBlock(coinsTo);
         chain.add(b1);
-        final Transaction t = b1.transactions.get(1);
+        final Transaction t = b1.transaction(1);
         assertEquals(FIFTY_COINS, wallet.getBalance());
         // genesis -> b1
         //         -> b2
         Block b2 = TESTNET.getGenesisBlock().createNextBlock(coinsTo);
-        Transaction b2coinbase = b2.transactions.get(0);
+        Transaction b2coinbase = b2.transaction(0);
         b2.replaceTransactions(Arrays.asList(b2coinbase, t));
         chain.add(roundtrip(b2));
         assertEquals(FIFTY_COINS, wallet.getBalance());
@@ -282,7 +282,7 @@ public class ChainSplitTest {
         // genesis -> b1 -> b3
         //         -> b2
         Block b3 = b1.createNextBlock(someOtherGuy);
-        b3.addTransaction(b2.transactions.get(1));
+        b3.addTransaction(b2.transaction(1));
         chain.add(roundtrip(b3));
         assertEquals(FIFTY_COINS, wallet.getBalance());
     }

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -342,9 +342,7 @@ public class FullBlockTestGenerator {
         //
         NewBlock b15 = createNextBlock(b13, chainHeadHeight + 6, out5, null);
         {
-            int sigOps = 0;
-            for (Transaction tx : b15.block.getTransactions())
-                sigOps += tx.getSigOpCount();
+            int sigOps = b15.block.sigOpCount();
             Transaction tx = new Transaction();
             byte[] outputScript = new byte[Block.MAX_BLOCK_SIGOPS - sigOps];
             Arrays.fill(outputScript, (byte) OP_CHECKSIG);
@@ -352,9 +350,7 @@ public class FullBlockTestGenerator {
             addOnlyInputToTransaction(tx, b15);
             b15.addTransaction(tx);
 
-            sigOps = 0;
-            for (Transaction tx2 : b15.block.getTransactions())
-                sigOps += tx2.getSigOpCount();
+            sigOps = b15.block.sigOpCount();
             checkState(sigOps == Block.MAX_BLOCK_SIGOPS);
         }
         b15.solve();
@@ -366,10 +362,7 @@ public class FullBlockTestGenerator {
 
         NewBlock b16 = createNextBlock(b15, chainHeadHeight + 7, out6, null);
         {
-            int sigOps = 0;
-            for (Transaction tx : b16.block.getTransactions()) {
-                sigOps += tx.getSigOpCount();
-            }
+            int sigOps = b16.block.sigOpCount();
             Transaction tx = new Transaction();
             byte[] outputScript = new byte[Block.MAX_BLOCK_SIGOPS - sigOps + 1];
             Arrays.fill(outputScript, (byte) OP_CHECKSIG);
@@ -377,9 +370,7 @@ public class FullBlockTestGenerator {
             addOnlyInputToTransaction(tx, b16);
             b16.addTransaction(tx);
 
-            sigOps = 0;
-            for (Transaction tx2 : b16.block.getTransactions())
-                sigOps += tx2.getSigOpCount();
+            sigOps = b16.block.sigOpCount();
             checkState(sigOps == Block.MAX_BLOCK_SIGOPS + 1);
         }
         b16.solve();
@@ -531,10 +522,7 @@ public class FullBlockTestGenerator {
 
         NewBlock b31 = createNextBlock(b30, chainHeadHeight + 9, out8, null);
         {
-            int sigOps = 0;
-            for (Transaction tx : b31.block.transactions) {
-                sigOps += tx.getSigOpCount();
-            }
+            int sigOps = b31.block.sigOpCount();
             Transaction tx = new Transaction();
             byte[] outputScript = new byte[(Block.MAX_BLOCK_SIGOPS - sigOps)/20];
             Arrays.fill(outputScript, (byte) OP_CHECKMULTISIG);
@@ -551,10 +539,7 @@ public class FullBlockTestGenerator {
 
         NewBlock b32 = createNextBlock(b31, chainHeadHeight + 10, out9, null);
         {
-            int sigOps = 0;
-            for (Transaction tx : b32.block.transactions) {
-                sigOps += tx.getSigOpCount();
-            }
+            int sigOps = b32.block.sigOpCount();
             Transaction tx = new Transaction();
             byte[] outputScript = new byte[(Block.MAX_BLOCK_SIGOPS - sigOps)/20 + (Block.MAX_BLOCK_SIGOPS - sigOps)%20 + 1];
             Arrays.fill(outputScript, (byte) OP_CHECKMULTISIG);
@@ -569,10 +554,7 @@ public class FullBlockTestGenerator {
 
         NewBlock b33 = createNextBlock(b31, chainHeadHeight + 10, out9, null);
         {
-            int sigOps = 0;
-            for (Transaction tx : b33.block.transactions) {
-                sigOps += tx.getSigOpCount();
-            }
+            int sigOps = b33.block.sigOpCount();
             Transaction tx = new Transaction();
             byte[] outputScript = new byte[(Block.MAX_BLOCK_SIGOPS - sigOps)/20];
             Arrays.fill(outputScript, (byte) OP_CHECKMULTISIGVERIFY);
@@ -589,10 +571,7 @@ public class FullBlockTestGenerator {
 
         NewBlock b34 = createNextBlock(b33, chainHeadHeight + 11, out10, null);
         {
-            int sigOps = 0;
-            for (Transaction tx : b34.block.getTransactions()) {
-                sigOps += tx.getSigOpCount();
-            }
+            int sigOps = b34.block.sigOpCount();
             Transaction tx = new Transaction();
             byte[] outputScript = new byte[(Block.MAX_BLOCK_SIGOPS - sigOps)/20 + (Block.MAX_BLOCK_SIGOPS - sigOps)%20 + 1];
             Arrays.fill(outputScript, (byte) OP_CHECKMULTISIGVERIFY);
@@ -607,10 +586,7 @@ public class FullBlockTestGenerator {
 
         NewBlock b35 = createNextBlock(b33, chainHeadHeight + 11, out10, null);
         {
-            int sigOps = 0;
-            for (Transaction tx : b35.block.getTransactions()) {
-                sigOps += tx.getSigOpCount();
-            }
+            int sigOps = b35.block.sigOpCount();
             Transaction tx = new Transaction();
             byte[] outputScript = new byte[Block.MAX_BLOCK_SIGOPS - sigOps];
             Arrays.fill(outputScript, (byte) OP_CHECKSIGVERIFY);
@@ -627,10 +603,7 @@ public class FullBlockTestGenerator {
 
         NewBlock b36 = createNextBlock(b35, chainHeadHeight + 12, out11, null);
         {
-            int sigOps = 0;
-            for (Transaction tx : b36.block.getTransactions()) {
-                sigOps += tx.getSigOpCount();
-            }
+            int sigOps = b36.block.sigOpCount();
             Transaction tx = new Transaction();
             byte[] outputScript = new byte[Block.MAX_BLOCK_SIGOPS - sigOps + 1];
             Arrays.fill(outputScript, (byte) OP_CHECKSIGVERIFY);
@@ -745,11 +718,7 @@ public class FullBlockTestGenerator {
 
         NewBlock b40 = createNextBlock(b39, chainHeadHeight + 13, out12, null);
         {
-            int sigOps = 0;
-            for (Transaction tx : b40.block.getTransactions()) {
-                sigOps += tx.getSigOpCount();
-            }
-
+            int sigOps = b40.block.sigOpCount();
             int numTxes = (Block.MAX_BLOCK_SIGOPS - sigOps) / b39sigOpsPerOutput;
             checkState(numTxes <= b39numP2SHOutputs);
 
@@ -810,11 +779,7 @@ public class FullBlockTestGenerator {
         if (runBarelyExpensiveTests) {
             b41 = createNextBlock(b39, chainHeadHeight + 13, out12, null);
             {
-                int sigOps = 0;
-                for (Transaction tx : b41.block.getTransactions()) {
-                    sigOps += tx.getSigOpCount();
-                }
-
+                int sigOps = b41.block.sigOpCount();
                 int numTxes = (Block.MAX_BLOCK_SIGOPS - sigOps)
                         / b39sigOpsPerOutput;
                 checkState(numTxes <= b39numP2SHOutputs);
@@ -1373,10 +1338,7 @@ public class FullBlockTestGenerator {
 
         NewBlock b73 = createNextBlock(b72, chainHeadHeight + 23, out22, null);
         {
-            int sigOps = 0;
-            for (Transaction tx : b73.block.getTransactions()) {
-                sigOps += tx.getSigOpCount();
-            }
+            int sigOps = b73.block.sigOpCount();
             Transaction tx = new Transaction();
             byte[] outputScript = new byte[Block.MAX_BLOCK_SIGOPS - sigOps + Script.MAX_SCRIPT_ELEMENT_SIZE + 1 + 5 + 1];
             Arrays.fill(outputScript, (byte) OP_CHECKSIG);
@@ -1392,10 +1354,7 @@ public class FullBlockTestGenerator {
 
         NewBlock b74 = createNextBlock(b72, chainHeadHeight + 23, out22, null);
         {
-            int sigOps = 0;
-            for (Transaction tx : b74.block.getTransactions()) {
-                sigOps += tx.getSigOpCount();
-            }
+            int sigOps = b74.block.sigOpCount();
             Transaction tx = new Transaction();
             byte[] outputScript = new byte[Block.MAX_BLOCK_SIGOPS - sigOps + Script.MAX_SCRIPT_ELEMENT_SIZE + 42];
             Arrays.fill(outputScript, (byte) OP_CHECKSIG);
@@ -1414,10 +1373,7 @@ public class FullBlockTestGenerator {
 
         NewBlock b75 = createNextBlock(b72, chainHeadHeight + 23, out22, null);
         {
-            int sigOps = 0;
-            for (Transaction tx : b75.block.getTransactions()) {
-                sigOps += tx.getSigOpCount();
-            }
+            int sigOps = b75.block.sigOpCount();
             Transaction tx = new Transaction();
             byte[] outputScript = new byte[Block.MAX_BLOCK_SIGOPS - sigOps + Script.MAX_SCRIPT_ELEMENT_SIZE + 42];
             Arrays.fill(outputScript, (byte) OP_CHECKSIG);
@@ -1439,10 +1395,7 @@ public class FullBlockTestGenerator {
 
         NewBlock b76 = createNextBlock(b75, chainHeadHeight + 24, out23, null);
         {
-            int sigOps = 0;
-            for (Transaction tx : b76.block.getTransactions()) {
-                sigOps += tx.getSigOpCount();
-            }
+            int sigOps = b76.block.sigOpCount();
             Transaction tx = new Transaction();
             byte[] outputScript = new byte[Block.MAX_BLOCK_SIGOPS - sigOps + Script.MAX_SCRIPT_ELEMENT_SIZE + 1 + 5];
             Arrays.fill(outputScript, (byte) OP_CHECKSIG);

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -107,7 +107,7 @@ class NewBlock {
     public void addTransaction(Transaction tx) { block.addTransaction(tx); }
 
     public TransactionOutPointWithValue getCoinbaseOutput() {
-        return new TransactionOutPointWithValue(block.getTransactions().get(0), 0);
+        return new TransactionOutPointWithValue(block.transaction(0), 0);
     }
 
     public TransactionOutPointWithValue getSpendableOutput() {
@@ -216,16 +216,16 @@ public class FullBlockTestGenerator {
         chainHead.solve();
         blocks.add(new BlockAndValidity(chainHead, true, false, chainHead.getHash(), 1, "Initial Block"));
         spendableOutputs.offer(new TransactionOutPointWithValue(
-                new TransactionOutPoint(0, chainHead.getTransactions().get(0).getTxId()),
-                FIFTY_COINS, chainHead.getTransactions().get(0).getOutput(0).getScriptPubKey()));
+                new TransactionOutPoint(0, chainHead.transaction(0).getTxId()),
+                FIFTY_COINS, chainHead.transaction(0).getOutput(0).getScriptPubKey()));
         for (int i = 1; i < params.getSpendableCoinbaseDepth(); i++) {
             chainHead = chainHead.createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, coinbaseOutKeyPubKey, chainHeadHeight);
             chainHeadHeight++;
             chainHead.solve();
             blocks.add(new BlockAndValidity(chainHead, true, false, chainHead.getHash(), i+1, "Initial Block chain output generation"));
             spendableOutputs.offer(new TransactionOutPointWithValue(
-                    new TransactionOutPoint(0, chainHead.getTransactions().get(0).getTxId()),
-                    FIFTY_COINS, chainHead.getTransactions().get(0).getOutput(0).getScriptPubKey()));
+                    new TransactionOutPoint(0, chainHead.transaction(0).getTxId()),
+                    FIFTY_COINS, chainHead.transaction(0).getOutput(0).getScriptPubKey()));
         }
 
         // Start by building a couple of blocks on top of the genesis block.
@@ -477,7 +477,7 @@ public class FullBlockTestGenerator {
         //
         NewBlock b26 = createNextBlock(b15, chainHeadHeight + 7, out6, null);
         // 1 is too small, but we already generate every other block with 2, so that is tested
-        b26.block.getTransactions().get(0).replaceInput(0, b26.block.getTransactions().get(0).getInput(0).withoutScriptBytes());
+        b26.block.transaction(0).replaceInput(0, b26.block.transaction(0).getInput(0).withoutScriptBytes());
         b26.block.setMerkleRoot(null);
         b26.solve();
         blocks.add(new BlockAndValidity(b26, false, true, b23.getHash(), chainHeadHeight + 7, "b26"));
@@ -490,7 +490,7 @@ public class FullBlockTestGenerator {
         {
             byte[] coinbase = new byte[101];
             Arrays.fill(coinbase, (byte)0);
-            b28.block.getTransactions().get(0).replaceInput(0, b28.block.getTransactions().get(0).getInput(0).withScriptBytes(coinbase));
+            b28.block.transaction(0).replaceInput(0, b28.block.transaction(0).getInput(0).withScriptBytes(coinbase));
         }
         b28.block.setMerkleRoot(null);
         b28.solve();
@@ -504,7 +504,7 @@ public class FullBlockTestGenerator {
         {
             byte[] coinbase = new byte[100];
             Arrays.fill(coinbase, (byte)0);
-            b30.block.getTransactions().get(0).replaceInput(0, b30.block.getTransactions().get(0).getInput(0).withScriptBytes(coinbase));
+            b30.block.transaction(0).replaceInput(0, b30.block.transaction(0).getInput(0).withScriptBytes(coinbase));
         }
         b30.block.setMerkleRoot(null);
         b30.solve();
@@ -722,7 +722,7 @@ public class FullBlockTestGenerator {
             int numTxes = (Block.MAX_BLOCK_SIGOPS - sigOps) / b39sigOpsPerOutput;
             checkState(numTxes <= b39numP2SHOutputs);
 
-            TransactionOutPoint lastOutPoint = new TransactionOutPoint(1, b40.block.getTransactions().get(1).getTxId());
+            TransactionOutPoint lastOutPoint = new TransactionOutPoint(1, b40.block.transaction(1).getTxId());
 
             byte[] scriptSig = null;
             for (int i = 1; i <= numTxes; i++) {
@@ -731,7 +731,7 @@ public class FullBlockTestGenerator {
                 tx.addInput(new TransactionInput(tx, new byte[]{OP_1}, lastOutPoint));
 
                 TransactionInput input = new TransactionInput(tx, new byte[]{},
-                        new TransactionOutPoint(0, b39.block.getTransactions().get(i).getTxId()));
+                        new TransactionOutPoint(0, b39.block.transaction(i).getTxId()));
                 tx.addInput(input);
                 int inputIndex = tx.getInputs().size() - 1;
 
@@ -785,7 +785,7 @@ public class FullBlockTestGenerator {
                 checkState(numTxes <= b39numP2SHOutputs);
 
                 TransactionOutPoint lastOutPoint = new TransactionOutPoint(
-                        1, b41.block.getTransactions().get(1).getTxId());
+                        1, b41.block.transaction(1).getTxId());
 
                 byte[] scriptSig = null;
                 for (int i = 1; i <= numTxes; i++) {
@@ -795,7 +795,7 @@ public class FullBlockTestGenerator {
                     tx.addInput(new TransactionInput(tx, new byte[] { OP_1 }, lastOutPoint));
 
                     TransactionInput input = new TransactionInput(tx, new byte[] {},
-                            new TransactionOutPoint(0, b39.block.getTransactions().get(i).getTxId()));
+                            new TransactionOutPoint(0, b39.block.transaction(i).getTxId()));
                     tx.addInput(input);
                     int inputIndex = tx.getInputs().size() - 1;
 
@@ -1130,9 +1130,9 @@ public class FullBlockTestGenerator {
 
         NewBlock b61 = createNextBlock(b60, chainHeadHeight + 19, out18, null);
         {
-            b61.block.getTransactions().get(0).replaceInput(0, b61.block.getTransactions().get(0).getInput(0).withScriptBytes(b60.block.getTransactions().get(0).getInput(0).getScriptBytes()));
+            b61.block.transaction(0).replaceInput(0, b61.block.transaction(0).getInput(0).withScriptBytes(b60.block.transaction(0).getInput(0).getScriptBytes()));
             b61.block.unCache();
-            checkState(b61.block.getTransactions().get(0).equals(b60.block.getTransactions().get(0)));
+            checkState(b61.block.transaction(0).equals(b60.block.transaction(0)));
         }
         b61.solve();
         blocks.add(new BlockAndValidity(b61, false, true, b60.getHash(), chainHeadHeight + 18, "b61"));
@@ -1159,9 +1159,9 @@ public class FullBlockTestGenerator {
         //
         NewBlock b63 = createNextBlock(b60, chainHeadHeight + 19, null, null);
         {
-            b63.block.getTransactions().get(0).setLockTime(0xffffffffL);
-            b63.block.getTransactions().get(0).replaceInput(0, b63.block.getTransactions().get(0).getInput(0).withSequence(0xdeadbeefL));
-            checkState(!b63.block.getTransactions().get(0).isFinal(chainHeadHeight + 17, b63.block.time()));
+            b63.block.transaction(0).setLockTime(0xffffffffL);
+            b63.block.transaction(0).replaceInput(0, b63.block.transaction(0).getInput(0).withSequence(0xdeadbeefL));
+            checkState(!b63.block.transaction(0).isFinal(chainHeadHeight + 17, b63.block.time()));
         }
         b63.solve();
         blocks.add(new BlockAndValidity(b63, false, true, b60.getHash(), chainHeadHeight + 18, "b63"));
@@ -1324,7 +1324,7 @@ public class FullBlockTestGenerator {
         b72.solve();
 
         Block b71 = params.getDefaultSerializer().makeBlock(ByteBuffer.wrap(b72.block.serialize()));
-        b71.addTransaction(b72.block.getTransactions().get(2));
+        b71.addTransaction(b72.block.transaction(2));
         checkState(b71.getHash().equals(b72.getHash()));
         blocks.add(new BlockAndValidity(b71, false, true, b69.getHash(), chainHeadHeight + 21, "b71"));
         blocks.add(new BlockAndValidity(b72, true, false, b72.getHash(), chainHeadHeight + 22, "b72"));
@@ -1629,7 +1629,7 @@ public class FullBlockTestGenerator {
             checkArgument(blockStorageFile != null);
 
             NewBlock lastBlock = b1001;
-            TransactionOutPoint lastOutput = new TransactionOutPoint(1, b1001.block.getTransactions().get(1).getTxId());
+            TransactionOutPoint lastOutput = new TransactionOutPoint(1, b1001.block.transaction(1).getTxId());
             int blockCountAfter1001;
             int nextHeight = heightAfter1001;
 

--- a/core/src/test/java/org/bitcoinj/core/ParseByteCacheTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ParseByteCacheTest.java
@@ -165,7 +165,7 @@ public class ParseByteCacheTest {
         
         // retrieve a value from a child
         if (b1.getTransactions().size() > 0) {
-            Transaction tx1 = b1.getTransactions().get(0);
+            Transaction tx1 = b1.transaction(0);
             
             // does it still match ref block?
             serDeser(serializer, b1, bos.toByteArray(), null, null);
@@ -189,7 +189,7 @@ public class ParseByteCacheTest {
         b1.difficultyTarget();
 
         if (b1.getTransactions().size() > 0) {
-            Transaction tx1 = b1.getTransactions().get(0);
+            Transaction tx1 = b1.transaction(0);
         }
         // does it still match ref block?
         serDeser(serializer, b1, bos.toByteArray(), null, null);
@@ -212,7 +212,7 @@ public class ParseByteCacheTest {
         
         // retrieve a value from a child of a child
         if (b1.getTransactions().size() > 0) {
-            Transaction tx1 = b1.getTransactions().get(0);
+            Transaction tx1 = b1.transaction(0);
             
             TransactionInput tin = tx1.getInput(0);
 
@@ -228,12 +228,12 @@ public class ParseByteCacheTest {
         
         // add an input
         if (b1.getTransactions().size() > 0) {
-            Transaction tx1 = b1.getTransactions().get(0);
+            Transaction tx1 = b1.transaction(0);
             
             if (tx1.getInputs().size() > 0) {
                 tx1.addInput(tx1.getInput(0));
                 // replicate on reference tx
-                bRef.getTransactions().get(0).addInput(bRef.getTransactions().get(0).getInput(0));
+                bRef.transaction(0).addInput(bRef.transaction(0).getInput(0));
                 
                 bos.reset();
                 serializerRef.serialize(bRef, bos);
@@ -256,16 +256,16 @@ public class ParseByteCacheTest {
         
         // reparent an input
         if (b1.getTransactions().size() > 0) {
-            Transaction tx1 = b1.getTransactions().get(0);
-            Transaction tx2 = b2.getTransactions().get(0);
+            Transaction tx1 = b1.transaction(0);
+            Transaction tx2 = b2.transaction(0);
             
             if (tx1.getInputs().size() > 0) {
                 TransactionInput fromTx1 = tx1.getInput(0);
                 tx2.addInput(fromTx1);
                 
                 // replicate on reference tx
-                TransactionInput fromTxRef = bRef.getTransactions().get(0).getInput(0);
-                bRef2.getTransactions().get(0).addInput(fromTxRef);
+                TransactionInput fromTxRef = bRef.transaction(0).getInput(0);
+                bRef2.transaction(0).addInput(fromTxRef);
                 
                 bos.reset();
                 serializerRef.serialize(bRef2, bos);

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -624,9 +624,9 @@ public class TransactionTest {
         Context.propagate(new Context(100, Transaction.DEFAULT_TX_FEE, false, true));
         Block genesis = TESTNET.getGenesisBlock();
         Block block1 = genesis.createNextBlock(ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET),
-                    genesis.getTransactions().get(0).getOutput(0).getOutPointFor());
+                    genesis.transaction(0).getOutput(0).getOutPointFor());
 
-        final Transaction tx = block1.getTransactions().get(1);
+        final Transaction tx = block1.transaction(1);
         final Sha256Hash txHash = tx.getTxId();
         final String txNormalizedHash = tx.hashForSignature(
                 0,

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -378,7 +378,7 @@ public class WalletProtobufSerializerTest {
         // Covers issue 420 where the outpoint index of a coinbase tx input was being mis-serialized.
         Context.propagate(new Context(100, Transaction.DEFAULT_TX_FEE, false, true));
         Block b = TESTNET.getGenesisBlock().createNextBlockWithCoinbase(Block.BLOCK_VERSION_GENESIS, myKey.getPubKey(), FIFTY_COINS, Block.BLOCK_HEIGHT_GENESIS);
-        Transaction coinbase = b.getTransactions().get(0);
+        Transaction coinbase = b.transaction(0);
         assertTrue(coinbase.isCoinBase());
         BlockChain chain = new BlockChain(BitcoinNetwork.TESTNET, myWallet, new MemoryBlockStore(TESTNET.getGenesisBlock()));
         assertTrue(chain.add(b));

--- a/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
@@ -82,7 +82,7 @@ public class DefaultRiskAnalysisTest {
     public void nonFinal() {
         // Verify that just having a lock time in the future is not enough to be considered risky (it's still final).
         Transaction tx = new Transaction();
-        TransactionInput input = tx.addInput(MAINNET.getGenesisBlock().getTransactions().get(0).getOutput(0));
+        TransactionInput input = tx.addInput(MAINNET.getGenesisBlock().transaction(0).getOutput(0));
         tx.addOutput(COIN, key1);
         tx.setLockTime(TIMESTAMP + 86400);
         DefaultRiskAnalysis analysis = DefaultRiskAnalysis.FACTORY.create(wallet, tx, NO_DEPS);
@@ -105,7 +105,7 @@ public class DefaultRiskAnalysisTest {
     public void selfCreatedAreNotRisky() {
         Transaction tx = new Transaction();
         TransactionInput input =
-                tx.addInput(MAINNET.getGenesisBlock().getTransactions().get(0).getOutput(0)).withSequence(1);
+                tx.addInput(MAINNET.getGenesisBlock().transaction(0).getOutput(0)).withSequence(1);
         tx.replaceInput(0, input);
         tx.addOutput(COIN, key1);
         tx.setLockTime(TIMESTAMP + 86400);
@@ -128,7 +128,7 @@ public class DefaultRiskAnalysisTest {
         // Final tx has a dependency that is non-final.
         Transaction tx1 = new Transaction();
         TransactionInput input1 =
-                tx1.addInput(MAINNET.getGenesisBlock().getTransactions().get(0).getOutput(0)).withSequence(1);
+                tx1.addInput(MAINNET.getGenesisBlock().transaction(0).getOutput(0)).withSequence(1);
         tx1.replaceInput(0, input1);
         TransactionOutput output = tx1.addOutput(COIN, key1);
         tx1.setLockTime(TIMESTAMP + 86400);
@@ -144,17 +144,17 @@ public class DefaultRiskAnalysisTest {
     @Test
     public void nonStandardDust() {
         Transaction standardTx = new Transaction();
-        standardTx.addInput(MAINNET.getGenesisBlock().getTransactions().get(0).getOutput(0));
+        standardTx.addInput(MAINNET.getGenesisBlock().transaction(0).getOutput(0));
         standardTx.addOutput(COIN, key1);
         assertEquals(RiskAnalysis.Result.OK, DefaultRiskAnalysis.FACTORY.create(wallet, standardTx, NO_DEPS).analyze());
 
         Transaction dustTx = new Transaction();
-        dustTx.addInput(MAINNET.getGenesisBlock().getTransactions().get(0).getOutput(0));
+        dustTx.addInput(MAINNET.getGenesisBlock().transaction(0).getOutput(0));
         dustTx.addOutput(Coin.SATOSHI, key1); // 1 Satoshi
         assertEquals(RiskAnalysis.Result.NON_STANDARD, DefaultRiskAnalysis.FACTORY.create(wallet, dustTx, NO_DEPS).analyze());
 
         Transaction edgeCaseTx = new Transaction();
-        edgeCaseTx.addInput(MAINNET.getGenesisBlock().getTransactions().get(0).getOutput(0));
+        edgeCaseTx.addInput(MAINNET.getGenesisBlock().transaction(0).getOutput(0));
         Coin dustThreshold = new TransactionOutput(null, Coin.COIN, key1).getMinNonDustValue();
         edgeCaseTx.addOutput(dustThreshold, key1);
         assertEquals(RiskAnalysis.Result.OK, DefaultRiskAnalysis.FACTORY.create(wallet, edgeCaseTx, NO_DEPS).analyze());
@@ -222,7 +222,7 @@ public class DefaultRiskAnalysisTest {
     @Test
     public void standardOutputs() {
         Transaction tx = new Transaction();
-        tx.addInput(MAINNET.getGenesisBlock().getTransactions().get(0).getOutput(0));
+        tx.addInput(MAINNET.getGenesisBlock().transaction(0).getOutput(0));
         // A pay to address output
         tx.addOutput(Coin.CENT, ScriptBuilder.createP2PKHOutputScript(key1));
         // A P2PK output

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -814,7 +814,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
             Address addr = key1.toAddress(ScriptType.P2PKH, UNITTEST.network());
             Block next = FakeTxBuilder.makeTestBlock(prev, FakeTxBuilder.createFakeTx(UNITTEST.network(), Coin.FIFTY_COINS, addr));
             next.solve();
-            expectedBalance = expectedBalance.add(next.getTransactions().get(1).getOutput(0).getValue());
+            expectedBalance = expectedBalance.add(next.transaction(1).getOutput(0).getValue());
             blocks.add(next);
             prev = next;
         }

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -411,7 +411,7 @@ public class PeerTest extends TestWithNetworkConnections {
         blockChain.add(b1);
         Block b2 = makeTestBlock(b1);
         Transaction t = new Transaction();
-        t.addInput(b1.getTransactions().get(0).getOutput(0));
+        t.addInput(b1.transaction(0).getOutput(0));
         t.addOutput(new TransactionOutput(t, Coin.ZERO, new byte[Block.MAX_BLOCK_SIZE - 1000]));
         b2.addTransaction(t);
 


### PR DESCRIPTION
Use it to prevent accessing `getTransactions()` whereever possible.

Child of #3687.