### PR TITLE
Update protobuf-javalite to 4.30.2, Gradle Protobuf Plugin to 0.9.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     // If using Gradle 7, use the compatible protobuf plugin, else use the one that works with oldest supported Gradle
     boolean isGradle7 = GradleVersion.current() >= GradleVersion.version("7.0")
-    def gradleProtobufVersion = isGradle7 ? "0.9.4" : "0.8.10"
+    def gradleProtobufVersion = isGradle7 ? "0.9.5" : "0.8.10"
     if (isGradle7) {
         System.err.println "Warning: Using com.google.protobuf:protobuf-gradle-plugin:${gradleProtobufVersion} because ${GradleVersion.current()}"
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     api project(':bitcoinj-base')
     api 'org.bouncycastle:bcprov-jdk15to18:1.80'
     api 'com.google.guava:guava:33.4.0-android'
-    api 'com.google.protobuf:protobuf-javalite:4.29.3'
+    api 'com.google.protobuf:protobuf-javalite:4.30.2'
     implementation 'org.slf4j:slf4j-api:2.0.16'
 
     testImplementation project(':bitcoinj-test-support')
@@ -51,7 +51,7 @@ javadoc.options.encoding = 'UTF-8'
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:4.29.3'
+        artifact = 'com.google.protobuf:protoc:4.30.2'
     }
     generateProtoTasks {
         all().each { task ->


### PR DESCRIPTION
This is 2 commits: 1 for `protobuf-javalite` and 1 for the Gradle Protobuf Plugin. They are independent, but we might was well update both in the same PR.

Note the this update does not resolve Issue #3806 which is an upstream deprecation warning issue for Protobuf with Java 24.