### PR TITLE
Replace Guava UnsignedBytes.checkedCast with ByteUtils.longToByteExact

### DIFF
--- a/base/src/main/java/org/bitcoinj/base/internal/ByteUtils.java
+++ b/base/src/main/java/org/bitcoinj/base/internal/ByteUtils.java
@@ -159,6 +159,20 @@ public class ByteUtils {
     }
 
     /**
+     * Checks if the {@code long} value fits in an unsigned byte (0-255) and returns it as a {@code byte}.
+     * <p>
+     * The value is expected as an unsigned {@code long} as per the Java Unsigned Integer API.
+     *
+     * @param value value to be checked and cast
+     * @return the value as a {@code byte}
+     * @throws IllegalArgumentException if the value doesn't fit in an unsigned byte
+     */
+    public static byte longToByteExact(long value) {
+        checkArgument(value >= 0 && value <= 255, () -> "Value " + value + " out of range for unsigned byte");
+        return (byte) value;
+    }
+
+    /**
      * Write a 32-bit integer to a given byte array in little-endian format, starting at a given offset.
      * <p>
      * The value is expected as an unsigned {@code long} as per the Java Unsigned Integer API.

--- a/base/src/test/java/org/bitcoinj/base/internal/ByteUtilsTest.java
+++ b/base/src/test/java/org/bitcoinj/base/internal/ByteUtilsTest.java
@@ -330,4 +330,21 @@ public class ByteUtilsTest {
     public void testDecodeMPI() {
         assertEquals(BigInteger.ZERO, ByteUtils.decodeMPI(new byte[]{}, false));
     }
+
+    @Test
+    public void longToByteExact_valid() {
+        assertEquals(0, ByteUtils.longToByteExact(0));
+        assertEquals((byte) 255, ByteUtils.longToByteExact(255));
+        assertEquals((byte) 127, ByteUtils.longToByteExact(127));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void longToByteExact_negative() {
+        ByteUtils.longToByteExact(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void longToByteExact_overflow() {
+        ByteUtils.longToByteExact(256);
+    }
 }

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -18,7 +18,6 @@
 package org.bitcoinj.crypto;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.primitives.UnsignedBytes;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.internal.ByteUtils;
@@ -555,7 +554,7 @@ public class DeterministicKey extends ECKey {
             ser.putInt(pub ? params.getBip32HeaderP2WPKHpub() : params.getBip32HeaderP2WPKHpriv());
         else
             throw new IllegalStateException(outputScriptType.toString());
-        ser.put(UnsignedBytes.checkedCast(getDepth()));
+        ser.put(ByteUtils.longToByteExact(getDepth()));
         ser.putInt(getParentFingerprint());
         ser.putInt(getChildNumber().i());
         ser.put(getChainCode());


### PR DESCRIPTION
This PR replaces the usage of Guava's `UnsignedBytes.checkedCast` with a method `ByteUtils.longToByteExact`, as requested in issue #4009.

## Changes
* Added `longToByteExact(long value)` to `org.bitcoinj.base.internal.ByteUtils`.
* Replaced the single usage of the Guava method in DeterministicKey.java.
* Updated `DeterministicKeyTest` to expect `ArithmeticException` instead of `IllegalArgumentException`.

Closes #4009