### PR TITLE
base module: add UNKOWN runtime and os, remove use of slf4j

### DIFF
--- a/base/src/main/java/org/bitcoinj/base/internal/PlatformUtils.java
+++ b/base/src/main/java/org/bitcoinj/base/internal/PlatformUtils.java
@@ -35,7 +35,7 @@ public class PlatformUtils {
 
     static {
         String runtimeProp = System.getProperty("java.runtime.name", "").toLowerCase(Locale.US);
-        if (runtimeProp.equals(""))
+        if (runtimeProp.isEmpty())
             runtime = PlatformUtils.Runtime.UNKNOWN;
         else if (runtimeProp.contains("android"))
             runtime = PlatformUtils.Runtime.ANDROID;
@@ -49,7 +49,7 @@ public class PlatformUtils {
             runtime = PlatformUtils.Runtime.UNKNOWN;
 
         String osProp = System.getProperty("os.name", "").toLowerCase(Locale.US);
-        if (osProp.equals(""))
+        if (osProp.isEmpty())
             os = PlatformUtils.OS.UNKNOWN;
         else if (osProp.contains("linux"))
             os = PlatformUtils.OS.LINUX;


### PR DESCRIPTION
Note that this also eliminates a nullable static field.

Update: and it allows us to make `os` and `runtime` into `final` fields, so I added a commit to do that.