### PR TITLE
WIP: TransactionOutPointReference and subtypes

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/BloomFilter.java
+++ b/core/src/main/java/org/bitcoinj/core/BloomFilter.java
@@ -265,7 +265,7 @@ public class BloomFilter implements Message {
     }
 
     /** Inserts the given transaction outpoint. */
-    public synchronized void insert(TransactionOutPoint outpoint) {
+    public synchronized void insert(TransactionOutPointReference outpoint) {
         insert(outpoint.serialize());
     }
 

--- a/core/src/main/java/org/bitcoinj/core/TestBlocks.java
+++ b/core/src/main/java/org/bitcoinj/core/TestBlocks.java
@@ -77,7 +77,7 @@ public class TestBlocks {
      * @return created block
      */
     static Block createNextBlock(Block prev, @Nullable Address to, long version,
-                                 @Nullable TransactionOutPoint prevOut, Instant time, byte[] pubKey,
+                                 @Nullable TransactionOutPointReference.TransactionOutPoint prevOut, Instant time, byte[] pubKey,
                                  Coin coinbaseValue, int height) {
         Block b = new Block(version, prev.getHash());
         b.setDifficultyTarget(prev.difficultyTarget());
@@ -90,7 +90,7 @@ public class TestBlocks {
             // The input does not really need to be a valid signature, as long as it has the right general form.
             TransactionInput input;
             if (prevOut == null) {
-                prevOut = new TransactionOutPoint(0, nextTestOutPointHash());
+                prevOut = TransactionOutPointReference.TransactionOutPoint.of(nextTestOutPointHash(), 0);
             }
             input = new TransactionInput(t, Script.createInputScript(EMPTY_BYTES, EMPTY_BYTES), prevOut);
             t.addInput(input);
@@ -124,7 +124,7 @@ public class TestBlocks {
      * @param prevOut previous output to spend by the "50 coins transaction"
      * @return created block
      */
-    public static Block createNextBlock(Block prev, @Nullable Address to, TransactionOutPoint prevOut) {
+    public static Block createNextBlock(Block prev, @Nullable Address to, TransactionOutPointReference.TransactionOutPoint prevOut) {
         return createNextBlock(prev, to, Block.BLOCK_VERSION_GENESIS, prevOut, prev.time().plusSeconds(5), pubkeyForTesting,
                 FIFTY_COINS, Block.BLOCK_HEIGHT_UNKNOWN);
     }
@@ -159,7 +159,7 @@ public class TestBlocks {
      */
     public static Block createNextBlockWithCoinbase(Block prev, long version, byte[] pubKey, Coin coinbaseValue,
                                                     int height) {
-        return createNextBlock(prev, null, version, (TransactionOutPoint) null, TimeUtils.currentTime(), pubKey,
+        return createNextBlock(prev, null, version,null, TimeUtils.currentTime(), pubKey,
                 coinbaseValue, height);
     }
 
@@ -173,7 +173,7 @@ public class TestBlocks {
      * @return created block
      */
     static Block createNextBlockWithCoinbase(Block prev, long version, byte[] pubKey, int height) {
-        return createNextBlock(prev, null, version, (TransactionOutPoint) null, TimeUtils.currentTime(), pubKey,
+        return createNextBlock(prev, null, version,null, TimeUtils.currentTime(), pubKey,
                 FIFTY_COINS, height);
     }
 

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPointReference.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPointReference.java
@@ -42,27 +42,59 @@ import static org.bitcoinj.base.internal.Preconditions.checkState;
  * 
  * <p>Instances of this class are not safe for use by multiple threads.</p>
  */
-public class TransactionOutPoint {
+public abstract class TransactionOutPointReference {
     public static final int BYTES = 36;
 
     /** Special outpoint that normally marks a coinbase input. It's also used as a test dummy. */
     public static final TransactionOutPoint UNCONNECTED =
-            TransactionOutPoint.of(Sha256Hash.ZERO_HASH, ByteUtils.MAX_UNSIGNED_INTEGER);
+            TransactionOutPointReference.of(Sha256Hash.ZERO_HASH, ByteUtils.MAX_UNSIGNED_INTEGER);
 
     /** Hash of the transaction to which we refer. */
-    private final Sha256Hash hash;
+    protected final Sha256Hash hash;
     /** Which output of that transaction we are talking about. */
-    private final long index;
+    protected final long index;
 
-    // `fromTx` and `connectedOutput` can both be `null`, but they both can't be non-`null`.
+    public static class TransactionOutPoint extends TransactionOutPointReference {
+        public TransactionOutPoint(Sha256Hash hash, long index) {
+            super(hash, index);
+        }
+    }
 
-    // This is not part of bitcoin serialization. It points to the connected transaction.
-    @Nullable
-    private final Transaction fromTx;
+    public interface HasConnectedOutput {
+        TransactionOutput connectedOutput();
+    }
 
-    // The connected output.
-    @Nullable
-    private final TransactionOutput connectedOutput;
+    public static class TransactionConnectedOutPoint extends TransactionOutPointReference implements HasConnectedOutput {
+        private final Transaction fromTx;
+
+        public TransactionConnectedOutPoint(Sha256Hash hash, long index, Transaction fromTx) {
+            super(hash, index);
+            this.fromTx = fromTx;
+        }
+
+        public Transaction fromTx() {
+            return fromTx;
+        }
+
+        @Override
+        public TransactionOutput connectedOutput() {
+            return fromTx.getOutput(index);
+        }
+    }
+
+    public static class OutputConnectedOutPoint extends TransactionOutPointReference implements HasConnectedOutput {
+        private final TransactionOutput connectedOutput;
+
+        public OutputConnectedOutPoint(Sha256Hash hash, long index, TransactionOutput connectedOutput) {
+            super(hash, index);
+            this.connectedOutput = connectedOutput;
+        }
+
+        @Override
+        public TransactionOutput connectedOutput() {
+            return connectedOutput;
+        }
+    }
 
     /**
      * Deserialize this transaction outpoint from a given payload.
@@ -74,28 +106,14 @@ public class TransactionOutPoint {
     public static TransactionOutPoint read(ByteBuffer payload) throws BufferUnderflowException, ProtocolException {
         Sha256Hash hash = Sha256Hash.read(payload);
         long index = ByteUtils.readUint32(payload);
-        return TransactionOutPoint.of(hash, index);
+        return TransactionOutPointReference.of(hash, index);
     }
 
-    /** @deprecated use {@link TransactionOutPoint#from(Transaction, long)} */
-    @Deprecated
-    public TransactionOutPoint(long index, Transaction fromTx) {
-        this(fromTx.getTxId(), index, fromTx, null);
-    }
-
-    @Deprecated
-    public TransactionOutPoint(long index, Sha256Hash hash) {
-        this(hash, index, null, null);
-    }
-
-    private TransactionOutPoint(Sha256Hash hash, long index) {
-        this(hash, index, null, null);
-    }
-
-    /** @deprecated use {@link TransactionOutPoint#from(TransactionOutput)} */
-    @Deprecated
-    public TransactionOutPoint(TransactionOutput connectedOutput) {
-        this(connectedOutput.getParentTransactionHash(), connectedOutput.getIndex(), null, connectedOutput);
+    private TransactionOutPointReference(Sha256Hash hash, long index) {
+        this.hash = Objects.requireNonNull(hash);
+        checkArgument(index >= 0 && index <= ByteUtils.MAX_UNSIGNED_INTEGER, () ->
+                "index out of range: " + index);
+        this.index = index;
     }
 
     /**
@@ -114,8 +132,8 @@ public class TransactionOutPoint {
      * @param index index of the transaction output the new outpoint will reference
      * @return a new transaction outpoint
      */
-    public static TransactionOutPoint from(Transaction fromTx, long index) {
-        return new TransactionOutPoint (fromTx.getTxId(), index, fromTx, null);
+    public static TransactionConnectedOutPoint from(Transaction fromTx, long index) {
+        return new TransactionConnectedOutPoint(fromTx.getTxId(), index, fromTx);
     }
 
     /**
@@ -123,24 +141,8 @@ public class TransactionOutPoint {
      * @param connectedOutput transaction output the new outpoint will reference (and be "connected to")
      * @return a new transaction outpoint
      */
-    public static TransactionOutPoint from(TransactionOutput connectedOutput) {
-        return new TransactionOutPoint(connectedOutput.getParentTransactionHash(), connectedOutput.getIndex(), null,
-                connectedOutput);
-    }
-
-    private TransactionOutPoint(Sha256Hash hash, long index, @Nullable Transaction fromTx,
-                                @Nullable TransactionOutput connectedOutput) {
-        this.hash = Objects.requireNonNull(hash);
-        checkArgument(index >= 0 && index <= ByteUtils.MAX_UNSIGNED_INTEGER, () ->
-                "index out of range: " + index);
-        this.index = index;
-        if (fromTx != null) {
-            TransactionOutput outputFromTx = fromTx.getOutput(index);
-            Objects.requireNonNull(outputFromTx);
-            checkArgument(connectedOutput == null, () -> "Both fromTx and connectedOutput are non-null");
-        }
-        this.fromTx = fromTx;
-        this.connectedOutput = connectedOutput;
+    public static OutputConnectedOutPoint from(TransactionOutput connectedOutput) {
+        return new OutputConnectedOutPoint(connectedOutput.getParentTransactionHash(), connectedOutput.getIndex(), connectedOutput);
     }
 
     /**
@@ -170,31 +172,46 @@ public class TransactionOutPoint {
      * sides in memory, and they have been linked together, this returns a pointer to the connected output, or {@code
      * null} if we don't have the output. In the latter case, {@link #hash()} and {@link #index()} could be used to
      * acquire the output elsewhere.
-     *
+     * @deprecated Use {@link OutputConnectedOutPoint#connectedOutput} (with typecheck if necessary)
      * @return output this outpoint points to, or {@code null} if we don't have the output
      */
+    @Deprecated
     @Nullable
     public TransactionOutput getConnectedOutput() {
-        return (fromTx != null) ? fromTx.getOutput(index) : connectedOutput;
+        if (this instanceof HasConnectedOutput) {
+            return ((HasConnectedOutput) this).connectedOutput();
+        } else {
+            return null;
+        }
     }
 
     /**
      * Return the connected {@link Transaction} if available.
      * @return connected transaction or {@code null} if not available
+     * @deprecated Use {@link TransactionConnectedOutPoint#fromTx} (with typecheck if necessary)
      */
+    @Deprecated
     @Nullable
     public Transaction getFromTx() {
-        return fromTx;
+        if (this instanceof TransactionConnectedOutPoint) {
+            return ((TransactionConnectedOutPoint) this).fromTx();
+        } else {
+            return null;
+        }
     }
 
     /**
      * Returns the pubkey script from the connected output.
-     * @throws java.lang.NullPointerException if there is no connected output.
+     * @throws java.lang.IllegalStateException if there is no connected output.
      */
     public byte[] getConnectedPubKeyScript() {
-        byte[] result = Objects.requireNonNull(getConnectedOutput()).getScriptBytes();
-        checkState(result.length > 0);
-        return result;
+        if (this instanceof HasConnectedOutput) {
+            byte[] result = ((HasConnectedOutput)this).connectedOutput().getScriptBytes();
+            checkState(result.length > 0);
+            return result;
+        } else {
+            throw new IllegalStateException();
+        }
     }
 
     /**
@@ -207,8 +224,10 @@ public class TransactionOutPoint {
      */
     @Nullable
     public ECKey getConnectedKey(KeyBag keyBag) throws ScriptException {
-        TransactionOutput connectedOutput = getConnectedOutput();
-        Objects.requireNonNull(connectedOutput, "Input is not connected so cannot retrieve key");
+        if (!(this instanceof HasConnectedOutput)) {
+            throw new NullPointerException("Input is not connected so cannot retrieve key");
+        }
+        TransactionOutput connectedOutput = ((HasConnectedOutput) this).connectedOutput();
         Script connectedScript = connectedOutput.getScriptPubKey();
         if (ScriptPattern.isP2PKH(connectedScript)) {
             byte[] addressBytes = ScriptPattern.extractHashFromP2PKH(connectedScript);
@@ -233,8 +252,10 @@ public class TransactionOutPoint {
      */
     @Nullable
     public RedeemData getConnectedRedeemData(KeyBag keyBag) throws ScriptException {
-        TransactionOutput connectedOutput = getConnectedOutput();
-        Objects.requireNonNull(connectedOutput, "Input is not connected so cannot retrieve key");
+        if (!(this instanceof HasConnectedOutput)) {
+            throw new NullPointerException("Input is not connected so cannot retrieve key");
+        }
+        TransactionOutput connectedOutput = ((HasConnectedOutput) this).connectedOutput();
         Script connectedScript = connectedOutput.getScriptPubKey();
         if (ScriptPattern.isP2PKH(connectedScript)) {
             byte[] addressBytes = ScriptPattern.extractHashFromP2PKH(connectedScript);
@@ -258,7 +279,7 @@ public class TransactionOutPoint {
      * @return outpoint with no connections
      */
     public TransactionOutPoint disconnectOutput() {
-        return new TransactionOutPoint(hash, index, null, null);
+        return new TransactionOutPoint(hash, index);
     }
 
     /**
@@ -266,8 +287,8 @@ public class TransactionOutPoint {
      * @param transaction transaction to set as fromTx
      * @return outpoint with fromTx set
      */
-    public TransactionOutPoint connectTransaction(Transaction transaction) {
-        return new TransactionOutPoint(hash, index, Objects.requireNonNull(transaction), null);
+    public TransactionConnectedOutPoint connectTransaction(Transaction transaction) {
+        return new TransactionConnectedOutPoint(hash, index, Objects.requireNonNull(transaction));
     }
 
     /**
@@ -302,8 +323,8 @@ public class TransactionOutPoint {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        TransactionOutPoint other = (TransactionOutPoint) o;
+        if (!(o instanceof TransactionOutPointReference)) return false;
+        TransactionOutPointReference other = (TransactionOutPointReference) o;
         return index == other.index && hash.equals(other.hash);
     }
 

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -22,7 +22,6 @@ import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.Sha256Hash;
-import org.bitcoinj.base.VarInt;
 import org.bitcoinj.base.internal.Buffers;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.crypto.ECKey;
@@ -417,11 +416,12 @@ public class TransactionOutput {
     }
 
     /**
-     * Returns a new {@link TransactionOutPoint}, which is essentially a structure pointing to this output.
+     * Returns a new {@link TransactionOutPointReference}, which is essentially a structure pointing to this output.
      * Requires that this output is not detached.
      */
-    public TransactionOutPoint getOutPointFor() {
-        return TransactionOutPoint.from(getParentTransaction(), getIndex());
+    public TransactionOutPointReference.TransactionConnectedOutPoint getOutPointFor() {
+        checkState(parent != null);
+        return TransactionOutPointReference.from(getParentTransaction(), getIndex());
     }
 
     /** Returns a copy of the output detached from its containing transaction, if need be. */

--- a/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
@@ -25,7 +25,7 @@ import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.core.StoredBlock;
 import org.bitcoinj.core.StoredUndoableBlock;
 import org.bitcoinj.core.Transaction;
-import org.bitcoinj.core.TransactionOutPoint;
+import org.bitcoinj.core.TransactionOutPointReference;
 import org.bitcoinj.core.UTXO;
 import org.bitcoinj.core.UTXOProviderException;
 import org.bitcoinj.core.VerificationException;
@@ -196,7 +196,7 @@ public class MemoryFullPrunedBlockStore implements FullPrunedBlockStore {
     private TransactionalHashMap<Sha256Hash, StoredBlockAndWasUndoableFlag> blockMap;
     private TransactionalFullBlockMap fullBlockMap;
     //TODO: Use something more suited to remove-heavy use?
-    private TransactionalHashMap<TransactionOutPoint, UTXO> transactionOutputMap;
+    private TransactionalHashMap<TransactionOutPointReference.TransactionOutPoint, UTXO> transactionOutputMap;
     private StoredBlock chainHead;
     private StoredBlock verifiedChainHead;
     private final int fullStoreDepth;
@@ -305,19 +305,19 @@ public class MemoryFullPrunedBlockStore implements FullPrunedBlockStore {
     @Nullable
     public synchronized UTXO getTransactionOutput(Sha256Hash hash, long index) throws BlockStoreException {
         Objects.requireNonNull(transactionOutputMap, "MemoryFullPrunedBlockStore is closed");
-        return transactionOutputMap.get(new TransactionOutPoint(index, hash));
+        return transactionOutputMap.get(TransactionOutPointReference.TransactionOutPoint.of(hash, index));
     }
 
     @Override
     public synchronized void addUnspentTransactionOutput(UTXO out) throws BlockStoreException {
         Objects.requireNonNull(transactionOutputMap, "MemoryFullPrunedBlockStore is closed");
-        transactionOutputMap.put(new TransactionOutPoint(out.getIndex(), out.getHash()), out);
+        transactionOutputMap.put(TransactionOutPointReference.TransactionOutPoint.of(out.getHash(), out.getIndex()), out);
     }
 
     @Override
     public synchronized void removeUnspentTransactionOutput(UTXO out) throws BlockStoreException {
         Objects.requireNonNull(transactionOutputMap, "MemoryFullPrunedBlockStore is closed");
-        if (transactionOutputMap.remove(new TransactionOutPoint(out.getIndex(), out.getHash())) == null)
+        if (transactionOutputMap.remove(TransactionOutPointReference.TransactionOutPoint.of(out.getHash(), out.getIndex())) == null)
             throw new BlockStoreException("Tried to remove a UTXO from MemoryFullPrunedBlockStore that it didn't have!");
     }
 

--- a/core/src/main/java/org/bitcoinj/testing/FakeTxBuilder.java
+++ b/core/src/main/java/org/bitcoinj/testing/FakeTxBuilder.java
@@ -33,7 +33,6 @@ import org.bitcoinj.core.StoredBlock;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionConfidence;
 import org.bitcoinj.core.TransactionInput;
-import org.bitcoinj.core.TransactionOutPoint;
 import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.crypto.TransactionSignature;

--- a/core/src/main/java/org/bitcoinj/wallet/FilteringCoinSelector.java
+++ b/core/src/main/java/org/bitcoinj/wallet/FilteringCoinSelector.java
@@ -18,7 +18,7 @@ package org.bitcoinj.wallet;
 
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.internal.StreamUtils;
-import org.bitcoinj.core.TransactionOutPoint;
+import org.bitcoinj.core.TransactionOutPointReference;
 import org.bitcoinj.core.TransactionOutput;
 
 import java.util.Collections;
@@ -31,9 +31,9 @@ import java.util.Set;
  */
 public class FilteringCoinSelector implements CoinSelector {
     protected final CoinSelector delegate;
-    protected final Set<TransactionOutPoint> spent;
+    protected final Set<TransactionOutPointReference> spent;
 
-    public FilteringCoinSelector(CoinSelector delegate, List<TransactionOutPoint> excludedOutPoints) {
+    public FilteringCoinSelector(CoinSelector delegate, List<TransactionOutPointReference> excludedOutPoints) {
         this.delegate = delegate;
         this.spent = Collections.unmodifiableSet(new HashSet<>(excludedOutPoints));
     }

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -32,7 +32,7 @@ import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionConfidence;
 import org.bitcoinj.core.TransactionConfidence.ConfidenceType;
 import org.bitcoinj.core.TransactionInput;
-import org.bitcoinj.core.TransactionOutPoint;
+import org.bitcoinj.core.TransactionOutPointReference;
 import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.core.TransactionWitness;
 import org.bitcoinj.crypto.KeyCrypter;
@@ -53,7 +53,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.Instant;
@@ -644,7 +643,7 @@ public class WalletProtobufSerializer {
 
         for (Protos.TransactionInput inputProto : txProto.getTransactionInputList()) {
             byte[] scriptBytes = inputProto.getScriptBytes().toByteArray();
-            TransactionOutPoint outpoint = TransactionOutPoint.of(
+            TransactionOutPointReference.TransactionOutPoint outpoint = TransactionOutPointReference.of(
                     byteStringToHash(inputProto.getTransactionOutPointHash()),
                     inputProto.getTransactionOutPointIndex() & 0xFFFFFFFFL
             );

--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -198,7 +198,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         TestBlocks.solve(rollingBlock);
         chain.add(rollingBlock);
         TransactionOutput spendableOutput = rollingBlock.transaction(0).getOutput(0);
-        TransactionOutPoint transactionOutPoint = spendableOutput.getOutPointFor();
+        TransactionOutPointReference transactionOutPoint = spendableOutput.getOutPointFor();
         Script spendableOutputScriptPubKey = spendableOutput.getScriptPubKey();
         for (int i = 1; i < PARAMS.getSpendableCoinbaseDepth(); i++) {
             rollingBlock = TestBlocks.createNextBlockWithCoinbase(rollingBlock, Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
@@ -275,7 +275,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         chain.add(rollingBlock);
         Transaction transaction = rollingBlock.transaction(0);
         TransactionOutput spendableOutput = transaction.getOutput(0);
-        TransactionOutPoint spendableOutputPoint = spendableOutput.getOutPointFor();
+        TransactionOutPointReference spendableOutputPoint = spendableOutput.getOutPointFor();
         Script spendableOutputScriptPubKey = spendableOutput.getScriptPubKey();
         for (int i = 1; i < PARAMS.getSpendableCoinbaseDepth(); i++) {
             rollingBlock = TestBlocks.createNextBlockWithCoinbase(rollingBlock, Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);
@@ -329,7 +329,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         chain.add(rollingBlock);
         Transaction transaction = rollingBlock.transaction(0);
         TransactionOutput spendableOutput = transaction.getOutput(0);
-        TransactionOutPoint spendableOutPoint = TransactionOutPoint.of(transaction.getTxId(), 0);
+        TransactionOutPointReference spendableOutPoint = TransactionOutPointReference.of(transaction.getTxId(), 0);
         Script spendableOutputScriptPubKey = spendableOutput.getScriptPubKey();
         for (int i = 1; i < PARAMS.getSpendableCoinbaseDepth(); i++) {
             rollingBlock = TestBlocks.createNextBlockWithCoinbase(rollingBlock, Block.BLOCK_VERSION_GENESIS, outKey.getPubKey(), height++);

--- a/core/src/test/java/org/bitcoinj/core/TransactionOutPointTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionOutPointTest.java
@@ -35,22 +35,22 @@ import static org.junit.Assert.assertFalse;
 public class TransactionOutPointTest {
     @Test
     @Parameters(method = "randomOutPoints")
-    public void readAndWrite(TransactionOutPoint outpoint) {
-        ByteBuffer buf = ByteBuffer.allocate(TransactionOutPoint.BYTES);
+    public void readAndWrite(TransactionOutPointReference outpoint) {
+        ByteBuffer buf = ByteBuffer.allocate(TransactionOutPointReference.BYTES);
         outpoint.write(buf);
         assertFalse(buf.hasRemaining());
         ((Buffer) buf).rewind();
-        TransactionOutPoint outpointCopy = TransactionOutPoint.read(buf);
+        TransactionOutPointReference.TransactionOutPoint outpointCopy = TransactionOutPointReference.read(buf);
         assertFalse(buf.hasRemaining());
         assertEquals(outpoint, outpointCopy);
     }
 
-    private Iterator<TransactionOutPoint> randomOutPoints() {
+    private Iterator<TransactionOutPointReference.TransactionOutPoint> randomOutPoints() {
         Random random = new Random();
         return Stream.generate(() -> {
             byte[] randomBytes = new byte[Sha256Hash.LENGTH];
             random.nextBytes(randomBytes);
-            return TransactionOutPoint.of(Sha256Hash.wrap(randomBytes), Integer.toUnsignedLong(random.nextInt()));
+            return TransactionOutPointReference.of(Sha256Hash.wrap(randomBytes), Integer.toUnsignedLong(random.nextInt()));
         }).limit(10).iterator();
     }
 }

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -39,7 +39,6 @@ import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.math.BigInteger;
 import java.nio.Buffer;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
@@ -47,7 +46,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
 import java.util.Iterator;
-import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
@@ -176,7 +174,7 @@ public class TransactionTest {
 
         // add fake transaction input
         TransactionInput input = new TransactionInput(null, ScriptBuilder.createEmpty().program(),
-                TransactionOutPoint.of(Sha256Hash.ZERO_HASH, 0));
+                TransactionOutPointReference.of(Sha256Hash.ZERO_HASH, 0));
         tx.addInput(input);
         length += input.messageSize();
 
@@ -214,7 +212,7 @@ public class TransactionTest {
         ECKey fromKey = ECKey.random();
         Address fromAddress = fromKey.toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
         Transaction tx = new Transaction();
-        TransactionOutPoint outPoint = TransactionOutPoint.of(utxo_id, 0);
+        TransactionOutPointReference outPoint = TransactionOutPointReference.of(utxo_id, 0);
         TransactionOutput output = new TransactionOutput(null, inAmount, fromAddress);
         tx.addOutput(outAmount, toAddr);
         TransactionInput input = tx.addSignedInput(outPoint, ScriptBuilder.createOutputScript(fromAddress), inAmount, fromKey);
@@ -237,7 +235,7 @@ public class TransactionTest {
         ECKey fromKey = ECKey.random();
         Address fromAddress = fromKey.toAddress(ScriptType.P2WPKH, BitcoinNetwork.TESTNET);
         Transaction tx = new Transaction();
-        TransactionOutPoint outPoint = TransactionOutPoint.of(utxo_id, 0);
+        TransactionOutPointReference outPoint = TransactionOutPointReference.of(utxo_id, 0);
         tx.addOutput(outAmount, toAddr);
         TransactionInput input = tx.addSignedInput(outPoint, ScriptBuilder.createOutputScript(fromAddress), inAmount, fromKey);
 
@@ -509,7 +507,7 @@ public class TransactionTest {
     @Test
     public void testToStringWhenIteratingOverAnInputCatchesAnException() {
         Transaction tx = FakeTxBuilder.createFakeTx(TESTNET.network());
-        TransactionInput ti = new TransactionInput(tx, new byte[0], TransactionOutPoint.UNCONNECTED) {
+        TransactionInput ti = new TransactionInput(tx, new byte[0], TransactionOutPointReference.UNCONNECTED) {
             @Override
             public Script getScriptSig() throws ScriptException {
                 throw new ScriptException(ScriptError.SCRIPT_ERR_UNKNOWN_ERROR, "");
@@ -624,7 +622,7 @@ public class TransactionTest {
         Context.propagate(new Context(100, Transaction.DEFAULT_TX_FEE, false, true));
         Block genesis = TESTNET.getGenesisBlock();
         Block block1 = TestBlocks.createNextBlock(genesis, ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET),
-                    genesis.transaction(0).getOutput(0).getOutPointFor());
+                    genesis.transaction(0).getOutput(0).getOutPointFor().disconnectOutput());
 
         final Transaction tx = block1.transaction(1);
         final Sha256Hash txHash = tx.getTxId();
@@ -708,7 +706,7 @@ public class TransactionTest {
         VarInt zero = VarInt.of(0);
         VarInt one = VarInt.of(1);
         VarInt huge = VarInt.of(Integer.MAX_VALUE);
-        TransactionInput in = new TransactionInput(null, new byte[0], TransactionOutPoint.UNCONNECTED);
+        TransactionInput in = new TransactionInput(null, new byte[0], TransactionOutPointReference.UNCONNECTED);
         // construct segwit transaction with one input and its witness with HUGE push count
         ByteBuffer buf = ByteBuffer.allocate(4 + 2 +
                 one.getSizeInBytes() + in.messageSize() + zero.getSizeInBytes() + huge.getSizeInBytes() + 4);

--- a/core/src/test/java/org/bitcoinj/script/ScriptTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptTest.java
@@ -37,7 +37,7 @@ import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.Transaction.SigHash;
 import org.bitcoinj.core.TransactionInput;
-import org.bitcoinj.core.TransactionOutPoint;
+import org.bitcoinj.core.TransactionOutPointReference;
 import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.crypto.TransactionSignature;
@@ -248,7 +248,7 @@ public class ScriptTest {
     public void testOp0() {
         // Check that OP_0 doesn't NPE and pushes an empty stack frame.
         Transaction tx = new Transaction();
-        tx.addInput(new TransactionInput(tx, new byte[0], TransactionOutPoint.UNCONNECTED));
+        tx.addInput(new TransactionInput(tx, new byte[0], TransactionOutPointReference.UNCONNECTED));
         Script script = new ScriptBuilder().smallNum(0).build();
 
         LinkedList<byte[]> stack = new LinkedList<>();
@@ -334,8 +334,8 @@ public class ScriptTest {
         }
     }
 
-    private Map<TransactionOutPoint, Script> parseScriptPubKeys(JsonNode inputs) throws IOException {
-        Map<TransactionOutPoint, Script> scriptPubKeys = new HashMap<>();
+    private Map<TransactionOutPointReference, Script> parseScriptPubKeys(JsonNode inputs) throws IOException {
+        Map<TransactionOutPointReference, Script> scriptPubKeys = new HashMap<>();
         for (JsonNode input : inputs) {
             String hash = input.get(0).asText();
             long index = input.get(1).asLong();
@@ -343,7 +343,7 @@ public class ScriptTest {
                 index = ByteUtils.MAX_UNSIGNED_INTEGER;
             String script = input.get(2).asText();
             Sha256Hash sha256Hash = Sha256Hash.wrap(ByteUtils.parseHex(hash));
-            scriptPubKeys.put(TransactionOutPoint.of(sha256Hash, index), parseScriptString(script));
+            scriptPubKeys.put(TransactionOutPointReference.of(sha256Hash, index), parseScriptString(script));
         }
         return scriptPubKeys;
     }
@@ -354,7 +354,7 @@ public class ScriptTest {
         tx.setLockTime(0);
 
         TransactionInput txInput = new TransactionInput(null,
-                new ScriptBuilder().number(0).number(0).build().program(), TransactionOutPoint.UNCONNECTED);
+                new ScriptBuilder().number(0).number(0).build().program(), TransactionOutPointReference.UNCONNECTED);
         txInput = txInput.withSequence(TransactionInput.NO_SEQUENCE);
         tx.addInput(txInput);
 
@@ -370,7 +370,7 @@ public class ScriptTest {
         tx.setLockTime(0);
 
         TransactionInput txInput = new TransactionInput(creditingTransaction, scriptSig.program(),
-                TransactionOutPoint.UNCONNECTED);
+                TransactionOutPointReference.UNCONNECTED);
         txInput = txInput.withSequence(TransactionInput.NO_SEQUENCE);
         tx.addInput(txInput);
 
@@ -390,7 +390,7 @@ public class ScriptTest {
                 continue; // This is a comment.
             Transaction transaction = null;
             try {
-                Map<TransactionOutPoint, Script> scriptPubKeys = parseScriptPubKeys(test.get(0));
+                Map<TransactionOutPointReference, Script> scriptPubKeys = parseScriptPubKeys(test.get(0));
                 transaction = TESTNET.getDefaultSerializer().makeTransaction(ByteBuffer.wrap(ByteUtils.parseHex(test.get(1).asText().toLowerCase())));
                 Transaction.verify(TESTNET.network(), transaction);
                 Set<VerifyFlag> verifyFlags = parseVerifyFlags(test.get(2).asText());
@@ -417,7 +417,7 @@ public class ScriptTest {
         for (JsonNode test : json) {
             if (test.isArray() && test.size() == 1 && test.get(0).isTextual())
                 continue; // This is a comment.
-            Map<TransactionOutPoint, Script> scriptPubKeys = parseScriptPubKeys(test.get(0));
+            Map<TransactionOutPointReference, Script> scriptPubKeys = parseScriptPubKeys(test.get(0));
             byte[] txBytes = ByteUtils.parseHex(test.get(1).asText().toLowerCase());
             MessageSerializer serializer = TESTNET.getDefaultSerializer();
             Transaction transaction;
@@ -440,7 +440,7 @@ public class ScriptTest {
 
             // Bitcoin Core checks this case in CheckTransaction, but we leave it to
             // later where we will see an attempt to double-spend, so we explicitly check here
-            HashSet<TransactionOutPoint> set = new HashSet<>();
+            HashSet<TransactionOutPointReference> set = new HashSet<>();
             for (TransactionInput input : transaction.getInputs()) {
                 if (set.contains(input.getOutpoint()))
                     valid = false;

--- a/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
@@ -22,7 +22,7 @@ import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.core.Context;
-import org.bitcoinj.core.TransactionOutPoint;
+import org.bitcoinj.core.TransactionOutPointReference;
 import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Transaction;
@@ -167,7 +167,7 @@ public class DefaultRiskAnalysisTest {
         // Test non-standard script as an input.
         Transaction tx = new Transaction();
         assertEquals(DefaultRiskAnalysis.RuleViolation.NONE, DefaultRiskAnalysis.isStandard(tx));
-        tx.addInput(new TransactionInput(null, nonStandardScript, TransactionOutPoint.UNCONNECTED));
+        tx.addInput(new TransactionInput(null, nonStandardScript, TransactionOutPointReference.UNCONNECTED));
         assertEquals(DefaultRiskAnalysis.RuleViolation.SHORTEST_POSSIBLE_PUSHDATA, DefaultRiskAnalysis.isStandard(tx));
         // Test non-standard script as an output.
         tx.clearInputs();
@@ -181,14 +181,14 @@ public class DefaultRiskAnalysisTest {
         TransactionSignature sig = TransactionSignature.dummy();
         Script scriptOk = ScriptBuilder.createInputScript(sig);
         assertEquals(RuleViolation.NONE,
-                DefaultRiskAnalysis.isInputStandard(new TransactionInput(null, scriptOk.program(), TransactionOutPoint.UNCONNECTED)));
+                DefaultRiskAnalysis.isInputStandard(new TransactionInput(null, scriptOk.program(), TransactionOutPointReference.UNCONNECTED)));
 
         byte[] sigBytes = sig.encodeToBitcoin();
         // Appending a zero byte makes the signature uncanonical without violating DER encoding.
         Script scriptUncanonicalEncoding = new ScriptBuilder().data(Arrays.copyOf(sigBytes, sigBytes.length + 1))
                 .build();
         assertEquals(RuleViolation.SIGNATURE_CANONICAL_ENCODING, DefaultRiskAnalysis.isInputStandard(
-                new TransactionInput(null, scriptUncanonicalEncoding.program(), TransactionOutPoint.UNCONNECTED)));
+                new TransactionInput(null, scriptUncanonicalEncoding.program(), TransactionOutPointReference.UNCONNECTED)));
     }
 
     @Test
@@ -198,7 +198,7 @@ public class DefaultRiskAnalysisTest {
         Script scriptHighS = ScriptBuilder
                 .createInputScript(new TransactionSignature(sig.r, ECKey.ecDomainParameters().getN().subtract(sig.s)));
         assertEquals(RuleViolation.SIGNATURE_CANONICAL_ENCODING, DefaultRiskAnalysis.isInputStandard(
-                new TransactionInput(null, scriptHighS.program(), TransactionOutPoint.UNCONNECTED)));
+                new TransactionInput(null, scriptHighS.program(), TransactionOutPointReference.UNCONNECTED)));
 
         // This is a real transaction. Its signatures S component is "low".
         Transaction tx1 = Transaction.read(ByteBuffer.wrap(ByteUtils.parseHex(

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -20,7 +20,6 @@ package org.bitcoinj.wallet;
 import com.google.common.collect.Lists;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
-import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.core.TestBlocks;
@@ -41,17 +40,15 @@ import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionConfidence;
 import org.bitcoinj.core.TransactionConfidence.ConfidenceType;
 import org.bitcoinj.core.TransactionInput;
-import org.bitcoinj.core.TransactionOutPoint;
+import org.bitcoinj.core.TransactionOutPointReference;
 import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.core.TransactionWitness;
 import org.bitcoinj.core.VerificationException;
-import org.bitcoinj.crypto.ChildNumber;
 import org.bitcoinj.crypto.DeterministicKey;
 import org.bitcoinj.crypto.HDPath;
 import org.bitcoinj.crypto.KeyCrypter;
 import org.bitcoinj.crypto.KeyCrypterException;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
-import org.bitcoinj.crypto.MnemonicCode;
 import org.bitcoinj.crypto.MnemonicException;
 import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.crypto.internal.CryptoUtils;
@@ -59,11 +56,7 @@ import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptChunk;
 import org.bitcoinj.script.ScriptPattern;
-import org.bitcoinj.signers.TransactionSigner;
-import org.bitcoinj.store.BlockStoreException;
-import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.testing.FakeTxBuilder;
-import org.bitcoinj.testing.KeyChainTransactionSigner;
 import org.bitcoinj.testing.MockTransactionBroadcaster;
 import org.bitcoinj.testing.NopTransactionSigner;
 import org.bitcoinj.testing.TestWithWallet;
@@ -92,7 +85,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -714,7 +706,7 @@ public class WalletTest extends TestWithWallet {
         EasyMock.expect(to.isAvailableForSpending()).andReturn(true);
         EasyMock.expect(to.isMineOrWatched(wallet)).andReturn(true);
         EasyMock.expect(to.getSpentBy()).andReturn(
-                new TransactionInput(null, new byte[0], TransactionOutPoint.UNCONNECTED));
+                new TransactionInput(null, new byte[0], TransactionOutPointReference.UNCONNECTED));
 
         Transaction tx = FakeTxBuilder.createFakeTxWithoutChange(to);
 
@@ -1638,7 +1630,7 @@ public class WalletTest extends TestWithWallet {
     public void watchingScriptsBloomFilter() {
         Address watchedAddress = ECKey.random().toAddress(ScriptType.P2PKH, TESTNET);
         Transaction t1 = createFakeTx(TESTNET, CENT, watchedAddress);
-        TransactionOutPoint outPoint = TransactionOutPoint.from(t1, 0);
+        TransactionOutPointReference outPoint = TransactionOutPointReference.from(t1, 0);
         wallet.addWatchedAddress(watchedAddress);
 
         // Note that this has a 1e-12 chance of failing this unit test due to a false positive
@@ -1692,7 +1684,7 @@ public class WalletTest extends TestWithWallet {
 
         for (Address addr : addressesForRemoval) {
             Transaction t1 = createFakeTx(TESTNET, CENT, addr);
-            TransactionOutPoint outPoint = TransactionOutPoint.from(t1, 0);
+            TransactionOutPointReference outPoint = TransactionOutPointReference.from(t1, 0);
 
             // Note that this has a 1e-12 chance of failing this unit test due to a false positive
             assertFalse(wallet.getBloomFilter(1e-12).contains(outPoint.serialize()));
@@ -2722,7 +2714,7 @@ public class WalletTest extends TestWithWallet {
 
         // However, if there is no connected output, we connect it
         SendRequest request3 = SendRequest.to(OTHER_ADDRESS, CENT);
-        request3.tx.addInput(new TransactionInput(request3.tx, new byte[] {}, TransactionOutPoint.of(tx3.getTxId(), 0)));
+        request3.tx.addInput(new TransactionInput(request3.tx, new byte[] {}, TransactionOutPointReference.of(tx3.getTxId(), 0)));
         // Now completeTx will find the matching UTXO from the wallet and add its value to the unconnected input
         request3.shuffleOutputs = false;
         wallet.completeTx(request3);
@@ -2753,7 +2745,7 @@ public class WalletTest extends TestWithWallet {
 
         // SendRequest using that output as an unconnected input
         SendRequest request = SendRequest.to(OTHER_ADDRESS, COIN);
-        request.tx.addInput(new TransactionInput(request.tx, new byte[] {}, TransactionOutPoint.of(tx.getTxId(), 0)));
+        request.tx.addInput(new TransactionInput(request.tx, new byte[] {}, TransactionOutPointReference.of(tx.getTxId(), 0)));
 
         // Complete the transaction
         wallet.completeTx(request);

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -624,7 +624,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         Transaction tx = FakeTxBuilder.createFakeTx(COIN, key);
         Transaction tx2 = new Transaction();
         tx2.addInput(tx.getOutput(0));
-        TransactionOutPoint outpoint = tx2.getInput(0).getOutpoint();
+        TransactionOutPointReference outpoint = tx2.getInput(0).getOutpoint();
         assertTrue(p1.lastReceivedFilter.contains(key.getPubKey()));
         assertTrue(p1.lastReceivedFilter.contains(key.getPubKeyHash()));
         assertFalse(p1.lastReceivedFilter.contains(tx.getTxId().getBytes()));

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -25,7 +25,6 @@ import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.core.listeners.BlocksDownloadedEventListener;
 import org.bitcoinj.core.listeners.PreMessageReceivedEventListener;
 import org.bitcoinj.crypto.ECKey;
-import org.bitcoinj.testing.FakeTxBuilder;
 import org.bitcoinj.testing.InboundMessageQueuer;
 import org.bitcoinj.testing.TestWithNetworkConnections;
 import org.bitcoinj.utils.Threading;
@@ -553,9 +552,9 @@ public class PeerTest extends TestWithNetworkConnections {
         t1.addInput(t2.getOutput(0));
         t1.addInput(t3.getOutput(0));
         Sha256Hash t7hash = Sha256Hash.wrap("2b801dd82f01d17bbde881687bf72bc62e2faa8ab8133d36fcb8c3abe7459da6");
-        t1.addInput(new TransactionInput(t1, new byte[]{}, TransactionOutPoint.of(t7hash, 0)));
+        t1.addInput(new TransactionInput(t1, new byte[]{}, TransactionOutPointReference.of(t7hash, 0)));
         Sha256Hash t8hash = Sha256Hash.wrap("3b801dd82f01d17bbde881687bf72bc62e2faa8ab8133d36fcb8c3abe7459da6");
-        t1.addInput(new TransactionInput(t1, new byte[]{}, TransactionOutPoint.of(t8hash, 1)));
+        t1.addInput(new TransactionInput(t1, new byte[]{}, TransactionOutPointReference.of(t8hash, 1)));
         t1.addOutput(COIN, to);
         t1 = roundTripTransaction(t1);
         t2 = roundTripTransaction(t2);
@@ -626,7 +625,7 @@ public class PeerTest extends TestWithNetworkConnections {
         // The ones in brackets are assumed to be in the chain and are represented only by hashes.
         Sha256Hash t4hash = Sha256Hash.wrap("2b801dd82f01d17bbde881687bf72bc62e2faa8ab8133d36fcb8c3abe7459da6");
         Transaction t3 = new Transaction();
-        t3.addInput(new TransactionInput(t3, new byte[]{}, TransactionOutPoint.of(t4hash, 0)));
+        t3.addInput(new TransactionInput(t3, new byte[]{}, TransactionOutPointReference.of(t4hash, 0)));
         t3.addOutput(COIN, ECKey.random());
         t3 = roundTripTransaction(t3);
         Transaction t2 = new Transaction();
@@ -728,7 +727,7 @@ public class PeerTest extends TestWithNetworkConnections {
         t2.setLockTime(999999);
         // Add a fake input to t3 that goes nowhere.
         Sha256Hash t3 = Sha256Hash.of("abc".getBytes(StandardCharsets.UTF_8));
-        t2.addInput(new TransactionInput(t2, new byte[] {}, TransactionOutPoint.of(t3, 0), 0xDEADBEEFL));
+        t2.addInput(new TransactionInput(t2, new byte[] {}, TransactionOutPointReference.of(t3, 0), 0xDEADBEEFL));
         t2.addOutput(COIN, ECKey.random());
         Transaction t1 = new Transaction();
         t1.addInput(t2.getOutput(0));
@@ -798,7 +797,7 @@ public class PeerTest extends TestWithNetworkConnections {
         });
         connect();
         Transaction t1 = new Transaction();
-        t1.addInput(new TransactionInput(t1, new byte[0], TransactionOutPoint.UNCONNECTED));
+        t1.addInput(new TransactionInput(t1, new byte[0], TransactionOutPointReference.UNCONNECTED));
         t1.addOutput(COIN, ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET));
         Transaction t2 = new Transaction();
         t2.addInput(t1.getOutput(0));


### PR DESCRIPTION
Rename TransactionOutPoint to TransactionOutPointReference and 
make abstract.  Three subclasses:

* TransactionOutPoint: Contains only hash and index
* TransactionConnectedOutPoint: Has a connected fromTx
* OutputConnectedOutPoint: Has a connectedOutput

Some of the TransactionInput constructors now take the TransactionOutPoint
subtype and could be change to return a "disconnected" TransactionInput.

This approach has the following advantages:

1. Stronger typing helps make invalid states impossible to represent
2. TransactionOutPoint subtype uses less memory and is returned
   when calling read(ByteBuffer payload)
3. Eliminates external use of `null` values
4. Allows using types and pattern matching for conditional logic. 
   (This will be bigger advantage when using newer JDKs, but also
   moves the code towards a more modern "data-oriented programming"
   style, even where the JDK 8 syntax is slightly more verbose)
5. Will help us created simplified "disconnected" TransactionInput
   type and will be useful for creating immutable blocks and 
   transactions.

Disadvantages:

1. In some cases the "instanceOf" code seems more verbose than
   using null-checking.
2. The current names for the subclasses are little bit long/unwieldy,
   but this can be changed.

TODO:

1. Consider different names for the types
2. Consider not nesting one or more of the subtypes
3. Consider making the base type an interface not abstract class
4. Use the stronger types to implement disconnect TransactionInput
   and our other "immutable" block and transactions types
5. Replace the nullable getConnectedKey() and getConnectedRedeemData() methods
