### PR TITLE
Reduce usage of NetworkParameters in blockchain-related classes

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
@@ -75,8 +75,8 @@ public class FullPrunedBlockChain extends AbstractBlockChain {
      * one from scratch, or you can deserialize a saved wallet from disk using
      * {@link Wallet#loadFromFile(File, WalletExtension...)}
      */
-    public FullPrunedBlockChain(NetworkParameters params, Wallet wallet, FullPrunedBlockStore blockStore) throws BlockStoreException {
-        this(params, Collections.singletonList(wallet), blockStore);
+    public FullPrunedBlockChain(BitcoinNetwork network, Wallet wallet, FullPrunedBlockStore blockStore) throws BlockStoreException {
+        this(NetworkParameters.of(network), Collections.singletonList(wallet), blockStore);
     }
 
     /**


### PR DESCRIPTION
A sequence of 9 commits to reduce usage of `NetworkParameters` by providing `Network`-based alternatives, reducing visibility, and using narrowed subtypes. They also remove a few uses of Guava's `@VisibleForTesting`.