### PR TITLE
LegacyAddress,SegwitAddress: use unmodifiableSet

### DIFF
--- a/base/src/main/java/org/bitcoinj/base/LegacyAddress.java
+++ b/base/src/main/java/org/bitcoinj/base/LegacyAddress.java
@@ -22,9 +22,11 @@ import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.internal.ByteUtils;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -214,7 +216,7 @@ public class LegacyAddress implements Address {
         X6F(0x6f, BitcoinNetwork.SIGNET);
 
         private final int headerByte;
-        private final EnumSet<BitcoinNetwork> networks;
+        private final Set<BitcoinNetwork> networks;
 
         /**
          * @param network network to find enum for
@@ -229,7 +231,7 @@ public class LegacyAddress implements Address {
 
         AddressHeader(int headerByte, BitcoinNetwork first, BitcoinNetwork... rest) {
             this.headerByte = headerByte;
-            this.networks = EnumSet.of(first, rest);
+            this.networks = Collections.unmodifiableSet(EnumSet.of(first, rest));
         }
 
         public int headerByte() {
@@ -245,7 +247,7 @@ public class LegacyAddress implements Address {
         X196(196, BitcoinNetwork.TESTNET, BitcoinNetwork.SIGNET, BitcoinNetwork.REGTEST);
 
         private final int headerByte;
-        private final EnumSet<BitcoinNetwork> networks;
+        private final Set<BitcoinNetwork> networks;
 
         /**
          * @param network network to find enum for
@@ -260,7 +262,7 @@ public class LegacyAddress implements Address {
 
         P2SHHeader(int headerByte, BitcoinNetwork first, BitcoinNetwork... rest) {
             this.headerByte = headerByte;
-            this.networks = EnumSet.of(first, rest);
+            this.networks = Collections.unmodifiableSet(EnumSet.of(first, rest));
         }
 
         public int headerByte() {

--- a/base/src/main/java/org/bitcoinj/base/SegwitAddress.java
+++ b/base/src/main/java/org/bitcoinj/base/SegwitAddress.java
@@ -20,10 +20,12 @@ import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.internal.ByteUtils;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -66,14 +68,14 @@ public class SegwitAddress implements Address {
         TB(BitcoinNetwork.TESTNET, BitcoinNetwork.SIGNET),
         BCRT(BitcoinNetwork.REGTEST);
 
-        private final EnumSet<BitcoinNetwork> networks;
+        private final Set<BitcoinNetwork> networks;
 
         SegwitHrp(BitcoinNetwork n) {
-            networks = EnumSet.of(n);
+            networks = Collections.unmodifiableSet(EnumSet.of(n));
         }
 
         SegwitHrp(BitcoinNetwork n1, BitcoinNetwork n2) {
-            networks = EnumSet.of(n1, n2);
+            networks = Collections.unmodifiableSet(EnumSet.of(n1, n2));
         }
 
         /**


### PR DESCRIPTION
`enum`s are supposed to be immutable, but EnumSet is mutable.

In each case, it's in a private field and is not mutated, but just to be a little more clear and defensive, let's wrap the EnumSets in `unmodifiableSet`. This also changes the type of the private fields to the `Set` interface.