### PR TITLE
BaseUtils: Use more specific exception handling

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/internal/BaseUtils.java
+++ b/core/src/main/java/org/bitcoinj/core/internal/BaseUtils.java
@@ -43,18 +43,17 @@ public class BaseUtils {
      * Replaces: BaseEncoding.base32().omitPadding().lowerCase().decode(string)
      */
     public static byte[] base32Decode(String string) {
-        try {
-            string = string.toUpperCase(Locale.ROOT);
+        string = string.toUpperCase(Locale.ROOT);
 
-            int padding = (8 - (string.length() % 8)) % 8;
-            if (padding != 0) {
-                StringBuilder sb = new StringBuilder(string);
-                for (int i = 0; i < padding; i++) {
-                    sb.append('=');
-                }
-                string = sb.toString();
+        int padding = (8 - (string.length() % 8)) % 8;
+        if (padding != 0) {
+            StringBuilder sb = new StringBuilder(string);
+            for (int i = 0; i < padding; i++) {
+                sb.append('=');
             }
-
+            string = sb.toString();
+        }
+        try {
             return Base32.decode(string);
         } catch (DecoderException e) {
             throw new IllegalArgumentException("Invalid Base32 input", e);


### PR DESCRIPTION
3 commits that narrow the type of exception caught and limit the try block to the code that can actually throw the exception.

cc: @nadavramon 