### PR TITLE
wallettool: add module-info.java, ignore when Gradle < 8.5

### DIFF
--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id 'org.graalvm.buildtools.native' version '0.11.0' apply false
 }
 
+def isModularBuild = GradleVersion.current() >= GradleVersion.version("8.5")
 def annotationProcessorMinVersion = GradleVersion.version("4.6")
 boolean hasAnnotationProcessor = GradleVersion.current() >= annotationProcessorMinVersion
 def junit5MinVersion = GradleVersion.version("4.6")
@@ -39,6 +40,10 @@ tasks.withType(JavaCompile) {
     options.compilerArgs.addAll(['--release', '17'])
     options.compilerArgs << '-Xlint:deprecation'
     options.encoding = 'UTF-8'
+    if (!isModularBuild) {
+        // Exclude the module-info.java file because Gradle 4.x doesn't handle module-info.java well.
+        source = source.filter { file -> !file.path.endsWith('module-info.java') }
+    }
 }
 
 javadoc.options.encoding = 'UTF-8'

--- a/wallettool/src/main/java/module-info.java
+++ b/wallettool/src/main/java/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module org.bitcoinj.wallettool {
+    requires java.logging;
+
+    requires org.jspecify;
+    requires org.slf4j;
+    requires info.picocli;
+
+    requires org.bitcoinj.core;
+
+    opens org.bitcoinj.wallettool to info.picocli;
+}


### PR DESCRIPTION
`wallettool` is built with JDK 17 and should have a `module-info.java`