### PR TITLE
Refactor: Replace Guava BaseEncoding.base16() with ByteUtils in tests

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BitcoinSerializerTest.java
@@ -17,7 +17,6 @@
 
 package org.bitcoinj.core;
 
-import com.google.common.io.BaseEncoding;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.params.MainNetParams;
@@ -40,12 +39,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class BitcoinSerializerTest {
-    private static final BaseEncoding HEX = BaseEncoding.base16().lowerCase();
     private static final NetworkParameters MAINNET = MainNetParams.get();
     private static final byte[] ADDRESS_MESSAGE_BYTES = ByteUtils.parseHex("f9beb4d96164647200000000000000001f000000" +
             "ed52399b01e215104d010000000000000000000000000000000000ffff0a000001208d");
 
-    private static final byte[] TRANSACTION_MESSAGE_BYTES = HEX.withSeparator(" ", 2).decode(
+    private static final byte[] TRANSACTION_MESSAGE_BYTES = ByteUtils.parseHex((
             "f9 be b4 d9 74 78 00 00  00 00 00 00 00 00 00 00" +
             "02 01 00 00 e2 93 cd be  01 00 00 00 01 6d bd db" +
             "08 5b 1d 8a f7 51 84 f0  bc 01 fa d5 8d 12 66 e9" +
@@ -63,7 +61,7 @@ public class BitcoinSerializerTest {
             "cd 1c be a6 e7 45 8a 7a  ba d5 12 a9 d9 ea 1a fb" +
             "22 5e 88 ac 80 fa e9 c7  00 00 00 00 19 76 a9 14" +
             "0e ab 5b ea 43 6a 04 84  cf ab 12 48 5e fd a0 b7" +
-            "8b 4e cc 52 88 ac 00 00  00 00");
+            "8b 4e cc 52 88 ac 00 00  00 00").replaceAll("\\s", ""));
 
     @Test
     public void testAddr() throws Exception {

--- a/core/src/test/java/org/bitcoinj/core/SendHeadersMessageTest.java
+++ b/core/src/test/java/org/bitcoinj/core/SendHeadersMessageTest.java
@@ -16,8 +16,8 @@
 
 package org.bitcoinj.core;
 
-import com.google.common.io.BaseEncoding;
 import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.internal.ByteUtils;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
@@ -25,12 +25,11 @@ import java.nio.ByteBuffer;
 import static org.junit.Assert.assertTrue;
 
 public class SendHeadersMessageTest {
-    private static final BaseEncoding HEX = BaseEncoding.base16().lowerCase();
 
     @Test
     public void decodeAndEncode() throws Exception {
-        byte[] message = HEX
-                .decode("00000000fabfb5da73656e646865616465727300000000005df6e0e2fabfb5da70696e670000000000000000080000009a"
+        byte[] message = ByteUtils.parseHex(
+                "00000000fabfb5da73656e646865616465727300000000005df6e0e2fabfb5da70696e670000000000000000080000009a"
                         + "65b9cc9840c9729e4502b200000000000000000000000000000d000000000000000000000000000000000000000000000000007ad82"
                         + "872c28ac782102f5361746f7368693a302e31342e312fe41d000001fabfb5da76657261636b000000000000000000005df6e0e2fabf"
                         + "b5da616c65727400000000000000a80000001bf9aaea60010000000000000000000000ffffff7f00000000ffffff7ffeffff7f01fff"


### PR DESCRIPTION
This is **Part 1 of 3** for Issue #3982 (Migrate away from usage of Guava).

This PR replaces usages of Guava's `BaseEncoding.base16()` with `bitcoinj`'s native `ByteUtils` in the test suite.

### Changes
* **`BitcoinSerializerTest.java`**: Replaced `BaseEncoding` with `ByteUtils.parseHex()`. Retained the `.replaceAll("\\s", "")` logic to handle the existing space-separated test data (replicating the previous `withSeparator(" ", 2)` behavior).
* **`SendHeadersMessageTest.java`**: Replaced `BaseEncoding` with `ByteUtils.parseHex()`. Removed unnecessary regex filtering since the source string is a contiguous hex block.
* **Cleanup**: Removed unused `HEX` constants and Guava imports.

### Verification
Ran specific tests for the modified classes:
```bash
./gradlew :bitcoinj-core:test --tests "org.bitcoinj.core.BitcoinSerializerTest" --tests "org.bitcoinj.core.SendHeadersMessageTest"