### PR TITLE
DeterministicKeyChain: add accountFullPath(), fix and improve tests

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -454,6 +454,15 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
         return accountPath;
     }
 
+    /**
+     * Return {@link HDPath.HDFullPath} with correct prefix based upon the type of the account key.
+     * @return full path
+     */
+    public HDPath.HDFullPath accountFullPath() {
+        boolean hasPrivateKey = !getWatchingKey().isWatching();
+        return accountPath.asPartial().asFull(hasPrivateKey ? HDPath.Prefix.PRIVATE : HDPath.Prefix.PUBLIC);
+    }
+
     public ScriptType getOutputScriptType() {
         return outputScriptType;
     }

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
@@ -1047,7 +1047,7 @@ public class KeyChainGroup implements KeyBag {
         // kinds of KeyPurpose are introduced.
         if (activeChain.getIssuedExternalKeys() > 0) {
             DeterministicKey currentExternalKey = activeChain.getKeyByPath(
-                    activeChain.getAccountPath()
+                    activeChain.accountFullPath()
                             .extend(DeterministicKeyChain.EXTERNAL_SUBPATH)
                             .extend(new ChildNumber(activeChain.getIssuedExternalKeys() - 1)));
             currentKeys.put(KeyChain.KeyPurpose.RECEIVE_FUNDS, currentExternalKey);
@@ -1055,7 +1055,7 @@ public class KeyChainGroup implements KeyBag {
 
         if (activeChain.getIssuedInternalKeys() > 0) {
             DeterministicKey currentInternalKey = activeChain.getKeyByPath(
-                    activeChain.getAccountPath()
+                    activeChain.accountFullPath()
                             .extend(DeterministicKeyChain.INTERNAL_SUBPATH)
                             .extend(new ChildNumber(activeChain.getIssuedInternalKeys() - 1)));
             currentKeys.put(KeyChain.KeyPurpose.CHANGE, currentInternalKey);

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -434,7 +434,7 @@ public class DeterministicKeyChainTest {
         List<Protos.Key> serialization = chain.serializeToProtobuf();
         checkSerialization(serialization, "watching-wallet-serialization.txt");
         chain = DeterministicKeyChain.fromProtobuf(serialization, null).get(0);
-        assertEquals(DeterministicKeyChain.ACCOUNT_ZERO_PATH, chain.getAccountPath());
+        assertEquals(DeterministicKeyChain.ACCOUNT_ZERO_PATH.asPublic(), chain.accountFullPath());
         final DeterministicKey rekey4 = chain.getKey(KeyChain.KeyPurpose.CHANGE);
         assertEquals(key4.getPubKeyPoint(), rekey4.getPubKeyPoint());
     }
@@ -471,7 +471,7 @@ public class DeterministicKeyChainTest {
         List<Protos.Key> serialization = chain.serializeToProtobuf();
         checkSerialization(serialization, "watching-wallet-arbitrary-path-serialization.txt");
         chain = DeterministicKeyChain.fromProtobuf(serialization, null).get(0);
-        assertEquals(BIP44_COIN_1_ACCOUNT_ZERO_PATH, chain.getAccountPath());
+        assertEquals(BIP44_COIN_1_ACCOUNT_ZERO_PATH.asPublic(), chain.accountFullPath());
         final DeterministicKey rekey4 = chain.getKey(KeyChain.KeyPurpose.CHANGE);
         assertEquals(key4.getPubKeyPoint(), rekey4.getPubKeyPoint());
     }
@@ -494,7 +494,7 @@ public class DeterministicKeyChainTest {
         watchingKey.setCreationTime(Instant.ofEpochSecond(100000));
         chain = DeterministicKeyChain.builder().watch(watchingKey).outputScriptType(chain1.getOutputScriptType())
                 .build();
-        assertEquals(accountOne, chain.getAccountPath());
+        assertEquals(accountOne.asPublic(), chain.accountFullPath());
         assertEquals(Instant.ofEpochSecond(100000), chain.earliestKeyCreationTime());
         chain.setLookaheadSize(10);
         chain.maybeLookAhead();
@@ -514,7 +514,7 @@ public class DeterministicKeyChainTest {
         List<Protos.Key> serialization = chain.serializeToProtobuf();
         checkSerialization(serialization, "watching-wallet-serialization-account-one.txt");
         chain = DeterministicKeyChain.fromProtobuf(serialization, null).get(0);
-        assertEquals(accountOne, chain.getAccountPath());
+        assertEquals(accountOne.asPublic(), chain.accountFullPath());
         final DeterministicKey rekey4 = chain.getKey(KeyChain.KeyPurpose.CHANGE);
         assertEquals(key4.getPubKeyPoint(), rekey4.getPubKeyPoint());
     }
@@ -555,7 +555,7 @@ public class DeterministicKeyChainTest {
         List<Protos.Key> serialization = segwitChain.serializeToProtobuf();
         checkSerialization(serialization, "watching-wallet-p2wpkh-serialization.txt");
         final DeterministicKeyChain chain = DeterministicKeyChain.fromProtobuf(serialization, null).get(0);
-        assertEquals(DeterministicKeyChain.ACCOUNT_ONE_PATH, chain.getAccountPath());
+        assertEquals(DeterministicKeyChain.ACCOUNT_ONE_PATH.asPublic(), chain.accountFullPath());
         assertEquals(ScriptType.P2WPKH, chain.getOutputScriptType());
         final DeterministicKey rekey4 = segwitChain.getKey(KeyChain.KeyPurpose.CHANGE);
         assertEquals(key4.getPubKeyPoint(), rekey4.getPubKeyPoint());
@@ -591,11 +591,11 @@ public class DeterministicKeyChainTest {
         } catch (ECKey.MissingPrivateKeyException e) {
             fail();
         }
-        // Test we can serialize and deserialize a watching chain OK.
+        // Test we can serialize and deserialize a spending chain OK.
         List<Protos.Key> serialization = chain.serializeToProtobuf();
         checkSerialization(serialization, "spending-wallet-serialization.txt");
         chain = DeterministicKeyChain.fromProtobuf(serialization, null).get(0);
-        assertEquals(DeterministicKeyChain.ACCOUNT_ZERO_PATH, chain.getAccountPath());
+        assertEquals(DeterministicKeyChain.ACCOUNT_ZERO_PATH.asPrivate(), chain.accountFullPath());
         final DeterministicKey rekey4 = chain.getKey(KeyChain.KeyPurpose.CHANGE);
         assertEquals(key4.getPubKeyPoint(), rekey4.getPubKeyPoint());
     }
@@ -620,7 +620,7 @@ public class DeterministicKeyChainTest {
         watchingKey.setCreationTime(secs);
         chain = DeterministicKeyChain.builder().spend(watchingKey).outputScriptType(chain.getOutputScriptType())
                 .build();
-        assertEquals(accountTwo, chain.getAccountPath());
+        assertEquals(accountTwo.asPrivate(), chain.accountFullPath());
         assertEquals(secs, chain.earliestKeyCreationTime());
         chain.setLookaheadSize(10);
         chain.maybeLookAhead();
@@ -661,7 +661,7 @@ public class DeterministicKeyChainTest {
         KeyChainGroup group = KeyChainGroup.builder(network).addChain(DeterministicKeyChain.builder().spend(accountKey)
                 .outputScriptType(bip44chain.getOutputScriptType()).build()).build();
         DeterministicKeyChain fromMasterKeyChain = group.getActiveKeyChain();
-        assertEquals(BIP44_COIN_1_ACCOUNT_ZERO_PATH, fromMasterKeyChain.getAccountPath());
+        assertEquals(BIP44_COIN_1_ACCOUNT_ZERO_PATH.asPrivate(), fromMasterKeyChain.accountFullPath());
         assertEquals(secs, fromMasterKeyChain.earliestKeyCreationTime());
         fromMasterKeyChain.setLookaheadSize(10);
         fromMasterKeyChain.maybeLookAhead();
@@ -716,7 +716,7 @@ public class DeterministicKeyChainTest {
         final DeterministicKey accountKey = chain.getKeyByPath(DeterministicKeyChain.ACCOUNT_ZERO_PATH);
         chain = DeterministicKeyChain.builder().watch(accountKey.withoutPrivateKey().withoutParent())
                 .outputScriptType(chain.getOutputScriptType()).build();
-        assertEquals(DeterministicKeyChain.ACCOUNT_ZERO_PATH, chain.getAccountPath());
+        assertEquals(DeterministicKeyChain.ACCOUNT_ZERO_PATH.asPublic(), chain.accountFullPath());
         chain = chain.toEncrypted("this doesn't make any sense");
     }
 

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -145,7 +145,7 @@ public class DeterministicKeyChainTest {
     @Test
     public void serializeAccountOne() throws Exception {
         Instant secs = Instant.ofEpochSecond(1389353062L);
-        final HDPath accountOne = HDPath.M(ChildNumber.ONE);
+        final HDPath.HDPartialPath accountOne = HDPath.partial(ChildNumber.ONE);
         DeterministicKeyChain chain1 = DeterministicKeyChain.builder().accountPath(accountOne)
                 .entropy(ENTROPY, secs).build();
         ECKey key1 = chain1.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
@@ -157,7 +157,7 @@ public class DeterministicKeyChainTest {
 
         List<Protos.Key> keys = chain1.serializeToProtobuf();
         chain1 = DeterministicKeyChain.fromProtobuf(keys, null).get(0);
-        assertEquals(accountOne, chain1.getAccountPath());
+        assertEquals(accountOne.asPrivate(), chain1.accountFullPath());
 
         ECKey key2 = chain1.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
         assertEquals("mnp2j9za5zMuz44vNxrJCXXhZsCdh89QXn", key2.toAddress(ScriptType.P2PKH, TESTNET).toString());
@@ -252,7 +252,7 @@ public class DeterministicKeyChainTest {
         // Round trip the data back and forth to check it is preserved.
         int oldLookaheadSize = chain.getLookaheadSize();
         chain = DeterministicKeyChain.fromProtobuf(keys, null).get(0);
-        assertEquals(DeterministicKeyChain.ACCOUNT_ZERO_PATH.asPublic(), chain.getAccountPath());
+        assertEquals(DeterministicKeyChain.ACCOUNT_ZERO_PATH.asPrivate(), chain.accountFullPath());
         assertEquals(EXPECTED_SERIALIZATION, protoToString(chain.serializeToProtobuf()));
         assertEquals(key1, chain.findKeyFromPubHash(key1.getPubKeyHash()));
         assertEquals(key2, chain.findKeyFromPubHash(key2.getPubKeyHash()));
@@ -327,7 +327,7 @@ public class DeterministicKeyChainTest {
         // Round trip the data back and forth to check it is preserved.
         int oldLookaheadSize = bip44chain.getLookaheadSize();
         bip44chain = DeterministicKeyChain.fromProtobuf(keys, null).get(0);
-        assertEquals(BIP44_COIN_1_ACCOUNT_ZERO_PATH.asPublic(), bip44chain.getAccountPath());
+        assertEquals(BIP44_COIN_1_ACCOUNT_ZERO_PATH.asPrivate(), bip44chain.accountFullPath());
         assertEquals(EXPECTED_SERIALIZATION, protoToString(bip44chain.serializeToProtobuf()));
         assertEquals(key1, bip44chain.findKeyFromPubHash(key1.getPubKeyHash()));
         assertEquals(key2, bip44chain.findKeyFromPubHash(key2.getPubKeyHash()));

--- a/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/KeyChainGroupTest.java
@@ -102,7 +102,7 @@ public class KeyChainGroupTest {
     public void freshCurrentKeys() {
         int numKeys = ((group.getLookaheadSize() + group.getLookaheadThreshold()) * 2)   // * 2 because of internal/external
                 + 1  // keys issued
-                + group.getActiveKeyChain().getAccountPath().size() + 2  /* account key + int/ext parent keys */;
+                + group.getActiveKeyChain().accountFullPath().size() + 2  /* account key + int/ext parent keys */;
         assertEquals(numKeys, group.numKeys());
         assertEquals(2 * numKeys, group.getBloomFilterElementCount());
         ECKey r1 = group.currentKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
@@ -325,7 +325,7 @@ public class KeyChainGroupTest {
 
     @Test
     public void serialization() throws Exception {
-        int initialKeys = INITIAL_KEYS + group.getActiveKeyChain().getAccountPath().size() - 1;
+        int initialKeys = INITIAL_KEYS + group.getActiveKeyChain().accountFullPath().size() - 1;
         assertEquals(initialKeys + 1 /* for the seed */, group.serializeToProtobuf().size());
         group = KeyChainGroup.fromProtobufUnencrypted(BitcoinNetwork.MAINNET, group.serializeToProtobuf());
         group.freshKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -2956,7 +2956,7 @@ public class WalletTest extends TestWithWallet {
         int numIssuedExternal = activeKeyChain.getIssuedExternalKeys();
         DeterministicKey rootKey = wallet.getActiveKeyChain().getRootKey();
         DeterministicKey watchingKey = activeKeyChain.getWatchingKey();
-        HDPath accountPath = activeKeyChain.getAccountPath();
+        HDPath.HDFullPath accountPath = activeKeyChain.accountFullPath();
         ScriptType outputScriptType = activeKeyChain.getOutputScriptType();
 
         Protos.Wallet protos = new WalletProtobufSerializer().walletToProto(wallet);
@@ -2969,7 +2969,7 @@ public class WalletTest extends TestWithWallet {
         assertEquals(numIssuedExternal, roundTrippedActiveKeyChain.getIssuedExternalKeys());
         assertEquals(rootKey, roundTrippedWallet.getActiveKeyChain().getRootKey());
         assertEquals(watchingKey, roundTrippedActiveKeyChain.getWatchingKey());
-        assertEquals(accountPath, roundTrippedActiveKeyChain.getAccountPath());
+        assertEquals(accountPath, roundTrippedActiveKeyChain.accountFullPath());
         assertEquals(outputScriptType, roundTrippedActiveKeyChain.getOutputScriptType());
         return roundTrippedWallet;
     }

--- a/integration-test/src/test/java/org/bitcoinj/wallet/WalletAccountPathTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/wallet/WalletAccountPathTest.java
@@ -62,20 +62,20 @@ public class WalletAccountPathTest {
         Wallet wallet = createWallet(walletFile, network, structure, scriptType);
 
         // Then the account path is as expected
-        assertEquals(expectedPath, wallet.getActiveKeyChain().getAccountPath());
+        assertEquals(expectedPath, wallet.getActiveKeyChain().accountFullPath());
     }
 
     private static Stream<Arguments> walletStructureParams() {
         return Stream.of(
             // Note: For BIP32 wallets the Network does not affect the path
-            Arguments.of(BIP32, "M/0H", P2PKH, MAINNET),
-            Arguments.of(BIP32, "M/0H", P2PKH, TESTNET),
-            Arguments.of(BIP32, "M/1H", P2WPKH, MAINNET),
-            Arguments.of(BIP32, "M/1H", P2WPKH, TESTNET),
-            Arguments.of(BIP43, "M/44H/0H/0H", P2PKH, MAINNET),
-            Arguments.of(BIP43, "M/44H/1H/0H", P2PKH, TESTNET),
-            Arguments.of(BIP43, "M/84H/0H/0H", P2WPKH, MAINNET),
-            Arguments.of(BIP43, "M/84H/1H/0H", P2WPKH, TESTNET)
+            Arguments.of(BIP32, "m/0H", P2PKH, MAINNET),
+            Arguments.of(BIP32, "m/0H", P2PKH, TESTNET),
+            Arguments.of(BIP32, "m/1H", P2WPKH, MAINNET),
+            Arguments.of(BIP32, "m/1H", P2WPKH, TESTNET),
+            Arguments.of(BIP43, "m/44H/0H/0H", P2PKH, MAINNET),
+            Arguments.of(BIP43, "m/44H/1H/0H", P2PKH, TESTNET),
+            Arguments.of(BIP43, "m/84H/0H/0H", P2WPKH, MAINNET),
+            Arguments.of(BIP43, "m/84H/1H/0H", P2WPKH, TESTNET)
         );
     }
 

--- a/integration-test/src/test/java/org/bitcoinj/wallet/WalletLoadTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/wallet/WalletLoadTest.java
@@ -44,7 +44,7 @@ public class WalletLoadTest {
         String mnemonic = wallet.getKeyChainSeed().getMnemonicString();
         assertEquals(testWalletMnemonic, mnemonic, "unexpected mnemonic");
 
-        HDPath accountPath = wallet.getActiveKeyChain().getAccountPath();
-        assertEquals(HDPath.parsePath("M/0H"), accountPath);
+        HDPath accountPath = wallet.getActiveKeyChain().accountFullPath();
+        assertEquals(HDPath.parsePath("m/0H"), accountPath);
     }
 }


### PR DESCRIPTION
This is a series of 4 related commits that: fix several incorrect tests, fix a few bugs, improve tests to use full path where they were only using partial paths.