### PR TITLE
gradle.yml, graalvm.yml: update Gradle to 9.4.1

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-24.04, ubuntu-24.04-arm, macOS-15, macOS-15-intel, windows-2022]
         java: ['17', '21', '25']
         distribution: ['temurin']
-        gradle: ['8.14.4', '9.2.1']
+        gradle: ['8.14.4', '9.4.1']
         exclude:
           # Java 25+ requires Gradle 9.1+
           - java: '25'
@@ -67,7 +67,7 @@ jobs:
         os: [ubuntu-24.04, ubuntu-24.04-arm, macOS-15]
         java: [ '25' ]
         distribution: [ 'graalvm-community' ]
-        gradle: ['9.2.1']
+        gradle: ['9.4.1']
       fail-fast: false
     name: ${{ matrix.os }} JDK ${{ matrix.java }}.${{ matrix.distribution }}
     steps:


### PR DESCRIPTION
PR is updated to Gradle 9.4.1, which works. This brings us JDK 26 build support.

It looks like our build doesn't work on Gradle 9.3.0, perhaps because of the following change:

> This results from Gradle adopting the incubating Test Event Reporting API internally.

See: https://docs.gradle.org/current/release-notes.html#test-reporting-improvements
However, as noted above it works on Gradle 9.4.1.