### PR TITLE
FutureUtil: Improve JavaDoc and make more readable

### DIFF
--- a/base/src/main/java/org/bitcoinj/base/internal/FutureUtils.java
+++ b/base/src/main/java/org/bitcoinj/base/internal/FutureUtils.java
@@ -65,7 +65,7 @@ public class FutureUtils {
     public static <T> CompletableFuture<List<T>> successfulAsList(
             List<? extends CompletionStage<? extends T>> stages) {
         // Convert List to Array and map exceptions to null results
-        final CompletableFuture<? extends T>[] all = listToArray2(stages);
+        final CompletableFuture<? extends T>[] all = listToArrayExceptionToNull(stages);
 
         // Create a single future that completes when all futures in the array complete
         final CompletableFuture<Void> allOf = CompletableFuture.allOf(all);
@@ -92,7 +92,7 @@ public class FutureUtils {
     }
 
     // Convert a list of CompletionStage to an array of CompletableFuture also mapping exceptions to null results
-    private static <T> CompletableFuture<? extends T>[] listToArray2( List<? extends CompletionStage<? extends T>> stages) {
+    private static <T> CompletableFuture<? extends T>[] listToArrayExceptionToNull(List<? extends CompletionStage<? extends T>> stages) {
         return listToArrayWithMapping(stages, stage -> stage.exceptionally(throwable -> null).toCompletableFuture());
     }
 

--- a/base/src/main/java/org/bitcoinj/base/internal/FutureUtils.java
+++ b/base/src/main/java/org/bitcoinj/base/internal/FutureUtils.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 
@@ -87,20 +88,19 @@ public class FutureUtils {
 
     // Convert a list of CompletionStage to an array of CompletableFuture
     private static <T> CompletableFuture<? extends T>[] listToArray( List<? extends CompletionStage<? extends T>> stages) {
-        // Convert List to Array
-        final CompletableFuture<? extends T>[] all = stages.stream()
-                .map(CompletionStage::toCompletableFuture)
-                .toArray(genericArray(CompletableFuture[]::new));
-        return all;
+        return listToArrayWithMapping(stages, CompletionStage::toCompletableFuture);
     }
 
     // Convert a list of CompletionStage to an array of CompletableFuture also mapping exceptions to null results
     private static <T> CompletableFuture<? extends T>[] listToArray2( List<? extends CompletionStage<? extends T>> stages) {
-        // Convert List to Array
-        final CompletableFuture<? extends T>[] all = stages.stream()
-                .map(s -> s.exceptionally(throwable -> null).toCompletableFuture())
+        return listToArrayWithMapping(stages, stage -> stage.exceptionally(throwable -> null).toCompletableFuture());
+    }
+
+    // Convert a list of CompletionStage to an array of CompletableFuture using a mapping function to transform each CompletionStage
+    private static <T> CompletableFuture<? extends T>[] listToArrayWithMapping(List<? extends CompletionStage<? extends T>> stages, Function<CompletionStage<? extends T>, CompletableFuture<? extends T>> mapper) {
+        return stages.stream()
+                .map(mapper::apply)
                 .toArray(genericArray(CompletableFuture[]::new));
-        return all;
     }
 
     // Transform a CompletableFuture returning Void to a CompletableFuture returning all results from an array of CompletableFuture

--- a/base/src/main/java/org/bitcoinj/base/internal/FutureUtils.java
+++ b/base/src/main/java/org/bitcoinj/base/internal/FutureUtils.java
@@ -25,14 +25,9 @@ import java.util.stream.Collectors;
 
 /**
  * Utilities for {@link CompletableFuture}.
- * <p>
- * Note: When the <b>bitcoinj</b> migration to {@code CompletableFuture} is finished this class will
- * either be removed or its remaining methods changed to use generic {@code CompletableFuture}s.
  */
 public class FutureUtils {
     /**
-     * Note: When the migration to {@code CompletableFuture} is complete this routine will
-     * either be removed or changed to return a generic {@code CompletableFuture}.
      * @param stages A list of {@code CompletionStage}s all returning the same type
      * @param <T> the result type
      * @return A CompletableFuture that returns a list of result type
@@ -43,8 +38,6 @@ public class FutureUtils {
     }
 
     /**
-     * Note: When the migration to {@code CompletableFuture} is complete this routine will
-     * either be removed or changed to return a generic {@code CompletableFuture}.
      * @param stages A list of {@code CompletionStage}s all returning the same type
      * @param <T> the result type
      * @return A CompletableFuture that returns a list of result type

--- a/base/src/main/java/org/bitcoinj/base/internal/FutureUtils.java
+++ b/base/src/main/java/org/bitcoinj/base/internal/FutureUtils.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.IntFunction;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -57,41 +56,6 @@ public class FutureUtils {
         CompletableFuture<T> future = new CompletableFuture<>();
         future.completeExceptionally(t);
         return future;
-    }
-
-    /**
-     * Subinterface of {@link Supplier} for Lambdas which throw exceptions.
-     * Can be used for two purposes:
-     * 1. To cast a lambda that throws an exception to a {@link Supplier} and
-     * automatically wrapping any exceptions with {@link RuntimeException}.
-     * 2. As a {@code FunctionalInterface} where a lambda that throws exceptions is
-     * expected or allowed.
-     *
-     * @param <T> the supplied type
-     */
-    @FunctionalInterface
-    public interface ThrowingSupplier<T> extends Supplier<T> {
-
-        /**
-         * Gets a result wrapping checked Exceptions with {@link RuntimeException}
-         * @return a result
-         */
-        @Override
-        default T get() {
-            try {
-                return getThrows();
-            } catch (final Exception e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        /**
-         * Gets a result.
-         *
-         * @return a result
-         * @throws Exception Any checked Exception
-         */
-        T getThrows() throws Exception;
     }
 
     /**

--- a/base/src/main/java/org/bitcoinj/base/internal/FutureUtils.java
+++ b/base/src/main/java/org/bitcoinj/base/internal/FutureUtils.java
@@ -85,6 +85,7 @@ public class FutureUtils {
         return future;
     }
 
+    // Convert a list of CompletionStage to an array of CompletableFuture
     private static <T> CompletableFuture<? extends T>[] listToArray( List<? extends CompletionStage<? extends T>> stages) {
         // Convert List to Array
         final CompletableFuture<? extends T>[] all = stages.stream()
@@ -93,6 +94,7 @@ public class FutureUtils {
         return all;
     }
 
+    // Convert a list of CompletionStage to an array of CompletableFuture also mapping exceptions to null results
     private static <T> CompletableFuture<? extends T>[] listToArray2( List<? extends CompletionStage<? extends T>> stages) {
         // Convert List to Array
         final CompletableFuture<? extends T>[] all = stages.stream()
@@ -101,6 +103,7 @@ public class FutureUtils {
         return all;
     }
 
+    // Transform a CompletableFuture returning Void to a CompletableFuture returning all results from an array of CompletableFuture
     private static <T> CompletableFuture<List<T>>  transformToListResult(CompletableFuture<Void> allOf, CompletableFuture<? extends T>[] all) {
         return allOf.thenApply(ignored -> Arrays.stream(all)
                 .map(CompletableFuture::join)


### PR DESCRIPTION
FutureUtils remains useful even after we've removed all the deprecated Guava Future adapters. But the JavaDoc needed an update and the code needed to be more readable in order to update the JavaDoc.

6 commits.