### PR TITLE
BaseUtils: transform to functional-style, more specific exception-handling

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/internal/BaseUtils.java
+++ b/core/src/main/java/org/bitcoinj/core/internal/BaseUtils.java
@@ -44,10 +44,9 @@ public class BaseUtils {
      */
     public static byte[] base32Decode(String string) {
         int padding = (8 - (string.length() % 8)) % 8;
-        String uppercasePadded = string.toUpperCase(Locale.ROOT);
-        if (padding != 0) {
-            uppercasePadded = uppercasePadded + "=".repeat(padding);
-        }
+        String uppercasePadded =  (padding != 0)
+            ? string.toUpperCase(Locale.ROOT) + "=".repeat(padding)
+            : string.toUpperCase(Locale.ROOT);
         try {
             return Base32.decode(uppercasePadded);
         } catch (DecoderException e) {


### PR DESCRIPTION
A sequence of 7 commits making execution handling more specific and using a more functional-style.

cc: @nadavramon 

I rushed this one a little and missed the fact that String.repeat requires Java 11. Marking as draft. I'll fix and force-push.