### PR TITLE
WalletProtobufSerializer: simplify writeConfidence()

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletProtobufSerializer.java
@@ -379,15 +379,16 @@ public class WalletProtobufSerializer {
                     confidenceBuilder.setOverridingTransaction(hashToByteString(overridingHash));
                 }
             }
-            TransactionConfidence.Source source = confidence.getSource();
-            switch (source) {
-                case SELF: confidenceBuilder.setSource(Protos.TransactionConfidence.Source.SOURCE_SELF); break;
-                case NETWORK: confidenceBuilder.setSource(Protos.TransactionConfidence.Source.SOURCE_NETWORK); break;
+            Protos.TransactionConfidence.Source source;
+            switch (confidence.getSource()) {
+                case SELF: source = Protos.TransactionConfidence.Source.SOURCE_SELF; break;
+                case NETWORK: source = Protos.TransactionConfidence.Source.SOURCE_NETWORK; break;
                 case UNKNOWN:
                     // Fall through.
                 default:
-                    confidenceBuilder.setSource(Protos.TransactionConfidence.Source.SOURCE_UNKNOWN); break;
+                    source = Protos.TransactionConfidence.Source.SOURCE_UNKNOWN; break;
             }
+            confidenceBuilder.setSource(source);
         }
 
         for (PeerAddress address : confidence.getBroadcastBy()) {


### PR DESCRIPTION
Two commits:

1. **WalletProtobufSerializer: simplify writeConfidence() parameters**

Instead of passing TransactionConfidence & Protos.TransactionConfidence.Builder objects to writeConfidence(), just pass the Transaction and create them inside the method. They are temporary objects and not used anywhere else.

This makes the code a little more readable and it also eliminates an IDE warning about synchronizing on `confidence`.

Also add some explanatory comments and a suggestion for further refactoring.


2. **WalletProtobufSerializer: simplify source switch in writeConfidence()**

Simplify this switch by making it more "functional-style". Developers and IDEs should immediately recognize this as a candidate for automatic conversion to a switch expression.
