### PR TITLE
Gradle 9 (9.1.0) take 3

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-24.04, macOS-13]
         java: [ '21', '23' ]
         distribution: [ 'graalvm-community' ]
-        gradle: ['8.14.3']
+        gradle: ['9.1.0']
       fail-fast: false
     name: ${{ matrix.os }} JDK ${{ matrix.java }}.${{ matrix.distribution }}
     steps:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-24.04, macOS-13, windows-2022]
         java: ['17', '21', '23']
         distribution: ['temurin']
-        gradle: ['8.5', '8.14.3']
+        gradle: ['8.5', '8.14.3', '9.1.0']
         exclude:
           # Java 23+ requires Gradle 8.10+
           - java: '23'


### PR DESCRIPTION
This has 3 cherry-picked commits, plus a 4th that adds `'9.1.0'` to the Gradle test matrix

In this draft PR we are testing in 8.14.3, 8.5, and 9.1.0. When we are ready to merge I propose we only use 8.5 and 9.1.0.