### PR TITLE
Replace Guava Lists in ECKeyTest with Arrays.asList

### DIFF
--- a/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
@@ -17,7 +17,7 @@
 
 package org.bitcoinj.crypto;
 
-import com.google.common.collect.Lists;
+
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.LegacyAddress;
 import org.bitcoinj.base.ScriptType;
@@ -323,7 +323,7 @@ public class ECKeyTest {
         ECKey.ECDSASignature sig = key.sign(hash);
         key = ECKey.fromPublicOnly(key);
 
-        List<Byte> possibleRecIds = Lists.newArrayList((byte) 0, (byte) 1, (byte) 2, (byte) 3);
+        List<Byte> possibleRecIds = Arrays.asList((byte) 0, (byte) 1, (byte) 2, (byte) 3);
         byte recId = key.findRecoveryId(hash, sig);
         assertTrue(possibleRecIds.contains(recId));
     }


### PR DESCRIPTION
Fixes #3995

Replaced the single usage of Guava's `Lists.newArrayList()` with `Arrays.asList()` in `ECKeyTest.java`.
This removes the unnecessary Guava dependency in this test file while maintaining Java 8 compatibility.

Verified by running `ECKeyTest` locally.