### PR TITLE
ClientConnectionManager: BUGFIX: stop() call stopAsync() not startAsync()

### DIFF
--- a/core/src/main/java/org/bitcoinj/net/ClientConnectionManager.java
+++ b/core/src/main/java/org/bitcoinj/net/ClientConnectionManager.java
@@ -59,7 +59,7 @@ public interface ClientConnectionManager extends Service {
      * @return a future that will complete when the service is stopped
      */
     default CompletableFuture<Void> stop() {
-        startAsync();
+        stopAsync();
         return CompletableFuture.runAsync(this::awaitTerminated);
     }
 }


### PR DESCRIPTION
This fixes a bug introduced by PR #3796.

Looks like I authored the bad commit in April of this year and it got merged on July 19, 2025.

I guess we didn't find it until now because it shows up intermittently and looks like existing intermittent failures.