### PR TITLE
HDPath: implement equals() and hashCode() after fixing tests

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/HDPath.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDPath.java
@@ -169,6 +169,20 @@ public abstract class HDPath extends AbstractList<ChildNumber> {
         public HDPartialPath asPartial() {
             return new HDPartialPath(this.childNumbers);
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if ((o == null) || getClass() != o.getClass()) return false;
+            HDFullPath other = (HDFullPath) o;
+            return Objects.equals(this.hasPrivateKey, other.hasPrivateKey) &&
+                    super.equals(other);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.hasPrivateKey, super.hashCode());
+        }
     }
 
     public static class HDPartialPath extends HDPath {
@@ -540,7 +554,7 @@ public abstract class HDPath extends AbstractList<ChildNumber> {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if ((o == null) || !(o instanceof HDPath)) return false;
+        if ((o == null) || getClass() != o.getClass()) return false;
         HDPath other = (HDPath) o;
         return Objects.equals(this.childNumbers, other.childNumbers);
     }

--- a/core/src/test/java/org/bitcoinj/crypto/HDKeyDerivationTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/HDKeyDerivationTest.java
@@ -155,13 +155,13 @@ public class HDKeyDerivationTest {
                                                         .limit(1)
                                                         .collect(Collectors.toList());
         assertEquals(1, keys1.size());
-        assertEquals(HDPath.m(CHILD_NUMBER), keys1.get(0).getPath());
+        assertEquals(HDPath.m(CHILD_NUMBER), keys1.get(0).fullPath());
 
         List<DeterministicKey> keys2 = HDKeyDerivation.generate(parent, CHILD_NUMBER.num())
                                                         .limit(2)
                                                         .collect(Collectors.toList());
         assertEquals(2, keys2.size());
-        assertEquals(HDPath.parsePath("m/1"), keys2.get(0).getPath());
-        assertEquals(HDPath.parsePath("m/2"), keys2.get(1).getPath());
+        assertEquals(HDPath.parsePath("m/1"), keys2.get(0).fullPath());
+        assertEquals(HDPath.parsePath("m/2"), keys2.get(1).fullPath());
     }
 }

--- a/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
@@ -70,7 +70,7 @@ public class HDPathTest {
 
         HDPath path2 = HDPath.parsePath("m/0H");
 
-        assertEquals(HDPath.parsePath(""), path2.parent());
+        assertEquals(HDPath.parsePath("m"), path2.parent());
 
         HDPath path3 = HDPath.parsePath("");
 

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -67,7 +67,7 @@ public class DeterministicKeyChainTest {
     private DeterministicKeyChain segwitChain;
     private DeterministicKeyChain bip44chain;
     private final byte[] ENTROPY = Sha256Hash.hash("don't use a string seed like this in real life".getBytes());
-    private static final HDPath BIP44_COIN_1_ACCOUNT_ZERO_PATH = HDPath.M(new ChildNumber(44, true),
+    private static final HDPath.HDPartialPath BIP44_COIN_1_ACCOUNT_ZERO_PATH = HDPath.partial(new ChildNumber(44, true),
             new ChildNumber(1, true), ChildNumber.ZERO_HARDENED);
 
     @Before
@@ -252,7 +252,7 @@ public class DeterministicKeyChainTest {
         // Round trip the data back and forth to check it is preserved.
         int oldLookaheadSize = chain.getLookaheadSize();
         chain = DeterministicKeyChain.fromProtobuf(keys, null).get(0);
-        assertEquals(DeterministicKeyChain.ACCOUNT_ZERO_PATH, chain.getAccountPath());
+        assertEquals(DeterministicKeyChain.ACCOUNT_ZERO_PATH.asPublic(), chain.getAccountPath());
         assertEquals(EXPECTED_SERIALIZATION, protoToString(chain.serializeToProtobuf()));
         assertEquals(key1, chain.findKeyFromPubHash(key1.getPubKeyHash()));
         assertEquals(key2, chain.findKeyFromPubHash(key2.getPubKeyHash()));
@@ -327,7 +327,7 @@ public class DeterministicKeyChainTest {
         // Round trip the data back and forth to check it is preserved.
         int oldLookaheadSize = bip44chain.getLookaheadSize();
         bip44chain = DeterministicKeyChain.fromProtobuf(keys, null).get(0);
-        assertEquals(BIP44_COIN_1_ACCOUNT_ZERO_PATH, bip44chain.getAccountPath());
+        assertEquals(BIP44_COIN_1_ACCOUNT_ZERO_PATH.asPublic(), bip44chain.getAccountPath());
         assertEquals(EXPECTED_SERIALIZATION, protoToString(bip44chain.serializeToProtobuf()));
         assertEquals(key1, bip44chain.findKeyFromPubHash(key1.getPubKeyHash()));
         assertEquals(key2, bip44chain.findKeyFromPubHash(key2.getPubKeyHash()));
@@ -479,7 +479,7 @@ public class DeterministicKeyChainTest {
     @Test
     public void watchingChainAccountOne() throws UnreadableWalletException {
         TimeUtils.setMockClock();
-        final HDPath accountOne = HDPath.M(ChildNumber.ONE);
+        final HDPath.HDPartialPath accountOne = HDPath.partial(ChildNumber.ONE);
         DeterministicKeyChain chain1 = DeterministicKeyChain.builder().accountPath(accountOne)
                 .seed(chain.getSeed()).build();
         DeterministicKey key1 = chain1.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
@@ -604,7 +604,7 @@ public class DeterministicKeyChainTest {
     public void spendingChainAccountTwo() throws UnreadableWalletException {
         TimeUtils.setMockClock();
         Instant secs = Instant.ofEpochSecond(1389353062L);
-        final HDPath accountTwo = HDPath.M(new ChildNumber(2, true));
+        final HDPath.HDPartialPath accountTwo = HDPath.partial(new ChildNumber(2, true));
         chain = DeterministicKeyChain.builder().accountPath(accountTwo).entropy(ENTROPY, secs).build();
         DeterministicKey firstReceiveKey = chain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         DeterministicKey secondReceiveKey = chain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);


### PR DESCRIPTION
This branch begins with cherry-picks of:

1. PR #3748 
2. PR #3745
3. PR #3747
4. PR #3749
5. PR #3751

**Update:** The above PRs have all been merged. There are 4 commits remaining:

3 commits to fix tests by being more precise about HDPath types.

The final commit adds the full `equals()` / `hasCode()` and passes all tests!