### PR TITLE
CryptoUtils: Add Charset param to hmacSha512 method that takes a string

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
@@ -23,6 +23,7 @@ import org.bouncycastle.math.ec.ECPoint;
 
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.function.Supplier;
@@ -64,7 +65,7 @@ public final class HDKeyDerivation {
         checkArgument(seed.length > 8, () ->
                 "seed is too short and could be brute forced");
         // Calculate I = HMAC-SHA512(key="Bitcoin seed", msg=S)
-        byte[] i = CryptoUtils.hmacSha512("Bitcoin seed", seed);
+        byte[] i = CryptoUtils.hmacSha512("Bitcoin seed", StandardCharsets.US_ASCII, seed);
         // Split I into two 32-byte sequences, Il and Ir.
         // Use Il as master secret key, and Ir as master chain code.
         checkState(i.length == 64, () ->

--- a/core/src/main/java/org/bitcoinj/crypto/internal/CryptoUtils.java
+++ b/core/src/main/java/org/bitcoinj/crypto/internal/CryptoUtils.java
@@ -22,6 +22,7 @@ import org.bouncycastle.crypto.macs.HMac;
 import org.bouncycastle.crypto.params.KeyParameter;
 import org.bouncycastle.jcajce.provider.digest.SHA3;
 
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
@@ -69,12 +70,15 @@ public class CryptoUtils {
     }
 
     /**
-     * Generate a MAC using a {@link String} key and data
-     * @param key The key
+     * Generate a MAC using a {@link String} tag and data. For example, this is used in our BIP-32
+     * implementation with a tag {@code String} of {@code "Bitcoin seed"}. The {@link Charset} parameter
+     * is typically {@link StandardCharsets#US_ASCII}.
+     * @param tag The tag
+     * @param charset The {@link Charset} to be used to encode the tag {@code String}
      * @param data The message data to process
      * @return The final result of the MAC operation
      */
-    public static byte[] hmacSha512(String key, byte[] data) {
-        return hmacSha512(key.getBytes(), data);
+    public static byte[] hmacSha512(String tag, Charset charset, byte[] data) {
+        return hmacSha512(tag.getBytes(charset), data);
     }
 }


### PR DESCRIPTION
~~Make the usage of Bouncy Castle HMacSHA512 a private implementation detail.~~ This PR was originally two commits, the first one making the core implementation private, the second doing some simplification. This PR now contains the second commit plus some additional improvements.

[The already merged commit] should allow PR #3791 to use `CryptoUtils` for hmacSha512, though this PR still contains a change to explicitly specify the CharSet (typically `US_ASCII`) which BIP85 requires.