### PR TITLE
.gitlab-ci.yml: Add trixie-jdk25 job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,6 +37,18 @@ trixie-jdk21:
     - gradle --version
     - sha256sum core/build/libs/*.jar wallettool/build/install/wallet-tool/bin/*  wallettool/build/install/wallet-tool/lib/*.jar
 
+trixie-jdk25:
+  image: debian:trixie-slim
+  before_script:
+    - apt-get update
+    - apt-get -y install openjdk-25-jdk-headless gradle
+  script:
+    - gradle --settings-file settings-empty.gradle wrapper --gradle-version=9.1.0 --stacktrace
+    - ./gradlew build :bitcoinj-base:publishToMavenLocal :bitcoinj-core:publishToMavenLocal :bitcoinj-wallettool:installDist --stacktrace
+  after_script:
+    - gradle --version
+    - sha256sum core/build/libs/*.jar wallettool/build/install/wallet-tool/bin/*  wallettool/build/install/wallet-tool/lib/*.jar
+
 sast:
   stage: test
 

--- a/settings-empty.gradle
+++ b/settings-empty.gradle
@@ -1,0 +1,1 @@
+// Empty settings file. Used to run the `wrapper` task to upgrade Gradle on CI. See .gitlab-ci.yml


### PR DESCRIPTION
This is a failed attempt.
The main problem is that although Debian provides a JDK 25, they don't provide a Gradle that works with it.
I'm trying the "use the built-in Gradle to download a wrapper for 9.1.0 then run from the wrapper" trick, we'll see if it works.

I also discovered that Gradle is removing the `--settings` command-line option: https://github.com/gradle/gradle/issues/33093