### PR TITLE
FullPrunedBlockChain: Use CompletableFuture and FutureUtils in the 2 connectTransactions() methods

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
@@ -205,7 +205,6 @@ public class FullPrunedBlockChain extends AbstractBlockChain {
         if (scriptVerificationExecutor.isShutdown())
             scriptVerificationExecutor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
 
-        List<CompletableFuture<VerificationException>> listScriptVerificationResults = new ArrayList<>(block.transactionCount());
         try {
             if (!params.isCheckpoint(height)) {
                 // BIP30 violator blocks are ones that contain a duplicated transaction. They are all in the
@@ -224,6 +223,7 @@ public class FullPrunedBlockChain extends AbstractBlockChain {
             }
             Coin totalFees = Coin.ZERO;
             Coin coinbaseValue = null;
+            List<CompletableFuture<VerificationException>> listScriptVerificationResults = new ArrayList<>(block.transactionCount());
             for (final Transaction tx : block.transactions()) {
                 boolean isCoinBase = tx.isCoinBase();
                 Coin valueIn = Coin.ZERO;


### PR DESCRIPTION
Replace `FutureTask` with `CompletableFuture` and make further improvements using `CompletableFuture`.

4 commits.

Reviewer note: You may want to look at PR #3802 if you want to understand the 3rd commit (`FutureUtils.allAsList`) better.
