### PR TITLE
integration-test, wallettemplate, wallettool: Use JUnit BOM in build.gradle

### DIFF
--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -8,14 +8,15 @@ dependencies {
     implementation project(':bitcoinj-examples')
 
     testImplementation 'org.slf4j:slf4j-jdk14:2.0.16'
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.11.4"
-    testImplementation "org.junit.jupiter:junit-jupiter-params:5.11.4"
+    testImplementation platform("org.junit:junit-bom:5.11.4")
+    testImplementation "org.junit.jupiter:junit-jupiter-api"
+    testImplementation "org.junit.jupiter:junit-jupiter-params"
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.easymock:easymock:5.5.0'
     testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.18.1'
     testImplementation 'org.hamcrest:hamcrest-library:3.0'
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.11.4"
-    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:5.11.4"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
 }
 
 tasks.withType(JavaCompile) {

--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -13,8 +13,9 @@ dependencies {
 
     runtimeOnly 'org.slf4j:slf4j-jdk14:2.0.16'
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.11.4"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.11.4"
+    testImplementation platform("org.junit:junit-bom:5.11.4")
+    testImplementation "org.junit.jupiter:junit-jupiter-api"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }
 
 javafx {

--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -25,8 +25,9 @@ dependencies {
         compileOnly 'info.picocli:picocli-codegen:4.7.6'
     }
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.11.4"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.11.4"
+    testImplementation platform("org.junit:junit-bom:5.11.4")
+    testImplementation "org.junit.jupiter:junit-jupiter-api"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 
     testImplementation 'org.slf4j:slf4j-jdk14:2.0.16'
 }


### PR DESCRIPTION
By including the BOM, Gradle will automatically make sure all JUnit libraries use the same version. So we only need to specify the version on the BOM and the others will follow.

~~Using the BOM is required to get JUnit 5.12 to work with (at least certain versions of) Gradle.~~ I also had to add `org.junit.platform:junit-platform-launcher` so I'm not sure if both are required.

Gradle now requires explicit use of `junit-platform-launcher`, see: https://docs.gradle.org/8.12/userguide/upgrading_version_8.html#test_framework_implementation_dependencies
