### PR TITLE
Update reference build to use Trixie and JDK 21

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 reference:
-  image: debian:bookworm-slim
+  image: debian:trixie-slim
   before_script:
     - apt-get update
     - apt-get -y install ca-certificates buildah

--- a/build.Containerfile
+++ b/build.Containerfile
@@ -16,14 +16,14 @@
 #
 
 # stage: set up debian environment
-FROM debian:bookworm-slim AS setup-stage
+FROM debian:trixie-slim AS setup-stage
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
     --mount=target=/var/cache/apt,type=cache,sharing=locked \
     /usr/bin/rm -f /etc/apt/apt.conf.d/docker-clean && \
     /usr/bin/apt-get update && \
-    /usr/bin/apt-get --yes --no-install-recommends install openjdk-17-jdk-headless gradle && \
+    /usr/bin/apt-get --yes --no-install-recommends install adduser openjdk-21-jdk-headless gradle && \
     /usr/sbin/adduser --disabled-login --gecos "" builder
 
 # stage: build


### PR DESCRIPTION
This was just a quick attempt. It seems to be having a problem:
 `setup network: netavark: nftables error: nft did not return successfully while applying ruleset`

More complete log:

```
$ buildah build --file build.Containerfile --output build .
[1/3] STEP 1/3: FROM debian:trixie-slim AS setup-stage
Resolved "debian" as an alias (/etc/containers/registries.conf.d/shortnames.conf)
Trying to pull docker.io/library/debian:trixie-slim...
Getting image source signatures
Copying blob sha256:1733a4cd59540b3470ff7a90963bcdea5b543279dd6bdaf022d7883fdad221e5
Copying config sha256:233eabc84b66a93289d2688a82dedad807224cc42969da1798c13b408e823ffd
Writing manifest to image destination
[1/3] STEP 2/3: ENV DEBIAN_FRONTEND noninteractive
[1/3] STEP 3/3: RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked     --mount=target=/var/cache/apt,type=cache,sharing=locked     /usr/bin/rm -f /etc/apt/apt.conf.d/docker-clean &&     /usr/bin/apt-get update &&     /usr/bin/apt-get --yes --no-install-recommends install adduser openjdk-21-jdk-headless gradle &&     /usr/sbin/adduser --disabled-login --gecos "" builder
internal:0:0-0: Error: Could not process rule: No such file or directory
internal:0:0-0: Error: Could not process rule: No such file or directory
error running container: did not get container start message from parent: EOF
Error: building at STEP "RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked --mount=target=/var/cache/apt,type=cache,sharing=locked /usr/bin/rm -f /etc/apt/apt.conf.d/docker-clean &&     /usr/bin/apt-get update &&     /usr/bin/apt-get --yes --no-install-recommends install adduser openjdk-21-jdk-headless gradle &&     /usr/sbin/adduser --disabled-login --gecos "" builder": setup network: netavark: nftables error: nft did not return successfully while applying ruleset
```
