### PR TITLE
wallettool/build.gradle: set mainModule in application block

### DIFF
--- a/wallettool/build.gradle
+++ b/wallettool/build.gradle
@@ -55,6 +55,10 @@ if (GradleVersion.current() > GradleVersion.version("8.0")) {
     application {
         mainClass = walletToolMainClassName
         applicationName = walletToolName
+        if (isModularBuild) {
+            // setting mainModule tells installDist to create a launch script that uses module path
+            mainModule = "org.bitcoinj.wallettool"
+        }
     }
 } else {
     mainClassName = walletToolMainClassName


### PR DESCRIPTION
~~This is a child of #3920 but is independent of the use of the BA JLink plugin.~~ (rebased)

Sets the `mainModule` property in the `application` block signifying that the application should be modular. This means that the existing `installDist` task will build a launch script that sets up the module path.

When applications run on the module path they have stricter integrity guarantees. E.g. if a module is accessing sun.misc.unsafe (in module jdk.unsupported) this will result in a warning or an error. It was by running wallet-tool as a module that I discovered that ProtoBuf is doing this. So enforcing these checks will help us make our modules better as well as warn us about bad behavior in 3rd-party modules. See also the discussion/rationale in Issue #3928.