### PR TITLE
add flake.nix to setup a simple nix devshell with Zulu 25

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1765296308,
+        "narHash": "sha256-s+FbSht05qub/71tqt/eSZ/XCqimqU5wiBkoECr1SFA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a21f77b1876ce8c43e47d852b2978488a3c5f4a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "bitcoinj";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/release-25.11";
+  };
+
+  outputs = inputs @ { nixpkgs, ... }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+      forEachSystem = f: builtins.listToAttrs (map (system: {
+        name = system;
+        value = f system;
+      }) systems);
+    in {
+      devShells = forEachSystem(system:
+        let
+        inherit (pkgs) stdenv;
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+        jdk = pkgs.zulu25.override { enableJavaFX = true; };
+        in {
+        default = pkgs.mkShell {
+          packages = with pkgs ; [
+                jdk                        # This JDK will be in PATH
+                (gradle_9.override {       # Gradle (Nix package) runs using an internally-linked JDK
+                    java = jdk;            # Run Gradle with this JDK
+                })
+            ];
+          shellHook = ''
+            echo "Welcome to bitcoinj!"
+          '';
+        };
+      });
+  };
+}


### PR DESCRIPTION
The devshell uses zulu25 to allow OpenJDK-based builds.

(It does not include a GraalVM JDK for native-image builds.)

I suggest we start `flake.nix` with this PR which is slightly simpler than PR #3906 which provides a devshell with GraalVM-CE

This has been updated to use Zulu 25 because it supports `enableJavaFX` on the 4 tier-1 platforms.