### PR TITLE
MemoryFullPrunedBlockStore: Network private member instead of NetworkParameters

### DIFF
--- a/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
@@ -206,7 +206,7 @@ public class MemoryFullPrunedBlockStore implements FullPrunedBlockStore {
     private TransactionalHashMap<TransactionOutPoint, UTXO> transactionOutputMap;
     private StoredBlock chainHead;
     private StoredBlock verifiedChainHead;
-    private int fullStoreDepth;
+    private final int fullStoreDepth;
     private final Network network;
     
     /**


### PR DESCRIPTION
3 commits.