### PR TITLE
ChildKeyDerivationTest: add a few asserts on depth to `pubOnlyDerivation()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -60,7 +60,7 @@ public class DeterministicKey extends ECKey {
     private final DeterministicKey parent;
     private final HDPath childNumberPath;
     private final int depth;
-    private int parentFingerprint; // 0 if this key is root node of key hierarchy
+    private final int parentFingerprint; // 0 if this key is root node of key hierarchy
 
     /** 32 bytes */
     private final byte[] chainCode;
@@ -140,13 +140,7 @@ public class DeterministicKey extends ECKey {
                             @Nullable DeterministicKey parent,
                             int depth,
                             int parentFingerprint) {
-        super(null, publicAsPoint.compress());
-        checkArgument(chainCode.length == 32);
-        this.parent = parent;
-        this.childNumberPath = HDPath.M(Objects.requireNonNull(childNumberPath));
-        this.chainCode = Arrays.copyOf(chainCode, chainCode.length);
-        this.depth = depth;
-        this.parentFingerprint = ascertainParentFingerprint(parent, parentFingerprint);
+        this(childNumberPath, chainCode, publicAsPoint, null, parent, depth, parentFingerprint);
     }
 
     /**
@@ -160,7 +154,17 @@ public class DeterministicKey extends ECKey {
                             @Nullable DeterministicKey parent,
                             int depth,
                             int parentFingerprint) {
-        super(priv, ECKey.publicPointFromPrivate(priv), true);
+        this(childNumberPath, chainCode, new LazyECPoint(ECKey.publicPointFromPrivate(priv), true), priv, parent, depth, parentFingerprint);
+    }
+
+    private DeterministicKey(List<ChildNumber> childNumberPath,
+                             byte[] chainCode,
+                             LazyECPoint pub,
+                             @Nullable BigInteger priv,
+                             @Nullable DeterministicKey parent,
+                             int depth,
+                             int parentFingerprint) {
+        super(priv, pub);
         checkArgument(chainCode.length == 32);
         this.parent = parent;
         this.childNumberPath = HDPath.M(Objects.requireNonNull(childNumberPath));
@@ -278,8 +282,7 @@ public class DeterministicKey extends ECKey {
      * private key at all.</p>
      */
     public DeterministicKey dropParent() {
-        DeterministicKey key = new DeterministicKey(getPath(), getChainCode(), pub, priv, null);
-        key.parentFingerprint = parentFingerprint;
+        DeterministicKey key = new DeterministicKey(getPath(), getChainCode(), pub, priv, null, depth, parentFingerprint);
         return key;
     }
 

--- a/core/src/test/java/org/bitcoinj/crypto/ChildKeyDerivationTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ChildKeyDerivationTest.java
@@ -200,20 +200,26 @@ public class ChildKeyDerivationTest {
     public void pubOnlyDerivation() {
         DeterministicKey key1 = HDKeyDerivation.createMasterPrivateKey("satoshi lives!".getBytes());
         assertFalse(key1.isPubKeyOnly());
+        assertEquals(0,key1.getDepth());
         DeterministicKey key2 = HDKeyDerivation.deriveChildKey(key1, ChildNumber.ZERO_HARDENED);
         assertFalse(key2.isPubKeyOnly());
+        assertEquals(1, key2.getDepth());
         DeterministicKey key3 = HDKeyDerivation.deriveChildKey(key2, ChildNumber.ZERO);
         assertFalse(key3.isPubKeyOnly());
+        assertEquals(2, key3.getDepth());
 
         key2 = key2.dropPrivateBytes();
         assertFalse(key2.isPubKeyOnly());   // still got private key bytes from the parents!
+        assertEquals(1, key2.getDepth());
 
         // pubkey2 got its cached private key bytes (if any) dropped, and now it'll lose its parent too, so now it
         // becomes a true pubkey-only object.
         DeterministicKey pubkey2 = key2.dropParent();
+        assertEquals(1, pubkey2.getDepth());
 
         DeterministicKey pubkey3 = HDKeyDerivation.deriveChildKey(pubkey2, ChildNumber.ZERO);
         assertTrue(pubkey3.isPubKeyOnly());
+        assertEquals(2, pubkey3.getDepth());
         assertEquals(key3.getPubKeyPoint(), pubkey3.getPubKeyPoint());
     }
 


### PR DESCRIPTION
This is another test that fails, but shouldn't afaict.