### PR TITLE
build.gradle: update Kotlin to 2.2.0

### DIFF
--- a/examples-kotlin/build.gradle
+++ b/examples-kotlin/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '2.0.21'
+    id 'org.jetbrains.kotlin.jvm' version '2.2.0'
 }
 
 dependencies {


### PR DESCRIPTION
Kotlin 2.2.0 supports JDK 24 byte code among other enhancements