### PR TITLE
wallettool module-info.java: add o.b.core transitive dependencies

### DIFF
--- a/wallettool/src/main/java/module-info.java
+++ b/wallettool/src/main/java/module-info.java
@@ -22,6 +22,11 @@ module org.bitcoinj.wallettool {
     requires info.picocli;
 
     requires org.bitcoinj.core;
+    // Since bitcoinj-core doesn't have a module-info and IDEs are generally unaware of the
+    // processing done by the jlink plugin, we include transitive dependencies here that would
+    // be unnecessary if bitcoinj-core were fully modular.
+    requires org.bitcoinj.base;     // Transitive via bitcoinj-core
+    requires com.google.protobuf;   // Transitive via bitcoinj-core
 
     opens org.bitcoinj.wallettool to info.picocli;
 }


### PR DESCRIPTION
Add transitive dependencies of bitcoinj-core that are not strictly needed for the build, but prevent errors/warnings in IDEs (e.g. IntelliJ)

These lines can be removed when bitcoinj-core gets a module-info.

This now a child of PR #3973 which also helps IDEA.