### PR TITLE
upgrade JUnit to 5.12.2 from 5.11.4

### DIFF
--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -8,13 +8,14 @@ dependencies {
     implementation project(':bitcoinj-examples')
 
     testImplementation 'org.slf4j:slf4j-jdk14:2.0.16'
-    testImplementation platform("org.junit:junit-bom:5.11.4")
+    testImplementation platform("org.junit:junit-bom:5.12.2")
     testImplementation "org.junit.jupiter:junit-jupiter-api"
     testImplementation "org.junit.jupiter:junit-jupiter-params"
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.easymock:easymock:5.5.0'
     testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.18.1'
     testImplementation 'org.hamcrest:hamcrest-library:3.0'
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
 }

--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -13,8 +13,9 @@ dependencies {
 
     runtimeOnly 'org.slf4j:slf4j-jdk14:2.0.16'
 
-    testImplementation platform("org.junit:junit-bom:5.11.4")
+    testImplementation platform("org.junit:junit-bom:5.12.2")
     testImplementation "org.junit.jupiter:junit-jupiter-api"
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }
 

--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -25,7 +25,8 @@ dependencies {
         compileOnly 'info.picocli:picocli-codegen:4.7.6'
     }
 
-    testImplementation platform("org.junit:junit-bom:5.11.4")
+    testImplementation platform("org.junit:junit-bom:5.12.2")
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher"
     testImplementation "org.junit.jupiter:junit-jupiter-api"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 


### PR DESCRIPTION
This is a child of PR #3773 -- it upgrades the version of the BOM and also adds  a runtime dependency on `junit-platform-launcher`

Gradle now requires explicit use of `junit-platform-launcher`, see: https://docs.gradle.org/8.12/userguide/upgrading_version_8.html#test_framework_implementation_dependencies
