### PR TITLE
wallettool-subcommands.adoc: fix Picocli capitalization

### DIFF
--- a/designdocs/wallettool-subcommands.adoc
+++ b/designdocs/wallettool-subcommands.adoc
@@ -1,4 +1,4 @@
-= WalletTool Conversion to PicoCLI Subcommands
+= WalletTool Conversion to Picocli Subcommands
 :toc: left
 :toclevels: 4
 


### PR DESCRIPTION
In the picocli documentation the capitalization is "picocli", but when used at the start of a sentence it is "Picocli".

So in the title of our document we should use "Picocli".

cc: @ItoroD 