### PR TITLE
HDPath: add TODO comment about asPartial only on HDFUllPath

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/HDPath.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDPath.java
@@ -424,6 +424,7 @@ public abstract class HDPath extends AbstractList<ChildNumber> {
                 Collections.emptyList();
     }
 
+    // TODO: Consider removing this method from here and HDPartialPath to encourage better use of types
     /**
      * Convert to a partial path, if necessary
      * @return New or existing partial path


### PR DESCRIPTION
Having asPartial() available on all HDPath subtypes discourages the use of consistent strong typing. We should consider removing it at some point.

We can either merge this now to put the reminder in the code or leave it open until we finish this round of refactoring.

I realize this could have been an Issue, but since we're focused on PRs right now, I thought I'd put this in the list.