### PR TITLE
PeerGroup: replace use of Guava Ordering with a Stream

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -19,7 +19,6 @@ package org.bitcoinj.core;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Ordering;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.Runnables;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -99,6 +98,8 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.bitcoinj.base.internal.Preconditions.checkArgument;
 import static org.bitcoinj.base.internal.Preconditions.checkState;
@@ -2294,31 +2295,30 @@ public class PeerGroup implements TransactionBroadcaster {
         return maxOfMostFreq(heights);
     }
 
-    private static class Pair implements Comparable<Pair> {
+    private static class Pair {
         final int item;
-        int count = 0;
-        public Pair(int item) { this.item = item; }
-        // note that in this implementation compareTo() is not consistent with equals()
-        @Override public int compareTo(Pair o) { return -Integer.compare(count, o.count); }
+        final long count;
+        public Pair(int item, long count ) { this.item = item; this.count = count;}
     }
 
     static int maxOfMostFreq(List<Integer> items) {
         if (items.isEmpty())
             return 0;
-        // This would be much easier in a functional language (or in Java 8).
-        items = Ordering.natural().reverse().sortedCopy(items);
-        LinkedList<Pair> pairs = new LinkedList<>();
-        pairs.add(new Pair(items.get(0)));
-        for (int item : items) {
-            Pair pair = pairs.getLast();
-            if (pair.item != item)
-                pairs.add((pair = new Pair(item)));
-            pair.count++;
-        }
-        // pairs now contains a uniquified list of the sorted inputs, with counts for how often that item appeared.
-        // Now sort by how frequently they occur, and pick the most frequent. If the first place is tied between two,
-        // don't pick any.
-        Collections.sort(pairs);
+
+        // Create a map of value to count
+        Map<Integer, Long> countMap = items.stream()
+                .collect(Collectors.groupingBy(
+                        Function.identity(),        // classifier is identity function (producing `Integer` key)
+                        Collectors.counting()       // downstream reduction is counting (as a `Long`)
+                ));
+
+        // `pairs` will contain a sorted, uniquified list of the sorted inputs (as keys), with counts (as values)
+        // for how often that item appeared. If the first place is tied between two entries, don't pick any.
+        List<Pair> pairs = countMap.entrySet().stream()
+                .map(e -> new Pair(e.getKey(), e.getValue()))
+                .sorted(Comparator.comparingLong(e -> -e.count))    // negation for descending order
+                .collect(Collectors.toList());
+
         final Pair firstPair = pairs.get(0);
         if (pairs.size() == 1)
             return firstPair.item;


### PR DESCRIPTION
Instead of reverse sorting with Guava `Ordering` and then counting with a for loop, use a `Stream` and `Collectors.counting()` to do the counting. Then convert from `Map.Entry` to `Pair` and sort by `count`.

The `Pair` class is kept, but simplified to a record-like class. Rather than have a comparator that wouldn't match equals, we'll use a lambda comparator in the `.sorted()` stream operation.