### PR TITLE
HDPath: add a precondition to the canonical constructor

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/HDPath.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDPath.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -104,7 +105,7 @@ public class HDPath extends AbstractList<ChildNumber> {
      */
     public HDPath(boolean hasPrivateKey, List<ChildNumber> list) {
         this.hasPrivateKey = hasPrivateKey;
-        this.unmodifiableList = Collections.unmodifiableList(list);
+        this.unmodifiableList = Collections.unmodifiableList(Objects.requireNonNull(list));
     }
 
     /**


### PR DESCRIPTION
Make sure `list` can't be null.