### PR TITLE
MemoryFullPrunedBlockStore: de-genericize TransactionalFullBlockMap from TransactionalMultiKeyHashMap

### DIFF
--- a/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
@@ -175,16 +175,11 @@ class TransactionalFullBlockMap {
         }
     }
     
-    @Nullable
-    public StoredUndoableBlock removeByUniqueKey(Sha256Hash hash) {
-        return mapValues.remove(hash);
-    }
-    
     public void removeByMultiKey(Integer height) {
         Set<Sha256Hash> set = mapKeys.remove(height);
         if (set != null)
             for (Sha256Hash hash : set)
-                removeByUniqueKey(hash);
+                mapValues.remove(hash);
     }
 }
 

--- a/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
@@ -163,28 +163,28 @@ class TransactionalFullBlockMap {
         return mapValues.get(key);
     }
     
-    public void put(Sha256Hash uniqueKey, Integer multiKey, StoredUndoableBlock value) {
-        mapValues.put(uniqueKey, value);
-        Set<Sha256Hash> set = mapKeys.get(multiKey);
+    public void put(Sha256Hash hash, Integer height, StoredUndoableBlock block) {
+        mapValues.put(hash, block);
+        Set<Sha256Hash> set = mapKeys.get(height);
         if (set == null) {
             set = new HashSet<>();
-            set.add(uniqueKey);
-            mapKeys.put(multiKey, set);
+            set.add(hash);
+            mapKeys.put(height, set);
         }else{
-            set.add(uniqueKey);
+            set.add(hash);
         }
     }
     
     @Nullable
-    public StoredUndoableBlock removeByUniqueKey(Sha256Hash key) {
-        return mapValues.remove(key);
+    public StoredUndoableBlock removeByUniqueKey(Sha256Hash hash) {
+        return mapValues.remove(hash);
     }
     
-    public void removeByMultiKey(Integer key) {
-        Set<Sha256Hash> set = mapKeys.remove(key);
+    public void removeByMultiKey(Integer height) {
+        Set<Sha256Hash> set = mapKeys.remove(height);
         if (set != null)
-            for (Sha256Hash uniqueKey : set)
-                removeByUniqueKey(uniqueKey);
+            for (Sha256Hash hash : set)
+                removeByUniqueKey(hash);
     }
 }
 

--- a/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
@@ -175,7 +175,7 @@ class TransactionalFullBlockMap {
         }
     }
     
-    public void removeByMultiKey(Integer height) {
+    public void removeByHeight(Integer height) {
         Set<Sha256Hash> set = mapKeys.remove(height);
         if (set != null)
             for (Sha256Hash hash : set)
@@ -291,7 +291,7 @@ public class MemoryFullPrunedBlockStore implements FullPrunedBlockStore {
             setChainHead(chainHead);
         // Potential leak here if not all blocks get setChainHead'd
         // Though the FullPrunedBlockStore allows for this, the current AbstractBlockChain will not do it.
-        fullBlockMap.removeByMultiKey(chainHead.getHeight() - fullStoreDepth);
+        fullBlockMap.removeByHeight(chainHead.getHeight() - fullStoreDepth);
     }
     
     @Override

--- a/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
@@ -163,7 +163,7 @@ class TransactionalFullBlockMap {
         return mapValues.get(key);
     }
     
-    public void put(Sha256Hash hash, Integer height, StoredUndoableBlock block) {
+    public void put(Sha256Hash hash, int height, StoredUndoableBlock block) {
         mapValues.put(hash, block);
         Set<Sha256Hash> set = mapKeys.get(height);
         if (set == null) {
@@ -175,7 +175,7 @@ class TransactionalFullBlockMap {
         }
     }
     
-    public void removeByHeight(Integer height) {
+    public void removeByHeight(int height) {
         Set<Sha256Hash> set = mapKeys.remove(height);
         if (set != null)
             for (Sha256Hash hash : set)


### PR DESCRIPTION
`TransactionalMultiKeyHashMap` is used a transaction `fullBlockMap` and has not been used for anything else for 13 years. Removing the type parameters and "de-genericizing" will make the code easier to read, enable further improvements, and hopefully performance optimizations that are specific to the "full block map" use case.

This is a sequence of 5 commits.

It is safe to consider this an internal class, so these changes are made without deprecation.