### PR TITLE
DeterministicKey: Use HDPartialPath for internal childNumberPath

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -58,7 +58,7 @@ public class DeterministicKey extends ECKey {
 
     @Nullable
     private final DeterministicKey parent;
-    private final HDPath childNumberPath;
+    private final HDPath.HDPartialPath childNumberPath;
     private final int depth;
     private final int parentFingerprint; // 0 if this key is root node of key hierarchy
 
@@ -186,18 +186,26 @@ public class DeterministicKey extends ECKey {
         this.parent = parent;
         this.parentFingerprint = ascertainParentFingerprint(parent, parentFingerprint);
         this.chainCode = Arrays.copyOf(chainCode, chainCode.length);
-        this.childNumberPath = Objects.requireNonNull(hdPath);
+        this.childNumberPath = Objects.requireNonNull(hdPath).asPartial();
         this.encryptedPrivateKey = encryptedPrivateKey;
         this.keyCrypter = keyCrypter;
     }
 
     /**
-     * Returns the path through some {@link DeterministicHierarchy} which reaches this keys position in the tree.
-     * A path can be written as 0/1/0 which means the first child of the root, the second child of that node, then
+     * Returns the {@link HDPath.HDFullPath} through the {@link DeterministicHierarchy} to this key's position in the tree.
+     * A path can be written as {@code M/0/1/0} which means the first child of the root, the second child of that node, then
      * the first child of that node.
+     * @return A full path starting with {@code 'm'} or {@code 'M'} depending upon whether ths private key is available.
      */
-    public HDPath getPath() {
-        return childNumberPath;
+    public HDPath.HDFullPath getPath() {
+        return childNumberPath.asFull(prefix());
+    }
+
+    /**
+     * @return The prefix {@code 'm'} or {@code 'M'} for this key's HD path.
+     */
+    private HDPath.Prefix prefix() {
+        return isWatching() ? HDPath.Prefix.PUBLIC : HDPath.Prefix.PRIVATE;
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/crypto/HDPath.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDPath.java
@@ -194,6 +194,18 @@ public abstract class HDPath extends AbstractList<ChildNumber> {
         public HDPartialPath asPartial() {
             return this;
         }
+
+        public HDFullPath asFull(Prefix prefix) {
+            return new HDFullPath(prefix, this.list());
+        }
+
+        public HDFullPath asPublic() {
+            return asFull(Prefix.PUBLIC);
+        }
+
+        public HDFullPath asPrivate() {
+            return asFull(Prefix.PRIVATE);
+        }
     }
 
     // Canonical superclass constructor

--- a/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
@@ -221,6 +221,26 @@ public class HDPathTest {
     }
 
     @Test
+    @Parameters(method = "toStringTestVectors, parseTestVectors")
+    public void testFullPathConversions(PathVector tv) {
+        if (tv.path instanceof HDPath.HDFullPath) {
+            // If test vector is full path, test roundtrip
+            HDPath.Prefix prefix = ((HDPath.HDFullPath) tv.path).prefix();
+            HDPath.HDPartialPath partialPath = tv.path.asPartial();
+            assertEquals(tv.path.childNumbers, partialPath.childNumbers);
+            HDPath.HDFullPath roundTripPath = partialPath.asFull(prefix);
+            assertEquals(tv.path, roundTripPath);
+        } else {
+            // If test vector is partial path, test conversion to public and private
+            HDPath.HDPartialPath partialPath = (HDPath.HDPartialPath) tv.path;
+            HDPath.HDFullPath expectedPublic = HDPath.M(partialPath.childNumbers);
+            HDPath.HDFullPath expectedPrivate = HDPath.m(partialPath.childNumbers);
+            assertEquals(expectedPublic, partialPath.asPublic());
+            assertEquals(expectedPrivate, partialPath.asPrivate());
+        }
+    }
+
+    @Test
     @Ignore("Ignored until we have a correct implementation of equals that compares the prefix")
     public void equals_not_M_m() {
         assertNotEquals(HDPath.M(), HDPath.m());


### PR DESCRIPTION
This is a child of PR #3743 (though it need not be)

The idea here is somewhat inspired by the concept of _database normalization_. If we know from other state variables of the `DeterministicKey` whether it has a public or private path, we don't need to replicate that state in an internal member field.

I think this is a clear win, _unless_ there is a corner case I'm not thinking of (e.g. the case where a key does not know the full path from the root, or where it doesn't know whether it's parents have the private key available, etc.)
