### PR TITLE
graalvm.yml: remove GraalVM JDK 21 from the matrix

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, macOS-15, macOS-15-intel]
-        java: [ '21', '25' ]
+        java: [ '25' ]
         distribution: [ 'graalvm-community' ]
         gradle: ['9.2.1']
       fail-fast: false


### PR DESCRIPTION
GraalVM support in bitcoinj is still considered experimental. GraalVM 25 has important fixes and improvements. Some of which needed for secp-jdk FFM.

Let's keep things simple and focus our efforts on GraalVM 25+.