### PR TITLE
Stopwatch, MonetaryFormat: add missing @Nullable annotations

### DIFF
--- a/base/src/main/java/org/bitcoinj/base/internal/Stopwatch.java
+++ b/base/src/main/java/org/bitcoinj/base/internal/Stopwatch.java
@@ -16,6 +16,8 @@ package org.bitcoinj.base.internal;
  * limitations under the License.
  */
 
+import org.jspecify.annotations.Nullable;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -33,6 +35,7 @@ import static org.bitcoinj.base.internal.Preconditions.checkArgument;
  */
 public class Stopwatch implements TemporalAmount {
     private final Instant startTime;
+    @Nullable
     private Instant stopTime = null;
 
     /**

--- a/base/src/main/java/org/bitcoinj/base/utils/MonetaryFormat.java
+++ b/base/src/main/java/org/bitcoinj/base/utils/MonetaryFormat.java
@@ -18,6 +18,7 @@ package org.bitcoinj.base.utils;
 
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Monetary;
+import org.jspecify.annotations.Nullable;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -78,10 +79,10 @@ public final class MonetaryFormat {
     private final char zeroDigit;
     private final char decimalMark;
     private final int minDecimals;
-    private final List<Integer> decimalGroups;
+    private final @Nullable List<Integer> decimalGroups;
     private final int shift;
     private final RoundingMode roundingMode;
-    private final String[] codes;
+    private final String @Nullable[] codes;
     private final char codeSeparator;
     private final boolean codePrefixed;
 
@@ -342,7 +343,7 @@ public final class MonetaryFormat {
     }
 
     private MonetaryFormat(char negativeSign, char positiveSign, char zeroDigit, char decimalMark, int minDecimals,
-            List<Integer> decimalGroups, int shift, RoundingMode roundingMode, String[] codes,
+            @Nullable List<Integer> decimalGroups, int shift, RoundingMode roundingMode, String @Nullable[] codes,
             char codeSeparator, boolean codePrefixed) {
         this.negativeSign = negativeSign;
         this.positiveSign = positiveSign;
@@ -513,6 +514,7 @@ public final class MonetaryFormat {
     /**
      * Get currency code that will be used for current shift.
      */
+    @Nullable
     public String code() {
         if (codes == null)
             return null;


### PR DESCRIPTION
These are the last missing nullability annotations to enable making `bitcoinj-base` @Nullmarked (meaning anything not marked @Nullable can be considered non-nullable)