### PR TITLE
HDPath: Deprecate (the only) public constructor

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/HDPath.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDPath.java
@@ -102,7 +102,9 @@ public class HDPath extends AbstractList<ChildNumber> {
      *
      * @param hasPrivateKey Whether it is a path to a private key or not
      * @param list List of children in the path
+     * @deprecated Use {@link HDPath#of(Prefix, List)} or another static constructor
      */
+    @Deprecated
     public HDPath(boolean hasPrivateKey, List<ChildNumber> list) {
         this.hasPrivateKey = hasPrivateKey;
         this.childNumbers = Collections.unmodifiableList(new ArrayList<>(Objects.requireNonNull(list)));

--- a/core/src/test/java/org/bitcoinj/crypto/DeterministicKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/DeterministicKeyTest.java
@@ -26,7 +26,7 @@ public class DeterministicKeyTest {
     public void serialize_maxDepth() {
         DeterministicKey masterPrivateKey = HDKeyDerivation.createMasterPrivateKey(new byte[16]);
         DeterministicHierarchy dh = new DeterministicHierarchy(masterPrivateKey);
-        HDPath path = new HDPath(false, Collections.nCopies(255, ChildNumber.ZERO)); // max
+        HDPath path = HDPath.M(Collections.nCopies(255, ChildNumber.ZERO)); // max
         DeterministicKey ehkey = dh.get(path, false, true);
 
         ehkey.serialize(BitcoinNetwork.MAINNET, false);
@@ -36,7 +36,7 @@ public class DeterministicKeyTest {
     public void serialize_depthOverflow_throws() {
         DeterministicKey masterPrivateKey = HDKeyDerivation.createMasterPrivateKey(new byte[16]);
         DeterministicHierarchy dh = new DeterministicHierarchy(masterPrivateKey);
-        HDPath path = new HDPath(false, Collections.nCopies(256, ChildNumber.ZERO)); // exceeds
+        HDPath path = HDPath.M(Collections.nCopies(256, ChildNumber.ZERO)); // exceeds
         DeterministicKey ehkey = dh.get(path, false, true);
 
         ehkey.serialize(BitcoinNetwork.MAINNET, false);

--- a/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
@@ -31,14 +31,14 @@ import static org.junit.Assert.assertTrue;
 public class HDPathTest {
     @Test
     public void testPrimaryConstructor() {
-        HDPath path = new HDPath(true, Collections.emptyList());
+        HDPath path = HDPath.m(Collections.emptyList());
         assertTrue("Has private key returns false incorrectly", path.hasPrivateKey());
-        assertEquals("Path not empty", path.size(), 0);
+        assertEquals("Path not empty", 0, path.size());
     }
 
     @Test
     public void testExtendVarargs() {
-        HDPath basePath = new HDPath(true, Collections.emptyList());
+        HDPath basePath = HDPath.m(Collections.emptyList());
 
         assertTrue(basePath.hasPrivateKey());
         assertEquals("m",  basePath.toString());


### PR DESCRIPTION
Replace with m() and M() factory methods in some tests.

This is cherry-picked from PR #3720 as a standalone. I want to cherry-pick some other commits (that were accidentally added to it) and then rebase PR #3721.