### PR TITLE
test-support/build.gradle: depend on bitcoinj-base (was bitcoinj-core)

### DIFF
--- a/test-support/build.gradle
+++ b/test-support/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    api project(':bitcoinj-core')
+    api project(':bitcoinj-base')
 }
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
This removes a circular dependency (in Maven, not Gradle):

core (tests) -> test-support -> core (main)

Gradle is able to understand that test-support is only used by tests in core, but Maven isn't.

This is a reasonable simplification, but may also be helpful with Issue #3840