### PR TITLE
Clean up, renaming findKeyFromPubHash to findKeyFromPubKeyHash

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,7 +11,7 @@ version = '0.18-SNAPSHOT'
 dependencies {
     api project(':bitcoinj-base')
     api 'org.jspecify:jspecify:1.0.0'
-    api 'org.bouncycastle:bcprov-jdk15to18:1.84'
+    api 'org.bouncycastle:bcprov-jdk18on:1.84'
     api 'com.google.guava:guava:33.5.0-android'
     api 'com.google.protobuf:protobuf-javalite:4.33.4'
 

--- a/core/src/main/java/org/bitcoinj/crypto/ChildNumber.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ChildNumber.java
@@ -74,7 +74,7 @@ public class ChildNumber implements Comparable<ChildNumber> {
      * @throws NumberFormatException when parsing fails
      */
     public static ChildNumber parse(String str) {
-        boolean isHard = str.endsWith("H");
+        boolean isHard = str.endsWith("H") || str.endsWith("'");
         String nodeNumber = isHard ?
                 str.substring(0, str.length() - 1) :
                 str;

--- a/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
@@ -235,6 +235,18 @@ public class HDPathTest {
             new PathVector (
                 "1 / 2 / 3 /",
                 HDPath.partial(new ChildNumber(1, false), new ChildNumber(2, false), new ChildNumber(3, false))
+            ),
+
+            // BIP-32 standard apostrophe notation
+            new PathVector (
+                "m/44'/0'/0'",
+                HDPath.m(new ChildNumber(44, true), new ChildNumber(0, true), new ChildNumber(0, true))
+            ),
+
+            new PathVector (
+                "M/44'/0'/0'/1/1",
+                HDPath.M(new ChildNumber(44, true), new ChildNumber(0, true), new ChildNumber(0, true),
+                    new ChildNumber(1, false), new ChildNumber(1, false))
             )
         };
     }


### PR DESCRIPTION
Minor clean up, but I think its better that the interfaces are consistent across the different components.

So the hash for that pubKey should be named pubKeyHash not pubHash.
And the pubKey should be named pubKey, not pubkey.