### PR TITLE
ParseByteCacheTest, FullBlockTestGenerator: make use of `Block.hasTransactions()`

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -906,7 +906,7 @@ public class FullBlockTestGenerator {
             try {
                 b45.addTransaction(t);
             } catch (RuntimeException e) { } // Should happen
-            if (b45.getTransactions().size() > 0)
+            if (b45.hasTransactions())
                 throw new RuntimeException("addTransaction doesn't properly check for adding a non-coinbase as first tx");
             b45.replaceTransactions(Arrays.asList(t));
 

--- a/core/src/test/java/org/bitcoinj/core/ParseByteCacheTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ParseByteCacheTest.java
@@ -164,7 +164,7 @@ public class ParseByteCacheTest {
         serDeser(serializer, b1, bos.toByteArray(), null, null);
         
         // retrieve a value from a child
-        if (b1.getTransactions().size() > 0) {
+        if (b1.hasTransactions()) {
             Transaction tx1 = b1.transaction(0);
             
             // does it still match ref block?
@@ -188,7 +188,7 @@ public class ParseByteCacheTest {
         // retrieve a value from a child and header
         b1.difficultyTarget();
 
-        if (b1.getTransactions().size() > 0) {
+        if (b1.hasTransactions()) {
             Transaction tx1 = b1.transaction(0);
         }
         // does it still match ref block?
@@ -211,7 +211,7 @@ public class ParseByteCacheTest {
         bRef = (Block) serializerRef.deserialize(ByteBuffer.wrap(blockBytes));
         
         // retrieve a value from a child of a child
-        if (b1.getTransactions().size() > 0) {
+        if (b1.hasTransactions()) {
             Transaction tx1 = b1.transaction(0);
             
             TransactionInput tin = tx1.getInput(0);
@@ -227,7 +227,7 @@ public class ParseByteCacheTest {
         bRef = (Block) serializerRef.deserialize(ByteBuffer.wrap(blockBytes));
         
         // add an input
-        if (b1.getTransactions().size() > 0) {
+        if (b1.hasTransactions()) {
             Transaction tx1 = b1.transaction(0);
             
             if (tx1.getInputs().size() > 0) {
@@ -255,7 +255,7 @@ public class ParseByteCacheTest {
         Block bRef2 = (Block) serializerRef.deserialize(ByteBuffer.wrap(blockBytes));
         
         // reparent an input
-        if (b1.getTransactions().size() > 0) {
+        if (b1.hasTransactions()) {
             Transaction tx1 = b1.transaction(0);
             Transaction tx2 = b2.transaction(0);
             


### PR DESCRIPTION
This prevents accessing all transactions in these cases.