### PR TITLE
AesKey: remove deprecations and obsolete JavaDoc

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/AesKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/AesKey.java
@@ -17,16 +17,13 @@
 package org.bitcoinj.crypto;
 
 import org.bitcoinj.base.internal.ByteArray;
-import org.bouncycastle.crypto.params.KeyParameter;
 
 /**
- *  Wrapper for a {@code byte[]}  containing an AES Key. This is a replacement for Bouncy Castle's {@link KeyParameter} which
+ *  Wrapper for a {@code byte[]}  containing an AES Key. This is a replacement for Bouncy Castle's {@code KeyParameter} which
  *  was used for this purpose in previous versions of <b>bitcoinj</b>. Unfortunately, this created a Gradle _API_ dependency
  *  on Bouncy Castle when that wasn't strictly necessary.
  *  <p>
  *  We have made this change without deprecation because it affected many method signatures and because updating is a trivial change.
- *  If for some reason you have code that uses the Bouncy Castle {@link KeyParameter} type and need to convert
- *  to or from {@code AesKey}, you can temporarily use {@link #ofKeyParameter(KeyParameter)} or {@link #toKeyParameter()}
  */
 public class AesKey extends ByteArray {
     /**
@@ -35,36 +32,5 @@ public class AesKey extends ByteArray {
      */
     public AesKey(byte[] keyBytes) {
         super(keyBytes);
-    }
-
-    /**
-     * Provided to ease migration from {@link KeyParameter}.
-     * @return The key bytes
-     * @deprecated Use {@link #bytes()}
-     */
-    @Deprecated
-    public byte[] getKey() {
-        return bytes();
-    }
-
-    /**
-     * Provided to ease migration from {@link KeyParameter}.
-     * @param keyParameter instance to convert
-     * @return new, preferred container for AES keys
-     * @deprecated Use {@code new AesKey(keyParameter.bytes())}
-     */
-    @Deprecated
-    public static AesKey ofKeyParameter(KeyParameter keyParameter) {
-        return new AesKey(keyParameter.getKey());
-    }
-
-    /**
-     * Provided to ease migration from {@link KeyParameter}.
-     * @return  if for some reason you still need (temporarily, we hope) a {@link KeyParameter}
-     * @deprecated Use {@code new KeyParameter(key.bytes)}
-     */
-    @Deprecated
-    public KeyParameter toKeyParameter() {
-        return new KeyParameter(this.bytes());
     }
 }

--- a/core/src/main/java/org/bitcoinj/crypto/AesKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/AesKey.java
@@ -19,11 +19,7 @@ package org.bitcoinj.crypto;
 import org.bitcoinj.base.internal.ByteArray;
 
 /**
- *  Wrapper for a {@code byte[]}  containing an AES Key. This is a replacement for Bouncy Castle's {@code KeyParameter} which
- *  was used for this purpose in previous versions of <b>bitcoinj</b>. Unfortunately, this created a Gradle _API_ dependency
- *  on Bouncy Castle when that wasn't strictly necessary.
- *  <p>
- *  We have made this change without deprecation because it affected many method signatures and because updating is a trivial change.
+ *  Wrapper for a {@code byte[]} containing an AES Key.
  */
 public class AesKey extends ByteArray {
     /**


### PR DESCRIPTION
2 commits: 1 for the removed methods, 1 for the JavaDoc changes.