### PR TITLE
PlatformUtils: add Runtime.GRAALVM

### DIFF
--- a/base/src/main/java/org/bitcoinj/base/internal/PlatformUtils.java
+++ b/base/src/main/java/org/bitcoinj/base/internal/PlatformUtils.java
@@ -27,7 +27,7 @@ import java.util.Locale;
 public class PlatformUtils {
     private static final Logger log = LoggerFactory.getLogger(PlatformUtils.class);
     public enum Runtime {
-        ANDROID, OPENJDK, ORACLE_JAVA
+        ANDROID, OPENJDK, ORACLE_JAVA, GRAALVM
     }
 
     public enum OS {
@@ -47,6 +47,8 @@ public class PlatformUtils {
             PlatformUtils.runtime = PlatformUtils.Runtime.OPENJDK;
         else if (runtimeProp.contains("java(tm) se"))
             PlatformUtils.runtime = PlatformUtils.Runtime.ORACLE_JAVA;
+        else if (runtimeProp.contains("graalvm"))
+            PlatformUtils.runtime = PlatformUtils.Runtime.GRAALVM;
         else
             log.info("Unknown java.runtime.name '{}'", runtimeProp);
 
@@ -73,6 +75,10 @@ public class PlatformUtils {
 
     public static boolean isOracleJavaRuntime() {
         return runtime == Runtime.ORACLE_JAVA;
+    }
+
+    public static boolean isGraalVMRuntime() {
+        return runtime == Runtime.GRAALVM;
     }
 
     public static boolean isLinux() {

--- a/base/src/test/java/org/bitcoinj/base/internal/PlatformUtilsTest.java
+++ b/base/src/test/java/org/bitcoinj/base/internal/PlatformUtilsTest.java
@@ -29,6 +29,7 @@ public class PlatformUtilsTest {
     public void runtime() {
         // This test assumes it is run within a Java runtime for desktop computers.
         assertTrue(PlatformUtils.isOpenJDKRuntime() || PlatformUtils.isOracleJavaRuntime());
+        assertFalse(PlatformUtils.isGraalVMRuntime());
         assertFalse(PlatformUtils.isAndroidRuntime());
     }
 }


### PR DESCRIPTION
Without this change the following message is displayed when running in a GraalVM native image:

```
Unknown java.runtime.name 'graalvm runtime environment'
```

We currently have no unit tests running in native images so I manually tested this by calling PlatformUtils.isGraalVMRuntime() from the wallet-tool both under both HotSpot and GraalVM and it worked correctly, returning `false` and `true`, respectively.