### PR TITLE
PeerGroup: 3 minor improvements

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -495,7 +495,6 @@ public class PeerGroup implements TransactionBroadcaster {
      * if there aren't enough current connections to meet the new requested max size, some will be added.
      */
     public void setMaxConnections(int maxConnections) {
-        int adjustment;
         lock.lock();
         try {
             this.maxConnections = maxConnections;
@@ -504,7 +503,7 @@ public class PeerGroup implements TransactionBroadcaster {
             lock.unlock();
         }
         // We may now have too many or too few open connections. Add more or drop some to get to the right amount.
-        adjustment = maxConnections - channels.getConnectedClientCount();
+        int adjustment = maxConnections - channels.getConnectedClientCount();
         if (adjustment > 0)
             triggerConnections();
 

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -503,11 +503,11 @@ public class PeerGroup implements TransactionBroadcaster {
             lock.unlock();
         }
         // We may now have too many or too few open connections. Add more or drop some to get to the right amount.
-        int adjustment = maxConnections - channels.getConnectedClientCount();
-        if (adjustment > 0)
+        int excessConnections = channels.getConnectedClientCount() - maxConnections;
+        if (excessConnections < 0)
             triggerConnections();
-        else if (adjustment < 0)
-            channels.closeConnections(-adjustment);
+        else if (excessConnections > 0)
+            channels.closeConnections(excessConnections);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -506,8 +506,7 @@ public class PeerGroup implements TransactionBroadcaster {
         int adjustment = maxConnections - channels.getConnectedClientCount();
         if (adjustment > 0)
             triggerConnections();
-
-        if (adjustment < 0)
+        else if (adjustment < 0)
             channels.closeConnections(-adjustment);
     }
 


### PR DESCRIPTION
Improve the handling of the (positive or negative) excess connections in 3 commits

The variable `adjustment` was renamed to `excessConnections` and its sign was flipped. This makes the code more readable (no negation operator) and makes the variable name indicative of what positive and negative values mean.