### PR TITLE
core: upgrade to Guava 33.4.8

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,7 +11,8 @@ version = '0.18-SNAPSHOT'
 dependencies {
     api project(':bitcoinj-base')
     api 'org.bouncycastle:bcprov-jdk15to18:1.80'
-    api 'com.google.guava:guava:33.4.0-android'
+    api 'com.google.guava:guava:33.4.4-android'
+    api 'com.google.code.findbugs:jsr305:3.0.2'
     api 'com.google.protobuf:protobuf-javalite:4.30.2'
     implementation 'org.slf4j:slf4j-api:2.0.16'
 


### PR DESCRIPTION
The first commit upgrades to 33.4.4:

Guava 33.4.4 uses JSpecify and removes a transitive dependency on com.google.code.findbugs:jsr305:3.0.2 which bitcoinj currently uses for null annotations.

We plan to switch bitcoinj to JSpecify, see Issue #3106, but this commit simply adds `com.google.code.findbugs:jsr305:3.0.2` as a direct dependency, so that bitcoinj can upgrade to JSpecify in a separate PR.