### PR TITLE
WIP: add o.b.btc.BtcBlock and other interfaces

### DIFF
--- a/base/src/main/java/org/bitcoinj/base/Sha256Hash.java
+++ b/base/src/main/java/org/bitcoinj/base/Sha256Hash.java
@@ -18,6 +18,7 @@
 package org.bitcoinj.base;
 
 import org.bitcoinj.base.internal.ByteUtils;
+import org.bitcoinj.btc.BtcSha256;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,7 +39,7 @@ import static org.bitcoinj.base.internal.Preconditions.checkArgument;
  * <p>
  * Given that {@code Sha256Hash} instances can be created using {@link #wrapReversed(byte[])} or {@link #twiceOf(byte[])} or by wrapping raw bytes, there is no guarantee that if two {@code Sha256Hash} instances are found equal (via {@link #equals(Object)}) that their preimages would be the same (even in the absence of a hash collision.)
  */
-public class Sha256Hash implements Comparable<Sha256Hash> {
+public class Sha256Hash implements Comparable<Sha256Hash>, BtcSha256 {
     public static final int LENGTH = 32; // bytes
     public static final Sha256Hash ZERO_HASH = wrap(new byte[LENGTH]);
 
@@ -261,11 +262,15 @@ public class Sha256Hash implements Comparable<Sha256Hash> {
         return ByteUtils.bytesToBigInteger(bytes);
     }
 
+    public byte[] toByteArray() {
+        return bytes;
+    }
+
     /**
      * Returns the internal byte array, without defensively copying. Therefore do NOT modify the returned array.
      */
     public byte[] getBytes() {
-        return bytes;
+        return toByteArray();
     }
 
     /**

--- a/base/src/main/java/org/bitcoinj/btc/BtcBlock.java
+++ b/base/src/main/java/org/bitcoinj/btc/BtcBlock.java
@@ -1,0 +1,7 @@
+package org.bitcoinj.btc;
+
+import java.util.List;
+
+public interface BtcBlock extends BtcBlockHeader {
+    List<? extends BtcTransaction> transactions();
+}

--- a/base/src/main/java/org/bitcoinj/btc/BtcBlockHash.java
+++ b/base/src/main/java/org/bitcoinj/btc/BtcBlockHash.java
@@ -1,0 +1,7 @@
+package org.bitcoinj.btc;
+
+// This is a "mix-in", either Block or BlockHeader implementations may implement it.
+public interface BtcBlockHash {
+    // stored, pre-computed hash
+    BtcSha256 hash();
+}

--- a/base/src/main/java/org/bitcoinj/btc/BtcBlockHeader.java
+++ b/base/src/main/java/org/bitcoinj/btc/BtcBlockHeader.java
@@ -1,0 +1,20 @@
+package org.bitcoinj.btc;
+
+import java.time.Instant;
+
+/**
+ * Implementations SHOULD be immutable.
+ * getHash() may be present/precomputed, computed each time or computed lazily.
+ * Implement {@code BtcBlockHash#hash()} if the Block hash is precomputed and
+ * returnable without computation.
+ */
+public interface BtcBlockHeader {
+    long version();   // TODO: Should this be long or int?
+    BtcSha256 prevHash();
+    BtcSha256 merkleRoot();
+    Instant time();
+    long bits();       // TODO: Should this be long, int, or a DifficultyTarget type?
+    long nonce();      // TODO: long or int?
+    // This _may_ compute or compute-and-memoize the hash, there is no performance guarantee
+    BtcSha256 getHash();
+}

--- a/base/src/main/java/org/bitcoinj/btc/BtcSha256.java
+++ b/base/src/main/java/org/bitcoinj/btc/BtcSha256.java
@@ -1,0 +1,15 @@
+package org.bitcoinj.btc;
+
+import java.math.BigInteger;
+
+/**
+ *
+ */
+public interface BtcSha256 {
+    // Bitcoin serialization fornat (reversed)
+    byte[] serialize();
+    // Returns a hex string
+    String toString();
+    BigInteger toBigInteger();
+    byte[] toByteArray();
+}

--- a/base/src/main/java/org/bitcoinj/btc/BtcTransaction.java
+++ b/base/src/main/java/org/bitcoinj/btc/BtcTransaction.java
@@ -1,0 +1,6 @@
+package org.bitcoinj.btc;
+
+// This is a minimal placeholder for now
+public interface BtcTransaction {
+    byte[] serialize();
+}

--- a/base/src/main/java/org/bitcoinj/btc/StoredHeader.java
+++ b/base/src/main/java/org/bitcoinj/btc/StoredHeader.java
@@ -1,0 +1,11 @@
+package org.bitcoinj.btc;
+
+import java.math.BigInteger;
+
+// Extra fields for bitcoinj StoredBlock (or equivalent)
+// TODO: Do we want this?
+// TODO: Refactor bitcoin StoredBlock and BlockStore to use this.
+public interface StoredHeader {
+    BigInteger chainWork();
+    int height();
+}

--- a/base/src/main/java/org/bitcoinj/btc/package-info.java
+++ b/base/src/main/java/org/bitcoinj/btc/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * Interfaces for basic bitcoin types like {@link org.bitcoinj.btc.BtcBlock} and {@link org.bitcoinj.btc.BtcSha256}.
+ * The intention for these interfaces is to allow libraries and applications to use the {@code org.bitcoinj.base} module
+ * without depending on {@code org.bitcoinj.core} and possibly using alternate implementations of the interfaces.
+ */
+@NullMarked
+package org.bitcoinj.btc;
+
+import org.jspecify.annotations.NullMarked;

--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -26,6 +26,7 @@ import org.bitcoinj.base.internal.StreamUtils;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.base.internal.InternalUtils;
+import org.bitcoinj.btc.BtcBlock;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 import org.slf4j.Logger;
@@ -68,7 +69,7 @@ import static org.bitcoinj.base.internal.Preconditions.checkState;
  * 
  * <p>Instances of this class are not safe for use by multiple threads.</p>
  */
-public class Block implements Message {
+public class Block implements Message, BtcBlock {
     /**
      * Flags used to control which elements of block validation are done on
      * received blocks.
@@ -635,6 +636,10 @@ public class Block implements Message {
         return merkleRoot;
     }
 
+    public Sha256Hash merkleRoot() {
+        return getMerkleRoot();  // See TODO in getMerkleRoot
+    }
+
     /** Exists only for unit testing. */
     // For testing only
     void setMerkleRoot(Sha256Hash value) {
@@ -755,12 +760,20 @@ public class Block implements Message {
         this.hash = null;
     }
 
+    public long bits() {
+        return difficultyTarget.compact();
+    }
+
     /**
      * Returns the nonce, an arbitrary value that exists only to make the hash of the block header fall below the
      * difficulty target.
      */
     public long getNonce() {
         return nonce;
+    }
+
+    public long nonce() {
+        return getNonce();
     }
 
     /** Sets the nonce and clears any cached data. */

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -25,6 +25,7 @@ import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.VarInt;
 import org.bitcoinj.base.internal.Buffers;
 import org.bitcoinj.base.internal.TimeUtils;
+import org.bitcoinj.btc.BtcTransaction;
 import org.bitcoinj.core.LockTime.HeightLock;
 import org.bitcoinj.core.LockTime.TimeLock;
 import org.bitcoinj.crypto.AesKey;
@@ -86,7 +87,7 @@ import static org.bitcoinj.base.internal.ByteUtils.writeInt32LE;
  * 
  * <p>Instances of this class are not safe for use by multiple threads.</p>
  */
-public class Transaction implements Message {
+public class Transaction implements Message, BtcTransaction {
     private static final Comparator<Transaction> SORT_TX_BY_ID = Comparator.comparing(Transaction::getTxId);
 
     /**
@@ -348,6 +349,10 @@ public class Transaction implements Message {
         outputs = new ArrayList<>();
         // We don't initialize appearsIn deliberately as it's only useful for transactions stored in the wallet.
         vLockTime = LockTime.unset();
+    }
+
+    public byte[] serialize() {
+        return write(ByteBuffer.allocate(messageSize())).array();
     }
 
     /**


### PR DESCRIPTION
This is WIP on an attempt to create some "universal" interfaces for key Bitcoin types. This is to allow special case implementations (e.g. FFM-based "flat" representations of Block, etc.) and interoperability with other implementations like Sparrow Wallet's **Drongo** (which is actually a fork of bitcoinj)

These interfaces would also help us with our immutability efforts, I think.

There are two major interoperability uses for these interfaces:

1. Methods and classes that need data from (for example) a "block" object could use the interface which would allow those methods to take any implementing class.
2. Classes that implement these interfaces could have copy constructors/factories that take the interface. For example: `public static Block of(BtcBlock block)`.