### PR TITLE
LazyECPoint: add java.s.s.ECPoint constructor

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
+++ b/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
@@ -70,6 +70,21 @@ public final class LazyECPoint implements ECPublicKey {
     }
 
     /**
+     * Construct a LazyECPoint from a Java ECPoint.
+     *
+     * @param point      the wrapped point
+     */
+    LazyECPoint(java.security.spec.ECPoint point) {
+        this(toBouncy(point), true);
+    }
+
+    private static org.bouncycastle.math.ec.ECPoint toBouncy(java.security.spec.ECPoint point) {
+        return point == java.security.spec.ECPoint.POINT_INFINITY
+                ? curve.getInfinity()
+                : curve.createPoint(point.getAffineX(), point.getAffineY());
+    }
+
+    /**
      * Returns a compressed version of this elliptic curve point. Returns the same point if it's already compressed.
      * See the {@link ECKey} class docs for a discussion of point compression.
      */

--- a/core/src/test/java/org/bitcoinj/crypto/LazyECPointTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/LazyECPointTest.java
@@ -17,11 +17,10 @@ public class LazyECPointTest {
 
     @Test
     public void convertRandomPoint() {
-        LazyECPoint point = ECKey.random().pub;
-        ECPoint javaPoint = point.getW();
-        assertNotNull(javaPoint);
-        assertEquals(point.getAffineXCoord().toBigInteger(), javaPoint.getAffineX());
-        assertEquals(point.getAffineYCoord().toBigInteger(), javaPoint.getAffineY());
+        LazyECPoint p1 = ECKey.random().pub;
+        LazyECPoint p2 = new LazyECPoint(p1.getW());    // Round-trip conversion Bouncy -> JCA -> Bouncy
+        assertNotNull(p2);
+        assertEquals(p1, p2);
     }
 
     @Test


### PR DESCRIPTION
* Add a constructor that takes `java.security.spec.ECPoint`
* Add private static method toBouncy() for JCA -> Bouncy `ECPoint` conversion
* Update `LazyECPointTest.convertRandomPoint()` to use it

This prepares for the removal of the deprecated delegated Bouncy Castle methods on `LazyECPoint`.  (See PR #3740)