### PR TITLE
Block: add iteration helper `forEachTransaction()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -50,6 +50,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -830,6 +831,16 @@ public class Block implements Message {
     public Transaction transaction(int index) {
         checkState(!isHeaderOnly());
         return transactions.get(index);
+    }
+
+    /**
+     * Performs the given action for each transaction in this block.
+     *
+     * @param action action to be performed for each transaction
+     */
+    public void forEachTransaction(Consumer<Transaction> action) {
+        checkState(!isHeaderOnly());
+        transactions.forEach(action);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -935,7 +935,7 @@ public class Peer extends PeerSocketHandler {
         if (log.isDebugEnabled())
             log.debug("{}: Received broadcast block {}", getAddress(), m.getHashAsString());
         if (!m.isHeaderOnly()) {
-            m.getTransactions().forEach(tx ->
+            m.forEachTransaction(tx ->
                 tx.getConfidence().maybeSetSourceToNetwork()
             );
         }

--- a/core/src/test/java/org/bitcoinj/core/BlockTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockTest.java
@@ -235,8 +235,7 @@ public class BlockTest {
                 block481815.getMerkleRoot().toString());
 
         // This block has no witnesses.
-        for (Transaction tx : block481815.getTransactions())
-            assertFalse(tx.hasWitnesses());
+        block481815.forEachTransaction(tx -> assertFalse(tx.hasWitnesses()));
 
         // Nevertheless, there is a witness commitment (but no witness reserved).
         Transaction coinbase = block481815.transaction(0);

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -1191,8 +1191,7 @@ public class FullBlockTestGenerator {
             buf.put(varIntBytes);
             checkState(VarInt.ofBytes(varIntBytes, 0).intValue() == b64Original.block.transactionCount());
 
-            for (Transaction transaction : b64Original.block.getTransactions())
-                transaction.write(buf);
+            b64Original.block.forEachTransaction(t -> t.write(buf));
             b64 = params.getSerializer().makeBlock(ByteBuffer.wrap(buf.array()));
 
             // The following checks are checking to ensure block serialization functions in the way needed for this test
@@ -1808,13 +1807,13 @@ public class FullBlockTestGenerator {
             coinbaseBlockMap.put(block.getCoinbaseOutput().outpoint.hash(), block.getHash());
             Integer blockHeight = blockToHeightMap.get(block.block.prevHash());
             if (blockHeight != null) {
-                blockHeight++;
-                for (Transaction t : block.block.getTransactions())
-                    for (TransactionInput in : t.getInputs()) {
+                block.block.forEachTransaction(tx -> {
+                    for (TransactionInput in : tx.getInputs()) {
                         Sha256Hash blockSpendingHash = coinbaseBlockMap.get(in.getOutpoint().hash());
                         checkState(blockSpendingHash == null || blockToHeightMap.get(blockSpendingHash) == null ||
-                                blockToHeightMap.get(blockSpendingHash) == blockHeight - params.getSpendableCoinbaseDepth());
+                                blockToHeightMap.get(blockSpendingHash) == blockHeight + 1 - params.getSpendableCoinbaseDepth());
                     }
+                });
             }
         }
 


### PR DESCRIPTION
Use it to prevent accessing `getTransactions()`

Child of #3687 and #3710.