### PR TITLE
GHA gradle.yml: add jlink task to main Gradle step

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           gradle-version: ${{ matrix.gradle }}
       - name: Run Gradle
-        run: gradle -PtestMinJdk=${{ env.MIN_JDK }} build installDist --init-script build-scan-agree.gradle --scan --info --stacktrace
+        run: gradle -PtestMinJdk=${{ env.MIN_JDK }} build installDist jlink --init-script build-scan-agree.gradle --scan --info --stacktrace
       - name: Upload Test Results and Reports
         uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
~~This is now a child of PR #3921~~ (Rebased)

The BA JLink Plugin now has a final `3.1.5` release.

This PR has been modified and rebased several times, but we now have a path to `jlink` working for both `wallettool` and `wallettemplate` for all versions of the (Temurin) JDK in our build matrix.

The steps are:

* PR #3917 -- `wallettemplate`: upgrade to BA JLink 3.1.5
* PR #3921 -- `wallettool`: add `jlink` using BA JLink 3.1.5
* This PR -- enable the `jlink` task on the main `gradle` "step" of the build. 

