### PR TITLE
Refactor: Replace Guava Strings and IntMath with standard Java 8

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -17,7 +17,6 @@
 package org.bitcoinj.core;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import org.bitcoinj.core.internal.GuardedBy;
 import org.bitcoinj.base.Coin;

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -18,7 +18,6 @@
 package org.bitcoinj.core;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.math.IntMath;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Network;
@@ -48,7 +47,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.jspecify.annotations.Nullable;
-import java.math.RoundingMode;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
@@ -397,7 +395,7 @@ public class Transaction implements Message {
     public int getVsize() {
         if (!hasWitnesses())
             return this.messageSize();
-        return IntMath.divide(getWeight(), 4, RoundingMode.CEILING); // round up
+        return (getWeight() + 3) / 4;
     }
 
 

--- a/core/src/main/java/org/bitcoinj/utils/BtcFormat.java
+++ b/core/src/main/java/org/bitcoinj/utils/BtcFormat.java
@@ -16,7 +16,6 @@
 
 package org.bitcoinj.utils;
 
-import com.google.common.base.Strings;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.utils.BtcAutoFormat.Style;
 
@@ -679,7 +678,7 @@ public abstract class BtcFormat extends Format {
          *  <p>Note that by applying a pattern you override the configured formatting style of
          *  {@link BtcAutoFormat} instances.  */
         public Builder pattern(String val) {
-            if (!Strings.isNullOrEmpty(localizedPattern))
+            if (localizedPattern != null && !localizedPattern.isEmpty())
                 throw new IllegalStateException("You cannot invoke both pattern() and localizedPattern()");
             pattern = val;
             return this;
@@ -713,7 +712,7 @@ public abstract class BtcFormat extends Format {
          *  <p>Note that by applying a pattern you override the configured formatting style of
          *  {@link BtcAutoFormat} instances.         */
         public Builder localizedPattern(String val) {
-            if (!Strings.isNullOrEmpty(pattern))
+            if (pattern != null && !pattern.isEmpty())
                 throw new IllegalStateException("You cannot invoke both pattern() and localizedPattern().");
             localizedPattern = val;
             return this;
@@ -723,16 +722,16 @@ public abstract class BtcFormat extends Format {
          *  to the state of this {@code Builder} instance at the time this method is invoked. */
         public BtcFormat build() {
             BtcFormat f = variant.newInstance(this);
-            if (!Strings.isNullOrEmpty(symbol) || !Strings.isNullOrEmpty(code)) { synchronized(f.numberFormat) {
+            if ((symbol != null && !symbol.isEmpty()) || (code != null && !code.isEmpty())) { synchronized(f.numberFormat) {
                 DecimalFormatSymbols defaultSigns = f.numberFormat.getDecimalFormatSymbols();
                 setSymbolAndCode(f.numberFormat,
-                        !Strings.isNullOrEmpty(symbol) ? symbol : defaultSigns.getCurrencySymbol(),
-                        !Strings.isNullOrEmpty(code) ? code : defaultSigns.getInternationalCurrencySymbol()
+                        (symbol != null && !symbol.isEmpty()) ? symbol : defaultSigns.getCurrencySymbol(),
+                        (code != null && !code.isEmpty()) ? code : defaultSigns.getInternationalCurrencySymbol()
                 );
             }}
-            if (!Strings.isNullOrEmpty(localizedPattern) || !Strings.isNullOrEmpty(pattern)) {
+            if ((localizedPattern != null && !localizedPattern.isEmpty()) || (pattern != null && !pattern.isEmpty())) {
                 int places = f.numberFormat.getMinimumFractionDigits();
-                if (!Strings.isNullOrEmpty(localizedPattern)) f.numberFormat.applyLocalizedPattern(negify(localizedPattern));
+                if (localizedPattern != null && !localizedPattern.isEmpty()) f.numberFormat.applyLocalizedPattern(negify(localizedPattern));
                 else f.numberFormat.applyPattern(negify(pattern));
                 f.numberFormat.setMinimumFractionDigits(places);
                 f.numberFormat.setMaximumFractionDigits(places);
@@ -1549,7 +1548,7 @@ public abstract class BtcFormat extends Format {
     public String pattern() { synchronized(numberFormat) {
         StringBuilder groups = new StringBuilder();
         for (int group : decimalGroups) {
-            groups.append("(").append(Strings.repeat("#", group)).append(")");
+            groups.append("(").append(String.join("", Collections.nCopies(group, "#"))).append(")");
         }
         DecimalFormatSymbols s = numberFormat.getDecimalFormatSymbols();
         String digit = String.valueOf(s.getDigit());

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -19,7 +19,6 @@ package org.bitcoinj.wallet;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.math.IntMath;
 import com.google.protobuf.ByteString;
 import org.bitcoinj.core.internal.GuardedBy;
 import org.bitcoinj.base.BitcoinNetwork;
@@ -111,7 +110,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.math.BigInteger;
-import java.math.RoundingMode;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
@@ -5367,8 +5365,8 @@ public class Wallet extends BaseTaggableObject
             } else if (ScriptPattern.isP2WPKH(script)) {
                 ECKey key = findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2WH(script), ScriptType.P2WPKH);
                 Objects.requireNonNull(key, "Coin selection includes unspendable outputs");
-                return IntMath.divide(script.getNumberOfBytesRequiredToSpend(key, null), 4,
-                        RoundingMode.CEILING); // round up
+                // equivalent to IntMath.divide(..., 4, RoundingMode.CEILING)
+                return (script.getNumberOfBytesRequiredToSpend(key, null) + 3) / 4;
             } else if (ScriptPattern.isP2SH(script)) {
                 Script redeemScript = findRedeemDataFromScriptHash(ScriptPattern.extractHashFromP2SH(script)).redeemScript;
                 Objects.requireNonNull(redeemScript, "Coin selection includes unspendable outputs");


### PR DESCRIPTION
This PR replaces usages of com.google.common.base.Strings and com.google.common.math.IntMath with standard Java 8 equivalents.

Contributes to #2000

Changes:

* BtcFormat.java: Replaced Strings.isNullOrEmpty() with null/empty checks and Strings.repeat() with Collections.nCopies.

* Transaction.java & Wallet.java: Replaced IntMath.checkedAdd() with Math.addExact().

* Transaction.java & Wallet.java: Replaced IntMath.divide(..., RoundingMode.CEILING) with standard integer arithmetic (x + y - 1) / y.

* Peer.java: Removed unused Strings import.

Verification:

* ./gradlew :bitcoinj-core:test passed successfully.