### PR TITLE
build.gradle: build wallettemplate with JDK 21

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -36,8 +36,10 @@ project(':wallettool').name = 'bitcoinj-wallettool'
 include 'examples'
 project(':examples').name = 'bitcoinj-examples'
 
-include 'wallettemplate'
-project(':wallettemplate').name = 'bitcoinj-wallettemplate'
+if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)) {
+    include 'wallettemplate'
+    project(':wallettemplate').name = 'bitcoinj-wallettemplate'
+}
 
 include 'integration-test'
 project(':integration-test').name = 'bitcoinj-integration-test'

--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -32,7 +32,7 @@ javafx {
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
-    options.release = 17
+    options.release = 21
     options.compilerArgs << '-Xlint:deprecation'
 }
 


### PR DESCRIPTION
PR #3913 (which changes CI to automatically run `installDist` in any included subproject that contains it) was merged, so this PR only touches two gradle build files.