### PR TITLE
GHA gradle.yml: Install JDK 8 via setup-java action

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,6 +19,9 @@ jobs:
           - java: '25'
             gradle: '8.14.3'
       fail-fast: false
+    env:
+      # Use env variable to specify the JDK version to use for the `testMinJdk` Gradle option
+      MIN_JDK: '8'
     name: ${{ matrix.os }} JDK ${{ matrix.java }}.${{ matrix.distribution }} Gradle ${{ matrix.gradle }}
     steps:
       - name: Git checkout
@@ -27,13 +30,15 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: ${{ matrix.distribution }}
-          java-version: ${{ matrix.java }}
+          java-version: |
+            ${{ env.MIN_JDK }}
+            ${{ matrix.java }}
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: ${{ matrix.gradle }}
       - name: Run Gradle
-        run: gradle -PtestMinJdk=8 build installDist --init-script build-scan-agree.gradle --scan --info --stacktrace
+        run: gradle -PtestMinJdk=${{ env.MIN_JDK }} build installDist --init-script build-scan-agree.gradle --scan --info --stacktrace
       - name: Upload Test Results and Reports
         uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
We previously relied on it being already installed on the GitHub runner, but we need to upgrade the macOS runner to macOS-15-intel which does not have JDK 8 built-in.

Note that since we have configured setup-java to use the Temurin distro, JDK 8 will now be the Temurin build rather than whatever was included with the runner.

Note that this PR does not fix the macOS builds (which still rely on the removed `macOS-13` runner) but is a standalone commit that when applied installs Temurin JDK 8 on _all_ runners and can be demonstrated to work correctly. PR #3960 can be applied later/separately to migrate from `macOS-13` to `macOS-15-intel`