### PR TITLE
Network/BitcoinNetwork: Add usage guidelines to JavaDoc

### DIFF
--- a/base/src/main/java/org/bitcoinj/base/BitcoinNetwork.java
+++ b/base/src/main/java/org/bitcoinj/base/BitcoinNetwork.java
@@ -30,7 +30,8 @@ import java.util.stream.Stream;
 import static org.bitcoinj.base.Coin.COIN;
 
 /**
- * A convenient {@code enum} representation of a Bitcoin network.
+ * A convenient {@code enum} representation of a Bitcoin {@link Network}. In most code you will probably want
+ * to use this {@link BitcoinNetwork} type rather than the {@link Network} type, see {@link Network} for details.
  * <p>
  * Note that the name of each {@code enum} constant is defined in <i>uppercase</i> as is the convention in Java.
  * However, the <q>canonical</q> representation in <b>bitcoinj</b> for user-facing display and input

--- a/base/src/main/java/org/bitcoinj/base/Network.java
+++ b/base/src/main/java/org/bitcoinj/base/Network.java
@@ -17,7 +17,14 @@
 package org.bitcoinj.base;
 
 /**
- * Interface for a generic Bitcoin-like cryptocurrency network. See {@link BitcoinNetwork} for the Bitcoin implementation.
+ * Interface describing important properties of a Bitcoin-like cryptocurrency network. See {@link BitcoinNetwork} for
+ * the Bitcoin implementation.
+ * <p>
+ * Use this interface in classes and methods that might support alternative Bitcoin-like networks. Use {@link BitcoinNetwork}
+ * to only support Bitcoin. As {@link BitcoinNetwork} is an {@code enum}, it also works better in {@code switch} statements/expressions.
+ * <p>
+ * For example, in the {@link BitcoinNetwork} enum implementation, {@link #hasMaxMoney()} is always {@code true} and
+ * {@link #maxMoney()} always returns {@link BitcoinNetwork#MAX_MONEY}.
  */
 public interface Network {
     /**


### PR DESCRIPTION
Update the main JavaDoc for both classes to better explain when to use each type.