### PR TITLE
HDPath: Do not inherit from List

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/HDPath.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDPath.java
@@ -48,7 +48,7 @@ import static org.bitcoinj.base.internal.Preconditions.checkArgument;
  * Take note of the overloaded factory methods {@link HDPath#M()} and {@link HDPath#m()}. These can be used to very
  * concisely create {@link HDFullPath} objects (especially when statically imported.)
  */
-public abstract class HDPath extends AbstractList<ChildNumber> {
+public abstract class HDPath {
     public enum Prefix {
         PRIVATE('m'),
         PUBLIC('M');
@@ -534,17 +534,14 @@ public abstract class HDPath extends AbstractList<ChildNumber> {
                 : new HDPartialPath(Collections.emptyList());
     }
 
-    @Override
     public ChildNumber get(int index) {
         return childNumbers.get(index);
     }
 
-    @Override
     public int size() {
         return childNumbers.size();
     }
 
-    @Override
     public boolean isEmpty() {
         return childNumbers.isEmpty();
     }


### PR DESCRIPTION
~~This is a child of PR #3763~~

~~The first commit is a duplicate of PR #3770, so this should be rebased after that is merged.~~

There are two preparatory commits to remove the last usages of `List<ChildNumber>` and dependencies on `HDPath` implementing `List`. The third commit simply removes the `extend AbstractList<ChildNumber>` and removes `@Override` annotations on methods that exist in `AbstractList `.