### PR TITLE
base,core/build.gradle: make jspecify an api dependency

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -8,8 +8,8 @@ plugins {
 version = '0.18-SNAPSHOT'
 
 dependencies {
+    api 'org.jspecify:jspecify:1.0.0'
     implementation 'org.slf4j:slf4j-api:2.0.16'
-    implementation 'org.jspecify:jspecify:1.0.0'
 
     testImplementation project(':bitcoinj-test-support')
     testImplementation 'junit:junit:4.13.2'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,11 +10,11 @@ version = '0.18-SNAPSHOT'
 
 dependencies {
     api project(':bitcoinj-base')
+    api 'org.jspecify:jspecify:1.0.0'
     api 'org.bouncycastle:bcprov-jdk15to18:1.80'
     api 'com.google.guava:guava:33.4.4-android'
     api 'com.google.protobuf:protobuf-javalite:4.30.2'
 
-    implementation 'org.jspecify:jspecify:1.0.0'
     implementation 'org.slf4j:slf4j-api:2.0.16'
 
     testImplementation project(':bitcoinj-test-support')


### PR DESCRIPTION
Nullability annotations are part of the API for a library module. Make sure the Gradle metadata reflects this.