### PR TITLE
TransactionOutPoint: deprecate disconnectTransaction()

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -232,7 +232,9 @@ public class TransactionOutPoint {
     /**
      * Returns a copy of this outpoint, but with fromTx removed.
      * @return outpoint with removed fromTx
+     * @deprecated use {@link #disconnectOutput()}
      */
+    @Deprecated
     public TransactionOutPoint disconnectTransaction() {
         return new TransactionOutPoint(hash, index, null, connectedOutput);
     }


### PR DESCRIPTION
It is unused internally and is `disconnectOutput()` has more straightforward behavior (i.e. it completely disconnects the output)