### PR TITLE
core, integration-test: improve guava android constraint

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -27,11 +27,14 @@ dependencies {
     testImplementation 'pl.pragmatists:JUnitParams:1.1.1'
 }
 
-// Prevent newer Gradle from switching to JRE version of Guava
+// Prevent newer Gradle from switching to JRE version of Guava for tests.
+// We want our tests to run on the lowest-common denominator Android variant. We only enforce
+// this on the `testImplementation` configuration because we don't want to affect dependent
+// modules like `wallettemplate`.
 def gradleVersionTargetJVM = GradleVersion.version("7.0")
 if (GradleVersion.current() > gradleVersionTargetJVM) {
     dependencies.constraints {
-        implementation("com.google.guava:guava") {
+        testImplementation("com.google.guava:guava") {
             attributes {
                 attribute(
                         TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE,

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.util.GradleVersion
+
 plugins {
     id 'java'
     id 'java-library'
@@ -17,6 +19,22 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-library:3.0'
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.11.4"
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:5.11.4"
+}
+
+// Prevent newer Gradle from switching to JRE version of Guava for building/running integration tests.
+// We want our tests to run on the lowest-common denominator Android variant. We can enforce
+// this on the `implementation` configuration because `integration-test` has no dependents.
+def gradleVersionTargetJVM = GradleVersion.version("7.0")
+if (GradleVersion.current() > gradleVersionTargetJVM) {
+    dependencies.constraints {
+        implementation("com.google.guava:guava") {
+            attributes {
+                attribute(
+                        TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE,
+                        objects.named(TargetJvmEnvironment, TargetJvmEnvironment.ANDROID))
+            }
+        }
+    }
 }
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
Instead of forcing usage of the Android version of Guava on the core `implementation` classpath, do it on the `testImplementation` classpath of both `core` and `integration-test`.

This makes sure our tests run against the Android version, which is what we really want. But with this change we can use the JRE version in other modules, such as the wallettemplate module.