### PR TITLE
module-info.java: add transitive dependencies for bitcoinj-core to wallettemplate

### DIFF
--- a/wallettemplate/src/main/java/module-info.java
+++ b/wallettemplate/src/main/java/module-info.java
@@ -27,6 +27,11 @@ module wallettemplate {
     requires com.google.zxing;
 
     requires org.bitcoinj.core;
+    // Since bitcoinj-core doesn't have a module-info and IDEs are generally unaware of the
+    // processing done by the jlink plugin, we include transitive dependencies here that would
+    // be unnecessary if bitcoinj-core were fully modular.
+    requires org.bitcoinj.base;     // Transitive via bitcoinj-core
+    requires com.google.protobuf;   // Transitive via bitcoinj-core
 
     exports wallettemplate;
     exports org.bitcoinj.walletfx.controls;


### PR DESCRIPTION
Add transitive dependencies of bitcoinj-core that are not strictly needed for the build, but prevent errors or warnings in IDEs.

These lines can be removed when bitcoinj-core gets a module-info.