### PR TITLE
wallettemplate: migrate to JSpecify

### DIFF
--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -8,8 +8,8 @@ plugins {
 dependencies {
     implementation project(':bitcoinj-core')
     implementation 'com.google.zxing:core:3.5.3'
+    implementation 'org.jspecify:jspecify:1.0.0'
     implementation 'org.slf4j:slf4j-api:2.0.16'
-    implementation 'jakarta.annotation:jakarta.annotation-api:3.0.0'
 
     runtimeOnly 'org.slf4j:slf4j-jdk14:2.0.16'
 

--- a/wallettemplate/src/main/java/module-info.java
+++ b/wallettemplate/src/main/java/module-info.java
@@ -20,7 +20,7 @@ module wallettemplate {
     requires javafx.controls;
     requires javafx.fxml;
 
-    requires jakarta.annotation;
+    requires org.jspecify;
 
     requires org.slf4j;
     requires com.google.zxing;

--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/application/WalletApplication.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/application/WalletApplication.java
@@ -17,7 +17,7 @@
 package org.bitcoinj.walletfx.application;
 
 import com.google.common.util.concurrent.Service;
-import jakarta.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import javafx.application.Platform;
 import javafx.scene.input.KeyCombination;
 import javafx.stage.Stage;

--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/controls/NotificationBarPane.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/controls/NotificationBarPane.java
@@ -16,7 +16,7 @@
 
 package org.bitcoinj.walletfx.controls;
 
-import jakarta.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import javafx.animation.Interpolator;
 import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;

--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/overlay/OverlayableStackPaneController.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/overlay/OverlayableStackPaneController.java
@@ -15,7 +15,7 @@
  */
 package org.bitcoinj.walletfx.overlay;
 
-import jakarta.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Node;
 import javafx.scene.layout.Pane;

--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/utils/KeyDerivationTasks.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/utils/KeyDerivationTasks.java
@@ -16,7 +16,7 @@
 
 package org.bitcoinj.walletfx.utils;
 
-import jakarta.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import javafx.beans.property.ReadOnlyDoubleProperty;
 import javafx.concurrent.Task;
 import org.bitcoinj.crypto.AesKey;

--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/utils/easing/package-info.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/utils/easing/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Easing Utilities.
+ */
+@NullMarked
+package org.bitcoinj.walletfx.utils.easing;
+
+import org.jspecify.annotations.NullMarked;

--- a/wallettemplate/src/main/java/wallettemplate/WalletSettingsController.java
+++ b/wallettemplate/src/main/java/wallettemplate/WalletSettingsController.java
@@ -17,7 +17,7 @@
 package wallettemplate;
 
 import com.google.common.util.concurrent.Service;
-import jakarta.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import javafx.application.Platform;
 import javafx.beans.binding.BooleanBinding;
 import javafx.event.ActionEvent;


### PR DESCRIPTION
2 commits:

* use JSpecify instead of jakarta.annotation -- just update libraries and import statements)
* o.b.walletfx.utils.easing: add package-info.java with `@NullMarked` for the `easing` package.