### PR TITLE
TestWithNetworkConnections, TestWithPeerGroup: handle nulls in tearDown()/stopPeerServer()

### DIFF
--- a/integration-test/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
+++ b/integration-test/src/test/java/org/bitcoinj/testing/TestWithNetworkConnections.java
@@ -165,8 +165,11 @@ public class TestWithNetworkConnections {
     }
 
     protected void stopPeerServer(int i) {
-        peerServers[i].stopAsync();
-        peerServers[i].awaitTerminated();
+        NioServer server = peerServers[i];
+        if (server != null) {
+            server.stopAsync();
+            server.awaitTerminated();
+        }
     }
 
     protected InboundMessageQueuer connect(Peer peer, VersionMessage versionMessage) throws Exception {

--- a/integration-test/src/test/java/org/bitcoinj/testing/TestWithPeerGroup.java
+++ b/integration-test/src/test/java/org/bitcoinj/testing/TestWithPeerGroup.java
@@ -91,7 +91,7 @@ public class TestWithPeerGroup extends TestWithNetworkConnections {
         try {
             super.tearDown();
             blockJobs = false;
-            if (peerGroup.isRunning())
+            if (peerGroup != null && peerGroup.isRunning())
                 peerGroup.stopAsync();
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
These two null checks prevent `DefaultMultiCauseException: Multiple Failures` during the intermittent `BindException: Address already in use: bind` we are seeing. They make the tearDown a little more orderly.