### PR TITLE
Block: rename to `transactions()` from `getTransactions()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
@@ -752,7 +752,7 @@ public abstract class AbstractBlockChain {
             // is relevant to both of them, they don't end up accidentally sharing the same object (which can
             // result in temporary in-memory corruption during re-orgs). See bug 257. We only duplicate in
             // the case of multiple wallets to avoid an unnecessary efficiency hit in the common case.
-            sendTransactionsToListener(newStoredBlock, newBlockType, listener, 0, block.getTransactions(),
+            sendTransactionsToListener(newStoredBlock, newBlockType, listener, 0, block.transactions(),
                     !first, falsePositives);
         } else if (filteredTxHashList != null) {
             Objects.requireNonNull(filteredTxn);

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -805,10 +805,25 @@ public class Block implements Message {
         this.hash = null;
     }
 
-    /** Returns an unmodifiable list of transactions held in this block, or null if this object represents just a header. */
+    /**
+     * Returns an unmodifiable view of the transactions held in this block. The transactions themselves can change.
+     * This can only be called on regular (non-header-only) blocks.
+     * <p>
+     * Before using this method, consider using one of: {@link #transactionCount()}, {@link #transaction(int)},
+     * {@link #forEachTransaction(Consumer)}, {@link #findTransactions(Predicate)}, {@link #addTransaction(Transaction)}
+     *
+     * @return transactions in this block, can be empty
+     */
+    public List<Transaction> transactions() {
+        checkState(!isHeaderOnly(), () -> "block is header-only");
+        return Collections.unmodifiableList(transactions);
+    }
+
+    /** @deprecated use {@link #transactions()} or {@link #isHeaderOnly()} */
+    @Deprecated
     @Nullable
     public List<Transaction> getTransactions() {
-        return isHeaderOnly() ? null : Collections.unmodifiableList(transactions);
+        return isHeaderOnly() ? null : transactions();
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/BloomFilter.java
+++ b/core/src/main/java/org/bitcoinj/core/BloomFilter.java
@@ -329,7 +329,7 @@ public class BloomFilter implements Message {
      * filtered block already has the matched transactions associated with it.
      */
     public synchronized FilteredBlock applyAndUpdate(Block block) {
-        List<Transaction> txns = block.getTransactions();
+        List<Transaction> txns = block.transactions();
         List<Sha256Hash> txHashes = new ArrayList<>(txns.size());
         List<Transaction> matched = new ArrayList<>();
         byte[] bits = new byte[(int) Math.ceil(txns.size() / 8.0)];

--- a/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
@@ -107,7 +107,7 @@ public class FullPrunedBlockChain extends AbstractBlockChain {
     protected StoredBlock addToBlockStore(StoredBlock storedPrev, Block block)
             throws BlockStoreException, VerificationException {
         StoredBlock newBlock = storedPrev.build(block);
-        blockStore.put(newBlock, new StoredUndoableBlock(newBlock.getHeader().getHash(), block.getTransactions()));
+        blockStore.put(newBlock, new StoredUndoableBlock(newBlock.getHeader().getHash(), block.transactions()));
         return newBlock;
     }
 
@@ -219,7 +219,7 @@ public class FullPrunedBlockChain extends AbstractBlockChain {
                 // BIP30 violator blocks are ones that contain a duplicated transaction. They are all in the
                 // checkpoints list and we therefore only check non-checkpoints for duplicated transactions here. See the
                 // BIP30 document for more details on this: https://github.com/bitcoin/bips/blob/master/bip-0030.mediawiki
-                for (Transaction tx : block.getTransactions()) {
+                for (Transaction tx : block.transactions()) {
                     final Set<VerifyFlag> verifyFlags = params.getTransactionVerificationFlags(block, tx, getVersionTally(), height);
                     Sha256Hash hash = tx.getTxId();
                     // If we already have unspent outputs for this hash, we saw the tx already. Either the block is
@@ -232,7 +232,7 @@ public class FullPrunedBlockChain extends AbstractBlockChain {
             }
             Coin totalFees = Coin.ZERO;
             Coin coinbaseValue = null;
-            for (final Transaction tx : block.getTransactions()) {
+            for (final Transaction tx : block.transactions()) {
                 boolean isCoinBase = tx.isCoinBase();
                 Coin valueIn = Coin.ZERO;
                 Coin valueOut = Coin.ZERO;

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -1879,7 +1879,7 @@ public class PeerGroup implements TransactionBroadcaster {
             blocksInLastSecond++;
             bytesInLastSecond += Block.HEADER_SIZE;
             // This whole area of the type hierarchy is a mess.
-            int txCount = (!block.isHeaderOnly() ? countAndMeasureSize(block.getTransactions()) : 0) +
+            int txCount = (!block.isHeaderOnly() ? countAndMeasureSize(block.transactions()) : 0) +
                           (filteredBlock != null ? countAndMeasureSize(filteredBlock.getAssociatedTransactions().values()) : 0);
             txnsInLastSecond = txnsInLastSecond + txCount;
             if (filteredBlock != null)

--- a/core/src/test/java/org/bitcoinj/core/BlockTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockTest.java
@@ -130,7 +130,7 @@ public class BlockTest {
     @Test
     public void testBadTransactions() {
         // Re-arrange so the coinbase transaction is not first.
-        List<Transaction> transactions = new ArrayList<>(block700000.getTransactions());
+        List<Transaction> transactions = new ArrayList<>(block700000.transactions());
         Transaction tx1 = transactions.get(0);
         Transaction tx2 = transactions.get(1);
         transactions.set(0, tx2);
@@ -217,8 +217,7 @@ public class BlockTest {
         assertEquals(Coin.ZERO, wallet.getBalance());
 
         // Give the wallet the first transaction in the block - this is the coinbase tx.
-        List<Transaction> transactions = block169482.getTransactions();
-        assertNotNull(transactions);
+        List<Transaction> transactions = block169482.transactions();
         wallet.receiveFromBlock(transactions.get(0), storedBlock, NewBlockType.BEST_CHAIN, 0);
 
         // Coinbase transaction should have been received successfully but be unavailable to spend (too young).

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -974,7 +974,7 @@ public class FullBlockTestGenerator {
             Transaction coinbase = new Transaction();
             coinbase.addInput(TransactionInput.coinbaseInput(coinbase, new byte[]{(byte) 0xff, 110, 1}));
             coinbase.addOutput(new TransactionOutput(coinbase, SATOSHI, outScriptBytes));
-            List<Transaction> transactions = new ArrayList<>(b51.block.getTransactions());
+            List<Transaction> transactions = new ArrayList<>(b51.block.transactions());
             transactions.add(coinbase);
             b51.block.replaceTransactions(transactions);
         }

--- a/core/src/test/java/org/bitcoinj/utils/BlockFileLoaderTest.java
+++ b/core/src/test/java/org/bitcoinj/utils/BlockFileLoaderTest.java
@@ -98,8 +98,7 @@ public class BlockFileLoaderTest {
         BlockFileLoader loader = new BlockFileLoader(BitcoinNetwork.MAINNET, Collections.singletonList(blockFile));
 
         long transactionCount = loader.stream()
-                .map(Block::getTransactions)
-                .filter(Objects::nonNull)
+                .map(Block::transactions)
                 .mapToLong(Collection::size)
                 .sum();
 


### PR DESCRIPTION
The new method doesn't return null any more and throws instead.

The old method is kept around as deprecated.
