### PR TITLE
TransactionOutPoint: static from() and of() constructors

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -903,7 +903,7 @@ public class Transaction implements Message {
      */
     public TransactionInput addInput(Sha256Hash spendTxHash, long outputIndex, Script script) {
         TransactionInput input = addInput(new TransactionInput(this, script.program(),
-                new TransactionOutPoint(outputIndex, spendTxHash)));
+                TransactionOutPoint.of(spendTxHash, outputIndex)));
         invalidateCachedTxIds();
         return input;
     }

--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -165,8 +165,8 @@ public class TransactionInput {
         this(parentTransaction,
                 null, EMPTY_ARRAY,
                 output.getParentTransaction() != null ?
-                        new TransactionOutPoint(output.getIndex(), output.getParentTransaction()) :
-                        new TransactionOutPoint(output),
+                        TransactionOutPoint.from(output.getParentTransaction(), output.getIndex()) :
+                        TransactionOutPoint.from(output),
                 NO_SEQUENCE,
                 output.getValue(),
                 null);

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -75,6 +75,8 @@ public class TransactionOutPoint {
         return new TransactionOutPoint(index, hash);
     }
 
+    /** @deprecated use {@link TransactionOutPoint#from(Transaction, long)} */
+    @Deprecated
     public TransactionOutPoint(long index, Transaction fromTx) {
         this(fromTx.getTxId(), index, fromTx, null);
     }
@@ -83,8 +85,30 @@ public class TransactionOutPoint {
         this(hash, index, null, null);
     }
 
+    /** @deprecated use {@link TransactionOutPoint#from(TransactionOutput)} */
+    @Deprecated
     public TransactionOutPoint(TransactionOutput connectedOutput) {
         this(connectedOutput.getParentTransactionHash(), connectedOutput.getIndex(), null, connectedOutput);
+    }
+
+    /**
+     * Create a {@code TransactionOutPoint} <i>from</i> an existing {@link Transaction}.
+     * @param fromTx transaction the new outpoint will reference (and be "connected to")
+     * @param index index of the transaction output the new outpoint will reference
+     * @return a new transaction outpoint
+     */
+    public static TransactionOutPoint from(Transaction fromTx, long index) {
+        return new TransactionOutPoint (fromTx.getTxId(), index, fromTx, null);
+    }
+
+    /**
+     * Create a {@code TransactionOutPoint} <i>from</i> an existing {@link TransactionOutput}.
+     * @param connectedOutput transaction output the new outpoint will reference (and be "connected to")
+     * @return a new transaction outpoint
+     */
+    public static TransactionOutPoint from(TransactionOutput connectedOutput) {
+        return new TransactionOutPoint(connectedOutput.getParentTransactionHash(), connectedOutput.getIndex(), null,
+                connectedOutput);
     }
 
     private TransactionOutPoint(Sha256Hash hash, long index, @Nullable Transaction fromTx,

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -47,7 +47,7 @@ public class TransactionOutPoint {
 
     /** Special outpoint that normally marks a coinbase input. It's also used as a test dummy. */
     public static final TransactionOutPoint UNCONNECTED =
-            new TransactionOutPoint(ByteUtils.MAX_UNSIGNED_INTEGER, Sha256Hash.ZERO_HASH);
+            TransactionOutPoint.of(Sha256Hash.ZERO_HASH, ByteUtils.MAX_UNSIGNED_INTEGER);
 
     /** Hash of the transaction to which we refer. */
     private final Sha256Hash hash;
@@ -72,7 +72,7 @@ public class TransactionOutPoint {
     public static TransactionOutPoint read(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         Sha256Hash hash = Sha256Hash.read(payload);
         long index = ByteUtils.readUint32(payload);
-        return new TransactionOutPoint(index, hash);
+        return TransactionOutPoint.of(hash, index);
     }
 
     /** @deprecated use {@link TransactionOutPoint#from(Transaction, long)} */
@@ -81,7 +81,12 @@ public class TransactionOutPoint {
         this(fromTx.getTxId(), index, fromTx, null);
     }
 
+    @Deprecated
     public TransactionOutPoint(long index, Sha256Hash hash) {
+        this(hash, index, null, null);
+    }
+
+    private TransactionOutPoint(Sha256Hash hash, long index) {
         this(hash, index, null, null);
     }
 
@@ -89,6 +94,16 @@ public class TransactionOutPoint {
     @Deprecated
     public TransactionOutPoint(TransactionOutput connectedOutput) {
         this(connectedOutput.getParentTransactionHash(), connectedOutput.getIndex(), null, connectedOutput);
+    }
+
+    /**
+     * Create a simple {@code TransactionOutPoint} with only {@code txid} and {@code index}.
+     * @param hash Transaction ID of the referenced transaction
+     * @param index Output index of the referenced output
+     * @return a new transaction outpoint
+     */
+    public static TransactionOutPoint of(Sha256Hash hash, long index) {
+        return new TransactionOutPoint(hash, index);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -421,7 +421,7 @@ public class TransactionOutput {
      * Requires that this output is not detached.
      */
     public TransactionOutPoint getOutPointFor() {
-        return new TransactionOutPoint(getIndex(), getParentTransaction());
+        return TransactionOutPoint.from(getParentTransaction(), getIndex());
     }
 
     /** Returns a copy of the output detached from its containing transaction, if need be. */

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -644,9 +644,9 @@ public class WalletProtobufSerializer {
 
         for (Protos.TransactionInput inputProto : txProto.getTransactionInputList()) {
             byte[] scriptBytes = inputProto.getScriptBytes().toByteArray();
-            TransactionOutPoint outpoint = new TransactionOutPoint(
-                    inputProto.getTransactionOutPointIndex() & 0xFFFFFFFFL,
-                    byteStringToHash(inputProto.getTransactionOutPointHash())
+            TransactionOutPoint outpoint = TransactionOutPoint.of(
+                    byteStringToHash(inputProto.getTransactionOutPointHash()),
+                    inputProto.getTransactionOutPointIndex() & 0xFFFFFFFFL
             );
             Coin value = inputProto.hasValue() ? Coin.valueOf(inputProto.getValue()) : null;
             long sequence = inputProto.hasSequence() ? 0xffffffffL & inputProto.getSequence() : TransactionInput.NO_SEQUENCE;

--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -329,7 +329,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         chain.add(rollingBlock);
         Transaction transaction = rollingBlock.transaction(0);
         TransactionOutput spendableOutput = transaction.getOutput(0);
-        TransactionOutPoint spendableOutPoint = new TransactionOutPoint(0, transaction.getTxId());
+        TransactionOutPoint spendableOutPoint = TransactionOutPoint.of(transaction.getTxId(), 0);
         Script spendableOutputScriptPubKey = spendableOutput.getScriptPubKey();
         for (int i = 1; i < PARAMS.getSpendableCoinbaseDepth(); i++) {
             rollingBlock = TestBlocks.createNextBlockWithCoinbase(rollingBlock, Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -1510,24 +1510,24 @@ public class FullBlockTestGenerator {
             Transaction tx2 = new Transaction();
             tx2.addOutput(new TransactionOutput(tx2, ZERO, new byte[]{OP_RETURN}));
             tx2.addOutput(new TransactionOutput(tx2, ZERO, new byte[]{OP_RETURN}));
-            tx2.addInput(new TransactionInput(tx2, new byte[]{OP_TRUE}, new TransactionOutPoint(1, b84tx1)));
+            tx2.addInput(new TransactionInput(tx2, new byte[]{OP_TRUE}, TransactionOutPoint.from(b84tx1, 1)));
             b84.addTransaction(tx2);
 
             Transaction tx3 = new Transaction();
             tx3.addOutput(new TransactionOutput(tx3, ZERO, new byte[]{OP_RETURN}));
             tx3.addOutput(new TransactionOutput(tx3, ZERO, new byte[]{OP_TRUE}));
-            tx3.addInput(new TransactionInput(tx3, new byte[]{OP_TRUE}, new TransactionOutPoint(2, b84tx1)));
+            tx3.addInput(new TransactionInput(tx3, new byte[]{OP_TRUE}, TransactionOutPoint.from(b84tx1, 2)));
             b84.addTransaction(tx3);
 
             Transaction tx4 = new Transaction();
             tx4.addOutput(new TransactionOutput(tx4, ZERO, new byte[]{OP_TRUE}));
             tx4.addOutput(new TransactionOutput(tx4, ZERO, new byte[]{OP_RETURN}));
-            tx4.addInput(new TransactionInput(tx4, new byte[]{OP_TRUE}, new TransactionOutPoint(3, b84tx1)));
+            tx4.addInput(new TransactionInput(tx4, new byte[]{OP_TRUE}, TransactionOutPoint.from(b84tx1, 3)));
             b84.addTransaction(tx4);
 
             Transaction tx5 = new Transaction();
             tx5.addOutput(new TransactionOutput(tx5, ZERO, new byte[]{OP_RETURN}));
-            tx5.addInput(new TransactionInput(tx5, new byte[]{OP_TRUE}, new TransactionOutPoint(4, b84tx1)));
+            tx5.addInput(new TransactionInput(tx5, new byte[]{OP_TRUE}, TransactionOutPoint.from(b84tx1, 4)));
             b84.addTransaction(tx5);
         }
         b84.solve();
@@ -1552,7 +1552,7 @@ public class FullBlockTestGenerator {
         {
             Transaction tx = new Transaction();
             tx.addOutput(new TransactionOutput(tx, ZERO, new byte[] {OP_TRUE}));
-            tx.addInput(new TransactionInput(tx, new byte[]{OP_TRUE}, new TransactionOutPoint(0, b84tx1)));
+            tx.addInput(new TransactionInput(tx, new byte[]{OP_TRUE}, TransactionOutPoint.from(b84tx1, 0)));
             b89.addTransaction(tx);
             b89.solve();
         }

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -127,7 +127,7 @@ class TransactionOutPointWithValue {
     }
 
     public TransactionOutPointWithValue(Transaction tx, int outputIndex) {
-        this(new TransactionOutPoint(outputIndex, tx.getTxId()),
+        this(TransactionOutPoint.of(tx.getTxId(), outputIndex),
                 tx.getOutput(outputIndex).getValue(), tx.getOutput(outputIndex).getScriptPubKey());
     }
 }
@@ -216,7 +216,7 @@ public class FullBlockTestGenerator {
         TestBlocks.solve(chainHead);
         blocks.add(new BlockAndValidity(chainHead, true, false, chainHead.getHash(), 1, "Initial Block"));
         spendableOutputs.offer(new TransactionOutPointWithValue(
-                new TransactionOutPoint(0, chainHead.transaction(0).getTxId()),
+                TransactionOutPoint.of(chainHead.transaction(0).getTxId(), 0),
                 FIFTY_COINS, chainHead.transaction(0).getOutput(0).getScriptPubKey()));
         for (int i = 1; i < params.getSpendableCoinbaseDepth(); i++) {
             chainHead = TestBlocks.createNextBlockWithCoinbase(chainHead, Block.BLOCK_VERSION_GENESIS, coinbaseOutKeyPubKey, chainHeadHeight);
@@ -224,7 +224,7 @@ public class FullBlockTestGenerator {
             TestBlocks.solve(chainHead);
             blocks.add(new BlockAndValidity(chainHead, true, false, chainHead.getHash(), i+1, "Initial Block chain output generation"));
             spendableOutputs.offer(new TransactionOutPointWithValue(
-                    new TransactionOutPoint(0, chainHead.transaction(0).getTxId()),
+                    TransactionOutPoint.of(chainHead.transaction(0).getTxId(), 0),
                     FIFTY_COINS, chainHead.transaction(0).getOutput(0).getScriptPubKey()));
         }
 
@@ -688,7 +688,7 @@ public class FullBlockTestGenerator {
                 tx.addOutput(new TransactionOutput(tx, SATOSHI, scriptPubKey.toByteArray()));
                 tx.addOutput(new TransactionOutput(tx, lastOutputValue, new byte[]{OP_1}));
                 addOnlyInputToTransaction(tx, out11);
-                lastOutPoint = new TransactionOutPoint(1, tx.getTxId());
+                lastOutPoint = TransactionOutPoint.of(tx.getTxId(), 1);
                 b39.addTransaction(tx);
             }
             b39numP2SHOutputs++;
@@ -701,7 +701,7 @@ public class FullBlockTestGenerator {
                 tx.addOutput(new TransactionOutput(tx, SATOSHI, scriptPubKey.toByteArray()));
                 tx.addOutput(new TransactionOutput(tx, lastOutputValue, new byte[]{OP_1}));
                 tx.addInput(new TransactionInput(tx, new byte[]{OP_1}, lastOutPoint));
-                lastOutPoint = new TransactionOutPoint(1, tx.getTxId());
+                lastOutPoint = TransactionOutPoint.of(tx.getTxId(), 1);
 
                 if (b39.block.messageSize() + tx.messageSize() < Block.MAX_BLOCK_SIZE) {
                     b39.addTransaction(tx);
@@ -722,7 +722,7 @@ public class FullBlockTestGenerator {
             int numTxes = (Block.MAX_BLOCK_SIGOPS - sigOps) / b39sigOpsPerOutput;
             checkState(numTxes <= b39numP2SHOutputs);
 
-            TransactionOutPoint lastOutPoint = new TransactionOutPoint(1, b40.block.transaction(1).getTxId());
+            TransactionOutPoint lastOutPoint = TransactionOutPoint.of(b40.block.transaction(1).getTxId(), 1);
 
             byte[] scriptSig = null;
             for (int i = 1; i <= numTxes; i++) {
@@ -731,7 +731,7 @@ public class FullBlockTestGenerator {
                 tx.addInput(new TransactionInput(tx, new byte[]{OP_1}, lastOutPoint));
 
                 TransactionInput input = new TransactionInput(tx, new byte[]{},
-                        new TransactionOutPoint(0, b39.block.transaction(i).getTxId()));
+                        TransactionOutPoint.of(b39.block.transaction(i).getTxId(), 0));
                 tx.addInput(input);
                 int inputIndex = tx.getInputs().size() - 1;
 
@@ -759,7 +759,7 @@ public class FullBlockTestGenerator {
 
                 tx.replaceInput(inputIndex, tx.getInput(inputIndex).withScriptBytes(scriptSig));
 
-                lastOutPoint = new TransactionOutPoint(0, tx.getTxId());
+                lastOutPoint = TransactionOutPoint.of(tx.getTxId(), 0);
 
                 b40.addTransaction(tx);
             }
@@ -784,8 +784,8 @@ public class FullBlockTestGenerator {
                         / b39sigOpsPerOutput;
                 checkState(numTxes <= b39numP2SHOutputs);
 
-                TransactionOutPoint lastOutPoint = new TransactionOutPoint(
-                        1, b41.block.transaction(1).getTxId());
+                TransactionOutPoint lastOutPoint = TransactionOutPoint.of(
+                        b41.block.transaction(1).getTxId(), 1);
 
                 byte[] scriptSig = null;
                 for (int i = 1; i <= numTxes; i++) {
@@ -795,7 +795,7 @@ public class FullBlockTestGenerator {
                     tx.addInput(new TransactionInput(tx, new byte[] { OP_1 }, lastOutPoint));
 
                     TransactionInput input = new TransactionInput(tx, new byte[] {},
-                            new TransactionOutPoint(0, b39.block.transaction(i).getTxId()));
+                            TransactionOutPoint.of(b39.block.transaction(i).getTxId(), 0));
                     tx.addInput(input);
                     int inputIndex = tx.getInputs().size() - 1;
 
@@ -829,8 +829,7 @@ public class FullBlockTestGenerator {
 
                     tx.replaceInput(inputIndex, tx.getInput(inputIndex).withScriptBytes(scriptSig));
 
-                    lastOutPoint = new TransactionOutPoint(0,
-                            tx.getTxId());
+                    lastOutPoint = TransactionOutPoint.of(tx.getTxId(), 0);
 
                     b41.addTransaction(tx);
                 }
@@ -1052,21 +1051,21 @@ public class FullBlockTestGenerator {
             Transaction tx2 = new Transaction();
             tx2.addOutput(new TransactionOutput(tx2, SATOSHI, new byte[] {OP_TRUE}));
             addOnlyInputToTransaction(tx2, new TransactionOutPointWithValue(
-                    new TransactionOutPoint(0, tx1.getTxId()),
+                    TransactionOutPoint.of(tx1.getTxId(), 0),
                     SATOSHI, tx1.getOutput(0).getScriptPubKey()));
             b57p2.addTransaction(tx2);
 
             b56p2txToDuplicate1 = new Transaction();
             b56p2txToDuplicate1.addOutput(new TransactionOutput(b56p2txToDuplicate1, SATOSHI, new byte[]{OP_TRUE}));
             addOnlyInputToTransaction(b56p2txToDuplicate1, new TransactionOutPointWithValue(
-                    new TransactionOutPoint(0, tx2.getTxId()),
+                    TransactionOutPoint.of(tx2.getTxId(), 0),
                     SATOSHI, tx2.getOutput(0).getScriptPubKey()));
             b57p2.addTransaction(b56p2txToDuplicate1);
 
             b56p2txToDuplicate2 = new Transaction();
             b56p2txToDuplicate2.addOutput(new TransactionOutput(b56p2txToDuplicate2, SATOSHI, new byte[]{}));
             addOnlyInputToTransaction(b56p2txToDuplicate2, new TransactionOutPointWithValue(
-                    new TransactionOutPoint(0, b56p2txToDuplicate1.getTxId()),
+                    TransactionOutPoint.of(b56p2txToDuplicate1.getTxId(), 0),
                     SATOSHI, b56p2txToDuplicate1.getOutput(0).getScriptPubKey()));
             b57p2.addTransaction(b56p2txToDuplicate2);
         }
@@ -1099,7 +1098,7 @@ public class FullBlockTestGenerator {
             Transaction tx = new Transaction();
             tx.addOutput(new TransactionOutput(tx, ZERO, new byte[] {}));
             // Replace the TransactionOutPoint with an out-of-range OutPoint
-            b58.getSpendableOutput().outpoint = new TransactionOutPoint(42, tx.getTxId());
+            b58.getSpendableOutput().outpoint = TransactionOutPoint.of(tx.getTxId(), 42);
             addOnlyInputToTransaction(tx, b58);
             b58.addTransaction(tx);
         }
@@ -1480,7 +1479,7 @@ public class FullBlockTestGenerator {
             Transaction tx2 = new Transaction();
             tx2.addOutput(new TransactionOutput(tx2, ZERO, new byte[]{OP_TRUE}));
             tx2.addInput(new TransactionInput(tx2, new byte[] { OP_FALSE },
-                    new TransactionOutPoint(0, tx1.getTxId())));
+                    TransactionOutPoint.of(tx1.getTxId(), 0)));
             b83.addTransaction(tx2);
         }
         b83.solve();
@@ -1628,7 +1627,7 @@ public class FullBlockTestGenerator {
             checkArgument(blockStorageFile != null);
 
             NewBlock lastBlock = b1001;
-            TransactionOutPoint lastOutput = new TransactionOutPoint(1, b1001.block.transaction(1).getTxId());
+            TransactionOutPoint lastOutput = TransactionOutPoint.of(b1001.block.transaction(1).getTxId(), 1);
             int blockCountAfter1001;
             int nextHeight = heightAfter1001;
 
@@ -1641,7 +1640,7 @@ public class FullBlockTestGenerator {
                     tx.addInput(lastOutput.hash(), lastOutput.index(), OP_NOP_SCRIPT);
                     tx.addOutput(ZERO, OP_TRUE_SCRIPT);
                     tx.addOutput(ZERO, OP_TRUE_SCRIPT);
-                    lastOutput = new TransactionOutPoint(1, tx.getTxId());
+                    lastOutput = TransactionOutPoint.of(tx.getTxId(), 1);
                     hashesToSpend.add(tx.getTxId());
                     block.addTransaction(tx);
                 }

--- a/core/src/test/java/org/bitcoinj/core/TransactionOutPointTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionOutPointTest.java
@@ -50,7 +50,7 @@ public class TransactionOutPointTest {
         return Stream.generate(() -> {
             byte[] randomBytes = new byte[Sha256Hash.LENGTH];
             random.nextBytes(randomBytes);
-            return new TransactionOutPoint(Integer.toUnsignedLong(random.nextInt()), Sha256Hash.wrap(randomBytes));
+            return TransactionOutPoint.of(Sha256Hash.wrap(randomBytes), Integer.toUnsignedLong(random.nextInt()));
         }).limit(10).iterator();
     }
 }

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -176,7 +176,7 @@ public class TransactionTest {
 
         // add fake transaction input
         TransactionInput input = new TransactionInput(null, ScriptBuilder.createEmpty().program(),
-                new TransactionOutPoint(0, Sha256Hash.ZERO_HASH));
+                TransactionOutPoint.of(Sha256Hash.ZERO_HASH, 0));
         tx.addInput(input);
         length += input.messageSize();
 
@@ -214,7 +214,7 @@ public class TransactionTest {
         ECKey fromKey = ECKey.random();
         Address fromAddress = fromKey.toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
         Transaction tx = new Transaction();
-        TransactionOutPoint outPoint = new TransactionOutPoint(0, utxo_id);
+        TransactionOutPoint outPoint = TransactionOutPoint.of(utxo_id, 0);
         TransactionOutput output = new TransactionOutput(null, inAmount, fromAddress);
         tx.addOutput(outAmount, toAddr);
         TransactionInput input = tx.addSignedInput(outPoint, ScriptBuilder.createOutputScript(fromAddress), inAmount, fromKey);
@@ -237,7 +237,7 @@ public class TransactionTest {
         ECKey fromKey = ECKey.random();
         Address fromAddress = fromKey.toAddress(ScriptType.P2WPKH, BitcoinNetwork.TESTNET);
         Transaction tx = new Transaction();
-        TransactionOutPoint outPoint = new TransactionOutPoint(0, utxo_id);
+        TransactionOutPoint outPoint = TransactionOutPoint.of(utxo_id, 0);
         tx.addOutput(outAmount, toAddr);
         TransactionInput input = tx.addSignedInput(outPoint, ScriptBuilder.createOutputScript(fromAddress), inAmount, fromKey);
 

--- a/core/src/test/java/org/bitcoinj/script/ScriptTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptTest.java
@@ -343,7 +343,7 @@ public class ScriptTest {
                 index = ByteUtils.MAX_UNSIGNED_INTEGER;
             String script = input.get(2).asText();
             Sha256Hash sha256Hash = Sha256Hash.wrap(ByteUtils.parseHex(hash));
-            scriptPubKeys.put(new TransactionOutPoint(index, sha256Hash), parseScriptString(script));
+            scriptPubKeys.put(TransactionOutPoint.of(sha256Hash, index), parseScriptString(script));
         }
         return scriptPubKeys;
     }

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -2722,7 +2722,7 @@ public class WalletTest extends TestWithWallet {
 
         // However, if there is no connected output, we connect it
         SendRequest request3 = SendRequest.to(OTHER_ADDRESS, CENT);
-        request3.tx.addInput(new TransactionInput(request3.tx, new byte[] {}, new TransactionOutPoint(0, tx3.getTxId())));
+        request3.tx.addInput(new TransactionInput(request3.tx, new byte[] {}, TransactionOutPoint.of(tx3.getTxId(), 0)));
         // Now completeTx will find the matching UTXO from the wallet and add its value to the unconnected input
         request3.shuffleOutputs = false;
         wallet.completeTx(request3);
@@ -2753,7 +2753,7 @@ public class WalletTest extends TestWithWallet {
 
         // SendRequest using that output as an unconnected input
         SendRequest request = SendRequest.to(OTHER_ADDRESS, COIN);
-        request.tx.addInput(new TransactionInput(request.tx, new byte[] {}, new TransactionOutPoint(0, tx.getTxId())));
+        request.tx.addInput(new TransactionInput(request.tx, new byte[] {}, TransactionOutPoint.of(tx.getTxId(), 0)));
 
         // Complete the transaction
         wallet.completeTx(request);

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -1638,7 +1638,7 @@ public class WalletTest extends TestWithWallet {
     public void watchingScriptsBloomFilter() {
         Address watchedAddress = ECKey.random().toAddress(ScriptType.P2PKH, TESTNET);
         Transaction t1 = createFakeTx(TESTNET, CENT, watchedAddress);
-        TransactionOutPoint outPoint = new TransactionOutPoint(0, t1);
+        TransactionOutPoint outPoint = TransactionOutPoint.from(t1, 0);
         wallet.addWatchedAddress(watchedAddress);
 
         // Note that this has a 1e-12 chance of failing this unit test due to a false positive
@@ -1692,7 +1692,7 @@ public class WalletTest extends TestWithWallet {
 
         for (Address addr : addressesForRemoval) {
             Transaction t1 = createFakeTx(TESTNET, CENT, addr);
-            TransactionOutPoint outPoint = new TransactionOutPoint(0, t1);
+            TransactionOutPoint outPoint = TransactionOutPoint.from(t1, 0);
 
             // Note that this has a 1e-12 chance of failing this unit test due to a false positive
             assertFalse(wallet.getBloomFilter(1e-12).contains(outPoint.serialize()));

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -553,9 +553,9 @@ public class PeerTest extends TestWithNetworkConnections {
         t1.addInput(t2.getOutput(0));
         t1.addInput(t3.getOutput(0));
         Sha256Hash t7hash = Sha256Hash.wrap("2b801dd82f01d17bbde881687bf72bc62e2faa8ab8133d36fcb8c3abe7459da6");
-        t1.addInput(new TransactionInput(t1, new byte[]{}, new TransactionOutPoint(0, t7hash)));
+        t1.addInput(new TransactionInput(t1, new byte[]{}, TransactionOutPoint.of(t7hash, 0)));
         Sha256Hash t8hash = Sha256Hash.wrap("3b801dd82f01d17bbde881687bf72bc62e2faa8ab8133d36fcb8c3abe7459da6");
-        t1.addInput(new TransactionInput(t1, new byte[]{}, new TransactionOutPoint(1, t8hash)));
+        t1.addInput(new TransactionInput(t1, new byte[]{}, TransactionOutPoint.of(t8hash, 1)));
         t1.addOutput(COIN, to);
         t1 = roundTripTransaction(t1);
         t2 = roundTripTransaction(t2);
@@ -626,7 +626,7 @@ public class PeerTest extends TestWithNetworkConnections {
         // The ones in brackets are assumed to be in the chain and are represented only by hashes.
         Sha256Hash t4hash = Sha256Hash.wrap("2b801dd82f01d17bbde881687bf72bc62e2faa8ab8133d36fcb8c3abe7459da6");
         Transaction t3 = new Transaction();
-        t3.addInput(new TransactionInput(t3, new byte[]{}, new TransactionOutPoint(0, t4hash)));
+        t3.addInput(new TransactionInput(t3, new byte[]{}, TransactionOutPoint.of(t4hash, 0)));
         t3.addOutput(COIN, ECKey.random());
         t3 = roundTripTransaction(t3);
         Transaction t2 = new Transaction();
@@ -728,7 +728,7 @@ public class PeerTest extends TestWithNetworkConnections {
         t2.setLockTime(999999);
         // Add a fake input to t3 that goes nowhere.
         Sha256Hash t3 = Sha256Hash.of("abc".getBytes(StandardCharsets.UTF_8));
-        t2.addInput(new TransactionInput(t2, new byte[] {}, new TransactionOutPoint(0, t3), 0xDEADBEEFL));
+        t2.addInput(new TransactionInput(t2, new byte[] {}, TransactionOutPoint.of(t3, 0), 0xDEADBEEFL));
         t2.addOutput(COIN, ECKey.random());
         Transaction t1 = new Transaction();
         t1.addInput(t2.getOutput(0));


### PR DESCRIPTION
`of()` constructor for a standalone outpoint, `from()` constructor that is connected to what it was constructed from.

Deprecate the two constructors that take a connected "fromTx" or a connected output and replace them with factory methods.

Deprecate (index, hash) constructor. Create private (hash, index) constructor. Replace with .of(hash, index) factory method.

This will allow us to factor out an interface or abstract base class in the future. It also completes our migration to hash parameter before index parameter.