### PR TITLE
GHA gradle.yml, graalvm.yml: use "Gradle" in workflow names

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -1,4 +1,4 @@
-name: GraalVM Build
+name: GraalVM Gradle Build
 
 on: [push, pull_request]
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,4 +1,4 @@
-name: Java CI
+name: Gradle Build
 
 on: [push, pull_request]
 


### PR DESCRIPTION
"Java CI" -> "Gradle Build"
"GraalVM Build" -> "GraalVM Gradle Build"

This allow us to distinguish between the Gradle workflows and new Maven workflows that are being tested for Issue #3840. (These changes were extracted from PR #3929)

And even if we don't migrate to Maven, they are more descriptive.