### PR TITLE
DeterministicKey: fix depth issue with `dropParent()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -287,9 +287,8 @@ public class DeterministicKey extends ECKey {
      * private key at all.</p>
      */
     public DeterministicKey dropParent() {
-        DeterministicKey key = new DeterministicKey(getPath(), getChainCode(), pub, priv, null);
-        key.parentFingerprint = parentFingerprint;
-        return key;
+        return new DeterministicKey(priv, pub, depth, null, parentFingerprint, chainCode, childNumberPath,
+                encryptedPrivateKey, keyCrypter);
     }
 
     static byte[] addChecksum(byte[] input) {

--- a/core/src/test/java/org/bitcoinj/crypto/ChildKeyDerivationTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ChildKeyDerivationTest.java
@@ -200,20 +200,26 @@ public class ChildKeyDerivationTest {
     public void pubOnlyDerivation() {
         DeterministicKey key1 = HDKeyDerivation.createMasterPrivateKey("satoshi lives!".getBytes());
         assertFalse(key1.isPubKeyOnly());
+        assertEquals(0,key1.getDepth());
         DeterministicKey key2 = HDKeyDerivation.deriveChildKey(key1, ChildNumber.ZERO_HARDENED);
         assertFalse(key2.isPubKeyOnly());
+        assertEquals(1, key2.getDepth());
         DeterministicKey key3 = HDKeyDerivation.deriveChildKey(key2, ChildNumber.ZERO);
         assertFalse(key3.isPubKeyOnly());
+        assertEquals(2, key3.getDepth());
 
         key2 = key2.dropPrivateBytes();
         assertFalse(key2.isPubKeyOnly());   // still got private key bytes from the parents!
+        assertEquals(1, key2.getDepth());
 
         // pubkey2 got its cached private key bytes (if any) dropped, and now it'll lose its parent too, so now it
         // becomes a true pubkey-only object.
         DeterministicKey pubkey2 = key2.dropParent();
+        assertEquals(1, pubkey2.getDepth());
 
         DeterministicKey pubkey3 = HDKeyDerivation.deriveChildKey(pubkey2, ChildNumber.ZERO);
         assertTrue(pubkey3.isPubKeyOnly());
+        assertEquals(2, pubkey3.getDepth());
         assertEquals(key3.getPubKeyPoint(), pubkey3.getPubKeyPoint());
     }
 


### PR DESCRIPTION
This method should not change anything but the parent. The canonical constructor is used to assure that.

Also adds asserts to `ChildKeyDerivationTest.pubOnlyDerivation()` to surface the issue.