### PR TITLE
GHA gradle.yml, graalvm.yml: Update to JDK 24 (where 23 was used)

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, macOS-13]
-        java: [ '21', '23' ]
+        java: [ '21', '24' ]
         distribution: [ 'graalvm-community' ]
         gradle: ['8.14']
       fail-fast: false

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,14 +9,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, macOS-13, windows-2022]
-        java: ['17', '21', '23']
+        java: ['17', '21', '24']
         distribution: ['temurin']
         gradle: ['7.3', '8.14']
         exclude:
           # Java 21+ requires Gradle 8.5+
           - java: '21'
             gradle: '7.3'
-          - java: '23'
+          - java: '24'
             gradle: '7.3'
       fail-fast: false
     name: ${{ matrix.os }} JDK ${{ matrix.java }}.${{ matrix.distribution }} Gradle ${{ matrix.gradle }}


### PR DESCRIPTION
This is a child of PR #3808 as Gradle 8.14 is required for JDK 24.

There is a problem building the `jlink`-ed version of WalletTemplate. It is an upstream issue with [JEP 493](https://openjdk.org/jeps/493) and the Gradle B.A. Link Plugin. See: https://github.com/beryx/badass-jlink-plugin/issues/299 This is why all the `gradle.yml` jobs are failing for JDK 24.