### PR TITLE
TransactionOutPoint: have disconnectOutput() clear `fromTx`

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -218,11 +218,11 @@ public class TransactionOutPoint {
     }
 
     /**
-     * Returns a copy of this outpoint, but with the connectedOutput removed.
-     * @return outpoint with removed connectedOutput
+     * Returns a copy of this outpoint, but without either {@code fromTx} or {@code connectedOutput}.
+     * @return outpoint with no connections
      */
     public TransactionOutPoint disconnectOutput() {
-        return new TransactionOutPoint(hash, index, fromTx, null);
+        return new TransactionOutPoint(hash, index, null, null);
     }
 
     /**


### PR DESCRIPTION
To be disconnected the returned/modified TransactionOutPoint should have neither a `fromTx` or a `connectedOutput`.
