### PR TITLE
settings*.gradle: normalize differences between the two files

### DIFF
--- a/settings-debian.gradle
+++ b/settings-debian.gradle
@@ -1,11 +1,11 @@
 /*
- * Setting file only for Debian Gradle 4.4.1.
+ * Settings file only for Debian Gradle 4.4.1.
  * Usage: gradle --settings-file=settings-debian.gradle build
  */
 
 import org.gradle.util.GradleVersion
 
-// required Gradle version for build
+// Required Gradle version for build
 def gradleVersion = GradleVersion.version("4.4.1")
 
 if (GradleVersion.current() != gradleVersion) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,7 +8,6 @@ import org.gradle.util.GradleVersion
 // Minimum Gradle version for build
 def minGradleVersion = GradleVersion.version("8.5")
 
-rootProject.name = 'bitcoinj-parent'
 
 if (GradleVersion.current() < minGradleVersion) {
     throw new GradleScriptException("bitcoinj build requires Gradle ${minGradleVersion.version} or later", null)
@@ -16,6 +15,8 @@ if (GradleVersion.current() < minGradleVersion) {
 if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
     throw new GradleScriptException("bitcoinj build requires Java 17 or later", null)
 }
+
+rootProject.name = 'bitcoinj-parent'
 
 include 'test-support'
 project(':test-support').name = 'bitcoinj-test-support'


### PR DESCRIPTION
Minor changes to comments and ordering to make `settings.gradle` and `settings-debian.gradle` easier to compare.