### PR TITLE
build.gradle: add hasConsistentArchives conditional for Gradle 9+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,13 +25,21 @@ allprojects {
     // Ensure standard artifacts in all projects are built reproducibly
 
     tasks.withType(AbstractArchiveTask) {
-        preserveFileTimestamps = false
-        reproducibleFileOrder = true
+        // Gradle 9+ has consistent timestamps and file order in archives by default
+        boolean hasConsistentArchives = GradleVersion.current() >= GradleVersion.version("9.0")
+        if (!hasConsistentArchives) {
+            preserveFileTimestamps = false
+            reproducibleFileOrder = true
+        }
     }
 
     tasks.withType(Jar) {
-        dirMode = 0755
-        fileMode = 0644
+        // Gradle 9+ has consistent permissions in jars by default
+        boolean hasConsistentArchives = GradleVersion.current() >= GradleVersion.version("9.0")
+        if (!hasConsistentArchives) {
+            dirMode = 0755
+            fileMode = 0644
+        }
     }
 
     tasks.withType(Javadoc) {


### PR DESCRIPTION
Gradle 9 removes the deprecated `dirMode` and `fileMode` settings, but dirPermissions/unix() was not added until Gradle 8.3.

This is an experiment and there might be another mechanism and/or something that was added earlier than 8.3.

We could also consider bumping the minimum supported (non-reference-build) Gradle to 8.3 or even Gradle 9.0+ (for Gradle 9+ we'd change the conditional to do nothing for the non Debian-4.4 build)