### PR TITLE
wallettemplate/build.gradle: direct dependency on Guava 33.4.8-jre

### DIFF
--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -7,6 +7,7 @@ plugins {
 
 dependencies {
     implementation project(':bitcoinj-core')
+    implementation 'com.google.guava:guava:33.4.8-jre'
     implementation 'com.google.zxing:core:3.5.3'
     implementation 'org.jspecify:jspecify:1.0.0'
     implementation 'org.slf4j:slf4j-api:2.0.16'
@@ -16,6 +17,12 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.11.4"
     testRuntimeOnly "org.junit.platform:junit-platform-launcher"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.11.4"
+}
+
+configurations.configureEach {
+    resolutionStrategy {
+        force 'com.google.guava:guava:33.4.8-jre'
+    }
 }
 
 javafx {

--- a/wallettemplate/src/main/java/module-info.java
+++ b/wallettemplate/src/main/java/module-info.java
@@ -23,6 +23,7 @@ module wallettemplate {
     requires org.jspecify;
 
     requires org.slf4j;
+    requires com.google.common;
     requires com.google.zxing;
 
     requires org.bitcoinj.core;


### PR DESCRIPTION
Add a direct dependency on the latest, modular, JRE version of Guava: 33.4.8-jre.

* Add as an `implementation` dependency
* Use a resolution strategy to force the JRE version
* Add `com.google.common` to module-info.java

~~This is a child of PR #3877 and will need a rebase.~~ Rebased.
