### PR TITLE
DeterministicKey: rewrite `withoutPrivateKey()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -265,24 +265,34 @@ public class DeterministicKey extends ECKey {
     }
 
     /**
-     * Returns the same key with the private bytes removed. May return the same instance. The purpose of this is to save
+     * Returns the same key with the private keys (cleartext and encrypted) removed. May return the same instance.
+     * <p>
+     * The purpose of this is to save
      * memory: the private key can always be very efficiently rederived from a parent that a private key, so storing
      * all the private keys in RAM is a poor tradeoff especially on constrained devices. This means that the returned
      * key may still be usable for signing and so on, so don't expect it to be a true pubkey-only object! If you want
      * that then you should follow this call with a call to {@link #dropParent()}.
+     *
+     * @return this key without private key
      */
+    public DeterministicKey withoutPrivateKey() {
+        return priv == null && encryptedPrivateKey == null && keyCrypter == null ?
+                this :
+                new DeterministicKey(null, pub, depth, parent, parentFingerprint, chainCode, childNumberPath,
+                        null, null);
+    }
+
+    /** @deprecated use {@link #withoutPrivateKey()} */
+    @Deprecated
     public DeterministicKey dropPrivateBytes() {
-        if (isPubKeyOnly())
-            return this;
-        else
-            return new DeterministicKey(getPath(), getChainCode(), pub, null, parent);
+        return withoutPrivateKey();
     }
 
     /**
      * <p>Returns the same key with the parent pointer removed (it still knows its own path and the parent fingerprint).</p>
      *
      * <p>If this key doesn't have private key bytes stored/cached itself, but could rederive them from the parent, then
-     * the new key returned by this method won't be able to do that. Thus, using dropPrivateBytes().dropParent() on a
+     * the new key returned by this method won't be able to do that. Thus, using withoutPrivateKey().dropParent() on a
      * regular DeterministicKey will yield a new DeterministicKey that cannot sign or do other things involving the
      * private key at all.</p>
      */

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -552,7 +552,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
     // Clone key to new hierarchy.
     private static DeterministicKey cloneKey(DeterministicHierarchy hierarchy, DeterministicKey key) {
         DeterministicKey parent = hierarchy.get(Objects.requireNonNull(key.getParent()).getPath(), false, false);
-        return new DeterministicKey(key.dropPrivateBytes(), parent);
+        return new DeterministicKey(key.withoutPrivateKey(), parent);
     }
 
     private void checkForBitFlip(DeterministicKey k) {
@@ -1254,7 +1254,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
         Stopwatch watch = Stopwatch.start();
         List<DeterministicKey> result = HDKeyDerivation.generate(parent, numChildren)
                 .limit(limit)
-                .map(DeterministicKey::dropPrivateBytes)
+                .map(DeterministicKey::withoutPrivateKey)
                 .collect(StreamUtils.toUnmodifiableList());
         log.info("Took {}", watch);
         return result;

--- a/core/src/test/java/org/bitcoinj/crypto/ChildKeyDerivationTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ChildKeyDerivationTest.java
@@ -142,26 +142,26 @@ public class ChildKeyDerivationTest {
             DeterministicKey ekpub_1_IN_4095 = HDKeyDerivation.deriveChildKey(ekpub_1_IN, 4095);
             assertEquals("M/1/1/4095", ekpub_1_IN_4095.getPath().toString());
 
-            assertEquals(hexEncodePub(ekprv.dropPrivateBytes().dropParent()), hexEncodePub(ekpub));
-            assertEquals(hexEncodePub(ekprv_0.dropPrivateBytes().dropParent()), hexEncodePub(ekpub_0));
-            assertEquals(hexEncodePub(ekprv_1.dropPrivateBytes().dropParent()), hexEncodePub(ekpub_1));
-            assertEquals(hexEncodePub(ekprv_0_IN.dropPrivateBytes().dropParent()), hexEncodePub(ekpub_0_IN));
-            assertEquals(hexEncodePub(ekprv_0_IN_0.dropPrivateBytes().dropParent()), hexEncodePub(ekpub_0_IN_0));
-            assertEquals(hexEncodePub(ekprv_0_IN_1.dropPrivateBytes().dropParent()), hexEncodePub(ekpub_0_IN_1));
-            assertEquals(hexEncodePub(ekprv_0_IN_2.dropPrivateBytes().dropParent()), hexEncodePub(ekpub_0_IN_2));
-            assertEquals(hexEncodePub(ekprv_0_EX_0.dropPrivateBytes().dropParent()), hexEncodePub(ekpub_0_EX_0));
-            assertEquals(hexEncodePub(ekprv_0_EX_1.dropPrivateBytes().dropParent()), hexEncodePub(ekpub_0_EX_1));
-            assertEquals(hexEncodePub(ekprv_0_EX_2.dropPrivateBytes().dropParent()), hexEncodePub(ekpub_0_EX_2));
-            assertEquals(hexEncodePub(ekprv_1_IN.dropPrivateBytes().dropParent()), hexEncodePub(ekpub_1_IN));
-            assertEquals(hexEncodePub(ekprv_1_IN_4095.dropPrivateBytes().dropParent()), hexEncodePub(ekpub_1_IN_4095));
+            assertEquals(hexEncodePub(ekprv.withoutPrivateKey().dropParent()), hexEncodePub(ekpub));
+            assertEquals(hexEncodePub(ekprv_0.withoutPrivateKey().dropParent()), hexEncodePub(ekpub_0));
+            assertEquals(hexEncodePub(ekprv_1.withoutPrivateKey().dropParent()), hexEncodePub(ekpub_1));
+            assertEquals(hexEncodePub(ekprv_0_IN.withoutPrivateKey().dropParent()), hexEncodePub(ekpub_0_IN));
+            assertEquals(hexEncodePub(ekprv_0_IN_0.withoutPrivateKey().dropParent()), hexEncodePub(ekpub_0_IN_0));
+            assertEquals(hexEncodePub(ekprv_0_IN_1.withoutPrivateKey().dropParent()), hexEncodePub(ekpub_0_IN_1));
+            assertEquals(hexEncodePub(ekprv_0_IN_2.withoutPrivateKey().dropParent()), hexEncodePub(ekpub_0_IN_2));
+            assertEquals(hexEncodePub(ekprv_0_EX_0.withoutPrivateKey().dropParent()), hexEncodePub(ekpub_0_EX_0));
+            assertEquals(hexEncodePub(ekprv_0_EX_1.withoutPrivateKey().dropParent()), hexEncodePub(ekpub_0_EX_1));
+            assertEquals(hexEncodePub(ekprv_0_EX_2.withoutPrivateKey().dropParent()), hexEncodePub(ekpub_0_EX_2));
+            assertEquals(hexEncodePub(ekprv_1_IN.withoutPrivateKey().dropParent()), hexEncodePub(ekpub_1_IN));
+            assertEquals(hexEncodePub(ekprv_1_IN_4095.withoutPrivateKey().dropParent()), hexEncodePub(ekpub_1_IN_4095));
         }
     }
 
     @Test
     public void inverseEqualsNormal() {
         DeterministicKey key1 = HDKeyDerivation.createMasterPrivateKey("Wired / Aug 13th 2014 / Snowden: I Left the NSA Clues, But They Couldn't Find Them".getBytes());
-        HDKeyDerivation.RawKeyBytes key2 = HDKeyDerivation.deriveChildKeyBytesFromPublic(key1.dropPrivateBytes().dropParent(), ChildNumber.ZERO, HDKeyDerivation.PublicDeriveMode.NORMAL);
-        HDKeyDerivation.RawKeyBytes key3 = HDKeyDerivation.deriveChildKeyBytesFromPublic(key1.dropPrivateBytes().dropParent(), ChildNumber.ZERO, HDKeyDerivation.PublicDeriveMode.WITH_INVERSION);
+        HDKeyDerivation.RawKeyBytes key2 = HDKeyDerivation.deriveChildKeyBytesFromPublic(key1.withoutPrivateKey().dropParent(), ChildNumber.ZERO, HDKeyDerivation.PublicDeriveMode.NORMAL);
+        HDKeyDerivation.RawKeyBytes key3 = HDKeyDerivation.deriveChildKeyBytesFromPublic(key1.withoutPrivateKey().dropParent(), ChildNumber.ZERO, HDKeyDerivation.PublicDeriveMode.WITH_INVERSION);
         assertArrayEquals(key2.keyBytes, key3.keyBytes);
         assertArrayEquals(key2.chainCode, key3.chainCode);
     }
@@ -208,7 +208,7 @@ public class ChildKeyDerivationTest {
         assertFalse(key3.isPubKeyOnly());
         assertEquals(2, key3.getDepth());
 
-        key2 = key2.dropPrivateBytes();
+        key2 = key2.withoutPrivateKey();
         assertFalse(key2.isPubKeyOnly());   // still got private key bytes from the parents!
         assertEquals(1, key2.getDepth());
 

--- a/core/src/test/java/org/bitcoinj/crypto/HDKeyDerivationTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/HDKeyDerivationTest.java
@@ -75,7 +75,7 @@ public class HDKeyDerivationTest {
     @Test
     public void testDeriveFromPublicParent() {
         DeterministicKey parent = new DeterministicKey(HDPath.M(), new byte[32], BigInteger.TEN,
-                null).dropPrivateBytes();
+                null).withoutPrivateKey();
         assertTrue(parent.isPubKeyOnly());
         assertFalse(parent.isEncrypted());
 

--- a/core/src/test/java/org/bitcoinj/testing/KeyChainTransactionSigner.java
+++ b/core/src/test/java/org/bitcoinj/testing/KeyChainTransactionSigner.java
@@ -46,6 +46,6 @@ public class KeyChainTransactionSigner extends CustomTransactionSigner {
     protected SignatureAndKey getSignature(Sha256Hash sighash, List<ChildNumber> derivationPath) {
         HDPath keyPath = HDPath.M(derivationPath);
         DeterministicKey key = keyChain.getKeyByPath(keyPath, true);
-        return new SignatureAndKey(key.sign(sighash), key.dropPrivateBytes().dropParent());
+        return new SignatureAndKey(key.sign(sighash), key.withoutPrivateKey().dropParent());
     }
 }

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -448,7 +448,7 @@ public class DeterministicKeyChainTest {
         DeterministicKey key4 = bip44chain.getKey(KeyChain.KeyPurpose.CHANGE);
 
         DeterministicKey watchingKey = bip44chain.getWatchingKey();
-        watchingKey = watchingKey.dropPrivateBytes().dropParent();
+        watchingKey = watchingKey.withoutPrivateKey().dropParent();
         watchingKey.setCreationTime(Instant.ofEpochSecond(100000));
         chain = DeterministicKeyChain.builder().watch(watchingKey).outputScriptType(bip44chain.getOutputScriptType())
                 .build();
@@ -714,7 +714,7 @@ public class DeterministicKeyChainTest {
     @Test(expected = IllegalStateException.class)
     public void watchingCannotEncrypt() {
         final DeterministicKey accountKey = chain.getKeyByPath(DeterministicKeyChain.ACCOUNT_ZERO_PATH);
-        chain = DeterministicKeyChain.builder().watch(accountKey.dropPrivateBytes().dropParent())
+        chain = DeterministicKeyChain.builder().watch(accountKey.withoutPrivateKey().dropParent())
                 .outputScriptType(chain.getOutputScriptType()).build();
         assertEquals(DeterministicKeyChain.ACCOUNT_ZERO_PATH, chain.getAccountPath());
         chain = chain.toEncrypted("this doesn't make any sense");
@@ -746,7 +746,7 @@ public class DeterministicKeyChainTest {
         DeterministicKey[] keys = new DeterministicKey[100];
         for (int i = 0; i < keys.length; i++)
             keys[i] = chain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
-        chain = DeterministicKeyChain.builder().watch(chain.getWatchingKey().dropPrivateBytes().dropParent())
+        chain = DeterministicKeyChain.builder().watch(chain.getWatchingKey().withoutPrivateKey().dropParent())
                 .outputScriptType(chain.getOutputScriptType()).build();
         int e = chain.numBloomFilterEntries();
         BloomFilter filter = chain.getFilter(e, 0.001, 1);

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -1540,7 +1540,7 @@ public class WalletTest extends TestWithWallet {
     public void isWatching() {
         assertFalse(wallet.isWatching());
         Wallet watchingWallet = Wallet.fromWatchingKey(TESTNET,
-                wallet.getWatchingKey().dropPrivateBytes().dropParent(), ScriptType.P2PKH);
+                wallet.getWatchingKey().withoutPrivateKey().dropParent(), ScriptType.P2PKH);
         assertTrue(watchingWallet.isWatching());
         wallet.encrypt(PASSWORD1);
         assertFalse(wallet.isWatching());
@@ -3054,7 +3054,7 @@ public class WalletTest extends TestWithWallet {
             TransactionInput input = req.tx.getInput(i).withoutScriptBytes();
             req.tx.replaceInput(i, input);
         }
-        Wallet watching = Wallet.fromWatchingKey(TESTNET, wallet.getWatchingKey().dropParent().dropPrivateBytes(),
+        Wallet watching = Wallet.fromWatchingKey(TESTNET, wallet.getWatchingKey().dropParent().withoutPrivateKey(),
                 ScriptType.P2PKH);
         watching.freshReceiveKey();
         watching.completeTx(SendRequest.forTx(req.tx));
@@ -3518,7 +3518,7 @@ public class WalletTest extends TestWithWallet {
                 .random(new SecureRandom())
                 .accountPath(accountPath)
                 .build();
-        DeterministicKey watchingKey = keyChain.getWatchingKey().dropPrivateBytes().dropParent();
+        DeterministicKey watchingKey = keyChain.getWatchingKey().withoutPrivateKey().dropParent();
 
         Wallet wallet7 = Wallet.fromWatchingKey(TESTNET, watchingKey, ScriptType.P2WPKH);
         assertEquals(TESTNET, wallet7.network());


### PR DESCRIPTION
* use canonical constructor to clear both cleartext and encrypted private keys and the keyCrypter
* be more strict about returning same instance
* amend the JavaDoc
    
Also rename the method from `dropPrivateBytes()` and keep the old method around as deprecated.

~~This a child of #3715.~~