### PR TITLE
DeterministicKeyChain: Fix depth issue in `toEncrypted()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -431,9 +431,11 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
         basicKeyChain.importKey(rootKey);
 
         for (HDPath path : getAccountPath().ancestors()) {
-            encryptNonLeaf(aesKey, chain, rootKey, path);
+            DeterministicKey parent = this.getKeyByPath(path.parent());
+            encryptNonLeaf(aesKey, chain, parent, path);
         }
-        DeterministicKey account = encryptNonLeaf(aesKey, chain, rootKey, getAccountPath());
+        DeterministicKey accountParent = this.getKeyByPath(getAccountPath().parent());
+        DeterministicKey account = encryptNonLeaf(aesKey, chain, accountParent, getAccountPath());
         externalParentKey = encryptNonLeaf(aesKey, chain, account, getAccountPath().extend(EXTERNAL_SUBPATH));
         internalParentKey = encryptNonLeaf(aesKey, chain, account, getAccountPath().extend(INTERNAL_SUBPATH));
 


### PR DESCRIPTION
In the `DeterministicKeyChain` constructor that uses a `KeyCrypter` to encrypt an existing keychain, there was a bug where encrypted non-leaf keys that are grandchildren or lower of the root were being constructed with their parent set to root rather than their direct encrypted parent.

This commit fixes the issue.

The problem was undetected until PR #3709 added `depth` to `DeterministicKey`'s `equals` and `hashCode`, which was than detecting the incorrect depth after a roundtrip.