### PR TITLE
Refactor: Replace Guava BaseEncoding.base32() with Bouncy Castle in TorUtils

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/internal/BaseUtils.java
+++ b/core/src/main/java/org/bitcoinj/core/internal/BaseUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.core.internal;
+
+import org.bouncycastle.util.encoders.Base32;
+import org.bouncycastle.util.encoders.DecoderException;
+
+import java.util.Locale;
+
+/**
+ * Base32 encoding utilities.
+ * <p>
+ * TODO: Remove the dependency on Bouncy Castle when possible.
+ */
+public class BaseUtils {
+
+    /**
+     * Encode bytes to a Base32 string (lower case, no padding).
+     * Replaces: BaseEncoding.base32().omitPadding().lowerCase().encode(bytes)
+     */
+    public static String base32Encode(byte[] bytes) {
+        String encoded = Base32.toBase32String(bytes);
+
+        return encoded.toLowerCase(Locale.ROOT).replace("=", "");
+    }
+
+    /**
+     * Decode a Base32 string to bytes.
+     * Replaces: BaseEncoding.base32().omitPadding().lowerCase().decode(string)
+     */
+    public static byte[] base32Decode(String string) {
+        try {
+            string = string.toUpperCase(Locale.ROOT);
+
+            int padding = (8 - (string.length() % 8)) % 8;
+            if (padding != 0) {
+                StringBuilder sb = new StringBuilder(string);
+                for (int i = 0; i < padding; i++) {
+                    sb.append('=');
+                }
+                string = sb.toString();
+            }
+
+            return org.bouncycastle.util.encoders.Base32.decode(string);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid Base32 input", e);
+        }
+    }
+}

--- a/core/src/main/java/org/bitcoinj/core/internal/TorUtils.java
+++ b/core/src/main/java/org/bitcoinj/core/internal/TorUtils.java
@@ -16,7 +16,6 @@
 
 package org.bitcoinj.core.internal;
 
-import com.google.common.io.BaseEncoding;
 import org.bitcoinj.crypto.internal.CryptoUtils;
 
 import java.nio.charset.StandardCharsets;
@@ -30,8 +29,6 @@ import static org.bitcoinj.base.internal.Preconditions.checkArgument;
  */
 public class TorUtils {
 
-    private static final BaseEncoding BASE32 = BaseEncoding.base32().omitPadding().lowerCase();
-
     /**
      * Encode an Onion URL from a Tor V2 address.
      * <p>
@@ -42,7 +39,7 @@ public class TorUtils {
      */
     public static String encodeOnionUrlV2(byte[] onionAddrBytes) {
         checkArgument(onionAddrBytes.length == 10);
-        return BASE32.encode(onionAddrBytes) + ".onion";
+        return BaseUtils.base32Encode(onionAddrBytes) + ".onion";
     }
 
     /**
@@ -60,7 +57,7 @@ public class TorUtils {
         System.arraycopy(onionAddrBytes, 0, onionAddress, 0, 32);
         System.arraycopy(onionChecksum(onionAddrBytes, torVersion), 0, onionAddress, 32, 2);
         onionAddress[34] = torVersion;
-        return BASE32.encode(onionAddress) + ".onion";
+        return BaseUtils.base32Encode(onionAddress) + ".onion";
     }
 
     /**
@@ -74,7 +71,7 @@ public class TorUtils {
     public static byte[] decodeOnionUrl(String onionUrl) {
         if (!onionUrl.toLowerCase(Locale.ROOT).endsWith(".onion"))
             throw new IllegalArgumentException("not an onion URL: " + onionUrl);
-        byte[] onionAddress = BASE32.decode(onionUrl.substring(0, onionUrl.length() - 6));
+        byte[] onionAddress = BaseUtils.base32Decode(onionUrl.substring(0, onionUrl.length() - 6));
         if (onionAddress.length == 10) {
             // TORv2
             return onionAddress;

--- a/core/src/test/java/org/bitcoinj/core/internal/BaseUtilsTest.java
+++ b/core/src/test/java/org/bitcoinj/core/internal/BaseUtilsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.core.internal;
+
+import org.junit.Test;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+
+public class BaseUtilsTest {
+    @Test
+    public void base32Roundtrip() {
+        byte[] data = new byte[128];
+        new Random().nextBytes(data);
+
+        String encoded = BaseUtils.base32Encode(data);
+        byte[] decoded = BaseUtils.base32Decode(encoded);
+
+        assertArrayEquals("Roundtrip decoding failed", data, decoded);
+    }
+
+    @Test
+    public void base32Vectors() {
+        checkEncoding("", "");
+        checkEncoding("f", "my");
+        checkEncoding("fo", "mzxq");
+        checkEncoding("foo", "mzxw6");
+        checkEncoding("foob", "mzxw6yq");
+        checkEncoding("fooba", "mzxw6ytb");
+        checkEncoding("foobar", "mzxw6ytboi");
+    }
+
+    private void checkEncoding(String input, String expectedOutput) {
+        byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+        assertEquals(expectedOutput, BaseUtils.base32Encode(inputBytes));
+        assertArrayEquals(inputBytes, BaseUtils.base32Decode(expectedOutput));
+    }
+}


### PR DESCRIPTION
This is **Part 2 of 3** for Issue #3982 (Migrate away from usage of Guava).

This PR replaces the usage of Guava's `BaseEncoding.base32()` in `TorUtils` with Bouncy Castle's implementation, wrapped in a new internal helper class as requested.

### Changes
* **`BaseUtils.java`**: Created a new internal utility class to wrap Bouncy Castle's `Base32` encoder/decoder.
    * **Configuration**: Configured to match Guava's behavior (lowercase output, no padding).
    * **Exception Handling**: Translates Bouncy Castle's `DecoderException` into `IllegalArgumentException`. This preserves API compatibility and ensures existing tests (like `TorUtilsTest.decodeOnionUrl_badLength`) continue to pass without modification.
* **`TorUtils.java`**: Replaced `BaseEncoding` usage with `BaseUtils.base32Encode()` and `base32Decode()`.

### Verification
Ran specific tests for the modified class:
```bash
./gradlew :bitcoinj-core:test --tests "org.bitcoinj.core.internal.TorUtilsTest"