### PR TITLE
wallettool/build.gradle: update GraalVM Native Plugin to 0.11.0

### DIFF
--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'java'
     id 'application'
     id 'org.asciidoctor.jvm.convert' version '3.3.2' apply false
-    id 'org.graalvm.buildtools.native' version '0.10.3' apply false
+    id 'org.graalvm.buildtools.native' version '0.11.0' apply false
 }
 
 def annotationProcessorMinVersion = GradleVersion.version("4.6")
@@ -12,7 +12,7 @@ boolean hasAnnotationProcessor = GradleVersion.current() >= annotationProcessorM
 def junit5MinVersion = GradleVersion.version("4.6")
 boolean hasJunit5 = GradleVersion.current() >= junit5MinVersion
 
-def graalVMMinVersion = GradleVersion.version("7.4")     // Toolchains with selection by vendor
+def graalVMMinVersion = GradleVersion.version("8.3")     // Gradle plugin for GraalVM requires 8.3+
 boolean hasGraalVM = GradleVersion.current() >= graalVMMinVersion
 
 dependencies {


### PR DESCRIPTION
The updated plugin requires Gradle 8.3 or later to run, so this commit also updates the minimum Gradle version for the nativeCompile task.