### PR TITLE
Block: rename to `asHeader()` from `cloneAsHeader()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
@@ -625,7 +625,7 @@ public abstract class AbstractBlockChain {
             if (shouldVerifyTransactions())
                 txOutChanges = connectTransactions(storedPrev.getHeight() + 1, block);
             StoredBlock newStoredBlock = addToBlockStore(storedPrev,
-                    block.isHeaderOnly() ? block : block.cloneAsHeader(), txOutChanges);
+                    block.isHeaderOnly() ? block : block.asHeader(), txOutChanges);
             versionTally.add(block.version());
             setChainHead(newStoredBlock);
             if (log.isDebugEnabled())
@@ -843,7 +843,7 @@ public abstract class AbstractBlockChain {
                     txOutChanges = connectTransactions(cursor);
                 else
                     txOutChanges = connectTransactions(newChainHead.getHeight(), block);
-                storedNewHead = addToBlockStore(storedNewHead, cursorBlock.cloneAsHeader(), txOutChanges);
+                storedNewHead = addToBlockStore(storedNewHead, cursorBlock.asHeader(), txOutChanges);
             }
         } else {
             // (Finally) write block to block store

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -291,8 +291,7 @@ public class Block implements Message {
         return size;
     }
 
-    // default for testing
-    void writeHeader(ByteBuffer buf) throws BufferOverflowException {
+    private void writeHeader(ByteBuffer buf) throws BufferOverflowException {
         ByteUtils.writeInt32LE(version, buf);
         prevHash.write(buf);
         getMerkleRoot().write(buf);
@@ -385,13 +384,20 @@ public class Block implements Message {
     }
 
     /**
-     * Returns a copy of the block, but without any transactions.
+     * Returns a copy of just the block header.
+     *
      * @return new, header-only {@code Block}
      */
-    public Block cloneAsHeader() {
+    public Block asHeader() {
         Block block = new Block(version, prevHash, getMerkleRoot(), time, difficultyTarget, nonce, null);
         block.hash = getHash();
         return block;
+    }
+
+    /** @deprecated use {@link #asHeader()} */
+    @Deprecated
+    public Block cloneAsHeader() {
+        return asHeader();
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/BloomFilter.java
+++ b/core/src/main/java/org/bitcoinj/core/BloomFilter.java
@@ -342,7 +342,7 @@ public class BloomFilter implements Message {
             }
         }
         PartialMerkleTree pmt = PartialMerkleTree.buildFromLeaves(bits, txHashes);
-        FilteredBlock filteredBlock = new FilteredBlock(block.cloneAsHeader(), pmt);
+        FilteredBlock filteredBlock = new FilteredBlock(block.asHeader(), pmt);
         for (Transaction transaction : matched)
             filteredBlock.provideTransaction(transaction);
         return filteredBlock;

--- a/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
+++ b/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
@@ -159,7 +159,7 @@ public class CheckpointManager {
             // This is thread safe because the map never changes after creation.
             Map.Entry<Instant, StoredBlock> entry = checkpoints.floorEntry(time);
             if (entry != null) return entry.getValue();
-            Block genesis = params.getGenesisBlock().cloneAsHeader();
+            Block genesis = params.getGenesisBlock().asHeader();
             return new StoredBlock(genesis, genesis.getWork(), 0);
         } catch (VerificationException e) {
             throw new RuntimeException(e);  // Cannot happen.

--- a/core/src/main/java/org/bitcoinj/core/FilteredBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/FilteredBlock.java
@@ -76,7 +76,7 @@ public class FilteredBlock implements Message {
         if (header.isHeaderOnly())
             header.write(buf);
         else
-            header.cloneAsHeader().write(buf);
+            header.asHeader().write(buf);
         merkleTree.write(buf);
         return buf;
     }
@@ -101,7 +101,7 @@ public class FilteredBlock implements Message {
      * Gets a copy of the block header
      */
     public Block getBlockHeader() {
-        return header.cloneAsHeader();
+        return header.asHeader();
     }
     
     /** Gets the hash of the block represented in this Filtered Block */

--- a/core/src/main/java/org/bitcoinj/core/HeadersMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/HeadersMessage.java
@@ -96,7 +96,7 @@ public class HeadersMessage implements Message {
     public ByteBuffer write(ByteBuffer buf) throws BufferOverflowException {
         VarInt.of(blockHeaders.size()).write(buf);
         for (Block header : blockHeaders) {
-            header.cloneAsHeader().write(buf);
+            header.asHeader().write(buf);
             buf.put((byte) 0);
         }
         return buf;

--- a/core/src/main/java/org/bitcoinj/store/MemoryBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryBlockStore.java
@@ -38,7 +38,7 @@ public class MemoryBlockStore implements BlockStore {
 
     public MemoryBlockStore(Block genesisBlock) {
         try {
-            Block genesisHeader = genesisBlock.cloneAsHeader();
+            Block genesisHeader = genesisBlock.asHeader();
             StoredBlock storedGenesis = new StoredBlock(genesisHeader, genesisHeader.getWork(), 0);
             put(storedGenesis);
             setChainHead(storedGenesis);

--- a/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
@@ -275,7 +275,7 @@ public class MemoryFullPrunedBlockStore implements FullPrunedBlockStore {
         this.fullStoreDepth = fullStoreDepth > 0 ? fullStoreDepth : 1;
         // Insert the genesis block.
         try {
-            StoredBlock storedGenesisHeader = new StoredBlock(params.getGenesisBlock().cloneAsHeader(), params.getGenesisBlock().getWork(), 0);
+            StoredBlock storedGenesisHeader = new StoredBlock(params.getGenesisBlock().asHeader(), params.getGenesisBlock().getWork(), 0);
             // The coinbase in the genesis block is not spendable
             List<Transaction> genesisTransactions = new LinkedList<>();
             StoredUndoableBlock storedGenesis = new StoredUndoableBlock(params.getGenesisBlock().getHash(), genesisTransactions);

--- a/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
@@ -210,7 +210,7 @@ public class SPVBlockStore implements BlockStore {
         } finally {
             lock.unlock();
         }
-        StoredBlock storedGenesis = new StoredBlock(genesisBlock.cloneAsHeader(), genesisBlock.getWork(), 0);
+        StoredBlock storedGenesis = new StoredBlock(genesisBlock.asHeader(), genesisBlock.getWork(), 0);
         put(storedGenesis);
         setChainHead(storedGenesis);
     }

--- a/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
@@ -134,10 +134,10 @@ public class BlockChainTest {
         assertTrue(testNetChain.add(b1));
         // Unconnected but stored. The head of the chain is still b1.
         assertFalse(testNetChain.add(b3));
-        assertEquals(testNetChain.getChainHead().getHeader(), b1.cloneAsHeader());
+        assertEquals(testNetChain.getChainHead().getHeader(), b1.asHeader());
         // Add in the middle block.
         assertTrue(testNetChain.add(b2));
-        assertEquals(testNetChain.getChainHead().getHeader(), b3.cloneAsHeader());
+        assertEquals(testNetChain.getChainHead().getHeader(), b3.asHeader());
     }
 
     // adds 2015 (interval-1) intermediate blocks between the transition points
@@ -483,23 +483,23 @@ public class BlockChainTest {
         Block b2 = b1.createNextBlock(coinbaseTo);
         // Add block 1, no frills.
         assertTrue(testNetChain.add(b1));
-        assertEquals(b1.cloneAsHeader(), testNetChain.getChainHead().getHeader());
+        assertEquals(b1.asHeader(), testNetChain.getChainHead().getHeader());
         assertEquals(1, testNetChain.getBestChainHeight());
         assertEquals(1, testNetWallet.getLastBlockSeenHeight());
         // Add block 2 while wallet is disconnected, to simulate crash.
         testNetChain.removeWallet(testNetWallet);
         assertTrue(testNetChain.add(b2));
-        assertEquals(b2.cloneAsHeader(), testNetChain.getChainHead().getHeader());
+        assertEquals(b2.asHeader(), testNetChain.getChainHead().getHeader());
         assertEquals(2, testNetChain.getBestChainHeight());
         assertEquals(1, testNetWallet.getLastBlockSeenHeight());
         // Add wallet back. This will detect the height mismatch and repair the damage done.
         testNetChain.addWallet(testNetWallet);
-        assertEquals(b1.cloneAsHeader(), testNetChain.getChainHead().getHeader());
+        assertEquals(b1.asHeader(), testNetChain.getChainHead().getHeader());
         assertEquals(1, testNetChain.getBestChainHeight());
         assertEquals(1, testNetWallet.getLastBlockSeenHeight());
         // Now add block 2 correctly.
         assertTrue(testNetChain.add(b2));
-        assertEquals(b2.cloneAsHeader(), testNetChain.getChainHead().getHeader());
+        assertEquals(b2.asHeader(), testNetChain.getChainHead().getHeader());
         assertEquals(2, testNetChain.getBestChainHeight());
         assertEquals(2, testNetWallet.getLastBlockSeenHeight());
     }

--- a/core/src/test/java/org/bitcoinj/core/BlockTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockTest.java
@@ -146,7 +146,7 @@ public class BlockTest {
 
     @Test
     public void testHeaderParse() {
-        Block header = block700000.cloneAsHeader();
+        Block header = block700000.asHeader();
         Block reparsed = TESTNET.getDefaultSerializer().makeBlock(ByteBuffer.wrap(header.serialize()));
         assertEquals(reparsed, header);
     }

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -1183,7 +1183,7 @@ public class FullBlockTestGenerator {
             checkState(b64Original.block.messageSize() == Block.MAX_BLOCK_SIZE);
 
             ByteBuffer buf = ByteBuffer.allocate(b64Original.block.messageSize() + 8);
-            b64Original.block.writeHeader(buf);
+            b64Original.block.asHeader().write(buf);
 
             byte[] varIntBytes = new byte[9];
             varIntBytes[0] = (byte) 255;
@@ -1793,7 +1793,7 @@ public class FullBlockTestGenerator {
             this.heightAfterBlock = heightAfterBlock;
 
             // Keep track of the set of blocks indexed by hash
-            hashHeaderMap.put(block.getHash(), block.cloneAsHeader());
+            hashHeaderMap.put(block.getHash(), block.asHeader());
 
             // Double-check that we are always marking any given block at the same height
             Integer height = blockToHeightMap.get(hashChainTipAfterBlock);

--- a/core/src/test/java/org/bitcoinj/store/SPVBlockStoreTest.java
+++ b/core/src/test/java/org/bitcoinj/store/SPVBlockStoreTest.java
@@ -79,7 +79,7 @@ public class SPVBlockStoreTest {
         assertEquals(0, genesis.getHeight());
 
         // Build a new block.
-        StoredBlock b1 = genesis.build(genesis.getHeader().createNextBlock(to).cloneAsHeader());
+        StoredBlock b1 = genesis.build(genesis.getHeader().createNextBlock(to).asHeader());
         store.put(b1);
         store.setChainHead(b1);
         store.close();
@@ -128,9 +128,9 @@ public class SPVBlockStoreTest {
         Address to = ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
         SPVBlockStore store = new SPVBlockStore(TESTNET, blockStoreFile, 10, true);
         final StoredBlock block0 = store.getChainHead();
-        final StoredBlock block1 = block0.build(block0.getHeader().createNextBlock(to).cloneAsHeader());
+        final StoredBlock block1 = block0.build(block0.getHeader().createNextBlock(to).asHeader());
         store.put(block1);
-        final StoredBlock block2 = block1.build(block1.getHeader().createNextBlock(to).cloneAsHeader());
+        final StoredBlock block2 = block1.build(block1.getHeader().createNextBlock(to).asHeader());
         store.put(block2);
         store.setChainHead(block2);
         store.close();
@@ -183,7 +183,7 @@ public class SPVBlockStoreTest {
         // Build a new block.
         Address to = ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
         StoredBlock genesis = store.getChainHead();
-        StoredBlock b1 = genesis.build(genesis.getHeader().createNextBlock(to).cloneAsHeader());
+        StoredBlock b1 = genesis.build(genesis.getHeader().createNextBlock(to).asHeader());
         store.put(b1);
         store.setChainHead(b1);
         assertEquals(b1.getHeader().getHash(), store.getChainHead().getHeader().getHash());
@@ -213,7 +213,7 @@ public class SPVBlockStoreTest {
                 SPVBlockStore.FILE_PROLOGUE_BYTES + SPVBlockStore.RECORD_SIZE_V1 * 3);
         buffer.put(SPVBlockStore.HEADER_MAGIC_V1); // header magic
         Block genesisBlock = TESTNET.getGenesisBlock();
-        StoredBlock storedGenesisBlock = new StoredBlock(genesisBlock.cloneAsHeader(), genesisBlock.getWork(), 0);
+        StoredBlock storedGenesisBlock = new StoredBlock(genesisBlock.asHeader(), genesisBlock.getWork(), 0);
         Sha256Hash genesisHash = storedGenesisBlock.getHeader().getHash();
         ((Buffer) buffer).position(SPVBlockStore.FILE_PROLOGUE_BYTES);
         buffer.put(genesisHash.getBytes());

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -459,8 +459,8 @@ public class PeerTest extends TestWithNetworkConnections {
         assertEquals(getheaders.getLocator(), expectedLocator);
         assertEquals(getheaders.getStopHash(), Sha256Hash.ZERO_HASH);
         // Now send all the headers.
-        HeadersMessage headers = new HeadersMessage(b2.cloneAsHeader(),
-                b3.cloneAsHeader(), b4.cloneAsHeader());
+        HeadersMessage headers = new HeadersMessage(b2.asHeader(),
+                b3.asHeader(), b4.asHeader());
         // We expect to be asked for b3 and b4 again, but this time, with a body.
         expectedLocator = BlockLocator.ofBlocks(
                 b2,


### PR DESCRIPTION
Keep the old method around as deprecated.

Also make `writeHeader()` private. Any non-private usages are converted to `asHeader().write()`.