### PR TITLE
Script: Use ScriptBuilder in 2 createInputScript() methods

### DIFF
--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -503,26 +503,18 @@ public class Script {
     }
 
     public static byte[] createInputScript(byte[] signature, byte[] pubkey) {
-        try {
-            // TODO: Do this by creating a Script *first* then having the script reassemble itself into bytes.
-            ByteArrayOutputStream bits = new ByteArrayOutputStream(signature.length + pubkey.length + 2);
-            writeBytes(bits, signature);
-            writeBytes(bits, pubkey);
-            return bits.toByteArray();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        return new ScriptBuilder()
+                .data(signature)
+                .data(pubkey)
+                .build()
+                .program();
     }
 
     public static byte[] createInputScript(byte[] signature) {
-        try {
-            // TODO: Do this by creating a Script *first* then having the script reassemble itself into bytes.
-            ByteArrayOutputStream bits = new ByteArrayOutputStream(signature.length + 2);
-            writeBytes(bits, signature);
-            return bits.toByteArray();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        return new ScriptBuilder()
+                .data(signature)
+                .build()
+                .program();
     }
 
     /**


### PR DESCRIPTION
This implements a 15-year-old TODO from the "Initial checkin of BitCoinJ"