### PR TITLE
Block: add method `transactionCount()` to determine number of transactions

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -811,6 +811,16 @@ public class Block implements Message {
     }
 
     /**
+     * Returns the number of transactions in this block.
+     *
+     * @return number of transactions
+     */
+    public int transactionCount() {
+        checkState(!isHeaderOnly());
+        return transactions.size();
+    }
+
+    /**
      * Gets the transaction at the given index.
      *
      * @param index index of the transaction to get

--- a/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
@@ -213,7 +213,7 @@ public class FullPrunedBlockChain extends AbstractBlockChain {
         if (scriptVerificationExecutor.isShutdown())
             scriptVerificationExecutor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
 
-        List<Future<VerificationException>> listScriptVerificationResults = new ArrayList<>(block.getTransactions().size());
+        List<Future<VerificationException>> listScriptVerificationResults = new ArrayList<>(block.transactionCount());
         try {
             if (!params.isCheckpoint(height)) {
                 // BIP30 violator blocks are ones that contain a duplicated transaction. They are all in the

--- a/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
@@ -227,7 +227,7 @@ public class BitcoindComparisonTool {
                     try {
                         Block b = blocks.next();
                         Block oldBlockWithSameHash = preloadedBlocks.put(b.getHash(), b);
-                        if (oldBlockWithSameHash != null && oldBlockWithSameHash.getTransactions().size() != b.getTransactions().size())
+                        if (oldBlockWithSameHash != null && oldBlockWithSameHash.transactionCount() != b.transactionCount())
                             blocksRequested.remove(b.getHash());
                         nextBlock = preloadedBlocks.get(block.blockHash);
                     } catch (NoSuchElementException e) {

--- a/core/src/test/java/org/bitcoinj/core/BlockTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockTest.java
@@ -230,7 +230,7 @@ public class BlockTest {
     public void testBlock481815_witnessCommitmentInCoinbase() throws Exception {
         Block block481815 = MAINNET.getDefaultSerializer().makeBlock(ByteBuffer.wrap(
                 ByteStreams.toByteArray(getClass().getResourceAsStream("block481815.dat"))));
-        assertEquals(2097, block481815.getTransactions().size());
+        assertEquals(2097, block481815.transactionCount());
         assertEquals("f115afa8134171a0a686bfbe9667b60ae6fb5f6a439e0265789babc315333262",
                 block481815.getMerkleRoot().toString());
 
@@ -251,7 +251,7 @@ public class BlockTest {
     public void testBlock481829_witnessTransactions() throws Exception {
         Block block481829 = MAINNET.getDefaultSerializer().makeBlock(ByteBuffer.wrap(
                 ByteStreams.toByteArray(getClass().getResourceAsStream("block481829.dat"))));
-        assertEquals(2020, block481829.getTransactions().size());
+        assertEquals(2020, block481829.transactionCount());
         assertEquals("f06f697be2cac7af7ed8cd0b0b81eaa1a39e444c6ebd3697e35ab34461b6c58d",
                 block481829.getMerkleRoot().toString());
         assertEquals("0a02ddb2f86a14051294f8d98dd6959dd12bf3d016ca816c3db9b32d3e24fc2d",

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -1187,9 +1187,9 @@ public class FullBlockTestGenerator {
 
             byte[] varIntBytes = new byte[9];
             varIntBytes[0] = (byte) 255;
-            ByteUtils.writeInt64LE(b64Original.block.getTransactions().size(), varIntBytes, 1);
+            ByteUtils.writeInt64LE(b64Original.block.transactionCount(), varIntBytes, 1);
             buf.put(varIntBytes);
-            checkState(VarInt.ofBytes(varIntBytes, 0).intValue() == b64Original.block.getTransactions().size());
+            checkState(VarInt.ofBytes(varIntBytes, 0).intValue() == b64Original.block.transactionCount());
 
             for (Transaction transaction : b64Original.block.getTransactions())
                 transaction.write(buf);


### PR DESCRIPTION
Use it to prevent accessing `getTransactions()` when possible.