### PR TITLE
modular-architecture.md: trivial updates

### DIFF
--- a/designdocs/modular-architecture.md
+++ b/designdocs/modular-architecture.md
@@ -61,7 +61,7 @@ class G,S,A,BC,P external;
 
 ## bitcoinj 0.18 (current plan)
  
-In this release the `bitcoinj-base` module will be a standalone module with minimal external dependencies. All use of Elliptic Curve Cryptography will be factored out to use the  `secp-api` module from [secp256k1-jdk](https://github.com/bitcoinj/secp256k1-jdk) with API implementations provided for **Bouncy Castle** and (hopefully) the [secp256k1](https://github.com/bitcoin-core/secp256k1) native ('C') library.
+In this release the `bitcoinj-base` module will be a standalone module with minimal external dependencies. All use of Elliptic Curve Cryptography will be factored out to use the `secp-api` module from [secp256k1-jdk](https://github.com/bitcoinj/secp256k1-jdk) with API implementations provided for **Bouncy Castle** and the [secp256k1](https://github.com/bitcoin-core/secp256k1) native ('C') library.
 
 ````mermaid
 flowchart TD
@@ -98,7 +98,7 @@ class G,S,JS,BC,SECPC,P external;
 
 In a proposed 0.19 release, we hope to do the following:
 
-1. Separate the current ProtoBuf-based wallet implementation into it's own module. This will require creating a `Wallet` interface in core.
+1. Separate the current ProtoBuf-based wallet implementation into its own module. This will require creating a `Wallet` interface in core.
 2. Eliminate dependencies on Guava for all modules.
 
 Stretch goal:


### PR DESCRIPTION
* Remove unnecessary `(hopefully)`
* it's -> its (proper form of possessive)
* Remove extra space before `secp-api`