### PR TITLE
build.gradle: disable asciidoctor manpage generation on gradle 9+

### DIFF
--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -50,27 +50,30 @@ if (hasJunit5) {
     }
 }
 
-task generateManpageAsciiDoc(type: JavaExec) {
-    dependsOn(classes)
-    group = "Documentation"
-    description = "Generate AsciiDoc manpage"
-    if (hasAnnotationProcessor) {
-        classpath(sourceSets.main.compileClasspath, configurations.annotationProcessor, sourceSets.main.runtimeClasspath)
-    } else {
-        classpath(sourceSets.main.compileClasspath, sourceSets.main.runtimeClasspath)
+// Disable asciidoctor manpage generation on Gradle 9+ (temporarily)
+if (GradleVersion.current() < GradleVersion.version("9.0")) {
+    task generateManpageAsciiDoc(type: JavaExec) {
+        dependsOn(classes)
+        group = "Documentation"
+        description = "Generate AsciiDoc manpage"
+        if (hasAnnotationProcessor) {
+            classpath(sourceSets.main.compileClasspath, configurations.annotationProcessor, sourceSets.main.runtimeClasspath)
+        } else {
+            classpath(sourceSets.main.compileClasspath, sourceSets.main.runtimeClasspath)
+        }
+        main 'picocli.codegen.docgen.manpage.ManPageGenerator'
+        args mainClassName, "--outdir=${project.buildDir}/generated-picocli-docs", "-v" //, "--template-dir=src/docs/mantemplates"
     }
-    main 'picocli.codegen.docgen.manpage.ManPageGenerator'
-    args mainClassName, "--outdir=${project.buildDir}/generated-picocli-docs", "-v" //, "--template-dir=src/docs/mantemplates"
-}
 
-apply plugin: 'org.asciidoctor.jvm.convert'
-asciidoctor {
-    dependsOn(generateManpageAsciiDoc)
-    sourceDir = file("${project.buildDir}/generated-picocli-docs")
-    outputDir = file("${project.buildDir}/docs")
-    logDocuments = true
-    outputOptions {
-        backends = ['manpage', 'html5']
+    apply plugin: 'org.asciidoctor.jvm.convert'
+    asciidoctor {
+        dependsOn(generateManpageAsciiDoc)
+        sourceDir = file("${project.buildDir}/generated-picocli-docs")
+        outputDir = file("${project.buildDir}/docs")
+        logDocuments = true
+        outputOptions {
+            backends = ['manpage', 'html5']
+        }
     }
 }
 


### PR DESCRIPTION
We can't upgrade the asciidoctor Gradle plugin to 4.0.4 without breaking the Debian Gradle build.

Since the official builds are still on Debian Gradle and we aren't really "shipping" the generated man page, it is ok to disable this for now.