### PR TITLE
LazyECPoint: implement java.s.i.ECPublicKey

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/secp/Secp256k1Constants.java
+++ b/core/src/main/java/org/bitcoinj/crypto/secp/Secp256k1Constants.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.crypto.secp;
+
+import java.math.BigInteger;
+import java.security.spec.ECFieldFp;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.EllipticCurve;
+
+/**
+ * This interface defines constants for SECP256K1 using standard Java Cryptography types.
+ * It will eventually be replaces by similar definitions in <b>secp256k1-jdk</b>
+ */
+public interface Secp256k1Constants {
+    ECFieldFp FIELD = new ECFieldFp(new BigInteger("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F", 16));
+    EllipticCurve CURVE = new EllipticCurve(FIELD, BigInteger.ZERO, BigInteger.valueOf(7));
+    ECParameterSpec EC_PARAMS = new ECParameterSpec(CURVE,
+            new java.security.spec.ECPoint(
+                    new BigInteger("79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798", 16),     // G.x
+                    new BigInteger("483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8", 16)),    // G.y
+            new BigInteger("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141", 16),         // n
+            1);                                                                                                       // h
+}

--- a/core/src/main/java/org/bitcoinj/crypto/secp/package-info.java
+++ b/core/src/main/java/org/bitcoinj/crypto/secp/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This is a <b>temporary</b> package for holding temporary classes and interfaces that we anticipate
+ * will eventually be replaced by classes and interfaces in <b>secp256k1-jdk</b>
+ */
+package org.bitcoinj.crypto.secp;

--- a/core/src/test/java/org/bitcoinj/crypto/LazyECPointTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/LazyECPointTest.java
@@ -1,0 +1,32 @@
+package org.bitcoinj.crypto;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.security.spec.ECPoint;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests for LazyECPoint
+ */
+public class LazyECPointTest {
+    org.bouncycastle.math.ec.ECPoint BOUNCY_INFINITY = ECKey.CURVE.getCurve().getInfinity();
+    ECPoint JAVA_INFINITY = ECPoint.POINT_INFINITY;
+
+    @Test
+    public void convertRandomPoint() {
+        LazyECPoint point = ECKey.random().pub;
+        ECPoint javaPoint = point.getW();
+        assertNotNull(javaPoint);
+        assertEquals(point.getAffineXCoord().toBigInteger(), javaPoint.getAffineX());
+        assertEquals(point.getAffineYCoord().toBigInteger(), javaPoint.getAffineY());
+    }
+
+    @Test
+    public void infinityConversionTest() {
+        LazyECPoint infinity = new LazyECPoint(BOUNCY_INFINITY, true);
+        assertEquals(JAVA_INFINITY, infinity.getW());
+    }
+}


### PR DESCRIPTION
Implement `java.security.interfaces.ECPublicKey` to help us migrate away from leaking Bouncy Castle APIs into our API.

It needs some constant definitions for the SECP256K1 curve. These are provided by a new, temporary sub-package `secp` that should eventually be replaced by definitions in the secp256k1-jdk API.

This PR/commit is IMO the minimal, first step to begin migration to Java Cryptography types and secp256k1-jdk.

Note that eventually `LazyECPoint` (or its possible renamed version or successor) will want to implement a Secp256K1-specific `ECPublicKey` subtype. But for now, I think it is simpler to just use the built-in Java type. We can narrow it later.