### PR TITLE
settings.gradle: set minGradleVersion to 8.0

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,13 +11,13 @@ jobs:
         os: [ubuntu-24.04, macOS-13, windows-2022]
         java: ['17', '21', '23']
         distribution: ['temurin']
-        gradle: ['7.3', '8.14']
+        gradle: ['8.0', '8.14']
         exclude:
           # Java 21+ requires Gradle 8.5+
           - java: '21'
-            gradle: '7.3'
+            gradle: '8.0'
           - java: '23'
-            gradle: '7.3'
+            gradle: '8.0'
       fail-fast: false
     name: ${{ matrix.os }} JDK ${{ matrix.java }}.${{ matrix.distribution }} Gradle ${{ matrix.gradle }}
     steps:

--- a/README.adoc
+++ b/README.adoc
@@ -13,7 +13,7 @@ The bitcoinj library is a Java implementation of the Bitcoin protocol, which all
 * Java 8+ (needs Java 8 API or Android 8.0 API, compiles to Java 8 bytecode) for `base` and `core` module
 * Java 17+ for `tools`, `wallettool`, `examples` and the JavaFX-based `wallettemplate`
 * https://gradle.org/[Gradle]
-** Gradle 7.3+ for building the whole project or
+** Gradle 8.0+ for building the whole project or
 ** Debian Gradle 4.4 for just the `base`, `core`, `tools`, `wallettool` and `examples` modules (see "reference build" below)
 * https://github.com/google/protobuf[Google Protocol Buffers] - for use with serialization and hardware communications
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,12 +1,12 @@
 /*
- * Settings file for Gradle 7.3 or later.
+ * Settings file for Gradle 8.0 or later.
  * For building with Debian Gradle 4.4, use the settings-debian.gradle settings.
  */
 
 import org.gradle.util.GradleVersion
 
 // Minimum Gradle version for build
-def minGradleVersion = GradleVersion.version("7.3")
+def minGradleVersion = GradleVersion.version("8.0")
 
 rootProject.name = 'bitcoinj-parent'
 


### PR DESCRIPTION
The gradle.yml GHA workflow is updated to use 8.0 as the minimum Gradle in the matrix.

README.adoc is updated to specify 8.0 as the minimum for non-reference-builds.

This PR will allow us to upgrade to Kotlin 2.2.0. See PR #3857.

Note that Gradle 7 is unsupported now, even for critical bug and security fixes: https://endoflife.date/gradle

Having a minimum of 8.0 for non-reference builds could also make it easier us support Gradle 9 (see Issue #3859) since for non-reference-build modules, we won't have to support Gradle 7.