### PR TITLE
build.gradle: Use -PtestMinJdk=8 instead of testJdk8

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           gradle-version: ${{ matrix.gradle }}
       - name: Run Gradle
-        run: gradle -PtestJdk8=true build bitcoinj-wallettemplate:installDist bitcoinj-wallettemplate:jlink --init-script build-scan-agree.gradle --scan --info --stacktrace
+        run: gradle -PtestMinJdk=8 build bitcoinj-wallettemplate:installDist bitcoinj-wallettemplate:jlink --init-script build-scan-agree.gradle --scan --info --stacktrace
       - name: Upload Test Results and Reports
         uses: actions/upload-artifact@v4
         if: always()

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -38,23 +38,22 @@ test {
 }
 
 def gradleVersionToolchains = GradleVersion.version("6.7")
+// Activate if `testMinJdk` is a integer > 0 in `gradle.properties` or set with `-P` on the command-line
+def minJdkVersion = Integer.valueOf((String) findProperty('testMinJdk') ?: "0")
 
-if (GradleVersion.current() > gradleVersionToolchains) {
+if (minJdkVersion > 0 && GradleVersion.current() > gradleVersionToolchains) {
     // If the Gradle Java Toolchains feature is available, run tests on older JDKs
-    System.err.println "Adding 'testOnJdk8' task, because ${GradleVersion.current()}"
+    System.err.println "Adding 'testOnMinJdk' task for version=${minJdkVersion}, because ${GradleVersion.current()}"
 
-    task('testOnJdk8', type: Test) {
+    task('testOnMinJdk', type: Test) {
         doFirst {
             logger.lifecycle("Testing with JDK ${javaLauncher.get().metadata.javaRuntimeVersion}")
         }
         javaLauncher = javaToolchains.launcherFor {
-            languageVersion = JavaLanguageVersion.of(8)
+            languageVersion = JavaLanguageVersion.of(minJdkVersion)
         }
     }
-    // Activate if `testJdk8` is `true` in `gradle.properties` or `-PtestJdk8=true` is on command-line
-    if (Boolean.valueOf(findProperty('testJdk8'))) {
-        check.dependsOn testOnJdk8
-    }
+    check.dependsOn testOnMinJdk
 }
 
 ext.moduleName = 'org.bitcoinj.base'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -85,23 +85,22 @@ test {
 }
 
 def gradleVersionToolchains = GradleVersion.version("6.7")
+// Activate if `testMinJdk` is a integer > 0 in `gradle.properties` or set with `-P` on the command-line
+def minJdkVersion = Integer.valueOf((String) findProperty('testMinJdk') ?: "0")
 
-if (GradleVersion.current() > gradleVersionToolchains) {
+if (minJdkVersion > 0 && GradleVersion.current() > gradleVersionToolchains) {
     // If the Gradle Java Toolchains feature is available, run tests on older JDKs
-    System.err.println "Adding 'testOnJdk8' task, because ${GradleVersion.current()}"
+    System.err.println "Adding 'testOnMinJdk' task for version=${minJdkVersion}, because ${GradleVersion.current()}"
 
-    task('testOnJdk8', type: Test) {
+    task('testOnMinJdk', type: Test) {
         doFirst {
             logger.lifecycle("Testing with JDK ${javaLauncher.get().metadata.javaRuntimeVersion}")
         }
         javaLauncher = javaToolchains.launcherFor {
-            languageVersion = JavaLanguageVersion.of(8)
+            languageVersion = JavaLanguageVersion.of(minJdkVersion)
         }
     }
-    // Activate if `testJdk8` is `true` in `gradle.properties` or `-PtestJdk8=true` is on command-line
-    if (Boolean.valueOf(findProperty('testJdk8'))) {
-        check.dependsOn testOnJdk8
-    }
+    check.dependsOn testOnMinJdk
 }
 
 ext.moduleName = 'org.bitcoinj.core'


### PR DESCRIPTION
Rather than use a boolean that runs hardcoded JDK8 tests, use a numeric parameter to set the minimum JDK to test on.

This makes it easier to change our minimum version and it also makes it possible to run the tests on the minimum available JDK on a particular platform or really any JDK you want.