### PR TITLE
BasicKeyChainTest: Remove use of ArrayList type.

### DIFF
--- a/core/src/test/java/org/bitcoinj/wallet/BasicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/BasicKeyChainTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -126,14 +125,14 @@ public class BasicKeyChainTest {
 
     @Test(expected = IllegalStateException.class)
     public void checkPasswordNotEncrypted() {
-        final ArrayList<ECKey> keys = Lists.newArrayList(ECKey.random(), ECKey.random());
+        final List<ECKey> keys = Lists.newArrayList(ECKey.random(), ECKey.random());
         chain.importKeys(keys);
         chain.checkPassword("test");
     }
 
     @Test(expected = IllegalStateException.class)
     public void doubleEncryptFails() {
-        final ArrayList<ECKey> keys = Lists.newArrayList(ECKey.random(), ECKey.random());
+        final List<ECKey> keys = Lists.newArrayList(ECKey.random(), ECKey.random());
         chain.importKeys(keys);
         chain = chain.toEncrypted("foo");
         chain.toEncrypted("foo");


### PR DESCRIPTION
2 commits to migrate away from use of `ArrayList`. This will make the transition away from Guava `Lists.newArrayList()` a little cleaner.  (See PR #3999)