### PR TITLE
HDPath: fix toString for HDPartialPath, refactor and improve tests

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/HDPath.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDPath.java
@@ -434,7 +434,9 @@ public abstract class HDPath extends AbstractList<ChildNumber> {
     @Override
     public String toString() {
         StringBuilder b = new StringBuilder();
-        b.append(((HDFullPath) this).prefix());
+        if (this instanceof HDFullPath) {
+            b.append(((HDFullPath) this).prefix());
+        }
         for (ChildNumber child : childNumbers) {
             b.append(SEPARATOR);
             b.append(child);

--- a/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
@@ -120,7 +120,7 @@ public class HDPathTest {
         assertEquals(0, empty3.size());
     }
 
-    private PathVector[] formatTestVectors() {
+    private PathVector[] toStringTestVectors() {
         return new PathVector[] {
                 new PathVector (
                         "M/44H/0H/0H/1/1",
@@ -144,8 +144,8 @@ public class HDPathTest {
     }
 
     @Test
-    @Parameters(method = "formatTestVectors")
-    public void testFormatPath(PathVector tv) {
+    @Parameters(method = "toStringTestVectors")
+    public void testToString(PathVector tv) {
         String generatedStrPath = tv.path.toString();
         assertEquals(tv.pathString, generatedStrPath);
     }

--- a/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
@@ -16,7 +16,10 @@
 
 package org.bitcoinj.crypto;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.List;
 
@@ -26,6 +29,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author Michael Sean Gilligan
  */
+@RunWith(JUnitParamsRunner.class)
 public class HDPathTest {
     @Test
     public void testPrimaryConstructor() {
@@ -116,69 +120,83 @@ public class HDPathTest {
         assertEquals(0, empty3.size());
     }
 
-    @Test
-    public void testFormatPath() {
-        Object[] tv = {
-                "M/44H/0H/0H/1/1",
-                HDPath.M(new ChildNumber(44, true), new ChildNumber(0, true), new ChildNumber(0, true),
-                        new ChildNumber(1, false), new ChildNumber(1, false)),
-
-                "M/7H/3/3/1H",
-                HDPath.M(new ChildNumber(7, true), new ChildNumber(3, false), new ChildNumber(3, false),
-                        new ChildNumber(1, true)),
-
-                "M/1H/2H/3H",
-                HDPath.M(new ChildNumber(1, true), new ChildNumber(2, true), new ChildNumber(3, true)),
-
-                "M/1/2/3",
-                HDPath.M(new ChildNumber(1, false), new ChildNumber(2, false), new ChildNumber(3, false))
+    private PathVector[] formatTestVectors() {
+        return new PathVector[] {
+                new PathVector (
+                        "M/44H/0H/0H/1/1",
+                        HDPath.M(new ChildNumber(44, true), new ChildNumber(0, true), new ChildNumber(0, true),
+                                new ChildNumber(1, false), new ChildNumber(1, false))
+                ),
+                new PathVector (
+                        "M/7H/3/3/1H",
+                        HDPath.M(new ChildNumber(7, true), new ChildNumber(3, false), new ChildNumber(3, false),
+                                new ChildNumber(1, true))
+                ),
+                new PathVector (
+                        "M/1H/2H/3H",
+                        HDPath.M(new ChildNumber(1, true), new ChildNumber(2, true), new ChildNumber(3, true))
+                ),
+                new PathVector (
+                        "M/1/2/3",
+                        HDPath.M(new ChildNumber(1, false), new ChildNumber(2, false), new ChildNumber(3, false))
+                )
         };
-
-        for (int i = 0; i < tv.length; i += 2) {
-            String expectedStrPath = (String) tv[i];
-            HDPath path = (HDPath) tv[i + 1];
-
-            String generatedStrPath = path.toString();
-
-            assertEquals(expectedStrPath, generatedStrPath);
-        }
     }
 
     @Test
-    public void testParsePath() {
-        Object[] tv = {
+    @Parameters(method = "formatTestVectors")
+    public void testFormatPath(PathVector tv) {
+        String generatedStrPath = tv.path.toString();
+        assertEquals(tv.pathString, generatedStrPath);
+    }
+
+    private PathVector[] parseTestVectors() {
+        return new PathVector[] {
+            new PathVector (
                 "M / 44H / 0H / 0H / 1 / 1",
                 HDPath.M(new ChildNumber(44, true), new ChildNumber(0, true), new ChildNumber(0, true),
-                        new ChildNumber(1, false), new ChildNumber(1, false)),
-                false,
+                    new ChildNumber(1, false), new ChildNumber(1, false))
+            ),
 
+            new PathVector (
                 "M/7H/3/3/1H/",
                 HDPath.M(new ChildNumber(7, true), new ChildNumber(3, false), new ChildNumber(3, false),
-                        new ChildNumber(1, true)),
-                false,
+                    new ChildNumber(1, true))
+            ),
 
+            new PathVector (
                 "m/7H/3/3/1H/",
                 HDPath.m(new ChildNumber(7, true), new ChildNumber(3, false), new ChildNumber(3, false),
-                        new ChildNumber(1, true)),
-                true,
+                    new ChildNumber(1, true))
+            ),
 
+            new PathVector (
                 "1 H / 2 H / 3 H /",
-                HDPath.partial(new ChildNumber(1, true), new ChildNumber(2, true), new ChildNumber(3, true)),
-                false,
+                HDPath.partial(new ChildNumber(1, true), new ChildNumber(2, true), new ChildNumber(3, true))
+            ),
 
+            new PathVector (
                 "1 / 2 / 3 /",
-                HDPath.partial(new ChildNumber(1, false), new ChildNumber(2, false), new ChildNumber(3, false)),
-                false
+                HDPath.partial(new ChildNumber(1, false), new ChildNumber(2, false), new ChildNumber(3, false))
+            )
         };
+    }
 
-        for (int i = 0; i < tv.length; i += 3) {
-            String strPath = (String) tv[i];
-            HDPath expectedPath = (HDPath) tv[i + 1];
-            boolean expectedHasPrivateKey = (Boolean) tv[i + 2];
+    @Test
+    @Parameters(method = "parseTestVectors")
+    public void testParsePath(PathVector tv) {
+        HDPath.HDFullPath path = HDPath.parsePath(tv.pathString);
+        assertEquals(tv.path, path);
+    }
+    
+    // This should/will be a record
+    public static class PathVector {
+        final String pathString;
+        final HDPath path;
 
-            HDPath.HDFullPath path = HDPath.parsePath(strPath);
-            assertEquals(expectedPath, path);
-            assertEquals(expectedHasPrivateKey, path.hasPrivateKey());
+        private PathVector(String pathString, HDPath path) {
+            this.pathString = pathString;
+            this.path = path;
         }
     }
 }

--- a/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
@@ -18,8 +18,6 @@ package org.bitcoinj.crypto;
 
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -165,17 +163,17 @@ public class HDPathTest {
                 true,
 
                 "1 H / 2 H / 3 H /",
-                Arrays.asList(new ChildNumber(1, true), new ChildNumber(2, true), new ChildNumber(3, true)),
+                HDPath.partial(new ChildNumber(1, true), new ChildNumber(2, true), new ChildNumber(3, true)),
                 false,
 
                 "1 / 2 / 3 /",
-                Arrays.asList(new ChildNumber(1, false), new ChildNumber(2, false), new ChildNumber(3, false)),
+                HDPath.partial(new ChildNumber(1, false), new ChildNumber(2, false), new ChildNumber(3, false)),
                 false
         };
 
         for (int i = 0; i < tv.length; i += 3) {
             String strPath = (String) tv[i];
-            List<ChildNumber> expectedPath = (List<ChildNumber>) tv[i + 1];
+            HDPath expectedPath = (HDPath) tv[i + 1];
             boolean expectedHasPrivateKey = (Boolean) tv[i + 2];
 
             HDPath.HDFullPath path = HDPath.parsePath(strPath);

--- a/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
@@ -201,7 +201,7 @@ public class HDPathTest {
     }
 
     @Test
-    @Parameters(method = "parseTestVectors")
+    @Parameters(method = "toStringTestVectors, parseTestVectors")
     public void testParsePath(PathVector tv) {
         HDPath.HDFullPath path = HDPath.parsePath(tv.pathString);
         assertEquals(tv.path, path);

--- a/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
@@ -139,6 +139,24 @@ public class HDPathTest {
                 new PathVector (
                         "M/1/2/3",
                         HDPath.M(new ChildNumber(1, false), new ChildNumber(2, false), new ChildNumber(3, false))
+                ),
+                new PathVector (
+                        "/44H/0H/0H/1/1",
+                        HDPath.partial(new ChildNumber(44, true), new ChildNumber(0, true), new ChildNumber(0, true),
+                                new ChildNumber(1, false), new ChildNumber(1, false))
+                ),
+                new PathVector (
+                        "/7H/3/3/1H",
+                        HDPath.partial(new ChildNumber(7, true), new ChildNumber(3, false), new ChildNumber(3, false),
+                                new ChildNumber(1, true))
+                ),
+                new PathVector (
+                        "/1H/2H/3H",
+                        HDPath.partial(new ChildNumber(1, true), new ChildNumber(2, true), new ChildNumber(3, true))
+                ),
+                new PathVector (
+                        "/1/2/3",
+                        HDPath.partial(new ChildNumber(1, false), new ChildNumber(2, false), new ChildNumber(3, false))
                 )
         };
     }


### PR DESCRIPTION
4 commits to cleanup tests, fix `HDPath.toString()` for `HDPartialPath`, and test the fix.

... and a 5th commit to test `parsePath` with the `toStringTestVectors`, too.