### PR TITLE
modular-architecture.md: two minor updates

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -8,7 +8,7 @@ plugins {
 version = '0.18-SNAPSHOT'
 
 dependencies {
-    implementation 'org.jspecify:jspecify:1.0.0'
+    api 'org.jspecify:jspecify:1.0.0'
 
     testImplementation project(':bitcoinj-test-support')
     testImplementation 'junit:junit:4.13.2'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,11 +10,11 @@ version = '0.18-SNAPSHOT'
 
 dependencies {
     api project(':bitcoinj-base')
+    api 'org.jspecify:jspecify:1.0.0'
     api 'org.bouncycastle:bcprov-jdk15to18:1.81'
     api 'com.google.guava:guava:33.5.0-android'
     api 'com.google.protobuf:protobuf-javalite:4.30.2'
 
-    implementation 'org.jspecify:jspecify:1.0.0'
     implementation 'org.slf4j:slf4j-api:2.0.16'
 
     testImplementation project(':bitcoinj-test-support')

--- a/designdocs/modular-architecture.md
+++ b/designdocs/modular-architecture.md
@@ -88,7 +88,7 @@ flowchart TD
     SECPFFM --> SECPC[libsecp256k1]
     CORE --> P[ProtoBuf]
     CORE .-> S[SLF4J]
-    BASE .-> JS[JSpecify]
+    BASE --> JS[JSpecify]
 
 classDef external fill:#999;
 class G,S,JS,BC,SECPC,P external;
@@ -125,7 +125,7 @@ flowchart TD
     CORE --> BASE
     CORE --> SECP
     CORE .-> S[SLF4J]
-    BASE .-> JS[JSpecify]
+    BASE --> JS[JSpecify]
     SECP[secp-api] .-> SECPFFM[secp-ffm]
     SECP .-> SECPBOUNCY[secp-bouncy]
     SECPBOUNCY .-> BC[Bouncy Castle]


### PR DESCRIPTION
Two commits:

* core, not base depends on SLF4J (see PR #3957)
* JSpecify dependency is `api` not `implementation` (see PR #3865)