### PR TITLE
gradle.yml, graalvm.yml: use Gradle 9.2.0 in the build matrices

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-24.04, macOS-13]
         java: [ '21', '25' ]
         distribution: [ 'graalvm-community' ]
-        gradle: ['9.1.0']
+        gradle: ['9.2.0']
       fail-fast: false
     name: ${{ matrix.os }} JDK ${{ matrix.java }}.${{ matrix.distribution }}
     steps:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-24.04, macOS-13, windows-2022]
         java: ['17', '21', '25']
         distribution: ['temurin']
-        gradle: ['8.5', '8.14.3', '9.1.0']
+        gradle: ['8.5', '8.14.3', '9.2.0']
         exclude:
           # Java 25+ requires Gradle 9.1+
           - java: '25'


### PR DESCRIPTION
Replace Gradle 9.1.0 with Gradle 9.2.0