### PR TITLE
build.gradle: simplify Automatic-Module-Name attribute.

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -56,12 +56,9 @@ if (minJdkVersion > 0 && GradleVersion.current() > gradleVersionToolchains) {
     check.dependsOn testOnMinJdk
 }
 
-ext.moduleName = 'org.bitcoinj.base'
-
 jar {
-    inputs.property("moduleName", moduleName)
     manifest {
-        attributes 'Automatic-Module-Name': moduleName
+        attributes 'Automatic-Module-Name': 'org.bitcoinj.base'
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -103,12 +103,9 @@ if (minJdkVersion > 0 && GradleVersion.current() > gradleVersionToolchains) {
     check.dependsOn testOnMinJdk
 }
 
-ext.moduleName = 'org.bitcoinj.core'
-
 jar {
-    inputs.property("moduleName", moduleName)
     manifest {
-        attributes 'Automatic-Module-Name': moduleName
+        attributes 'Automatic-Module-Name': 'org.bitcoinj.core'
     }
 }
 

--- a/test-support/build.gradle
+++ b/test-support/build.gradle
@@ -12,11 +12,8 @@ tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
-ext.moduleName = 'org.bitcoinj.test-support'
-
 jar {
-    inputs.property("moduleName", moduleName)
     manifest {
-        attributes 'Automatic-Module-Name': moduleName
+        attributes 'Automatic-Module-Name': 'org.bitcoinj.test-support'
     }
 }


### PR DESCRIPTION
Using a variable for `Automatic-Module-Name` is confusing JetBrains. This commit removes the variable to simplify 3 build.gradle files.

To be more specific: JetBrains is effectively unaware of the `Automatic-Module-Name` because of the variable and will complain that (for example) Module `org.bitcoinj.core` is not found.