### PR TITLE
add flake.nix to setup a simple nix devshell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1758446476,
+        "narHash": "sha256-5rdAi7CTvM/kSs6fHe1bREIva5W3TbImsto+dxG4mBo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a1f79a1770d05af18111fbbe2a3ab2c42c0f6cd0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "bitcoinj";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = inputs @ { nixpkgs, ... }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+      forEachSystem = f: builtins.listToAttrs (map (system: {
+        name = system;
+        value = f system;
+      }) systems);
+    in {
+      devShells = forEachSystem(system:
+        let
+        inherit (pkgs) stdenv;
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+        graalvm = pkgs.graalvmPackages.graalvm-ce;
+        in {
+        default = pkgs.mkShell {
+          packages = with pkgs ; [
+                graalvm                    # This JDK will be in PATH
+                (gradle_9.override {       # Gradle (Nix package) runs using an internally-linked JDK
+                    java = graalvm;        # Run Gradle with this JDK
+                })
+            ];
+          shellHook = ''
+            # setup GRAALVM_HOME
+            export GRAALVM_HOME=${graalvm}
+            echo "Welcome to bitcoinj!"
+          '';
+        };
+      });
+  };
+}

--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -99,6 +99,8 @@ if (hasGraalVM) {
                 imageName = walletToolName
                 configurationFileDirectories.from(file('src/main/graal'))
                 buildArgs.add('--allow-incomplete-classpath')
+                buildArgs.add('-H:+UnlockExperimentalVMOptions')
+                buildArgs.add('-H:-CheckToolchain')
             }
         }
     }


### PR DESCRIPTION
The devshell using graalvm-ce to provide both a standard JDK and native image support.

Because Nixified paths confuse native-image's CheckToolchain, we will disabled it.

Among other advantages, this will provide a mechanism to get Gradle 9.1+ on Debian.