### PR TITLE
graalvm.yml: Use java 25 in the matrix (in place of 23)

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, macOS-13]
-        java: [ '21', '23' ]
+        java: [ '21', '25' ]
         distribution: [ 'graalvm-community' ]
         gradle: ['9.1.0']
       fail-fast: false


### PR DESCRIPTION
There's no reason not to replace EOL Java 23 with LTS Java 25 for our GraalVM-CE builds.