### PR TITLE
WIP wallettool use jlink gradle 8.5

### DIFF
--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -45,6 +45,12 @@ application {
 
 jlink {
     options = ['--add-modules', 'org.slf4j.jul']
+    mergedModule {
+        requires 'java.logging'
+        requires 'jdk.unsupported'
+
+        requires 'org.slf4j'
+    }
 }
 
 test {

--- a/wallettemplate/build.gradle
+++ b/wallettemplate/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'application'
     id 'org.openjfx.javafxplugin' version '0.1.0'
-    id 'org.beryx.jlink' version '3.1.3'
+    id 'org.beryx.jlink' version '3.1.4-rc'
 }
 
 dependencies {

--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id 'org.graalvm.buildtools.native' version '0.11.0' apply false
 }
 
+def isModularBuild = GradleVersion.current() >= GradleVersion.version("8.5")
 def annotationProcessorMinVersion = GradleVersion.version("4.6")
 boolean hasAnnotationProcessor = GradleVersion.current() >= annotationProcessorMinVersion
 def junit5MinVersion = GradleVersion.version("4.6")
@@ -39,6 +40,10 @@ tasks.withType(JavaCompile) {
     options.compilerArgs.addAll(['--release', '17'])
     options.compilerArgs << '-Xlint:deprecation'
     options.encoding = 'UTF-8'
+    if (!isModularBuild) {
+        // Exclude the module-info.java file because Gradle 4.x doesn't handle module-info.java well.
+        source = source.filter { file -> !file.path.endsWith('module-info.java') }
+    }
 }
 
 javadoc.options.encoding = 'UTF-8'

--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -3,6 +3,7 @@ import org.gradle.util.GradleVersion
 plugins {
     id 'java'
     id 'application'
+    id 'org.beryx.jlink' version '3.1.4-rc' apply false
     id 'org.asciidoctor.jvm.convert' version '3.3.2' apply false
     id 'org.graalvm.buildtools.native' version '0.11.0' apply false
 }
@@ -58,6 +59,20 @@ if (GradleVersion.current() > GradleVersion.version("8.0")) {
 } else {
     mainClassName = walletToolMainClassName
     applicationName = walletToolName
+}
+
+if (isModularBuild) {
+    apply plugin: 'org.beryx.jlink'
+
+    jlink {
+        options = ['--add-modules', 'org.slf4j.jul']
+        mergedModule {
+            requires 'jdk.unsupported'    // For protobuf
+            requires 'java.logging'       // For bitcoinj-core
+
+            requires 'org.slf4j'          // For bitcoinj-core
+        }
+    }
 }
 
 // wallettool is using JUnit 5 for testing, if it's not available no tests will be run

--- a/wallettool/src/main/java/module-info.java
+++ b/wallettool/src/main/java/module-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module org.bitcoinj.wallettool {
+    requires java.logging;
+
+    requires org.jspecify;
+    requires org.slf4j;
+    requires info.picocli;
+
+    requires org.bitcoinj.core;
+
+    opens org.bitcoinj.wallettool to info.picocli;
+}


### PR DESCRIPTION
This is a WIP PR that contains 4 commits:

* 94831e3dbd3c5e874325ad107ce6c5fc270821eb -- PR #3920 
* 8f8f83fe7b1ca4933fa82b4ee6e09e56b6417206 -- unique to this PR add `wallettool` `jlink` task
* 268f8ffca7e9568ab352a9da379ac166389b4adc -- PR #3919 
* 0aabd8a26c404ddf4e24db8e07f20e5f335cc763 -- PR #3917 

The combination of these 4 allows building both `wallettempalte` and `wallettool` in all our GHA and GitLib CI configurations.

