### PR TITLE
ClientConnectionManager: Deprecate inheritence of Guava `Service`

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -1153,8 +1153,8 @@ public class PeerGroup implements TransactionBroadcaster {
         CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
             try {
                 log.info("Starting ...");
-                channels.startAsync();
-                channels.awaitRunning();
+                CompletableFuture<Void> started = channels.start(); // Start asynchronously
+                started.get();                                      // Wait until started
                 triggerConnections();
                 setupPinging();
             } catch (Throwable e) {
@@ -1179,8 +1179,8 @@ public class PeerGroup implements TransactionBroadcaster {
                 // The log output this creates can be useful.
                 setDownloadPeer(null);
                 // Blocking close of all sockets.
-                channels.stopAsync();
-                channels.awaitTerminated();
+                CompletableFuture<Void> stopped = channels.stop();  // Stop asynchronously
+                stopped.get();                                      // Wait until stopped
                 for (PeerDiscovery peerDiscovery : peerDiscoverers) {
                     peerDiscovery.shutdown();
                 }

--- a/core/src/main/java/org/bitcoinj/net/ClientConnectionManager.java
+++ b/core/src/main/java/org/bitcoinj/net/ClientConnectionManager.java
@@ -25,8 +25,12 @@ import java.util.concurrent.CompletableFuture;
  * A generic interface for an object which keeps track of a set of open client connections, creates new ones and
  * ensures they are serviced properly.
  * <p>
- * When the service is stopped via {@link com.google.common.util.concurrent.Service#stopAsync()}, all connections will be closed and
- * the appropriate connectionClosed() calls must be made.
+ * When the service is stopped via {@link #stop()}, all connections will be closed and the appropriate
+ * {@code connectionClosed()} calls must be made.
+ * <p>
+ * <b>Deprecation warning:</b> this class currently extends <b>Guava</b> {@link Service} but this will be removed
+ * in the next release. {@link #start()} amd {@link #stop()} have been provided to replace existing uses of {@link Service}
+ * methods and in a future release {@link ClientConnectionManager} instances will not be Guava services.
  */
 public interface ClientConnectionManager extends Service {
     /**
@@ -40,4 +44,22 @@ public interface ClientConnectionManager extends Service {
 
     /** Closes n peer connections */
     void closeConnections(int n);
+
+    /**
+     * Start the service asynchronously.
+     * @return a future that will complete when the service is started
+     */
+    default CompletableFuture<Void> start() {
+        startAsync();
+        return CompletableFuture.runAsync(this::awaitRunning);
+    }
+
+    /**
+     * Stop the service asynchronously and close all connections.
+     * @return a future that will complete when the service is stopped
+     */
+    default CompletableFuture<Void> stop() {
+        startAsync();
+        return CompletableFuture.runAsync(this::awaitTerminated);
+    }
 }


### PR DESCRIPTION
This contains a preliminary commit to simplify the JavaDoc of `ClientConnectionManager` before updating the comment as part of the main commit.