### PR TITLE
WalletAccountPathTest: test receive address 0

### DIFF
--- a/integration-test/src/test/java/org/bitcoinj/test/integration/wallet/WalletAccountPathTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/test/integration/wallet/WalletAccountPathTest.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.test.integration.wallet;
 
+import org.bitcoinj.base.Address;
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
@@ -43,6 +44,7 @@ import static org.bitcoinj.base.ScriptType.P2WPKH;
 import static org.bitcoinj.wallet.KeyChainGroupStructure.BIP32;
 import static org.bitcoinj.wallet.KeyChainGroupStructure.BIP43;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Create new Wallets in a temp directory and make sure their account paths are correct.
@@ -67,6 +69,10 @@ public class WalletAccountPathTest {
 
         // Then the account path is as expected
         assertEquals(expectedPath, wallet.getActiveKeyChain().accountFullPath());
+
+        // We can get the first receive address
+        Address address = wallet.currentReceiveAddress();
+        assertNotNull(address);
     }
 
     static final List<Arguments> walletStructureParams = List.of(


### PR DESCRIPTION
Make sure we can get currentReceiveAddress() for each path.

This is extracted from PR #3342 which can be rebased after this is merged.