### PR TITLE
Replace Guava Lists usage in AbstractFullPrunedBlockChainTest with JDK alternatives

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -17,7 +17,7 @@
 
 package org.bitcoinj.core;
 
-import com.google.common.collect.Lists;
+
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Coin;
@@ -298,7 +298,7 @@ public abstract class AbstractFullPrunedBlockChainTest {
         chain.add(rollingBlock);
         totalAmount = totalAmount.add(amount);
 
-        List<UTXO> outputs = store.getOpenTransactionOutputs(Lists.newArrayList(toKey));
+        List<UTXO> outputs = store.getOpenTransactionOutputs(Arrays.asList(toKey));
         assertNotNull(outputs);
         assertEquals("Wrong Number of Outputs", 1, outputs.size());
         UTXO output = outputs.get(0);


### PR DESCRIPTION
Fixes #3990

Replaced Guava's `Lists.newArrayList()` with `Arrays.asList()` in `AbstractFullPrunedBlockChainTest.java`.
This removes the unnecessary Guava dependency in this test file.

Verified by running `MemoryFullPrunedBlockChainTest`, which extends this abstract class.