### PR TITLE
GHA graavm.yml, gradle.yml: Use macOS-15-intel

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [ubuntu-24.04, macOS-13]
+        os: [ubuntu-24.04, macOS-15-intel]
         java: [ '21', '25' ]
         distribution: [ 'graalvm-community' ]
         gradle: ['9.2.0']

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [ubuntu-24.04, macOS-13, windows-2022]
+        os: [ubuntu-24.04, macOS-15-intel, windows-2022]
         java: ['17', '21', '25']
         distribution: ['temurin']
         gradle: ['8.5', '8.14.3', '9.2.0']


### PR DESCRIPTION
macOS-13 has been dropped by GitHub.