### PR TITLE
LazyECPoint: remove deprecated (unused delegated) methods

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
+++ b/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
@@ -18,11 +18,9 @@ package org.bitcoinj.crypto;
 
 import org.bitcoinj.crypto.secp.Secp256k1Constants;
 import org.bouncycastle.math.ec.ECCurve;
-import org.bouncycastle.math.ec.ECFieldElement;
 import org.bouncycastle.math.ec.ECPoint;
 
 import javax.annotation.Nullable;
-import java.math.BigInteger;
 import java.security.interfaces.ECPublicKey;
 import java.util.Arrays;
 import java.util.Objects;
@@ -148,147 +146,6 @@ public final class LazyECPoint implements ECPublicKey {
             return Arrays.copyOf(bits, bits.length);
         else
             return get().getEncoded(compressed);
-    }
-
-    // Delegated methods.
-    // These are deprecated now as we are migrating away from using the Bouncy Castle API directly.
-
-    @Deprecated
-    public ECPoint getDetachedPoint() {
-        return get().getDetachedPoint();
-    }
-
-    @Deprecated
-    public boolean isInfinity() {
-        return get().isInfinity();
-    }
-
-    @Deprecated
-    public ECPoint timesPow2(int e) {
-        return get().timesPow2(e);
-    }
-
-    @Deprecated
-    public ECFieldElement getYCoord() {
-        return get().getYCoord();
-    }
-
-    @Deprecated
-    public ECFieldElement[] getZCoords() {
-        return get().getZCoords();
-    }
-
-    @Deprecated
-    public boolean isNormalized() {
-        return get().isNormalized();
-    }
-
-    @Deprecated
-    public boolean isCompressed() {
-        return isCompressedInternal() ;
-    }
-
-    @Deprecated
-    public ECPoint multiply(BigInteger k) {
-        return get().multiply(k);
-    }
-
-    @Deprecated
-    public ECPoint subtract(ECPoint b) {
-        return get().subtract(b);
-    }
-
-    @Deprecated
-    public boolean isValid() {
-        return get().isValid();
-    }
-
-    @Deprecated
-    public ECPoint scaleY(ECFieldElement scale) {
-        return get().scaleY(scale);
-    }
-
-    @Deprecated
-    public ECFieldElement getXCoord() {
-        return get().getXCoord();
-    }
-
-    @Deprecated
-    public ECPoint scaleX(ECFieldElement scale) {
-        return get().scaleX(scale);
-    }
-
-    @Deprecated
-    public boolean equals(ECPoint other) {
-        return get().equals(other);
-    }
-
-    @Deprecated
-    public ECPoint negate() {
-        return get().negate();
-    }
-
-    @Deprecated
-    public ECPoint threeTimes() {
-        return get().threeTimes();
-    }
-
-    @Deprecated
-    public ECFieldElement getZCoord(int index) {
-        return get().getZCoord(index);
-    }
-
-    @Deprecated
-    public byte[] getEncoded(boolean compressed) {
-        if (compressed == isCompressedInternal() && bits != null)
-            return Arrays.copyOf(bits, bits.length);
-        else
-            return get().getEncoded(compressed);
-    }
-
-    @Deprecated
-    public ECPoint add(ECPoint b) {
-        return get().add(b);
-    }
-
-    @Deprecated
-    public ECPoint twicePlus(ECPoint b) {
-        return get().twicePlus(b);
-    }
-
-    @Deprecated
-    public ECCurve getCurve() {
-        return get().getCurve();
-    }
-
-    @Deprecated
-    public ECPoint normalize() {
-        return get().normalize();
-    }
-
-    @Deprecated
-    public ECFieldElement getY() {
-        return this.normalize().getYCoord();
-    }
-
-    @Deprecated
-    public ECPoint twice() {
-        return get().twice();
-    }
-
-    @Deprecated
-    public ECFieldElement getAffineYCoord() {
-        return get().getAffineYCoord();
-    }
-
-    @Deprecated
-    public ECFieldElement getAffineXCoord() {
-        return get().getAffineXCoord();
-    }
-
-    @Deprecated
-    public ECFieldElement getX() {
-        return this.normalize().getXCoord();
     }
 
     @Override


### PR DESCRIPTION
This is a child of PR #3739.