### PR TITLE
GHA graalvm.yml: Add -gradle-<version> to artifact name

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -32,5 +32,5 @@ jobs:
       - name: Upload wallet-tool as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wallet-tool-${{ matrix.os }}-${{ matrix.java }}
+          name: wallet-tool-${{ matrix.os }}-${{ matrix.java }}-gradle-${{ matrix.gradle }}
           path: wallettool/build/native/nativeCompile/wallet-tool


### PR DESCRIPTION
This prevents artifact uploading from breaking if we have two Gradle versions in the build matrix.