### PR TITLE
gradle.yml: exclude older versions of Gradle on macOS and Windows

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,6 +18,19 @@ jobs:
             gradle: '8.5'
           - java: '25'
             gradle: '8.14.3'
+          # Exclude older versions of Gradle on macOS and Windows
+          - os: macOS-15
+            gradle: '8.5'
+          - os: macOS-15
+            gradle: '8.14.3'
+          - os: macOS-15-intel
+            gradle: '8.5'
+          - os: macOS-15-intel
+            gradle: '8.14.3'
+          - os: windows-2022
+            gradle: '8.5'
+          - os: windows-2022
+            gradle: '8.14.3'
       fail-fast: false
     env:
       # Use env variable to specify the JDK version to use for the `testMinJdk` Gradle option


### PR DESCRIPTION
The tests with the older versions of Gradle are mostly to make sure we didn't break the build on older versions of Gradle, so running them on Ubuntu only should be sufficient.