### PR TITLE
integration-test, wallettemplate: add testRuntimeOnly junit-platform-launcher

### DIFF
--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     testImplementation 'org.easymock:easymock:5.5.0'
     testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.18.1'
     testImplementation 'org.hamcrest:hamcrest-library:3.0'
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.11.4"
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:5.11.4"
 }

--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     runtimeOnly 'org.slf4j:slf4j-jdk14:2.0.16'
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.11.4"
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.11.4"
 }
 


### PR DESCRIPTION
This is needed for Gradle 9 compatibility.