### PR TITLE
require Gradle 8.5+ for non-reference builds

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,13 +11,11 @@ jobs:
         os: [ubuntu-24.04, macOS-13, windows-2022]
         java: ['17', '21', '23']
         distribution: ['temurin']
-        gradle: ['8.0', '8.14.3']
+        gradle: ['8.5', '8.14.3']
         exclude:
-          # Java 21+ requires Gradle 8.5+
-          - java: '21'
-            gradle: '8.0'
+          # Java 23+ requires Gradle 8.10+
           - java: '23'
-            gradle: '8.0'
+            gradle: '8.5'
       fail-fast: false
     name: ${{ matrix.os }} JDK ${{ matrix.java }}.${{ matrix.distribution }} Gradle ${{ matrix.gradle }}
     steps:

--- a/README.adoc
+++ b/README.adoc
@@ -13,7 +13,7 @@ The bitcoinj library is a Java implementation of the Bitcoin protocol, which all
 * Java 8+ (needs Java 8 API or Android 8.0 API, compiles to Java 8 bytecode) for `base` and `core` module
 * Java 17+ for `tools`, `wallettool`, `examples` and the JavaFX-based `wallettemplate`
 * https://gradle.org/[Gradle]
-** Gradle 8.0+ for building the whole project or
+** Gradle 8.5+ for building the whole project or
 ** Debian Gradle 4.4 for just the `base`, `core`, `tools`, `wallettool` and `examples` modules (see "reference build" below)
 * https://github.com/google/protobuf[Google Protocol Buffers] - for use with serialization and hardware communications
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@
 import org.gradle.util.GradleVersion
 
 // Minimum Gradle version for build
-def minGradleVersion = GradleVersion.version("8.0")
+def minGradleVersion = GradleVersion.version("8.5")
 
 rootProject.name = 'bitcoinj-parent'
 


### PR DESCRIPTION
This guarantees the `dirPermissions` stuff is there (8.3+) and also is the minimum Gradle for JDK 21.