### PR TITLE
wallettemplate: update to BA JLink Plugin 3.1.5

### DIFF
--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'application'
     id 'org.openjfx.javafxplugin' version '0.1.0'
-    id 'org.beryx.jlink' version '3.1.3'
+    id 'org.beryx.jlink' version '3.1.5'
 }
 
 dependencies {


### PR DESCRIPTION
~~This a draft PR until `3.1.4` final is released~~ ~~and PR #3919 is merged.~~

~~The PR will _build_ if applied to current `master`, but on Temurin JDK 24+ will crash at launch until PR #3919 is merged first.~~ 

BA JLink `3.1.5` is final. (they skipped a "final" release of 3.1.4-rc and bumped the version to 3.1.5)

As a reminder: this change is necessary for us to enable `jlink` in CI using Temurin 25. See:

* PR #3918