### PR TITLE
WalletTool: remove upgrade from basic to deterministic keychain

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyChainGroup.java
@@ -957,7 +957,7 @@ public class KeyChainGroup implements KeyBag {
     }
 
     /**
-     * <p>This method will upgrade the wallet along the following path: {@code Basic --> P2PKH --> P2WPKH}</p>
+     * <p>This method will upgrade the wallet along the following path: {@code P2PKH --> P2WPKH}</p>
      * <p>It won't skip any steps in that upgrade path because the user might be restoring from a backup and
      * still expects money on the P2PKH chain.</p>
      * <p>It will extract and reuse the seed from the current wallet, so that a fresh backup isn't required


### PR DESCRIPTION
This ability was removed from `KeyChainGroup` with commit 4e8a19997d4c08d3e2633cf9368d0cef9b6f7ba7.