### PR TITLE
Refactor: Replace Guava Lists.newArrayList with JDK equivalents globally

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/TransactionInputTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionInputTest.java
@@ -16,7 +16,6 @@
 
 package org.bitcoinj.core;
 
-import com.google.common.collect.Lists;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.bitcoinj.base.Address;
@@ -37,6 +36,7 @@ import org.junit.runner.RunWith;
 
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
@@ -106,7 +106,7 @@ public class TransactionInputTest {
 
             @Override
             public List<UTXO> getOpenTransactionOutputs(List<ECKey> addresses) throws UTXOProviderException {
-                return Lists.newArrayList(utxo);
+                return Arrays.asList(utxo);
             }
 
             @Override

--- a/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
@@ -17,7 +17,6 @@
 
 package org.bitcoinj.crypto;
 
-import com.google.common.collect.Lists;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.LegacyAddress;
 import org.bitcoinj.base.ScriptType;
@@ -323,7 +322,7 @@ public class ECKeyTest {
         ECKey.ECDSASignature sig = key.sign(hash);
         key = ECKey.fromPublicOnly(key);
 
-        List<Byte> possibleRecIds = Lists.newArrayList((byte) 0, (byte) 1, (byte) 2, (byte) 3);
+        List<Byte> possibleRecIds = Arrays.asList((byte) 0, (byte) 1, (byte) 2, (byte) 3);
         byte recId = key.findRecoveryId(hash, sig);
         assertTrue(possibleRecIds.contains(recId));
     }

--- a/core/src/test/java/org/bitcoinj/script/ScriptPatternTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptPatternTest.java
@@ -18,7 +18,6 @@
 
 package org.bitcoinj.script;
 
-import com.google.common.collect.Lists;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.crypto.DumpedPrivateKey;
@@ -35,7 +34,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class ScriptPatternTest {
-    private List<ECKey> keys = Lists.newArrayList(ECKey.random(), ECKey.random(), ECKey.random());
+    private List<ECKey> keys = Arrays.asList(ECKey.random(), ECKey.random(), ECKey.random());
 
     @Test
     public void testCreateP2PKHOutputScript() {

--- a/core/src/test/java/org/bitcoinj/script/ScriptTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptTest.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.common.collect.Lists;
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.internal.ByteUtils;
@@ -116,7 +115,7 @@ public class ScriptTest {
 
     @Test
     public void testMultiSig() {
-        List<ECKey> keys = Lists.newArrayList(ECKey.random(), ECKey.random(), ECKey.random());
+        List<ECKey> keys = Arrays.asList(ECKey.random(), ECKey.random(), ECKey.random());
         assertTrue(ScriptPattern.isSentToMultisig(ScriptBuilder.createMultiSigOutputScript(2, keys)));
         Script script = ScriptBuilder.createMultiSigOutputScript(3, keys);
         assertTrue(ScriptPattern.isSentToMultisig(script));

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -17,7 +17,6 @@
 
 package org.bitcoinj.wallet;
 
-import com.google.common.collect.Lists;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.Address;
@@ -50,6 +49,7 @@ import java.nio.file.Paths;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -375,7 +375,7 @@ public class DeterministicKeyChainTest {
 
         // Round-trip to ensure de/serialization works and that we can store two chains and they both deserialize.
         List<Protos.Key> serialized = encChain.serializeToProtobuf();
-        List<Protos.Key> doubled = Lists.newArrayListWithExpectedSize(serialized.size() * 2);
+        List<Protos.Key> doubled = new ArrayList<>(serialized.size() * 2);
         doubled.addAll(serialized);
         doubled.addAll(serialized);
         final List<DeterministicKeyChain> chains = DeterministicKeyChain.fromProtobuf(doubled, encChain.getKeyCrypter());

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -17,7 +17,6 @@
 
 package org.bitcoinj.wallet;
 
-import com.google.common.collect.Lists;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.bitcoinj.base.BitcoinNetwork;
@@ -1019,8 +1018,8 @@ public class WalletTest extends TestWithWallet {
         FakeTxBuilder.BlockPair blockPair2 = createFakeBlock(blockStore, blockPair0.storedBlock, 2, txA1, txB1);
         wallet.receiveFromBlock(txA1, blockPair2.storedBlock, AbstractBlockChain.NewBlockType.SIDE_CHAIN, 0);
         wallet.receiveFromBlock(txB1, blockPair2.storedBlock, AbstractBlockChain.NewBlockType.SIDE_CHAIN, 1);
-        wallet.reorganize(blockPair0.storedBlock, Lists.newArrayList(blockPair1.storedBlock),
-                Lists.newArrayList(blockPair2.storedBlock));
+        wallet.reorganize(blockPair0.storedBlock, Arrays.asList(blockPair1.storedBlock),
+                Arrays.asList(blockPair2.storedBlock));
         assertSpent(txA1);
         assertDead(txA2);
         assertDead(txA3);
@@ -1036,8 +1035,8 @@ public class WalletTest extends TestWithWallet {
         wallet.receiveFromBlock(txA1, blockPair3.storedBlock, AbstractBlockChain.NewBlockType.SIDE_CHAIN, 0);
         wallet.receiveFromBlock(txB1, blockPair3.storedBlock, AbstractBlockChain.NewBlockType.SIDE_CHAIN, 1);
         wallet.receiveFromBlock(txC1, blockPair3.storedBlock, AbstractBlockChain.NewBlockType.SIDE_CHAIN, 2);
-        wallet.reorganize(blockPair0.storedBlock, Lists.newArrayList(blockPair2.storedBlock),
-                Lists.newArrayList(blockPair3.storedBlock));
+        wallet.reorganize(blockPair0.storedBlock, Arrays.asList(blockPair2.storedBlock),
+                Arrays.asList(blockPair3.storedBlock));
         assertSpent(txA1);
         assertDead(txA2);
         assertDead(txA3);
@@ -1051,8 +1050,8 @@ public class WalletTest extends TestWithWallet {
         // A reorg: previous block "replaced" by new block containing txB1
         FakeTxBuilder.BlockPair blockPair4 = createFakeBlock(blockStore, blockPair0.storedBlock, 2, txB1);
         wallet.receiveFromBlock(txB1, blockPair4.storedBlock, AbstractBlockChain.NewBlockType.SIDE_CHAIN, 0);
-        wallet.reorganize(blockPair0.storedBlock, Lists.newArrayList(blockPair3.storedBlock),
-                Lists.newArrayList(blockPair4.storedBlock));
+        wallet.reorganize(blockPair0.storedBlock, Arrays.asList(blockPair3.storedBlock),
+                Arrays.asList(blockPair4.storedBlock));
         assertPending(txA1);
         assertDead(txA2);
         assertDead(txA3);
@@ -1066,8 +1065,8 @@ public class WalletTest extends TestWithWallet {
         // A reorg: previous block "replaced" by new block containing txA2
         FakeTxBuilder.BlockPair blockPair5 = createFakeBlock(blockStore, blockPair0.storedBlock, 2, txA2);
         wallet.receiveFromBlock(txA2, blockPair5.storedBlock, AbstractBlockChain.NewBlockType.SIDE_CHAIN, 0);
-        wallet.reorganize(blockPair0.storedBlock, Lists.newArrayList(blockPair4.storedBlock),
-                Lists.newArrayList(blockPair5.storedBlock));
+        wallet.reorganize(blockPair0.storedBlock, Arrays.asList(blockPair4.storedBlock),
+                Arrays.asList(blockPair5.storedBlock));
         assertDead(txA1);
         assertUnspent(txA2);
         assertDead(txA3);
@@ -1080,8 +1079,8 @@ public class WalletTest extends TestWithWallet {
 
         // A reorg: previous block "replaced" by new empty block
         FakeTxBuilder.BlockPair blockPair6 = createFakeBlock(blockStore, blockPair0.storedBlock, 2);
-        wallet.reorganize(blockPair0.storedBlock, Lists.newArrayList(blockPair5.storedBlock),
-                Lists.newArrayList(blockPair6.storedBlock));
+        wallet.reorganize(blockPair0.storedBlock, Arrays.asList(blockPair5.storedBlock),
+                Arrays.asList(blockPair6.storedBlock));
         assertDead(txA1);
         assertPending(txA2);
         assertDead(txA3);
@@ -1124,8 +1123,8 @@ public class WalletTest extends TestWithWallet {
         // A reorg: previous block "replaced" by new block containing doubleSpends.t2
         FakeTxBuilder.BlockPair blockPair2 = createFakeBlock(blockStore, blockPair0.storedBlock, 2, doubleSpends.t2);
         wallet.receiveFromBlock(doubleSpends.t2, blockPair2.storedBlock, AbstractBlockChain.NewBlockType.SIDE_CHAIN, 0);
-        wallet.reorganize(blockPair0.storedBlock, Lists.newArrayList(blockPair1.storedBlock),
-                Lists.newArrayList(blockPair2.storedBlock));
+        wallet.reorganize(blockPair0.storedBlock, Arrays.asList(blockPair1.storedBlock),
+                Arrays.asList(blockPair2.storedBlock));
         assertDead(doubleSpends.t1);
         assertSpent(doubleSpends.t2);
         assertDead(t1b);


### PR DESCRIPTION
This PR replaces all occurrences of Lists.newArrayList across the project with standard JDK 8 equivalents, as requested in the review of #3996.

Contributes to #2000

Supersedes: #3996 (This PR includes the fix for ECKeyTest.java and extends it to the rest of the codebase).

Changes:

Lists.newArrayList() → new ArrayList<>()

Lists.newArrayList(e1, e2) → Arrays.asList(e1, e2)

Lists.newArrayListWithExpectedSize(n) → new ArrayList<>(n)

Removed unused com.google.common.collect.Lists imports.

Verification:

Passed full core:test suite.

Verified compilation and tests for WalletTest, BasicKeyChainTest, TransactionInputTest, and others.