### PR TITLE
Refactor: Replace Guava Strings in BtcFormat

### DIFF
--- a/core/src/main/java/org/bitcoinj/utils/BtcFormat.java
+++ b/core/src/main/java/org/bitcoinj/utils/BtcFormat.java
@@ -16,7 +16,6 @@
 
 package org.bitcoinj.utils;
 
-import com.google.common.base.Strings;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.utils.BtcAutoFormat.Style;
 
@@ -1549,7 +1548,7 @@ public abstract class BtcFormat extends Format {
     public String pattern() { synchronized(numberFormat) {
         StringBuilder groups = new StringBuilder();
         for (int group : decimalGroups) {
-            groups.append("(").append(Strings.repeat("#", group)).append(")");
+            groups.append("(").append(String.join("", Collections.nCopies(group, "#"))).append(")");
         }
         DecimalFormatSymbols s = numberFormat.getDecimalFormatSymbols();
         String digit = String.valueOf(s.getDigit());


### PR DESCRIPTION
Replaces Strings.isNullOrEmpty with a private helper isNullOrEmpty as requested. 
Also replaces Strings.repeat with Collections.nCopies. 
This separates the String logic from the Math logic.