### PR TITLE
.gitlab-ci.yml, build.Containerfile: run `publishToMavenLocal` target on every subproject

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ bookworm-jdk17:
     - apt-get update
     - apt-get -y install openjdk-17-jdk-headless gradle
   script:
-    - gradle --settings-file settings-debian.gradle build :bitcoinj-base:publishToMavenLocal :bitcoinj-core:publishToMavenLocal installDist --init-script build-scan-agree.gradle --scan --stacktrace
+    - gradle --settings-file settings-debian.gradle build publishToMavenLocal installDist --init-script build-scan-agree.gradle --scan --stacktrace
   after_script:
     - gradle --version
     - sha256sum core/build/libs/*.jar wallettool/build/install/wallet-tool/bin/*  wallettool/build/install/wallet-tool/lib/*.jar
@@ -32,7 +32,7 @@ trixie-jdk21:
     - apt-get update
     - apt-get -y install openjdk-21-jdk-headless gradle
   script:
-    - gradle --settings-file settings-debian.gradle build :bitcoinj-base:publishToMavenLocal :bitcoinj-core:publishToMavenLocal installDist --init-script build-scan-agree.gradle --scan --stacktrace
+    - gradle --settings-file settings-debian.gradle build publishToMavenLocal installDist --init-script build-scan-agree.gradle --scan --stacktrace
   after_script:
     - gradle --version
     - sha256sum core/build/libs/*.jar wallettool/build/install/wallet-tool/bin/*  wallettool/build/install/wallet-tool/lib/*.jar

--- a/build.Containerfile
+++ b/build.Containerfile
@@ -44,7 +44,7 @@ RUN --mount=target=/home/builder/.gradle,type=cache,uid=1000,gid=1000,sharing=lo
     --no-build-cache --no-daemon --no-parallel \
     --settings-file=settings-debian.gradle \
     -Dmaven.repo.local=repo \
-    clean ${ADDITIONAL_GRADLE_TASK} :bitcoinj-base:publishToMavenLocal :bitcoinj-core:publishToMavenLocal :bitcoinj-wallettool:installDist
+    clean ${ADDITIONAL_GRADLE_TASK} publishToMavenLocal :bitcoinj-wallettool:installDist
 
 # stage: export build output
 FROM scratch AS export-stage


### PR DESCRIPTION
`publishToMavenLocal` is a no-op on subprojects that don't use the `maven-publish` plugin, but runs on every subproject that does.
