### PR TITLE
Remove incorrect usages of HDFullPath in deterministic key implementations

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicHierarchy.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicHierarchy.java
@@ -67,7 +67,7 @@ public class DeterministicHierarchy {
      * inserted in order.
      */
     public final void putKey(DeterministicKey key) {
-        HDPath.HDPartialPath path = key.getPath().asPartial();
+        HDPath.HDPartialPath path = key.getPath();
         // Update our tracking of what the next child in each branch of the tree should be. Just assume that keys are
         // inserted in order here.
         final DeterministicKey parent = key.getParent();

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -653,7 +653,7 @@ public class DeterministicKey extends ECKey {
         final int parentFingerprint = buffer.getInt();
         final int i = buffer.getInt();
         final ChildNumber childNumber = new ChildNumber(i);
-        HDPath path;
+        HDPath.HDPartialPath path;
         if (parent != null) {
             if (parentFingerprint == 0)
                 throw new IllegalArgumentException("Parent was provided but this key doesn't have one");
@@ -668,8 +668,8 @@ public class DeterministicKey extends ECKey {
                 // This can happen when deserializing an account key for a watching wallet.  In this case, we assume that
                 // the client wants to conceal the key's position in the hierarchy.  The path is truncated at the
                 // parent's node.
-                path = HDPath.M(childNumber);
-            else path = HDPath.M();
+                path = HDPath.partial(childNumber);
+            else path = HDPath.partial();
         }
         byte[] chainCode = new byte[32];
         buffer.get(chainCode);

--- a/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
@@ -87,7 +87,7 @@ public final class HDKeyDerivation {
         BigInteger priv = ByteUtils.bytesToBigInteger(privKeyBytes);
         assertNonZero(priv, "Generated master key is invalid.");
         assertLessThanN(priv, "Generated master key is invalid.");
-        return new DeterministicKey(HDPath.m(), chainCode, priv, null);
+        return new DeterministicKey(HDPath.partial(), chainCode, priv, null);
     }
 
     public static DeterministicKey createMasterPubKeyFromBytes(byte[] pubKeyBytes, byte[] chainCode) {

--- a/core/src/test/java/org/bitcoinj/crypto/HDKeyDerivationTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/HDKeyDerivationTest.java
@@ -43,7 +43,7 @@ public class HDKeyDerivationTest {
 
     @Test
     public void testDeriveFromPrivateParent() {
-        DeterministicKey parent = new DeterministicKey(HDPath.M(), new byte[32], BigInteger.TEN,
+        DeterministicKey parent = new DeterministicKey(HDPath.partial(), new byte[32], BigInteger.TEN,
                 null);
         assertFalse(parent.isPubKeyOnly());
         assertFalse(parent.isEncrypted());
@@ -74,7 +74,7 @@ public class HDKeyDerivationTest {
 
     @Test
     public void testDeriveFromPublicParent() {
-        DeterministicKey parent = new DeterministicKey(HDPath.M(), new byte[32], BigInteger.TEN,
+        DeterministicKey parent = new DeterministicKey(HDPath.partial(), new byte[32], BigInteger.TEN,
                 null).withoutPrivateKey();
         assertTrue(parent.isPubKeyOnly());
         assertFalse(parent.isEncrypted());
@@ -103,7 +103,7 @@ public class HDKeyDerivationTest {
 
     @Test
     public void testDeriveFromEncryptedParent() {
-        DeterministicKey parent = new DeterministicKey(HDPath.M(), new byte[32], BigInteger.TEN,
+        DeterministicKey parent = new DeterministicKey(HDPath.partial(), new byte[32], BigInteger.TEN,
                 null);
         parent = parent.encrypt(KEY_CRYPTER, AES_KEY, null);
         assertTrue(parent.isEncrypted());
@@ -141,7 +141,7 @@ public class HDKeyDerivationTest {
 
     @Test
     public void testGenerate() {
-        DeterministicKey parent = new DeterministicKey(HDPath.m(), new byte[32], BigInteger.TEN,
+        DeterministicKey parent = new DeterministicKey(HDPath.partial(), new byte[32], BigInteger.TEN,
                 null);
         assertFalse(parent.isPubKeyOnly());
         assertFalse(parent.isEncrypted());

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -123,7 +123,7 @@ public class DeterministicKeyChainTest {
     @Test
     public void deriveAccountOne() {
         final Instant secs = Instant.ofEpochSecond(1389353062L);
-        final HDPath accountOne = HDPath.M(ChildNumber.ONE);
+        final HDPath.HDPartialPath accountOne = HDPath.partial(ChildNumber.ONE);
         DeterministicKeyChain chain1 = DeterministicKeyChain.builder().accountPath(accountOne)
                 .entropy(ENTROPY, secs).build();
         ECKey key1 = chain1.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);


### PR DESCRIPTION
This is child of #3783 (but doesn't strictly need to be)