### PR TITLE
Script.writeBytes: Improve API and JavaDoc

### DIFF
--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -41,7 +41,6 @@ import org.jspecify.annotations.Nullable;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -327,11 +326,11 @@ public class Script {
     /**
      * Writes a byte array to an output stream with the correct "push" opcode prefix
      * To write an integer call writeBytes(out, Utils.reverseBytes(Utils.encodeMPI(val, false)));
-     * @param os OutputStream to write to
+     * @param os ByteArrayOutputStream to write to
      * @param bytes byte array to prefix with push opcode and write
      * @throws IOException shouldn't happen when using ByteArrayOutputStream
      */
-    public static void writeBytes(OutputStream os, byte[] bytes) throws IOException {
+    public static void writeBytes(ByteArrayOutputStream os, byte[] bytes) throws IOException {
         if (bytes.length < OP_PUSHDATA1) {
             os.write(bytes.length);       // opcode *is* length
             os.write(bytes);


### PR DESCRIPTION
A sequence of commits to improve the API (parameter types and names, exception error message) and JavaDoc.

This is mainly in preparation for deprecating the method and replacing it with a ByteBuffer version. See DRAFT PR #4085 