### PR TITLE
Wallettool: subcommand methods

### DIFF
--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -361,12 +361,7 @@ public class WalletTool implements Callable<Integer> {
         if (action == ActionEnum.RAW_DUMP) {
             // Just parse the protobuf and print, then bail out. Don't try and do a real deserialization. This is
             // useful mostly for investigating corrupted wallets.
-            try (FileInputStream stream = new FileInputStream(walletFile)) {
-                Protos.Wallet proto = WalletProtobufSerializer.parseToProto(stream);
-                proto = attemptHexConversion(proto);
-                System.out.println(proto.toString());
-                return 0;
-            }
+            return rawDumpWallet();
         }
 
         boolean forceReset = action == ActionEnum.RESET
@@ -394,55 +389,7 @@ public class WalletTool implements Callable<Integer> {
             case CURRENT_RECEIVE_ADDR: currentReceiveAddr(); break;
             case RESET: reset(); break;
             case SYNC: syncChain(); break;
-            case SEND:
-                if (feePerVkbStr != null && feeSatPerVbyteStr != null) {
-                    System.err.println("--fee-per-kb and --fee-sat-per-byte cannot be used together.");
-                    return 1;
-                } else if (outputsStr != null) {
-                    Coin feePerVkb;
-                    if (feePerVkbStr != null)
-                        feePerVkb = parseCoin(feePerVkbStr);
-                    else if (feeSatPerVbyteStr != null)
-                        feePerVkb = Coin.valueOf(Long.parseLong(feeSatPerVbyteStr) * 1000);
-                    else
-                        feePerVkb = null;
-                    if (selectAddrStr != null && selectOutputStr != null) {
-                        System.err.println("--select-addr and --select-output cannot be used together.");
-                        return 1;
-                    }
-                    CoinSelector coinSelector;
-                    if (selectAddrStr != null) {
-                        Address selectAddr;
-                        try {
-                            selectAddr = wallet.parseAddress(selectAddrStr);
-                        } catch (AddressFormatException x) {
-                            System.err.println("Could not parse given address, or wrong network: " + selectAddrStr);
-                            return 1;
-                        }
-                        final Address validSelectAddr = selectAddr;
-                        coinSelector = CoinSelector.fromPredicate(candidate -> {
-                            try {
-                                return candidate.getScriptPubKey().getToAddress(net).equals(validSelectAddr);
-                            } catch (ScriptException x) {
-                                return false;
-                            }
-                        });
-                    } else if (selectOutputStr != null) {
-                        String[] parts = selectOutputStr.split(":", 2);
-                        Sha256Hash selectTransactionHash = Sha256Hash.wrap(parts[0]);
-                        int selectIndex = Integer.parseInt(parts[1]);
-                        coinSelector = CoinSelector.fromPredicate(candidate ->
-                             candidate.getIndex() == selectIndex && candidate.getParentTransactionHash().equals(selectTransactionHash)
-                        );
-                    } else {
-                        coinSelector = null;
-                    }
-                    send(coinSelector, outputsStr, feePerVkb, lockTimeStr, allowUnconfirmed);
-                } else {
-                    System.err.println("You must specify at least one --output=addr:value.");
-                    return 1;
-                }
-                break;
+            case SEND: send(); break;
             case ENCRYPT: encrypt(); break;
             case DECRYPT: decrypt(); break;
             case UPGRADE: upgrade(); break;
@@ -1096,6 +1043,66 @@ public class WalletTool implements Callable<Integer> {
         } else {
             printWallet(null);
         }
+    }
+
+    private Integer rawDumpWallet() throws IOException {
+        try (FileInputStream stream = new FileInputStream(walletFile)) {
+            Protos.Wallet proto = WalletProtobufSerializer.parseToProto(stream);
+            proto = attemptHexConversion(proto);
+            System.out.println(proto.toString());
+            return 0;
+        }
+    }
+
+    private Integer send(){
+        if (feePerVkbStr != null && feeSatPerVbyteStr != null) {
+            System.err.println("--fee-per-kb and --fee-sat-per-byte cannot be used together.");
+            return 1;
+        } else if (outputsStr != null) {
+            Coin feePerVkb;
+            if (feePerVkbStr != null)
+                feePerVkb = parseCoin(feePerVkbStr);
+            else if (feeSatPerVbyteStr != null)
+                feePerVkb = Coin.valueOf(Long.parseLong(feeSatPerVbyteStr) * 1000);
+            else
+                feePerVkb = null;
+            if (selectAddrStr != null && selectOutputStr != null) {
+                System.err.println("--select-addr and --select-output cannot be used together.");
+                return 1;
+            }
+            CoinSelector coinSelector;
+            if (selectAddrStr != null) {
+                Address selectAddr;
+                try {
+                    selectAddr = wallet.parseAddress(selectAddrStr);
+                } catch (AddressFormatException x) {
+                    System.err.println("Could not parse given address, or wrong network: " + selectAddrStr);
+                    return 1;
+                }
+                final Address validSelectAddr = selectAddr;
+                coinSelector = CoinSelector.fromPredicate(candidate -> {
+                    try {
+                        return candidate.getScriptPubKey().getToAddress(net).equals(validSelectAddr);
+                    } catch (ScriptException x) {
+                        return false;
+                    }
+                });
+            } else if (selectOutputStr != null) {
+                String[] parts = selectOutputStr.split(":", 2);
+                Sha256Hash selectTransactionHash = Sha256Hash.wrap(parts[0]);
+                int selectIndex = Integer.parseInt(parts[1]);
+                coinSelector = CoinSelector.fromPredicate(candidate ->
+                        candidate.getIndex() == selectIndex && candidate.getParentTransactionHash().equals(selectTransactionHash)
+                );
+            } else {
+                coinSelector = null;
+            }
+            send(coinSelector, outputsStr, feePerVkb, lockTimeStr, allowUnconfirmed);
+        } else {
+            System.err.println("You must specify at least one --output=addr:value.");
+            return 1;
+        }
+        return 0;
     }
 
     private void printWallet(@Nullable AesKey aesKey) {

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -453,27 +453,28 @@ public class WalletTool implements Callable<Integer> {
         return ByteString.copyFrom(ByteUtils.formatHex(bytes.toByteArray()).getBytes());
     }
 
-    private void upgrade() {
+    private Integer upgrade() {
         DeterministicKeyChain activeKeyChain = wallet.getActiveKeyChain();
         ScriptType currentOutputScriptType = activeKeyChain != null ? activeKeyChain.getOutputScriptType() : null;
         if (!wallet.isDeterministicUpgradeRequired(outputScriptType)) {
             System.err
                     .println("No upgrade from " + (currentOutputScriptType != null ? currentOutputScriptType : "basic")
                             + " to " + outputScriptType);
-            return;
+            return 1;
         }
         AesKey aesKey = null;
         if (wallet.isEncrypted()) {
             aesKey = passwordToKey(true);
             if (aesKey == null)
-                return;
+                return 1;
         }
         wallet.upgradeToDeterministic(outputScriptType, aesKey);
         System.out.println("Upgraded from " + (currentOutputScriptType != null ? currentOutputScriptType : "basic")
                 + " to " + outputScriptType);
+        return 0;
     }
 
-    private void rotate() throws BlockStoreException {
+    private Integer rotate() throws BlockStoreException {
         setup();
         peerGroup.start();
         // Set a key rotation time and possibly broadcast the resulting maintenance transactions.
@@ -489,43 +490,47 @@ public class WalletTool implements Callable<Integer> {
         if (wallet.isEncrypted()) {
             aesKey = passwordToKey(true);
             if (aesKey == null)
-                return;
+                return 1;
         }
         wallet.doMaintenance(aesKey, true).join();
+        return 0;
     }
 
-    private void encrypt() {
+    private Integer encrypt() {
         if (password == null) {
             System.err.println("You must provide a --password");
-            return;
+            return 1;
         }
         if (wallet.isEncrypted()) {
             System.err.println("This wallet is already encrypted.");
-            return;
+            return 1;
         }
         wallet.encrypt(password);
+        return 0;
     }
 
-    private void decrypt() {
+    private Integer decrypt() {
         if (password == null) {
             System.err.println("You must provide a --password");
-            return;
+            return 1;
         }
         if (!wallet.isEncrypted()) {
             System.err.println("This wallet is not encrypted.");
-            return;
+            return 1;
         }
         try {
             wallet.decrypt(password);
         } catch (KeyCrypterException e) {
             System.err.println("Password incorrect.");
+            return 1;
         }
+        return 0;
     }
 
-    private void addAddr() {
+    private Integer addAddr() {
         if (addrStr == null) {
             System.err.println("You must specify an --addr to watch.");
-            return;
+            return 1;
         }
         try {
             Address address = LegacyAddress.fromBase58(addrStr, net);
@@ -536,6 +541,7 @@ public class WalletTool implements Callable<Integer> {
         } catch (AddressFormatException e) {
             System.err.println("Could not parse given address, or wrong network: " + addrStr);
         }
+        return 0;
     }
 
     private void send(CoinSelector coinSelector, List<String> outputs, Coin feePerVkb, String lockTimeStr,
@@ -747,10 +753,11 @@ public class WalletTool implements Callable<Integer> {
         return future;
     }
 
-    private void reset() {
+    private Integer reset() {
         // Delete the transactions and save. In future, reset the chain head pointer.
         wallet.clearTransactions(0);
         saveWallet(walletFile);
+        return 0;
     }
 
     // Sets up all objects needed for network communication but does not bring up the peers.
@@ -804,7 +811,7 @@ public class WalletTool implements Callable<Integer> {
         }
     }
 
-    private void syncChain() {
+    private Integer syncChain() {
         try {
             setup();
             int startTransactions = wallet.getTransactions(true).size();
@@ -824,7 +831,9 @@ public class WalletTool implements Callable<Integer> {
         } catch (BlockStoreException e) {
             System.err.println("Error reading block chain file " + chainFile + ": " + e.getMessage());
             e.printStackTrace();
+            return 1;
         }
+        return 0;
     }
 
     private void shutdown() {
@@ -840,12 +849,12 @@ public class WalletTool implements Callable<Integer> {
         }
     }
 
-    private void createWallet(Network network, File walletFile) throws IOException {
+    private Integer createWallet(Network network, File walletFile) throws IOException {
         KeyChainGroupStructure keyChainGroupStructure = KeyChainGroupStructure.BIP32;
 
         if (walletFile.exists() && !force) {
             System.err.println("Wallet creation requested but " + walletFile + " already exists, use --force");
-            return;
+            return 1;
         }
         Instant creationTime = getCreationTime().orElse(MnemonicCode.BIP39_STANDARDISATION_TIME);
         if (seedStr != null) {
@@ -858,13 +867,13 @@ public class WalletTool implements Callable<Integer> {
                 seed.check();
             } catch (MnemonicException.MnemonicLengthException e) {
                 System.err.println("The seed did not have 12 words in, perhaps you need quotes around it?");
-                return;
+                return 1;
             } catch (MnemonicException.MnemonicWordException e) {
                 System.err.println("The seed contained an unrecognised word: " + e.badWord);
-                return;
+                return 1;
             } catch (MnemonicException.MnemonicChecksumException e) {
                 System.err.println("The seed did not pass checksumming, perhaps one of the words is wrong?");
-                return;
+                return 1;
             } catch (MnemonicException e) {
                 // not reached - all subclasses handled above
                 throw new RuntimeException(e);
@@ -878,6 +887,7 @@ public class WalletTool implements Callable<Integer> {
         if (password != null)
             wallet.encrypt(password);
         wallet.saveToFile(walletFile);
+        return 0;
     }
 
     private List<String> splitMnemonic(String seedStr) {
@@ -897,7 +907,7 @@ public class WalletTool implements Callable<Integer> {
         }
     }
 
-    private void addKey() {
+    private Integer addKey() {
         ECKey key;
         Optional<Instant> creationTime = getCreationTime();
         if (privKeyStr != null) {
@@ -908,7 +918,7 @@ public class WalletTool implements Callable<Integer> {
                 byte[] decode = parseAsHexOrBase58(privKeyStr);
                 if (decode == null) {
                     System.err.println("Could not understand --privkey as either WIF, hex or base58: " + privKeyStr);
-                    return;
+                    return 1;
                 }
                 key = ECKey.fromPrivate(ByteUtils.bytesToBigInteger(decode));
             }
@@ -923,23 +933,23 @@ public class WalletTool implements Callable<Integer> {
             creationTime.ifPresentOrElse(key::setCreationTime, key::clearCreationTime);
         } else {
             System.err.println("Either --privkey or --pubkey must be specified.");
-            return;
+            return 1;
         }
         if (wallet.hasKey(key)) {
             System.err.println("That key already exists in this wallet.");
-            return;
+            return 1;
         }
         try {
             if (wallet.isEncrypted()) {
                 AesKey aesKey = passwordToKey(true);
                 if (aesKey == null)
-                    return;   // Error message already printed.
+                    return 1;   // Error message already printed.
                 key = key.encrypt(Objects.requireNonNull(wallet.getKeyCrypter()), aesKey);
             }
         } catch (KeyCrypterException kce) {
             System.err.println("There was an encryption related error when adding the key. The error was '"
                     + kce.getMessage() + "'.");
-            return;
+            return 1;
         }
         if (!key.isCompressed())
             System.out.println("WARNING: Importing an uncompressed key");
@@ -948,6 +958,7 @@ public class WalletTool implements Callable<Integer> {
         if (key.isCompressed())
             System.out.print("," + key.toAddress(ScriptType.P2WPKH, net));
         System.out.println();
+        return 0;
     }
 
     @Nullable
@@ -991,10 +1002,10 @@ public class WalletTool implements Callable<Integer> {
             return Optional.empty();
     }
 
-    private void deleteKey() {
+    private Integer deleteKey() {
         if (pubKeyStr == null && addrStr == null) {
             System.err.println("One of --pubkey or --addr must be specified.");
-            return;
+            return 1;
         }
         ECKey key;
         if (pubKeyStr != null) {
@@ -1005,26 +1016,28 @@ public class WalletTool implements Callable<Integer> {
                 key = wallet.findKeyFromAddress(address);
             } catch (AddressFormatException e) {
                 System.err.println(addrStr + " does not parse as a Bitcoin address of the right network parameters.");
-                return;
+                return 1;
             }
         }
         if (key == null) {
             System.err.println("Wallet does not seem to contain that key.");
-            return;
+            return 1;
         }
         boolean removed = wallet.removeKey(key);
         if (removed)
             System.out.println("Key " + key + " was removed");
         else
             System.err.println("Key " + key + " could not be removed");
+        return 0;
     }
 
-    private void currentReceiveAddr() {
+    private Integer currentReceiveAddr() {
         Address address = wallet.currentReceiveAddress();
         System.out.println(address);
+        return 0;
     }
 
-    private void dumpWallet() throws BlockStoreException {
+    private Integer dumpWallet() throws BlockStoreException {
         // Setup to get the chain height so we can estimate lock times, but don't wipe the transactions if it's not
         // there just for the dump case.
         if (chainFile.exists())
@@ -1034,15 +1047,16 @@ public class WalletTool implements Callable<Integer> {
             if (password != null) {
                 final AesKey aesKey = passwordToKey(true);
                 if (aesKey == null)
-                    return; // Error message already printed.
+                    return 1; // Error message already printed.
                 printWallet(aesKey);
             } else {
                 System.err.println("Can't dump privkeys, wallet is encrypted.");
-                return;
+                return 1;
             }
         } else {
             printWallet(null);
         }
+        return 0;
     }
 
     private Integer rawDumpWallet() throws IOException {
@@ -1109,7 +1123,7 @@ public class WalletTool implements Callable<Integer> {
         System.out.println(wallet.toString(dumpLookAhead, dumpPrivKeys, aesKey, true, true, chain));
     }
 
-    private void setCreationTime() {
+    private Integer setCreationTime() {
         Optional<Instant> creationTime = getCreationTime();
         for (DeterministicKeyChain chain : wallet.getActiveKeyChains()) {
             DeterministicSeed seed = chain.getSeed();
@@ -1122,5 +1136,6 @@ public class WalletTool implements Callable<Integer> {
         System.out.println(creationTime
                 .map(time -> "Setting creation time to: " + TimeUtils.dateTimeFormat(time))
                 .orElse("Clearing creation time."));
+        return 0;
     }
 }


### PR DESCRIPTION
This PR is an attempt to show the usage of subcommands in wallettool. I have been able to migrate `dump, create, and current-receive-addr` to subcommands. Currently we can run the commands like this:

`wallettool --wallet=<myWalletPath> --net=<myNetwork> --dump-privkeys dump`

My next step is to be able to pass specific options to the subcommand that need those options. Those options should no longer be global but specific to the particular subcommand. So that we can have something like. 

`wallettool --wallet=<myWalletPath> --net=<myNetwork> dump  --dump-privkeys`

This can easily be done. But before I do I want to take my time to note what options should be global and what options should be local. (by global I mean after main command `wallettool` and local after subcommand `dump, create...`