### PR TITLE
HDPath, HDPartialPath cleanup (prepare for full equals/hashCode implementation)

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicHierarchy.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicHierarchy.java
@@ -104,7 +104,7 @@ public class DeterministicHierarchy {
                 throw new IllegalArgumentException(String.format(Locale.US, "No key found for %s path %s.",
                     relativePath ? "relative" : "absolute", partialPath));
             checkArgument(!searchPath.isEmpty(), () -> "can't derive the master key: nothing to derive from");
-            DeterministicKey parent = get(searchPath.subList(0, searchPath.size() - 1), false, true);
+            DeterministicKey parent = get(searchPath.parent(), false, true);
             putKey(HDKeyDerivation.deriveChildKey(parent, searchPath.get(searchPath.size() - 1)));
         }
         return keys.get(searchPath);

--- a/core/src/main/java/org/bitcoinj/crypto/HDPath.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDPath.java
@@ -234,9 +234,9 @@ public abstract class HDPath extends AbstractList<ChildNumber> {
     }
 
     /**
-     * Deserialize a list of integers into an HDPath (internal use only)
+     * Deserialize a list of integers into an HDPartialPath (internal use only)
      * @param integerList A list of integers (what we use in ProtoBuf for an HDPath)
-     * @return a deserialized HDPath (hasPrivateKey is false/unknown)
+     * @return a deserialized HDPartialPath
      */
     public static HDPartialPath deserialize(List<Integer> integerList) {
         return HDPath.partial(integerList.stream()

--- a/core/src/main/java/org/bitcoinj/crypto/HDPath.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDPath.java
@@ -145,7 +145,7 @@ public abstract class HDPath extends AbstractList<ChildNumber> {
 
         @Override
         public HDFullPath extend(HDPath.HDPartialPath partialPath) {
-            return new HDFullPath(this.hasPrivateKey, extendInternal(partialPath));
+            return new HDFullPath(this.hasPrivateKey, extendInternal(partialPath.childNumbers));
         }
 
         @Override
@@ -177,7 +177,7 @@ public abstract class HDPath extends AbstractList<ChildNumber> {
 
         @Override
         public HDPartialPath extend(HDPath.HDPartialPath partialPath) {
-            return new HDPartialPath(extendInternal(partialPath));
+            return new HDPartialPath(extendInternal(partialPath.childNumbers));
         }
 
         @Override

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -53,6 +53,7 @@ import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -845,7 +846,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
         int lookaheadSize = -1;
         int sigsRequiredToSpend = 1;
 
-        HDPath accountPath = HDPath.M();
+        HDPath.HDPartialPath accountPath = HDPath.partial(Collections.emptyList());
         ScriptType outputScriptType = ScriptType.P2PKH;
         for (Protos.Key key : keys) {
             final Protos.Key.Type t = key.getType();
@@ -1001,8 +1002,8 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
         chains.add(chain);
     }
 
-    private static HDPath deserializeAccountPath(List<Integer> integerList) {
-        HDPath path = HDPath.deserialize(integerList);
+    private static HDPath.HDPartialPath deserializeAccountPath(List<Integer> integerList) {
+        HDPath.HDPartialPath path = HDPath.deserialize(integerList);
         return path.isEmpty() ? ACCOUNT_ZERO_PATH : path;
     }
 

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -3513,7 +3513,7 @@ public class WalletTest extends TestWithWallet {
         Wallet wallet6 = Wallet.fromSeed(TESTNET, DeterministicSeed.ofEntropy(new byte[20], ""), ScriptType.P2WPKH, HDPath.BIP44_PARENT);
         assertEquals(TESTNET, wallet6.network());
 
-        HDPath accountPath = KeyChainGroupStructure.BIP43.accountPathFor(ScriptType.P2WPKH, TESTNET);
+        HDPath.HDPartialPath accountPath = KeyChainGroupStructure.BIP43.accountPathFor(ScriptType.P2WPKH, TESTNET);
         DeterministicKeyChain keyChain = DeterministicKeyChain.builder()
                 .random(new SecureRandom())
                 .accountPath(accountPath)


### PR DESCRIPTION
A series of 5 commits focused on:

* Preparing for `HDPath` not implementing `List`
* Preferring the use of `HDPath.HDPartial` in internal places where that is all we need.
