### PR TITLE
Threading.java: Deprecate or make private all CycleDetectingLockFactory members

### DIFF
--- a/core/src/main/java/org/bitcoinj/utils/Threading.java
+++ b/core/src/main/java/org/bitcoinj/utils/Threading.java
@@ -143,7 +143,7 @@ public class Threading {
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     private static CycleDetectingLockFactory.Policy policy;
-    public static CycleDetectingLockFactory factory;
+    private static CycleDetectingLockFactory factory;
 
     public static ReentrantLock lock(Class clazz) {
         return lock(clazz.getSimpleName() + " lock");


### PR DESCRIPTION
There are follow-on PRs to disable and remove use of `CycleDetectingLockFactory`:

* PR #4026 
* PR #4027 