### PR TITLE
WalletTool: Fix `date` to `rotationTime` conversion.

### DIFF
--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -533,7 +533,7 @@ public class WalletTool implements Callable<Integer> {
         // Set a key rotation time and possibly broadcast the resulting maintenance transactions.
         Instant rotationTime = TimeUtils.currentTime();
         if (date != null) {
-            rotationTime = Instant.from(date);
+            rotationTime = date.atStartOfDay(ZoneId.systemDefault()).toInstant();
         } else if (unixtime != null) {
             rotationTime = Instant.ofEpochSecond(unixtime);
         }


### PR DESCRIPTION
`date` is a `LocalDate` which can't be converted to an `Instant` by `Instant.from()`

By using `atStartOfDay()` with a timezone, we can use `toInstant()`.

This fixes Issue #3969.