### PR TITLE
WalletTest, TransactionOutputTest: MatcherAssert.assertThat replaces assertThat

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/TransactionOutputTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionOutputTest.java
@@ -30,6 +30,7 @@ import org.bitcoinj.script.ScriptPattern;
 import org.bitcoinj.testing.TestWithWallet;
 import org.bitcoinj.wallet.SendRequest;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,7 +45,6 @@ import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnitParamsRunner.class)
@@ -80,7 +80,7 @@ public class TransactionOutputTest extends TestWithWallet {
         this.wallet.completeTx(req);
         TransactionOutput multiSigTransactionOutput = multiSigTransaction.getOutput(0);
 
-        assertThat(multiSigTransactionOutput.toString(), CoreMatchers.containsString("CHECKMULTISIG"));
+        MatcherAssert.assertThat(multiSigTransactionOutput.toString(), CoreMatchers.containsString("CHECKMULTISIG"));
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -75,6 +75,7 @@ import org.bitcoinj.protobuf.wallet.Protos.Wallet.EncryptionType;
 import org.bitcoinj.wallet.Wallet.BalanceType;
 import org.bitcoinj.wallet.WalletTransaction.Pool;
 import org.easymock.EasyMock;
+import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -126,7 +127,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -2660,7 +2660,7 @@ public class WalletTest extends TestWithWallet {
         emptyReq.allowUnconfirmed();
         wallet.completeTx(emptyReq);
         final Coin feePerKb = emptyReq.tx.getFee().multiply(1000).divide(emptyReq.tx.getVsize());
-        assertThat((double) feePerKb.toSat(), closeTo(Transaction.REFERENCE_DEFAULT_MIN_TX_FEE.toSat(),20));
+        MatcherAssert.assertThat((double) feePerKb.toSat(), closeTo(Transaction.REFERENCE_DEFAULT_MIN_TX_FEE.toSat(),20));
         wallet.commitTx(emptyReq.tx);
     }
 


### PR DESCRIPTION
`assertThat()` is deprecated and replaced by `MatcherAssert.assertThat()`

Fixes two deprecation warnings in tests.