### PR TITLE
build.gradle: Upgrade to EasyMock 5.6.0

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation project(':bitcoinj-test-support')
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.easymock:easymock:5.5.0'
+    testImplementation 'org.easymock:easymock:5.6.0'
     testImplementation 'org.slf4j:slf4j-jdk14:2.0.16'
     testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.18.1'
     testImplementation 'org.hamcrest:hamcrest-library:3.0'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 
     testImplementation project(':bitcoinj-test-support')
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.easymock:easymock:5.5.0'
+    testImplementation 'org.easymock:easymock:5.6.0'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.18.2'
     testImplementation 'org.slf4j:slf4j-jdk14:2.0.16'
     testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.18.1'

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.11.4"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.11.4"
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.easymock:easymock:5.5.0'
+    testImplementation 'org.easymock:easymock:5.6.0'
     testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.18.1'
     testImplementation 'org.hamcrest:hamcrest-library:3.0'
     testRuntimeOnly "org.junit.platform:junit-platform-launcher"


### PR DESCRIPTION
EasyMock 5.6.0 is required for Java 25 compatibility.
