### PR TITLE
HDPath: make abstract, add HDFullPath and HDPartialPath subclasses

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/HDPath.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDPath.java
@@ -102,7 +102,9 @@ public class HDPath extends AbstractList<ChildNumber> {
      *
      * @param hasPrivateKey Whether it is a path to a private key or not
      * @param list List of children in the path
+     * @deprecated Use {@link HDPath#of(Prefix, List)} or another static constructor
      */
+    @Deprecated
     public HDPath(boolean hasPrivateKey, List<ChildNumber> list) {
         this.hasPrivateKey = hasPrivateKey;
         this.childNumbers = Collections.unmodifiableList(new ArrayList<>(Objects.requireNonNull(list)));

--- a/core/src/main/java/org/bitcoinj/crypto/HDPath.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDPath.java
@@ -48,7 +48,7 @@ import java.util.stream.Stream;
  * Take note of the overloaded factory methods {@link HDPath#M()} and {@link HDPath#m()}. These can be used to very
  * concisely create HDPath objects (especially when statically imported.)
  */
-public class HDPath extends AbstractList<ChildNumber> {
+public abstract class HDPath extends AbstractList<ChildNumber> {
     public enum Prefix {
         PRIVATE('m'),
         PUBLIC('M');
@@ -87,8 +87,7 @@ public class HDPath extends AbstractList<ChildNumber> {
     private static final InternalUtils.Splitter SEPARATOR_SPLITTER = s -> Stream.of(s.split(SEPARATOR))
             .map(String::trim)
             .collect(Collectors.toList());
-    private final boolean hasPrivateKey;
-    private final List<ChildNumber> childNumbers;
+    protected final List<ChildNumber> childNumbers;
 
     /** Partial path with BIP44 purpose */
     public static final HDPath BIP44_PARENT = m(ChildNumber.PURPOSE_BIP44);
@@ -97,27 +96,50 @@ public class HDPath extends AbstractList<ChildNumber> {
     /** Partial path with BIP86 purpose */
     public static final HDPath BIP86_PARENT = m(ChildNumber.PURPOSE_BIP86);
 
-    /**
-     * Constructs a path for a public or private key. Should probably be a private constructor.
-     *
-     * @param hasPrivateKey Whether it is a path to a private key or not
-     * @param list List of children in the path
-     * @deprecated Use {@link HDPath#of(Prefix, List)} or another static constructor
-     */
-    @Deprecated
-    public HDPath(boolean hasPrivateKey, List<ChildNumber> list) {
-        this.hasPrivateKey = hasPrivateKey;
-        this.childNumbers = Collections.unmodifiableList(new ArrayList<>(Objects.requireNonNull(list)));
+    public static class HDFullPath extends HDPath {
+        private final boolean hasPrivateKey;
+
+        /**
+         * Constructs a path for a public or private key. Should probably be a private constructor.
+         *
+         * @param hasPrivateKey Whether it is a path to a private key or not
+         * @param list List of children in the path
+         */
+        public HDFullPath(boolean hasPrivateKey, List<ChildNumber> list) {
+            super(list);
+            this.hasPrivateKey = hasPrivateKey;
+        }
+        /**
+         * Constructs a path for a public or private key. Should probably be a private constructor.
+         *
+         * @param prefix 'M' or 'm'
+         * @param list          List of children in the path
+         */
+        public HDFullPath(Prefix prefix, List<ChildNumber> list) {
+            this(prefix == Prefix.PRIVATE, list);
+        }
+
+        /**
+         * Return the correct prefix for this path.
+         *
+         * @return prefix
+         */
+        public Prefix prefix() {
+            return hasPrivateKey ? Prefix.PRIVATE : Prefix.PUBLIC;
+        }
+
+        /**
+         * Is this a path to a private key?
+         *
+         * @return true if yes, false if no or a partial path
+         */
+        public boolean hasPrivateKey() {
+            return hasPrivateKey;
+        }
     }
 
-    /**
-     * Constructs a path for a public or private key.
-     *
-     * @param prefix 'M' or 'm'
-     * @param list List of children in the path
-     */
-    private HDPath(Prefix prefix, List<ChildNumber> list) {
-        this(prefix == Prefix.PRIVATE, list);
+    private HDPath(List<ChildNumber> list) {
+        this.childNumbers = Collections.unmodifiableList(new ArrayList<>(Objects.requireNonNull(list)));
     }
 
     /**
@@ -126,8 +148,8 @@ public class HDPath extends AbstractList<ChildNumber> {
      * @param prefix Indicates if it is a path to a public or private key
      * @param list List of children in the path
      */
-    public static HDPath of(Prefix prefix, List<ChildNumber> list) {
-        return new HDPath(prefix, list);
+    public static HDFullPath of(Prefix prefix, List<ChildNumber> list) {
+        return new HDFullPath(prefix, list);
     }
 
     /**
@@ -136,8 +158,8 @@ public class HDPath extends AbstractList<ChildNumber> {
      * @param hasPrivateKey Whether it is a path to a private key or not
      * @param list List of children in the path
      */
-    private static HDPath of(boolean hasPrivateKey, List<ChildNumber> list) {
-        return new HDPath(hasPrivateKey, list);
+    private static HDFullPath of(boolean hasPrivateKey, List<ChildNumber> list) {
+        return new HDFullPath(hasPrivateKey, list);
     }
 
     /**
@@ -145,7 +167,7 @@ public class HDPath extends AbstractList<ChildNumber> {
      * @param integerList A list of integers (what we use in ProtoBuf for an HDPath)
      * @return a deserialized HDPath (hasPrivateKey is false/unknown)
      */
-    public static HDPath deserialize(List<Integer> integerList) {
+    public static HDFullPath deserialize(List<Integer> integerList) {
         return integerList.stream()
                 .map(ChildNumber::new)
                 .collect(Collectors.collectingAndThen(Collectors.toList(), HDPath::M));
@@ -156,14 +178,14 @@ public class HDPath extends AbstractList<ChildNumber> {
      *
      * @param list List of children in the path
      */
-    public static HDPath M(List<ChildNumber> list) {
+    public static HDFullPath M(List<ChildNumber> list) {
         return HDPath.of(Prefix.PUBLIC, list);
     }
 
     /**
      * Returns an empty path for a public key.
      */
-    public static HDPath M() {
+    public static HDFullPath M() {
         return HDPath.M(Collections.emptyList());
     }
 
@@ -172,7 +194,7 @@ public class HDPath extends AbstractList<ChildNumber> {
      *
      * @param childNumber Single child in path
      */
-    public static HDPath M(ChildNumber childNumber) {
+    public static HDFullPath M(ChildNumber childNumber) {
         return HDPath.M(Collections.singletonList(childNumber));
     }
 
@@ -181,7 +203,7 @@ public class HDPath extends AbstractList<ChildNumber> {
      *
      * @param children Children in the path
      */
-    public static HDPath M(ChildNumber... children) {
+    public static HDFullPath M(ChildNumber... children) {
         return HDPath.M(Arrays.asList(children));
     }
 
@@ -190,14 +212,14 @@ public class HDPath extends AbstractList<ChildNumber> {
      *
      * @param list List of children in the path
      */
-    public static HDPath m(List<ChildNumber> list) {
+    public static HDFullPath m(List<ChildNumber> list) {
         return HDPath.of(Prefix.PRIVATE, list);
     }
 
     /**
      * Returns an empty path for a private key.
      */
-    public static HDPath m() {
+    public static HDFullPath m() {
         return HDPath.m(Collections.emptyList());
     }
 
@@ -206,7 +228,7 @@ public class HDPath extends AbstractList<ChildNumber> {
      *
      * @param childNumber Single child in path
      */
-    public static HDPath m(ChildNumber childNumber) {
+    public static HDFullPath m(ChildNumber childNumber) {
         return HDPath.m(Collections.singletonList(childNumber));
     }
 
@@ -215,7 +237,7 @@ public class HDPath extends AbstractList<ChildNumber> {
      *
      * @param children Children in the path
      */
-    public static HDPath m(ChildNumber... children) {
+    public static HDFullPath m(ChildNumber... children) {
         return HDPath.m(Arrays.asList(children));
     }
 
@@ -226,7 +248,7 @@ public class HDPath extends AbstractList<ChildNumber> {
      * <p>
      * Where a letter {@code H} means hardened key. Spaces are ignored.
      */
-    public static HDPath parsePath(@Nonnull String path) {
+    public static HDFullPath parsePath(@Nonnull String path) {
         List<String> parsedNodes = SEPARATOR_SPLITTER.splitToList(path);
         Optional<Prefix> prefix = parsedNodes.isEmpty() ? Optional.empty() : Prefix.of(parsedNodes.get(0));
 
@@ -239,23 +261,6 @@ public class HDPath extends AbstractList<ChildNumber> {
         return HDPath.of(prefix.orElse(Prefix.PUBLIC), nodes);
     }
 
-    /**
-     * Return the correct prefix for this path.
-     *
-     * @return prefix
-     */
-    public Prefix prefix() {
-        return hasPrivateKey ? Prefix.PRIVATE : Prefix.PUBLIC;
-    }
-
-    /**
-     * Is this a path to a private key?
-     *
-     * @return true if yes, false if no or a partial path
-     */
-    public boolean hasPrivateKey() {
-        return hasPrivateKey;
-    }
 
     /**
      * Extend the path by appending additional ChildNumber objects.
@@ -264,11 +269,11 @@ public class HDPath extends AbstractList<ChildNumber> {
      * @param children zero or more additional children to append
      * @return A new immutable path
      */
-    public HDPath extend(ChildNumber child1, ChildNumber... children) {
+    public HDFullPath extend(ChildNumber child1, ChildNumber... children) {
         List<ChildNumber> mutable = new ArrayList<>(this.childNumbers); // Mutable copy
         mutable.add(child1);
         mutable.addAll(Arrays.asList(children));
-        return new HDPath(this.hasPrivateKey, mutable);
+        return new HDFullPath(((HDFullPath) this).hasPrivateKey, mutable);
     }
 
     /**
@@ -277,10 +282,10 @@ public class HDPath extends AbstractList<ChildNumber> {
      * @param path2 the relative path to append
      * @return A new immutable path
      */
-    public HDPath extend(HDPath path2) {
+    public HDFullPath extend(HDPath path2) {
         List<ChildNumber> mutable = new ArrayList<>(this.childNumbers); // Mutable copy
         mutable.addAll(path2);
-        return new HDPath(this.hasPrivateKey, mutable);
+        return new HDFullPath(((HDFullPath) this).hasPrivateKey, mutable);
     }
 
     /**
@@ -289,7 +294,7 @@ public class HDPath extends AbstractList<ChildNumber> {
      * @param path2 the relative path to append
      * @return A new immutable path
      */
-    public HDPath extend(List<ChildNumber> path2) {
+    public HDFullPath extend(List<ChildNumber> path2) {
         return this.extend(HDPath.M(path2));
     }
 
@@ -310,10 +315,11 @@ public class HDPath extends AbstractList<ChildNumber> {
      * {@link HDPath#isEmpty()} before or after using {@code HDPath#parent()}
      * @return parent path (which can be empty -- see above)
      */
-    public HDPath parent() {
-        return childNumbers.size() > 1 ?
-                HDPath.of(hasPrivateKey, childNumbers.subList(0, childNumbers.size() - 1)) :
-                HDPath.of(hasPrivateKey, Collections.emptyList());
+    public HDFullPath parent() {
+        HDFullPath childNumbers1 = childNumbers.size() > 1 ?
+                HDPath.of(((HDFullPath) this).hasPrivateKey, childNumbers.subList(0, childNumbers.size() - 1)) :
+                HDPath.of(((HDFullPath) this).hasPrivateKey, Collections.emptyList());
+        return childNumbers1;
     }
 
     /**
@@ -333,7 +339,7 @@ public class HDPath extends AbstractList<ChildNumber> {
         int endExclusive =  childNumbers.size() + (includeSelf ? 1 : 0);
         return IntStream.range(1, endExclusive)
                 .mapToObj(i -> childNumbers.subList(0, i))
-                .map(l -> HDPath.of(hasPrivateKey, l))
+                .map(l -> HDPath.of(((HDFullPath) this).hasPrivateKey, l))
                 .collect(StreamUtils.toUnmodifiableList());
     }
 
@@ -350,7 +356,7 @@ public class HDPath extends AbstractList<ChildNumber> {
     @Override
     public String toString() {
         StringBuilder b = new StringBuilder();
-        b.append(this.prefix());
+        b.append(((HDFullPath) this).prefix());
         for (ChildNumber child : childNumbers) {
             b.append(SEPARATOR);
             b.append(child);

--- a/core/src/main/java/org/bitcoinj/crypto/HDPath.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDPath.java
@@ -90,11 +90,11 @@ public abstract class HDPath extends AbstractList<ChildNumber> {
     protected final List<ChildNumber> childNumbers;
 
     /** Partial path with BIP44 purpose */
-    public static final HDPath BIP44_PARENT = m(ChildNumber.PURPOSE_BIP44);
+    public static final HDPartialPath BIP44_PARENT = partial(ChildNumber.PURPOSE_BIP44);
     /** Partial path with BIP84 purpose */
-    public static final HDPath BIP84_PARENT = m(ChildNumber.PURPOSE_BIP84);
+    public static final HDPartialPath BIP84_PARENT = partial(ChildNumber.PURPOSE_BIP84);
     /** Partial path with BIP86 purpose */
-    public static final HDPath BIP86_PARENT = m(ChildNumber.PURPOSE_BIP86);
+    public static final HDPartialPath BIP86_PARENT = partial(ChildNumber.PURPOSE_BIP86);
 
     public static class HDFullPath extends HDPath {
         private final boolean hasPrivateKey;
@@ -136,8 +136,56 @@ public abstract class HDPath extends AbstractList<ChildNumber> {
         public boolean hasPrivateKey() {
             return hasPrivateKey;
         }
+
+        @Override
+        public HDFullPath extend(ChildNumber child1, ChildNumber... children) {
+            return new HDFullPath(this.hasPrivateKey, extendInternal(child1, children));
+        }
+
+        @Override
+        public HDFullPath extend(HDPath.HDPartialPath partialPath) {
+            return new HDFullPath(this.hasPrivateKey, extendInternal(partialPath));
+        }
+
+        @Override
+        public HDFullPath extend(List<ChildNumber> partialPath) {
+            return new HDFullPath(this.hasPrivateKey, extendInternal(partialPath));
+        }
+
+        @Override
+        public HDFullPath parent() {
+            return new HDFullPath(this.hasPrivateKey, parentInternal());
+        }
     }
 
+    public static class HDPartialPath extends HDPath {
+
+        private HDPartialPath(List<ChildNumber> list) {
+            super(list);
+        }
+
+        @Override
+        public HDPartialPath extend(ChildNumber child1, ChildNumber... children) {
+            return new HDPartialPath(extendInternal(child1, children));
+        }
+
+        @Override
+        public HDPartialPath extend(HDPath.HDPartialPath partialPath) {
+            return new HDPartialPath(extendInternal(partialPath));
+        }
+
+        @Override
+        public HDPartialPath extend(List<ChildNumber> partialPath) {
+            return new HDPartialPath(extendInternal(partialPath));
+        }
+
+        @Override
+        public HDPartialPath parent() {
+            return new HDPartialPath(parentInternal());
+        }
+    }
+
+    // Canonical superclass constructor
     private HDPath(List<ChildNumber> list) {
         this.childNumbers = Collections.unmodifiableList(new ArrayList<>(Objects.requireNonNull(list)));
     }
@@ -167,10 +215,37 @@ public abstract class HDPath extends AbstractList<ChildNumber> {
      * @param integerList A list of integers (what we use in ProtoBuf for an HDPath)
      * @return a deserialized HDPath (hasPrivateKey is false/unknown)
      */
-    public static HDFullPath deserialize(List<Integer> integerList) {
-        return integerList.stream()
+    public static HDPartialPath deserialize(List<Integer> integerList) {
+        return HDPath.partial(integerList.stream()
                 .map(ChildNumber::new)
-                .collect(Collectors.collectingAndThen(Collectors.toList(), HDPath::M));
+                .collect(StreamUtils.toUnmodifiableList()));
+    }
+
+    /**
+     * Returns a partial path.
+     *
+     * @param list list of children
+     */
+    public static HDPartialPath partial(List<ChildNumber> list) {
+        return new HDPartialPath(list);
+    }
+
+    /**
+     * Returns a partial path.
+     *
+     * @param childNumber Single child in path
+     */
+    public static HDPartialPath partial(ChildNumber childNumber) {
+        return partial(Collections.singletonList(childNumber));
+    }
+
+    /**
+     * Returns a partial path.
+     *
+     * @param children Children in the path
+     */
+    public static HDPartialPath partial(ChildNumber... children) {
+        return partial(Arrays.asList(children));
     }
 
     /**
@@ -261,7 +336,6 @@ public abstract class HDPath extends AbstractList<ChildNumber> {
         return HDPath.of(prefix.orElse(Prefix.PUBLIC), nodes);
     }
 
-
     /**
      * Extend the path by appending additional ChildNumber objects.
      *
@@ -269,11 +343,13 @@ public abstract class HDPath extends AbstractList<ChildNumber> {
      * @param children zero or more additional children to append
      * @return A new immutable path
      */
-    public HDFullPath extend(ChildNumber child1, ChildNumber... children) {
+    public abstract HDPath extend(ChildNumber child1, ChildNumber... children);
+
+    protected List<ChildNumber> extendInternal(ChildNumber child1, ChildNumber... children) {
         List<ChildNumber> mutable = new ArrayList<>(this.childNumbers); // Mutable copy
         mutable.add(child1);
         mutable.addAll(Arrays.asList(children));
-        return new HDFullPath(((HDFullPath) this).hasPrivateKey, mutable);
+        return mutable;
     }
 
     /**
@@ -282,20 +358,20 @@ public abstract class HDPath extends AbstractList<ChildNumber> {
      * @param path2 the relative path to append
      * @return A new immutable path
      */
-    public HDFullPath extend(HDPath path2) {
+    public abstract HDPath extend(HDPath.HDPartialPath path2);
+
+    /**
+     * Extend the path by appending a relative path.
+     *
+     * @param path2 the relative path to append
+     * @return A new immutable path
+     */
+    public abstract HDPath extend(List<ChildNumber> path2);
+
+    protected List<ChildNumber> extendInternal(List<ChildNumber> children) {
         List<ChildNumber> mutable = new ArrayList<>(this.childNumbers); // Mutable copy
-        mutable.addAll(path2);
-        return new HDFullPath(((HDFullPath) this).hasPrivateKey, mutable);
-    }
-
-    /**
-     * Extend the path by appending a relative path.
-     *
-     * @param path2 the relative path to append
-     * @return A new immutable path
-     */
-    public HDFullPath extend(List<ChildNumber> path2) {
-        return this.extend(HDPath.M(path2));
+        mutable.addAll(children);
+        return mutable;
     }
 
     /**
@@ -315,11 +391,12 @@ public abstract class HDPath extends AbstractList<ChildNumber> {
      * {@link HDPath#isEmpty()} before or after using {@code HDPath#parent()}
      * @return parent path (which can be empty -- see above)
      */
-    public HDFullPath parent() {
-        HDFullPath childNumbers1 = childNumbers.size() > 1 ?
-                HDPath.of(((HDFullPath) this).hasPrivateKey, childNumbers.subList(0, childNumbers.size() - 1)) :
-                HDPath.of(((HDFullPath) this).hasPrivateKey, Collections.emptyList());
-        return childNumbers1;
+    public abstract HDPath parent();
+
+    protected List<ChildNumber> parentInternal() {
+        return childNumbers.size() > 1 ?
+                childNumbers.subList(0, childNumbers.size() - 1) :
+                Collections.emptyList();
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -136,14 +136,14 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
     // a payment request that can generate lots of addresses independently.
     // The account path may be overridden by subclasses.
     // m / 0'
-    public static final HDPath ACCOUNT_ZERO_PATH = HDPath.M(ChildNumber.ZERO_HARDENED);
+    public static final HDPath.HDPartialPath ACCOUNT_ZERO_PATH = HDPath.partial(ChildNumber.ZERO_HARDENED);
     // m / 1'
-    public static final HDPath ACCOUNT_ONE_PATH = HDPath.M(ChildNumber.ONE_HARDENED);
+    public static final HDPath.HDPartialPath ACCOUNT_ONE_PATH = HDPath.partial(ChildNumber.ONE_HARDENED);
     // m / 44' / 0' / 0'
-    public static final HDPath BIP44_ACCOUNT_ZERO_PATH = HDPath.M(new ChildNumber(44, true))
+    public static final HDPath.HDPartialPath BIP44_ACCOUNT_ZERO_PATH = HDPath.partial(new ChildNumber(44, true))
                         .extend(ChildNumber.ZERO_HARDENED, ChildNumber.ZERO_HARDENED);
-    public static final HDPath EXTERNAL_SUBPATH = HDPath.M(ChildNumber.ZERO);
-    public static final HDPath INTERNAL_SUBPATH = HDPath.M(ChildNumber.ONE);
+    public static final HDPath.HDPartialPath EXTERNAL_SUBPATH = HDPath.partial(ChildNumber.ZERO);
+    public static final HDPath.HDPartialPath INTERNAL_SUBPATH = HDPath.partial(ChildNumber.ONE);
 
     // We try to ensure we have at least this many keys ready and waiting to be handed out via getKey().
     // See docs for getLookaheadSize() for more info on what this is for. The -1 value means it hasn't been calculated

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroupStructure.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroupStructure.java
@@ -54,7 +54,7 @@ public interface KeyChainGroupStructure {
      * @param network network/coin type
      * @return The HD Path: purpose / coinType / accountIndex
      */
-    HDPath accountPathFor(ScriptType outputScriptType, Network network);
+    HDPath.HDPartialPath accountPathFor(ScriptType outputScriptType, Network network);
 
     /**
      * Original <b>bitcoinj</b> {@link KeyChainGroupStructure} implementation. Based on BIP32 "Wallet structure".
@@ -89,7 +89,7 @@ public interface KeyChainGroupStructure {
      * @param scriptType script/address type
      * @return An HDPath with a BIP44 "purpose" entry
      */
-    static HDPath purpose(ScriptType scriptType) {
+    static HDPath.HDPartialPath purpose(ScriptType scriptType) {
         if (scriptType == null || scriptType == ScriptType.P2PKH) {
             return HDPath.BIP44_PARENT;
         } else if (scriptType == ScriptType.P2WPKH) {

--- a/core/src/test/java/org/bitcoinj/crypto/DeterministicKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/DeterministicKeyTest.java
@@ -26,7 +26,7 @@ public class DeterministicKeyTest {
     public void serialize_maxDepth() {
         DeterministicKey masterPrivateKey = HDKeyDerivation.createMasterPrivateKey(new byte[16]);
         DeterministicHierarchy dh = new DeterministicHierarchy(masterPrivateKey);
-        HDPath path = new HDPath(false, Collections.nCopies(255, ChildNumber.ZERO)); // max
+        HDPath path = HDPath.M(Collections.nCopies(255, ChildNumber.ZERO)); // max
         DeterministicKey ehkey = dh.get(path, false, true);
 
         ehkey.serialize(BitcoinNetwork.MAINNET, false);
@@ -36,7 +36,7 @@ public class DeterministicKeyTest {
     public void serialize_depthOverflow_throws() {
         DeterministicKey masterPrivateKey = HDKeyDerivation.createMasterPrivateKey(new byte[16]);
         DeterministicHierarchy dh = new DeterministicHierarchy(masterPrivateKey);
-        HDPath path = new HDPath(false, Collections.nCopies(256, ChildNumber.ZERO)); // exceeds
+        HDPath path = HDPath.M(Collections.nCopies(256, ChildNumber.ZERO)); // exceeds
         DeterministicKey ehkey = dh.get(path, false, true);
 
         ehkey.serialize(BitcoinNetwork.MAINNET, false);

--- a/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
@@ -31,14 +31,14 @@ import static org.junit.Assert.assertTrue;
 public class HDPathTest {
     @Test
     public void testPrimaryConstructor() {
-        HDPath path = HDPath.m(Collections.emptyList());
+        HDPath.HDFullPath path = HDPath.m();
         assertTrue("Has private key returns false incorrectly", path.hasPrivateKey());
         assertEquals("Path not empty", 0, path.size());
     }
 
     @Test
     public void testExtendVarargs() {
-        HDPath basePath = HDPath.m(Collections.emptyList());
+        HDPath.HDFullPath  basePath = HDPath.m();
 
         assertTrue(basePath.hasPrivateKey());
         assertEquals("m",  basePath.toString());
@@ -178,7 +178,7 @@ public class HDPathTest {
             List<ChildNumber> expectedPath = (List<ChildNumber>) tv[i + 1];
             boolean expectedHasPrivateKey = (Boolean) tv[i + 2];
 
-            HDPath path = HDPath.parsePath(strPath);
+            HDPath.HDFullPath path = HDPath.parsePath(strPath);
             assertEquals(expectedPath, path);
             assertEquals(expectedHasPrivateKey, path.hasPrivateKey());
         }

--- a/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
@@ -31,14 +31,14 @@ import static org.junit.Assert.assertTrue;
 public class HDPathTest {
     @Test
     public void testPrimaryConstructor() {
-        HDPath path = new HDPath(true, Collections.emptyList());
+        HDPath path = HDPath.m(Collections.emptyList());
         assertTrue("Has private key returns false incorrectly", path.hasPrivateKey());
-        assertEquals("Path not empty", path.size(), 0);
+        assertEquals("Path not empty", 0, path.size());
     }
 
     @Test
     public void testExtendVarargs() {
-        HDPath basePath = new HDPath(true, Collections.emptyList());
+        HDPath basePath = HDPath.m(Collections.emptyList());
 
         assertTrue(basePath.hasPrivateKey());
         assertEquals("m",  basePath.toString());

--- a/integration-test/src/test/java/org/bitcoinj/wallet/WalletAccountPathTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/wallet/WalletAccountPathTest.java
@@ -56,7 +56,7 @@ public class WalletAccountPathTest {
 
     @MethodSource("walletStructureParams")
     @ParameterizedTest(name = "path {1} generated for {2}, {3}")
-    void walletStructurePathTest2(KeyChainGroupStructure structure, HDPath expectedPath, ScriptType scriptType,
+    void walletStructurePathTest2(KeyChainGroupStructure structure, HDPath.HDFullPath expectedPath, ScriptType scriptType,
                                   BitcoinNetwork network) throws IOException, UnreadableWalletException {
         // When we create a wallet with parameterized structure, network, and scriptType
         Wallet wallet = createWallet(walletFile, network, structure, scriptType);


### PR DESCRIPTION
This is a child of PR #3722 and adds two new commits:

* 0566b9c3280cb10ab285ac266c02d36b4008ee8b - make abstract and add `HDFullPath` subclass
* 12dba13dbc6cdd1aae42a1281eedced19ca52e93 - add `HDPartialPath` subclass

The first of the two is not much use without the second, but it's useful to break the refactoring into two steps.

Before we merge this we should have a discussion about how we want to name the subclasses:

`HDPath.HDFullPath` and `HDPath.HDPartialPath` is pretty verbose. We could shorten it to `HDPath.Full` and `HDPath.Partial` or something similar. Or we could move `HDFullPath` and HDPartialPath` into standalone files so they are no longer nested classes with nested names.

Note that the idea of having `HDFullPathPublic` and `HDFullPathPrivate` subclasses of an `HDFullPath` (or similar) was considered and rejected in favor of continuing to use an internal boolean to distinguish.