### PR TITLE
Convert to JSpecify

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -9,7 +9,7 @@ version = '0.18-SNAPSHOT'
 
 dependencies {
     implementation 'org.slf4j:slf4j-api:2.0.16'
-    implementation 'com.google.code.findbugs:jsr305:3.0.2'
+    implementation 'org.jspecify:jspecify:1.0.0'
 
     testImplementation project(':bitcoinj-test-support')
     testImplementation 'junit:junit:4.13.2'

--- a/base/src/main/java/org/bitcoinj/base/LegacyAddress.java
+++ b/base/src/main/java/org/bitcoinj/base/LegacyAddress.java
@@ -21,7 +21,7 @@ package org.bitcoinj.base;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.internal.ByteUtils;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumSet;
@@ -113,7 +113,7 @@ public class LegacyAddress implements Address {
      * @throws AddressFormatException              if the given base58 doesn't parse or the checksum is invalid
      * @throws AddressFormatException.WrongNetwork if the given address is valid but for a different chain (e.g. testnet vs mainnet)
      */
-    public static LegacyAddress fromBase58(String base58, @Nonnull Network network)
+    public static LegacyAddress fromBase58(String base58, @NonNull Network network)
             throws AddressFormatException, AddressFormatException.WrongNetwork {
         byte[] versionAndDataBytes = Base58.decodeChecked(base58);
         int version = versionAndDataBytes[0] & 0xFF;

--- a/base/src/main/java/org/bitcoinj/base/SegwitAddress.java
+++ b/base/src/main/java/org/bitcoinj/base/SegwitAddress.java
@@ -19,7 +19,7 @@ package org.bitcoinj.base;
 import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.internal.ByteUtils;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumSet;
@@ -252,7 +252,7 @@ public class SegwitAddress implements Address {
      * @return constructed address
      * @throws AddressFormatException if something about the given bech32 address isn't right
      */
-    public static SegwitAddress fromBech32(String bech32, @Nonnull Network network)
+    public static SegwitAddress fromBech32(String bech32, @NonNull Network network)
             throws AddressFormatException {
         Bech32.Bech32Data bechData = Bech32.decode(bech32);
         if (bechData.hrp.equals(network.segwitAddressHrp()))
@@ -260,7 +260,7 @@ public class SegwitAddress implements Address {
         throw new AddressFormatException.WrongNetwork(bechData.hrp);
     }
 
-    static SegwitAddress fromBechData(@Nonnull Network network, Bech32.Bech32Data bechData) {
+    static SegwitAddress fromBechData(@NonNull Network network, Bech32.Bech32Data bechData) {
         if (bechData.bytes().length < 1) {
             throw new AddressFormatException.InvalidDataLength("invalid address length (0)");
         }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -13,7 +13,8 @@ dependencies {
     api 'org.bouncycastle:bcprov-jdk15to18:1.80'
     api 'com.google.guava:guava:33.4.4-android'
     api 'com.google.protobuf:protobuf-javalite:4.30.2'
-    implementation 'com.google.code.findbugs:jsr305:3.0.2'
+
+    implementation 'org.jspecify:jspecify:1.0.0'
     implementation 'org.slf4j:slf4j-api:2.0.16'
 
     testImplementation project(':bitcoinj-test-support')

--- a/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
@@ -35,7 +35,7 @@ import org.bitcoinj.wallet.Wallet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.time.Instant;

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -31,7 +31,7 @@ import org.bitcoinj.script.ScriptBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.math.BigInteger;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;

--- a/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
+++ b/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
@@ -29,7 +29,7 @@ import org.bitcoinj.store.SPVBlockStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.DataInputStream;

--- a/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
@@ -34,7 +34,7 @@ import org.bitcoinj.wallet.WalletExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/core/src/main/java/org/bitcoinj/core/InsufficientMoneyException.java
+++ b/core/src/main/java/org/bitcoinj/core/InsufficientMoneyException.java
@@ -18,7 +18,7 @@ package org.bitcoinj.core;
 
 import org.bitcoinj.base.Coin;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Objects;
 
 /**

--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -43,7 +43,7 @@ import org.bitcoinj.wallet.Wallet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.net.SocketAddress;
 import java.time.Duration;
 import java.time.Instant;

--- a/core/src/main/java/org/bitcoinj/core/PeerAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerAddress.java
@@ -23,7 +23,7 @@ import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.core.internal.TorUtils;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -57,7 +57,7 @@ import org.bitcoinj.wallet.listeners.WalletCoinsSentEventListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.net.Inet6Address;
 import java.net.InetAddress;

--- a/core/src/main/java/org/bitcoinj/core/StoredUndoableBlock.java
+++ b/core/src/main/java/org/bitcoinj/core/StoredUndoableBlock.java
@@ -19,7 +19,7 @@ package org.bitcoinj.core;
 
 import org.bitcoinj.base.Sha256Hash;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 import java.util.Objects;
 

--- a/core/src/main/java/org/bitcoinj/core/TestBlocks.java
+++ b/core/src/main/java/org/bitcoinj/core/TestBlocks.java
@@ -28,7 +28,7 @@ import org.bitcoinj.script.ScriptBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -47,7 +47,7 @@ import org.bitcoinj.wallet.WalletTransaction.Pool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.math.RoundingMode;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;

--- a/core/src/main/java/org/bitcoinj/core/TransactionBag.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionBag.java
@@ -23,7 +23,7 @@ import org.bitcoinj.script.Script;
 import org.bitcoinj.wallet.Wallet;
 import org.bitcoinj.wallet.WalletTransaction;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Map;
 
 /**

--- a/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
@@ -25,7 +25,7 @@ import org.bitcoinj.wallet.Wallet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
@@ -26,7 +26,7 @@ import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.CoinSelector;
 import org.bitcoinj.wallet.Wallet;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashSet;

--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -30,7 +30,7 @@ import org.bitcoinj.wallet.DefaultRiskAnalysis;
 import org.bitcoinj.wallet.KeyBag;
 import org.bitcoinj.wallet.RedeemData;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.lang.ref.WeakReference;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -28,7 +28,7 @@ import org.bitcoinj.script.ScriptPattern;
 import org.bitcoinj.wallet.KeyBag;
 import org.bitcoinj.wallet.RedeemData;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -34,7 +34,7 @@ import org.bitcoinj.wallet.Wallet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;

--- a/core/src/main/java/org/bitcoinj/core/TransactionWitness.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionWitness.java
@@ -24,7 +24,7 @@ import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.script.Script;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;

--- a/core/src/main/java/org/bitcoinj/core/TxConfidenceTable.java
+++ b/core/src/main/java/org/bitcoinj/core/TxConfidenceTable.java
@@ -19,7 +19,7 @@ package org.bitcoinj.core;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.utils.Threading;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;

--- a/core/src/main/java/org/bitcoinj/core/VersionMessage.java
+++ b/core/src/main/java/org/bitcoinj/core/VersionMessage.java
@@ -21,7 +21,7 @@ import org.bitcoinj.base.internal.Buffers;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.base.internal.ByteUtils;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.BufferOverflowException;

--- a/core/src/main/java/org/bitcoinj/core/listeners/BlocksDownloadedEventListener.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/BlocksDownloadedEventListener.java
@@ -21,7 +21,7 @@ import org.bitcoinj.core.FilteredBlock;
 import org.bitcoinj.core.Peer;
 import org.bitcoinj.core.PeerGroup;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * <p>Implementors can listen to events like blocks being downloaded/transactions being broadcast/connect/disconnects,

--- a/core/src/main/java/org/bitcoinj/core/listeners/DownloadProgressTracker.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/DownloadProgressTracker.java
@@ -24,7 +24,7 @@ import org.bitcoinj.core.Peer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.time.Instant;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;

--- a/core/src/main/java/org/bitcoinj/core/listeners/GetDataEventListener.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/GetDataEventListener.java
@@ -22,7 +22,7 @@ import org.bitcoinj.core.Peer;
 import org.bitcoinj.core.PeerGroup;
 import org.bitcoinj.utils.Threading;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.List;
 
 /**

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -28,7 +28,7 @@ import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.crypto.internal.CryptoUtils;
 import org.bouncycastle.math.ec.ECPoint;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.time.Instant;
@@ -387,9 +387,8 @@ public class DeterministicKey extends ECKey {
         return findParentWithPrivKey() != null;
     }
 
-    @Nullable
     @Override
-    public byte[] getSecretBytes() {
+    public byte @Nullable [] getSecretBytes() {
         return priv != null ? getPrivKeyBytes() : null;
     }
 

--- a/core/src/main/java/org/bitcoinj/crypto/DumpedPrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DumpedPrivateKey.java
@@ -23,7 +23,7 @@ import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.params.Networks;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Arrays;
 
 import static org.bitcoinj.base.internal.Preconditions.checkArgument;

--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -66,7 +66,7 @@ import org.bouncycastle.util.encoders.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
@@ -1247,9 +1247,8 @@ public class ECKey implements EncryptableItem {
         return keyCrypter != null && encryptedPrivateKey != null && encryptedPrivateKey.encryptedBytes.length > 0;
     }
 
-    @Nullable
     @Override
-    public Protos.Wallet.EncryptionType getEncryptionType() {
+    public Protos.Wallet.@Nullable EncryptionType getEncryptionType() {
         return keyCrypter != null ? keyCrypter.getUnderstoodEncryptionType() : Protos.Wallet.EncryptionType.UNENCRYPTED;
     }
 
@@ -1258,8 +1257,7 @@ public class ECKey implements EncryptableItem {
      * to be derived (for the HD key case).
      */
     @Override
-    @Nullable
-    public byte[] getSecretBytes() {
+    public byte @Nullable [] getSecretBytes() {
         if (hasPrivKey())
             return getPrivKeyBytes();
         else

--- a/core/src/main/java/org/bitcoinj/crypto/EncryptableItem.java
+++ b/core/src/main/java/org/bitcoinj/crypto/EncryptableItem.java
@@ -18,7 +18,7 @@ package org.bitcoinj.crypto;
 
 import org.bitcoinj.protobuf.wallet.Protos;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.time.Instant;
 import java.util.Optional;
 
@@ -32,8 +32,7 @@ public interface EncryptableItem {
     boolean isEncrypted();
 
     /** Returns the raw bytes of the item, if not encrypted, or null if encrypted or the secret is missing. */
-    @Nullable
-    byte[] getSecretBytes();
+    byte @Nullable [] getSecretBytes();
 
     /** Returns the initialization vector and encrypted secret bytes, or null if not encrypted. */
     @Nullable

--- a/core/src/main/java/org/bitcoinj/crypto/HDPath.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDPath.java
@@ -19,7 +19,7 @@ package org.bitcoinj.crypto;
 import org.bitcoinj.base.internal.StreamUtils;
 import org.bitcoinj.base.internal.InternalUtils;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -374,7 +374,7 @@ public abstract class HDPath {
      * <p>
      * Where a letter {@code H} means hardened key. Spaces are ignored.
      */
-    public static HDPath parsePath(@Nonnull String path) {
+    public static HDPath parsePath(@NonNull String path) {
         List<String> parsedNodes = SEPARATOR_SPLITTER.splitToList(path);
         Optional<Prefix> prefix = parsedNodes.isEmpty() ? Optional.empty() : Prefix.of(parsedNodes.get(0));
 

--- a/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
+++ b/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
@@ -20,7 +20,7 @@ import org.bitcoinj.crypto.secp.Secp256k1Constants;
 import org.bouncycastle.math.ec.ECCurve;
 import org.bouncycastle.math.ec.ECPoint;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.security.interfaces.ECPublicKey;
 import java.util.Arrays;
 import java.util.Objects;
@@ -36,8 +36,7 @@ public final class LazyECPoint implements ECPublicKey {
     private static final ECCurve curve = ECKey.CURVE.getCurve();
 
     // bits will be null if LazyECPoint is constructed from an (already decoded) point
-    @Nullable
-    private final byte[] bits;
+    private final byte @Nullable [] bits;
     private final boolean compressed;
 
     // This field is lazy - once set it won't change again. However, it can be set after construction.

--- a/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
+++ b/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
@@ -44,8 +44,8 @@ import org.bitcoinj.wallet.WalletProtobufSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -109,7 +109,7 @@ public class WalletAppKit extends AbstractIdleService implements Closeable {
     protected InputStream checkpoints;
     protected boolean blockingStartup = true;
     protected String userAgent, version;
-    @Nonnull protected WalletProtobufSerializer.WalletFactory walletFactory = WalletProtobufSerializer.WalletFactory.DEFAULT;
+    protected WalletProtobufSerializer.@NonNull WalletFactory walletFactory = WalletProtobufSerializer.WalletFactory.DEFAULT;
     @Nullable protected DeterministicSeed restoreFromSeed;
     @Nullable protected DeterministicKey restoreFromKey;
     @Nullable protected PeerDiscovery discovery;
@@ -281,7 +281,7 @@ public class WalletAppKit extends AbstractIdleService implements Closeable {
      * @param walletFactory Factory for making new wallets (Use {@link WalletProtobufSerializer.WalletFactory#DEFAULT} for default behavior)
      * @return WalletAppKit for method chaining purposes
      */
-    public WalletAppKit setWalletFactory(@Nonnull WalletProtobufSerializer.WalletFactory walletFactory) {
+    public WalletAppKit setWalletFactory(WalletProtobufSerializer.@NonNull WalletFactory walletFactory) {
         Objects.requireNonNull(walletFactory);
         this.walletFactory = walletFactory;
         return this;

--- a/core/src/main/java/org/bitcoinj/net/BlockingClient.java
+++ b/core/src/main/java/org/bitcoinj/net/BlockingClient.java
@@ -21,7 +21,7 @@ import org.bitcoinj.core.Peer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import javax.net.SocketFactory;
 import java.io.IOException;
 import java.io.InputStream;

--- a/core/src/main/java/org/bitcoinj/net/ConnectionHandler.java
+++ b/core/src/main/java/org/bitcoinj/net/ConnectionHandler.java
@@ -22,7 +22,7 @@ import org.bitcoinj.utils.Threading;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.bitcoinj.core.internal.GuardedBy;
 import java.io.IOException;
 import java.nio.Buffer;

--- a/core/src/main/java/org/bitcoinj/net/StreamConnectionFactory.java
+++ b/core/src/main/java/org/bitcoinj/net/StreamConnectionFactory.java
@@ -16,7 +16,7 @@
 
 package org.bitcoinj.net;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.net.InetAddress;
 
 /**

--- a/core/src/main/java/org/bitcoinj/net/discovery/SeedPeers.java
+++ b/core/src/main/java/org/bitcoinj/net/discovery/SeedPeers.java
@@ -21,7 +21,7 @@ import org.bitcoinj.core.NetworkParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;

--- a/core/src/main/java/org/bitcoinj/params/BitcoinNetworkParams.java
+++ b/core/src/main/java/org/bitcoinj/params/BitcoinNetworkParams.java
@@ -26,7 +26,7 @@ import org.bitcoinj.base.Coin;
 import org.bitcoinj.core.DifficultyTransitions;
 import org.bitcoinj.core.NetworkParameters;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Parameters for Bitcoin-like networks.

--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -37,7 +37,7 @@ import org.bitcoinj.crypto.TransactionSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -88,7 +88,7 @@ public class Script {
     private final List<ScriptChunk> chunks;
     // Unfortunately, scripts are not ever re-serialized or canonicalized when used in signature hashing. Thus we
     // must preserve the exact bytes that we read off the wire, along with the parsed form.
-    @Nullable private final byte[] program;
+    private final byte @Nullable [] program;
 
     /**
      * If this is set, the script is associated with a creation time. This is currently used in the context of

--- a/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptBuilder.java
@@ -29,7 +29,7 @@ import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.crypto.internal.CryptoUtils;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -352,7 +352,7 @@ public class ScriptBuilder {
      * Create a program that satisfies an OP_CHECKMULTISIG program, using pre-encoded signatures. 
      * Optionally, appends the script program bytes if spending a P2SH output.
      */
-    public static Script createMultiSigInputScriptBytes(List<byte[]> signatures, @Nullable byte[] multisigProgramBytes) {
+    public static Script createMultiSigInputScriptBytes(List<byte[]> signatures, byte @Nullable [] multisigProgramBytes) {
         checkArgument(signatures.size() <= 16);
         ScriptBuilder builder = new ScriptBuilder();
         builder.smallNum(0);  // Work around a bug in CHECKMULTISIG that is now a required part of the protocol.

--- a/core/src/main/java/org/bitcoinj/script/ScriptChunk.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptChunk.java
@@ -19,7 +19,7 @@ package org.bitcoinj.script;
 
 import org.bitcoinj.base.internal.ByteUtils;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Objects;
@@ -45,10 +45,9 @@ public class ScriptChunk {
      * For push operations, this is the vector to be pushed on the stack. For {@link ScriptOpCodes#OP_0}, the vector is
      * empty. Null for non-push operations.
      */
-    @Nullable
-    final byte[] data;
+    final byte @Nullable [] data;
 
-    public ScriptChunk(int opcode, @Nullable byte[] data) {
+    public ScriptChunk(int opcode, byte @Nullable [] data) {
         this.opcode = opcode;
         this.data = data;
     }

--- a/core/src/main/java/org/bitcoinj/script/ScriptExecution.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptExecution.java
@@ -34,7 +34,7 @@ import org.bitcoinj.crypto.internal.CryptoUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;

--- a/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
@@ -32,7 +32,7 @@ import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptPattern;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
@@ -26,7 +26,7 @@ import org.bitcoinj.utils.Threading;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;

--- a/core/src/main/java/org/bitcoinj/testing/FakeTxBuilder.java
+++ b/core/src/main/java/org/bitcoinj/testing/FakeTxBuilder.java
@@ -41,7 +41,7 @@ import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.BlockStoreException;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/core/src/main/java/org/bitcoinj/uri/BitcoinURI.java
+++ b/core/src/main/java/org/bitcoinj/uri/BitcoinURI.java
@@ -23,8 +23,8 @@ import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Address;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -116,7 +116,7 @@ public class BitcoinURI {
      * @param network The network the URI is from
      * @throws BitcoinURIParseException If the input fails Bitcoin URI syntax and semantic checks.
      */
-    public static BitcoinURI of(String uri, @Nonnull Network network) throws BitcoinURIParseException {
+    public static BitcoinURI of(String uri, @NonNull Network network) throws BitcoinURIParseException {
         return new BitcoinURI(uri, Objects.requireNonNull(network));
     }
 

--- a/core/src/main/java/org/bitcoinj/utils/BaseTaggableObject.java
+++ b/core/src/main/java/org/bitcoinj/utils/BaseTaggableObject.java
@@ -18,7 +18,7 @@ package org.bitcoinj.utils;
 
 import com.google.protobuf.ByteString;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;

--- a/core/src/main/java/org/bitcoinj/utils/DaemonThreadFactory.java
+++ b/core/src/main/java/org/bitcoinj/utils/DaemonThreadFactory.java
@@ -16,8 +16,8 @@
 
 package org.bitcoinj.utils;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 
@@ -34,7 +34,7 @@ public class DaemonThreadFactory implements ThreadFactory {
     }
 
     @Override
-    public Thread newThread(@Nonnull Runnable runnable) {
+    public Thread newThread(@NonNull Runnable runnable) {
         Thread thread = Executors.defaultThreadFactory().newThread(runnable);
         thread.setDaemon(true);
         if (name != null)

--- a/core/src/main/java/org/bitcoinj/utils/TaggableObject.java
+++ b/core/src/main/java/org/bitcoinj/utils/TaggableObject.java
@@ -18,7 +18,7 @@ package org.bitcoinj.utils;
 
 import com.google.protobuf.ByteString;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.Map;
 
 /**

--- a/core/src/main/java/org/bitcoinj/utils/Threading.java
+++ b/core/src/main/java/org/bitcoinj/utils/Threading.java
@@ -22,7 +22,7 @@ import org.bitcoinj.base.internal.PlatformUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -80,8 +80,7 @@ public class Threading {
      * bitcoinj library code is run, setting it after you started network traffic and other forms of processing
      * may result in the change not taking effect.
      */
-    @Nullable
-    public static volatile Thread.UncaughtExceptionHandler uncaughtExceptionHandler;
+    public static volatile Thread.@Nullable UncaughtExceptionHandler uncaughtExceptionHandler;
 
     public static class UserThread extends Thread implements Executor {
         private static final Logger log = LoggerFactory.getLogger(UserThread.class);

--- a/core/src/main/java/org/bitcoinj/wallet/BasicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/BasicKeyChain.java
@@ -32,7 +32,7 @@ import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.listeners.KeyChainEventListener;
 import org.bitcoinj.protobuf.wallet.Protos;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/core/src/main/java/org/bitcoinj/wallet/DecryptingKeyBag.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DecryptingKeyBag.java
@@ -20,7 +20,7 @@ import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.crypto.AesKey;
 import org.bitcoinj.crypto.ECKey;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;

--- a/core/src/main/java/org/bitcoinj/wallet/DefaultRiskAnalysis.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DefaultRiskAnalysis.java
@@ -30,7 +30,7 @@ import org.bitcoinj.script.ScriptChunk;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -47,7 +47,7 @@ import org.bitcoinj.protobuf.wallet.Protos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.math.BigInteger;
 import java.security.SecureRandom;
 import java.time.Instant;

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
@@ -27,7 +27,7 @@ import org.bitcoinj.crypto.KeyCrypter;
 import org.bitcoinj.crypto.MnemonicCode;
 import org.bitcoinj.crypto.MnemonicException;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.time.Instant;
@@ -52,7 +52,7 @@ public class DeterministicSeed implements EncryptableItem {
     public static final int DEFAULT_SEED_ENTROPY_BITS = 128;
     public static final int MAX_SEED_ENTROPY_BITS = 512;
 
-    @Nullable private final byte[] seed;
+    private final byte @Nullable [] seed;
     @Nullable private final List<String> mnemonicCode; // only one of mnemonicCode/encryptedMnemonicCode will be set
     @Nullable private final EncryptedData encryptedMnemonicCode;
     @Nullable private final EncryptedData encryptedSeed;
@@ -160,7 +160,7 @@ public class DeterministicSeed implements EncryptableItem {
     }
 
     /** Internal use only. */
-    private DeterministicSeed(List<String> mnemonicCode, @Nullable byte[] seed, String passphrase, @Nullable Instant creationTime) {
+    private DeterministicSeed(List<String> mnemonicCode, byte @Nullable [] seed, String passphrase, @Nullable Instant creationTime) {
         this((seed != null ? seed : MnemonicCode.toSeed(mnemonicCode, Objects.requireNonNull(passphrase))), mnemonicCode, creationTime);
     }
 
@@ -217,14 +217,12 @@ public class DeterministicSeed implements EncryptableItem {
         return seed != null ? ByteUtils.formatHex(seed) : null;
     }
 
-    @Nullable
     @Override
-    public byte[] getSecretBytes() {
+    public byte @Nullable [] getSecretBytes() {
         return getMnemonicAsBytes();
     }
 
-    @Nullable
-    public byte[] getSeedBytes() {
+    public byte @Nullable [] getSeedBytes() {
         return seed;
     }
 

--- a/core/src/main/java/org/bitcoinj/wallet/EncryptableKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/EncryptableKeyChain.java
@@ -21,7 +21,7 @@ import org.bitcoinj.crypto.KeyCrypter;
 import org.bitcoinj.crypto.KeyCrypterException;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An encryptable key chain is a key-chain that can be encrypted with a user-provided password or AES key.

--- a/core/src/main/java/org/bitcoinj/wallet/KeyBag.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyBag.java
@@ -19,7 +19,7 @@ package org.bitcoinj.wallet;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.crypto.ECKey;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A KeyBag is simply an object that can map public keys, their 160-bit hashes and script hashes to ECKey

--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
@@ -42,7 +42,7 @@ import org.bitcoinj.protobuf.wallet.Protos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.ArrayList;

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -102,7 +102,7 @@ import org.bitcoinj.wallet.listeners.WalletReorganizeEventListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -1680,7 +1680,7 @@ public class Wallet extends BaseTaggableObject
      * @param delay How much time to wait until saving the wallet on a background thread.
      * @param eventListener callback to be informed when the auto-save thread does things, or null
      */
-    public WalletFiles autosaveToFile(File f, Duration delay, @Nullable WalletFiles.Listener eventListener) {
+    public WalletFiles autosaveToFile(File f, Duration delay, WalletFiles.@Nullable Listener eventListener) {
         lock.lock();
         try {
             checkState(vFileManager == null, () ->
@@ -5409,7 +5409,7 @@ public class Wallet extends BaseTaggableObject
      * re-organisation of the wallet contents on the block chain. For instance, in future the wallet may choose to
      * optimise itself to reduce fees or improve privacy.</p>
      */
-    public void setTransactionBroadcaster(@Nullable org.bitcoinj.core.TransactionBroadcaster broadcaster) {
+    public void setTransactionBroadcaster(org.bitcoinj.core.@Nullable TransactionBroadcaster broadcaster) {
         Transaction[] toBroadcast = {};
         lock.lock();
         try {

--- a/core/src/main/java/org/bitcoinj/wallet/WalletFiles.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletFiles.java
@@ -23,7 +23,7 @@ import org.bitcoinj.utils.ContextPropagatingThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -112,7 +112,7 @@ public class WalletFiles {
     /**
      * The given listener will be called on the autosave thread before and after the wallet is saved to disk.
      */
-    public void setListener(@Nonnull Listener listener) {
+    public void setListener(@NonNull Listener listener) {
         this.vListener = Objects.requireNonNull(listener);
     }
 

--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -46,7 +46,7 @@ import org.bitcoinj.protobuf.wallet.Protos.Wallet.EncryptionType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;

--- a/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
+++ b/core/src/test/java/org/bitcoinj/core/FullBlockTestGenerator.java
@@ -32,7 +32,7 @@ import org.bitcoinj.script.ScriptException;
 import org.bitcoinj.script.ScriptExecution;
 import org.bitcoinj.script.ScriptPattern;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;

--- a/core/src/test/java/org/bitcoinj/testing/TestWithWallet.java
+++ b/core/src/test/java/org/bitcoinj/testing/TestWithWallet.java
@@ -37,7 +37,7 @@ import org.bitcoinj.wallet.KeyChainGroupStructure;
 import org.bitcoinj.wallet.Wallet;
 import org.junit.BeforeClass;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import static org.bitcoinj.testing.FakeTxBuilder.createFakeBlock;
 import static org.bitcoinj.testing.FakeTxBuilder.createFakeTx;

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -6,8 +6,8 @@ plugins {
 dependencies {
     implementation project(':bitcoinj-core')
     implementation project(':bitcoinj-examples')
-    implementation 'com.google.code.findbugs:jsr305:3.0.2'
 
+    testImplementation 'org.jspecify:jspecify:1.0.0'
     testImplementation 'org.slf4j:slf4j-jdk14:2.0.16'
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.11.4"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.11.4"

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.InetAddress;

--- a/integration-test/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
+++ b/integration-test/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
@@ -49,7 +49,7 @@ import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.KeyChainGroup;
 import org.bitcoinj.wallet.Wallet;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import javax.net.SocketFactory;
 import java.io.IOException;
 import java.net.InetAddress;

--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -18,7 +18,7 @@ boolean hasGraalVM = GradleVersion.current() >= graalVMMinVersion
 dependencies {
     implementation project(':bitcoinj-core')
     implementation 'info.picocli:picocli:4.7.6'
-    implementation 'com.google.code.findbugs:jsr305:3.0.2'
+    implementation 'org.jspecify:jspecify:1.0.0'
     implementation 'org.slf4j:slf4j-jdk14:2.0.16'
     if (hasAnnotationProcessor) {
         annotationProcessor 'info.picocli:picocli-codegen:4.7.6'

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -67,7 +67,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;


### PR DESCRIPTION
The first commit migrates the dependency and includes. The second fixes the JSpecify array annotations to indicate they mean it is the array reference that is nullable not the individual array items.