### PR TITLE
PeerGroup: replace Guava Future.getUnchecked()

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -20,7 +20,6 @@ package org.bitcoinj.core;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.Runnables;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.bitcoinj.core.internal.GuardedBy;
@@ -1095,7 +1094,11 @@ public class PeerGroup implements TransactionBroadcaster {
 
     // For testing only
     void waitForJobQueue() {
-        Futures.getUnchecked(executor.submit(Runnables.doNothing()));
+        try {
+            InternalUtils.getUninterruptibly(executor.submit(Runnables.doNothing()));
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private int countConnectedAndPendingPeers() {


### PR DESCRIPTION
Implement equivalent behavior by calling InternalUtils.getUninterruptibly() and catching and rethrowing ExecutionException as a RuntimeException.