### PR TITLE
TransactionOutPoint: make connectedOutput private

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -58,7 +58,7 @@ public class TransactionOutPoint {
     private final Transaction fromTx;
 
     // The connected output.
-    final TransactionOutput connectedOutput;
+    private final TransactionOutput connectedOutput;
 
     /**
      * Deserialize this transaction outpoint from a given payload.


### PR DESCRIPTION
This is a child of PR #3815 and includes a cherry-pick of PR #3816. Once those two PRs are merged this can rebased and will only contain a 1-line change to make `connectedOutput` `private`.