### PR TITLE
base module: add JSpecify @NullMarked annotations to all packages

### DIFF
--- a/base/src/main/java/org/bitcoinj/base/exceptions/package-info.java
+++ b/base/src/main/java/org/bitcoinj/base/exceptions/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Exceptions thrown by classes in bitcoinj base.
  */
+@NullMarked
 package org.bitcoinj.base.exceptions;
+
+import org.jspecify.annotations.NullMarked;

--- a/base/src/main/java/org/bitcoinj/base/internal/package-info.java
+++ b/base/src/main/java/org/bitcoinj/base/internal/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Classes for internal use only (in both {@code bitcoinj-base} and {@code bitcoinj-core}.)
  */
+@NullMarked
 package org.bitcoinj.base.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/base/src/main/java/org/bitcoinj/base/package-info.java
+++ b/base/src/main/java/org/bitcoinj/base/package-info.java
@@ -18,4 +18,7 @@
  * The {@code base} package provides foundational types for <b>bitcoinj</b>. This package
  * has no dependencies other than {@code slf4j-api} and {@code jspecify}.
  */
+@NullMarked
 package org.bitcoinj.base;
+
+import org.jspecify.annotations.NullMarked;

--- a/base/src/main/java/org/bitcoinj/base/utils/package-info.java
+++ b/base/src/main/java/org/bitcoinj/base/utils/package-info.java
@@ -17,4 +17,7 @@
 /**
  * bitcoinj utility classes.
  */
+@NullMarked
 package org.bitcoinj.base.utils;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
Add `@NullMarked` to all 4 packages. This will tell static analyzers, IDEs, and languages like Kotlin that there are no nullable parameters or return values in `base` unless explicitly annotated.

The first commit adds `package-info.java` files for the `exceptions`, `internals`, and `utils` packages.

This is a child of PR #3992 which adds the last missing `@Nullable` annotations which allow us to correctly add `@Nullmarked` to all packages in this module.

