### PR TITLE
BitcoinNetworkParams: deprecate fromId()

### DIFF
--- a/core/src/main/java/org/bitcoinj/params/BitcoinNetworkParams.java
+++ b/core/src/main/java/org/bitcoinj/params/BitcoinNetworkParams.java
@@ -53,7 +53,9 @@ public abstract class BitcoinNetworkParams extends NetworkParameters {
      * Return network parameters for a network id
      * @param id the network id
      * @return the network parameters for the given string ID or NULL if not recognized
+     * @deprecated use {@link BitcoinNetwork#fromIdString(String)} or {@link BitcoinNetworkParams#of(BitcoinNetwork)}
      */
+    @Deprecated
     @Nullable
     public static BitcoinNetworkParams fromID(String id) {
         return BitcoinNetwork.fromIdString(id)


### PR DESCRIPTION
This is a child of PR #3732 and dependent upon PR #3731 to remove the last internal usage of the deprecated method.
