### PR TITLE
Experiment: ECKey store `compressed`

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
@@ -157,7 +157,7 @@ public class BIP38PrivateKey extends EncodedPrivateKey {
                 passFactorBytes = Sha256Hash.hashTwice(hashBytes);
             }
             BigInteger passFactor = ByteUtils.bytesToBigInteger(passFactorBytes);
-            ECKey k = ECKey.fromPrivate(passFactor, true);
+            ECKey k = ECKey.fromPrivate(passFactor);
 
             byte[] salt = ByteUtils.concat(addressHash, ownerEntropy);
             checkState(salt.length == 12);

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -128,7 +128,7 @@ public class DeterministicKey extends ECKey {
                             LazyECPoint pub,
                             EncryptedData encryptedPrivateKey,
                             @Nullable DeterministicKey parent) {
-        this(new ECKey(null, pub, pub.isCompressedInternal()), parent == null ? 0 : parent.depth + 1, parent,
+        this(new ECKey(null, pub, true), parent == null ? 0 : parent.depth + 1, parent,
                 parent != null ? parent.getFingerprint() : 0, chainCode, HDPath.M(childNumberPath),
                 Objects.requireNonNull(encryptedPrivateKey), Objects.requireNonNull(crypter));
     }
@@ -158,7 +158,7 @@ public class DeterministicKey extends ECKey {
                             @Nullable DeterministicKey parent,
                             int depth,
                             int parentFingerprint) {
-        this(new ECKey(null, publicAsPoint, publicAsPoint.isCompressedInternal()), depth, parent, parentFingerprint, chainCode, HDPath.M(childNumberPath),
+        this(new ECKey(null, publicAsPoint, true), depth, parent, parentFingerprint, chainCode, HDPath.M(childNumberPath),
                 null, null);
     }
 
@@ -173,7 +173,7 @@ public class DeterministicKey extends ECKey {
                             @Nullable DeterministicKey parent,
                             int depth,
                             int parentFingerprint) {
-        this(new ECKey(priv, new LazyECPoint(ECKey.publicPointFromPrivate(priv))), depth, parent, parentFingerprint,
+        this(new ECKey(priv, new LazyECPoint(ECKey.publicPointFromPrivate(priv)), true), depth, parent, parentFingerprint,
                 chainCode, HDPath.M(childNumberPath), null, null);
     }
 
@@ -204,7 +204,7 @@ public class DeterministicKey extends ECKey {
     private DeterministicKey(@Nullable BigInteger priv, LazyECPoint pub, int depth, @Nullable DeterministicKey parent,
                              int parentFingerprint, byte[] chainCode, HDPath hdPath,
                              @Nullable EncryptedData encryptedPrivateKey, @Nullable KeyCrypter keyCrypter) {
-        this(new ECKey(priv, pub, pub.isCompressedInternal()), depth, parent, parentFingerprint, chainCode, hdPath, encryptedPrivateKey, keyCrypter);
+        this(new ECKey(priv, pub, true), depth, parent, parentFingerprint, chainCode, hdPath, encryptedPrivateKey, keyCrypter);
     }
 
     // NEW CANONICAL CONSTRUCTOR
@@ -742,7 +742,7 @@ public class DeterministicKey extends ECKey {
     @Override
     public String toString() {
         final MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this).omitNullValues();
-        helper.add("pub", ByteUtils.formatHex(pub.getEncoded()));
+        helper.add("pub", ByteUtils.formatHex(pub.getEncoded(compressed)));
         helper.add("chainCode", ByteUtils.formatHex(chainCode));
         helper.add("path", getPathAsString());
         helper.add("depth", depth);

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -89,7 +89,7 @@ public class DeterministicKey extends ECKey {
                             byte[] chainCode,
                             BigInteger priv,
                             @Nullable DeterministicKey parent) {
-        this(priv, new LazyECPoint(ECKey.publicPointFromPrivate(priv), true), parent == null ? 0 : parent.depth + 1,
+        this(priv, new LazyECPoint(ECKey.publicPointFromPrivate(priv)), parent == null ? 0 : parent.depth + 1,
                 parent, parent != null ? parent.getFingerprint() : 0, chainCode, hdPath, null, null);
     }
 
@@ -145,7 +145,7 @@ public class DeterministicKey extends ECKey {
                             @Nullable DeterministicKey parent,
                             int depth,
                             int parentFingerprint) {
-        this(priv, new LazyECPoint(ECKey.publicPointFromPrivate(priv), true), depth, parent, parentFingerprint,
+        this(priv, new LazyECPoint(ECKey.publicPointFromPrivate(priv)), depth, parent, parentFingerprint,
                 chainCode, HDPath.M(childNumberPath), null, null);
     }
 

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -75,6 +75,11 @@ public class DeterministicKey extends ECKey {
                 parent != null ? parent.getFingerprint() : 0, chainCode, HDPath.M(childNumberPath), null, null);
     }
 
+    /**
+     * @deprecated Avoid using Bouncy Castle {@link ECPoint}, if possible. Otherwise, construct a {@link LazyECPoint}
+     * from the Bouncy {@code ECPoint}
+     */
+    @Deprecated
     public DeterministicKey(List<ChildNumber> childNumberPath,
                             byte[] chainCode,
                             ECPoint publicAsPoint,

--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -1340,7 +1340,6 @@ public class ECKey implements EncryptableItem {
         ECKey other = (ECKey) o;
         return Objects.equals(this.priv, other.priv)
                 && Objects.equals(this.pub, other.pub)
-                && Objects.equals(this.compressed, other.compressed)
                 && Objects.equals(this.creationTime, other.creationTime)
                 && Objects.equals(this.keyCrypter, other.keyCrypter)
                 && Objects.equals(this.encryptedPrivateKey, other.encryptedPrivateKey);

--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -325,7 +325,7 @@ public class ECKey implements EncryptableItem {
      * never need this: it's for specialised scenarios or when backwards compatibility in encoded form is necessary.
      */
     public ECKey decompress() {
-        if (!pub.isCompressed())
+        if (!pub.isCompressedInternal())
             return this;
         else
             return new ECKey(priv, new LazyECPoint(pub.get(), false));
@@ -453,7 +453,7 @@ public class ECKey implements EncryptableItem {
      * Returns whether this key is using the compressed form or not. Compressed pubkeys are only 33 bytes, not 64.
      */
     public boolean isCompressed() {
-        return pub.isCompressed();
+        return pub.isCompressedInternal();
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -328,7 +328,7 @@ public class ECKey implements EncryptableItem {
         if (!pub.isCompressedInternal())
             return this;
         else
-            return new ECKey(priv, new LazyECPoint(pub.get(), false));
+            return new ECKey(priv, pub.decompress());
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -216,7 +216,7 @@ public class ECKey implements EncryptableItem {
         ECPrivateKeyParameters privParams = (ECPrivateKeyParameters) keypair.getPrivate();
         ECPublicKeyParameters pubParams = (ECPublicKeyParameters) keypair.getPublic();
         priv = privParams.getD();
-        pub = new LazyECPoint(pubParams.getQ(), true);
+        pub = new LazyECPoint(pubParams.getQ());
         creationTime = TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS);
     }
 

--- a/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
+++ b/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
@@ -32,7 +32,6 @@ import java.util.Objects;
 public final class LazyECPoint {
     private static final ECCurve curve = ECKey.CURVE.getCurve();
 
-    private final boolean compressed;
     private final ECPoint point;
 
     /**
@@ -43,7 +42,6 @@ public final class LazyECPoint {
      */
     public LazyECPoint(byte[] bits) {
         this.point = curve.decodePoint(bits);
-        this.compressed = ECKey.isPubKeyCompressed(bits);
     }
 
     /**
@@ -54,35 +52,6 @@ public final class LazyECPoint {
      */
     public LazyECPoint(ECPoint point) {
         this.point = Objects.requireNonNull(point).normalize();
-        this.compressed = true;
-    }
-
-    /**
-     * Construct a LazyECPoint from an already decoded point.
-     *
-     * @param point      the wrapped point
-     * @param compressed true if the represented public key is compressed
-     */
-    @Deprecated
-    LazyECPoint(ECPoint point, boolean compressed) {
-        this.point = Objects.requireNonNull(point).normalize();
-        this.compressed = compressed;
-    }
-
-    /**
-     * Returns a compressed version of this elliptic curve point. Returns the same point if it's already compressed.
-     * See the {@link ECKey} class docs for a discussion of point compression.
-     */
-    public LazyECPoint compress() {
-        return compressed ? this : new LazyECPoint(get());
-    }
-
-    /**
-     * Returns a decompressed version of this elliptic curve point. Returns the same point if it's already compressed.
-     * See the {@link ECKey} class docs for a discussion of point compression.
-     */
-    public LazyECPoint decompress() {
-        return !compressed ? this : new LazyECPoint(get(), false);
     }
 
     public ECPoint get() {
@@ -90,12 +59,11 @@ public final class LazyECPoint {
     }
 
     public byte[] getEncoded() {
-        return get().getEncoded(compressed);
+        return get().getEncoded(true);
     }
 
-    // package-private
-    boolean isCompressedInternal() {
-        return compressed;
+    public byte[] getEncoded(boolean compressed) {
+        return get().getEncoded(compressed);
     }
 
     // package-private

--- a/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
+++ b/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
@@ -63,7 +63,8 @@ public final class LazyECPoint {
      * @param point      the wrapped point
      * @param compressed true if the represented public key is compressed
      */
-    public LazyECPoint(ECPoint point, boolean compressed) {
+    @Deprecated
+    LazyECPoint(ECPoint point, boolean compressed) {
         this.point = Objects.requireNonNull(point).normalize();
         this.compressed = compressed;
     }

--- a/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
+++ b/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
@@ -47,6 +47,17 @@ public final class LazyECPoint {
     }
 
     /**
+     * Construct a compressed LazyECPoint from an already decoded point.
+     * <p>
+     * Compressed format is preferred.
+     * @param point      the wrapped point
+     */
+    public LazyECPoint(ECPoint point) {
+        this.point = Objects.requireNonNull(point).normalize();
+        this.compressed = true;
+    }
+
+    /**
      * Construct a LazyECPoint from an already decoded point.
      *
      * @param point      the wrapped point
@@ -62,7 +73,7 @@ public final class LazyECPoint {
      * See the {@link ECKey} class docs for a discussion of point compression.
      */
     public LazyECPoint compress() {
-        return compressed ? this : new LazyECPoint(get(), true);
+        return compressed ? this : new LazyECPoint(get());
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
+++ b/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
@@ -17,11 +17,9 @@
 package org.bitcoinj.crypto;
 
 import org.bouncycastle.math.ec.ECCurve;
-import org.bouncycastle.math.ec.ECFieldElement;
 import org.bouncycastle.math.ec.ECPoint;
 
 import javax.annotation.Nullable;
-import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -107,147 +105,6 @@ public final class LazyECPoint {
             return Arrays.copyOf(bits, bits.length);
         else
             return get().getEncoded(compressed);
-    }
-
-    // Delegated methods.
-    // These are deprecated now as we are migrating away from using the Bouncy Castle API directly.
-
-    @Deprecated
-    public ECPoint getDetachedPoint() {
-        return get().getDetachedPoint();
-    }
-
-    @Deprecated
-    public boolean isInfinity() {
-        return get().isInfinity();
-    }
-
-    @Deprecated
-    public ECPoint timesPow2(int e) {
-        return get().timesPow2(e);
-    }
-
-    @Deprecated
-    public ECFieldElement getYCoord() {
-        return get().getYCoord();
-    }
-
-    @Deprecated
-    public ECFieldElement[] getZCoords() {
-        return get().getZCoords();
-    }
-
-    @Deprecated
-    public boolean isNormalized() {
-        return get().isNormalized();
-    }
-
-    @Deprecated
-    public boolean isCompressed() {
-        return isCompressedInternal() ;
-    }
-
-    @Deprecated
-    public ECPoint multiply(BigInteger k) {
-        return get().multiply(k);
-    }
-
-    @Deprecated
-    public ECPoint subtract(ECPoint b) {
-        return get().subtract(b);
-    }
-
-    @Deprecated
-    public boolean isValid() {
-        return get().isValid();
-    }
-
-    @Deprecated
-    public ECPoint scaleY(ECFieldElement scale) {
-        return get().scaleY(scale);
-    }
-
-    @Deprecated
-    public ECFieldElement getXCoord() {
-        return get().getXCoord();
-    }
-
-    @Deprecated
-    public ECPoint scaleX(ECFieldElement scale) {
-        return get().scaleX(scale);
-    }
-
-    @Deprecated
-    public boolean equals(ECPoint other) {
-        return get().equals(other);
-    }
-
-    @Deprecated
-    public ECPoint negate() {
-        return get().negate();
-    }
-
-    @Deprecated
-    public ECPoint threeTimes() {
-        return get().threeTimes();
-    }
-
-    @Deprecated
-    public ECFieldElement getZCoord(int index) {
-        return get().getZCoord(index);
-    }
-
-    @Deprecated
-    public byte[] getEncoded(boolean compressed) {
-        if (compressed == isCompressedInternal() && bits != null)
-            return Arrays.copyOf(bits, bits.length);
-        else
-            return get().getEncoded(compressed);
-    }
-
-    @Deprecated
-    public ECPoint add(ECPoint b) {
-        return get().add(b);
-    }
-
-    @Deprecated
-    public ECPoint twicePlus(ECPoint b) {
-        return get().twicePlus(b);
-    }
-
-    @Deprecated
-    public ECCurve getCurve() {
-        return get().getCurve();
-    }
-
-    @Deprecated
-    public ECPoint normalize() {
-        return get().normalize();
-    }
-
-    @Deprecated
-    public ECFieldElement getY() {
-        return this.normalize().getYCoord();
-    }
-
-    @Deprecated
-    public ECPoint twice() {
-        return get().twice();
-    }
-
-    @Deprecated
-    public ECFieldElement getAffineYCoord() {
-        return get().getAffineYCoord();
-    }
-
-    @Deprecated
-    public ECFieldElement getAffineXCoord() {
-        return get().getAffineXCoord();
-    }
-
-    @Deprecated
-    public ECFieldElement getX() {
-        return this.normalize().getXCoord();
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
+++ b/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
@@ -96,115 +96,156 @@ public final class LazyECPoint {
             return get().getEncoded(compressed);
     }
 
-    // Delegated methods.
-
-    public ECPoint getDetachedPoint() {
-        return get().getDetachedPoint();
-    }
-
-    public boolean isInfinity() {
-        return get().isInfinity();
-    }
-
-    public ECPoint timesPow2(int e) {
-        return get().timesPow2(e);
-    }
-
-    public ECFieldElement getYCoord() {
-        return get().getYCoord();
-    }
-
-    public ECFieldElement[] getZCoords() {
-        return get().getZCoords();
-    }
-
-    public boolean isNormalized() {
-        return get().isNormalized();
-    }
-
-    public boolean isCompressed() {
+    // package-private
+    boolean isCompressedInternal() {
         return compressed;
     }
 
-    public ECPoint multiply(BigInteger k) {
-        return get().multiply(k);
-    }
-
-    public ECPoint subtract(ECPoint b) {
-        return get().subtract(b);
-    }
-
-    public boolean isValid() {
-        return get().isValid();
-    }
-
-    public ECPoint scaleY(ECFieldElement scale) {
-        return get().scaleY(scale);
-    }
-
-    public ECFieldElement getXCoord() {
-        return get().getXCoord();
-    }
-
-    public ECPoint scaleX(ECFieldElement scale) {
-        return get().scaleX(scale);
-    }
-
-    public boolean equals(ECPoint other) {
-        return get().equals(other);
-    }
-
-    public ECPoint negate() {
-        return get().negate();
-    }
-
-    public ECPoint threeTimes() {
-        return get().threeTimes();
-    }
-
-    public ECFieldElement getZCoord(int index) {
-        return get().getZCoord(index);
-    }
-
-    public byte[] getEncoded(boolean compressed) {
-        if (compressed == isCompressed() && bits != null)
+    // package-private
+    byte[] getEncodedInternal(boolean compressed) {
+        if (compressed == isCompressedInternal() && bits != null)
             return Arrays.copyOf(bits, bits.length);
         else
             return get().getEncoded(compressed);
     }
 
+    // Delegated methods.
+    // These are deprecated now as we are migrating away from using the Bouncy Castle API directly.
+
+    @Deprecated
+    public ECPoint getDetachedPoint() {
+        return get().getDetachedPoint();
+    }
+
+    @Deprecated
+    public boolean isInfinity() {
+        return get().isInfinity();
+    }
+
+    @Deprecated
+    public ECPoint timesPow2(int e) {
+        return get().timesPow2(e);
+    }
+
+    @Deprecated
+    public ECFieldElement getYCoord() {
+        return get().getYCoord();
+    }
+
+    @Deprecated
+    public ECFieldElement[] getZCoords() {
+        return get().getZCoords();
+    }
+
+    @Deprecated
+    public boolean isNormalized() {
+        return get().isNormalized();
+    }
+
+    @Deprecated
+    public boolean isCompressed() {
+        return isCompressedInternal() ;
+    }
+
+    @Deprecated
+    public ECPoint multiply(BigInteger k) {
+        return get().multiply(k);
+    }
+
+    @Deprecated
+    public ECPoint subtract(ECPoint b) {
+        return get().subtract(b);
+    }
+
+    @Deprecated
+    public boolean isValid() {
+        return get().isValid();
+    }
+
+    @Deprecated
+    public ECPoint scaleY(ECFieldElement scale) {
+        return get().scaleY(scale);
+    }
+
+    @Deprecated
+    public ECFieldElement getXCoord() {
+        return get().getXCoord();
+    }
+
+    @Deprecated
+    public ECPoint scaleX(ECFieldElement scale) {
+        return get().scaleX(scale);
+    }
+
+    @Deprecated
+    public boolean equals(ECPoint other) {
+        return get().equals(other);
+    }
+
+    @Deprecated
+    public ECPoint negate() {
+        return get().negate();
+    }
+
+    @Deprecated
+    public ECPoint threeTimes() {
+        return get().threeTimes();
+    }
+
+    @Deprecated
+    public ECFieldElement getZCoord(int index) {
+        return get().getZCoord(index);
+    }
+
+    @Deprecated
+    public byte[] getEncoded(boolean compressed) {
+        if (compressed == isCompressedInternal() && bits != null)
+            return Arrays.copyOf(bits, bits.length);
+        else
+            return get().getEncoded(compressed);
+    }
+
+    @Deprecated
     public ECPoint add(ECPoint b) {
         return get().add(b);
     }
 
+    @Deprecated
     public ECPoint twicePlus(ECPoint b) {
         return get().twicePlus(b);
     }
 
+    @Deprecated
     public ECCurve getCurve() {
         return get().getCurve();
     }
 
+    @Deprecated
     public ECPoint normalize() {
         return get().normalize();
     }
 
+    @Deprecated
     public ECFieldElement getY() {
         return this.normalize().getYCoord();
     }
 
+    @Deprecated
     public ECPoint twice() {
         return get().twice();
     }
 
+    @Deprecated
     public ECFieldElement getAffineYCoord() {
         return get().getAffineYCoord();
     }
 
+    @Deprecated
     public ECFieldElement getAffineXCoord() {
         return get().getAffineXCoord();
     }
 
+    @Deprecated
     public ECFieldElement getX() {
         return this.normalize().getXCoord();
     }
@@ -222,6 +263,6 @@ public final class LazyECPoint {
     }
 
     private byte[] getCanonicalEncoding() {
-        return getEncoded(true);
+        return getEncodedInternal(true);
     }
 }

--- a/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
@@ -157,7 +157,7 @@ public class ECKeyTest {
         // Now re-encode and decode the ASN.1 to see if it is equivalent (it does not produce the exact same byte
         // sequence, some integers are padded now).
         ECKey roundtripKey =
-            ECKey.fromPrivateAndPrecalculatedPublic(decodedKey.getPrivKey(), decodedKey.getPubKeyPoint(), decodedKey.isCompressed());
+            ECKey.fromPrivateAndPrecalculatedPublic(decodedKey.getPrivKey(), decodedKey);
 
         for (ECKey key : new ECKey[] {decodedKey, roundtripKey}) {
             byte[] message = reverseBytes(ByteUtils.parseHex(


### PR DESCRIPTION
This experimental branch/PR moves the `compressed` `boolean` variable from `LazyECPoint` to `ECKey`.

`compressed` is serialized with/from `ECKey` and is used in the `ECKey` constructors. It will simplify the code (including the constructors) if `compressed` is made a direct property of `ECKey` and `LazyECPoint` does not keep this state, but has the ability to serialize in either compressed or uncompressed format.

This PR is a (currently) child of the following (in order):

* https://github.com/bitcoinj/bitcoinj/pull/3739
* https://github.com/bitcoinj/bitcoinj/pull/3740
* https://github.com/bitcoinj/bitcoinj/pull/3741

Not all of these changes are required to get to the result of `ECKey` storing `compressed` directly, but most of them are. I mention this because we have not yet measured the performance impact of removing the laziness of `LazyECPoint`, so we probably will want to skip that commit as we work to apply these changes one-by-one.