### PR TITLE
Refactor: Replace Guava VisibleForTesting with internal annotation

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -17,7 +17,6 @@
 
 package org.bitcoinj.core;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.bitcoinj.base.Difficulty;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.VarInt;
@@ -26,6 +25,7 @@ import org.bitcoinj.base.internal.StreamUtils;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.base.internal.InternalUtils;
+import org.bitcoinj.core.internal.VisibleForTesting;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 import org.slf4j.Logger;

--- a/core/src/main/java/org/bitcoinj/core/PeerSocketHandler.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerSocketHandler.java
@@ -16,8 +16,8 @@
 
 package org.bitcoinj.core;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.bitcoinj.base.internal.FutureUtils;
+import org.bitcoinj.core.internal.VisibleForTesting;
 import org.bitcoinj.net.MessageWriteTarget;
 import org.bitcoinj.net.NioClient;
 import org.bitcoinj.net.NioClientManager;

--- a/core/src/main/java/org/bitcoinj/core/TestBlocks.java
+++ b/core/src/main/java/org/bitcoinj/core/TestBlocks.java
@@ -16,12 +16,12 @@
 
 package org.bitcoinj.core;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.internal.Stopwatch;
 import org.bitcoinj.base.internal.TimeUtils;
+import org.bitcoinj.core.internal.VisibleForTesting;
 import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;

--- a/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionBroadcast.java
@@ -16,10 +16,10 @@
 
 package org.bitcoinj.core;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.bitcoinj.base.internal.FutureUtils;
 import org.bitcoinj.base.internal.StreamUtils;
 import org.bitcoinj.base.internal.InternalUtils;
+import org.bitcoinj.core.internal.VisibleForTesting;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.Wallet;
 import org.slf4j.Logger;

--- a/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionConfidence.java
@@ -17,10 +17,10 @@
 
 package org.bitcoinj.core;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterators;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.internal.TimeUtils;
+import org.bitcoinj.core.internal.VisibleForTesting;
 import org.bitcoinj.utils.ListenerRegistration;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.CoinSelector;

--- a/core/src/main/java/org/bitcoinj/core/internal/VisibleForTesting.java
+++ b/core/src/main/java/org/bitcoinj/core/internal/VisibleForTesting.java
@@ -1,0 +1,15 @@
+package org.bitcoinj.core.internal;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Annotates a program element that exists, or is more widely visible than otherwise necessary, only for use in test code.
+ * <p>
+ * Replaces Guava's {@code @VisibleForTesting}.
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS)
+public @interface VisibleForTesting {
+}

--- a/core/src/main/java/org/bitcoinj/testing/FakeTxBuilder.java
+++ b/core/src/main/java/org/bitcoinj/testing/FakeTxBuilder.java
@@ -17,13 +17,13 @@
 
 package org.bitcoinj.testing;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.core.Block;
+import org.bitcoinj.core.internal.VisibleForTesting;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.core.TestBlocks;
 import org.bitcoinj.crypto.ECKey;

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -17,11 +17,11 @@
 
 package org.bitcoinj.wallet;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.math.IntMath;
 import com.google.protobuf.ByteString;
 import org.bitcoinj.core.internal.GuardedBy;
+import org.bitcoinj.core.internal.VisibleForTesting;
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.exceptions.AddressFormatException;


### PR DESCRIPTION
This PR replaces the dependency on Guava's @VisibleForTesting with a lightweight internal annotation.

Contributes to #2000 (Remove Guava dependency)

Changes:

* Created org.bitcoinj.core.internal.VisibleForTesting.

* Replaced all com.google.common.annotations.VisibleForTesting imports with the new internal class.

* Verified via grep that no Guava usages for this annotation remain.

Verification:

* gradlew :bitcoinj-core:classes passed successfully.