### PR TITLE
build.gradle: add conditional testRuntimeOnly dependency junit-platform-launcher

### DIFF
--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -28,6 +28,9 @@ dependencies {
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.11.4"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.11.4"
+    if (hasJunit5) {
+        testRuntimeOnly "org.junit.platform:junit-platform-launcher"
+    }
 
     testImplementation 'org.slf4j:slf4j-jdk14:2.0.16'
 }


### PR DESCRIPTION
This works towards supporting Gradle 9.