### PR TITLE
DnsDiscovery: Don't create/dispose defaultThreadFactory for each thread 

### DIFF
--- a/core/src/main/java/org/bitcoinj/net/discovery/DnsDiscovery.java
+++ b/core/src/main/java/org/bitcoinj/net/discovery/DnsDiscovery.java
@@ -77,8 +77,7 @@ public class DnsDiscovery extends MultiplexingDiscovery {
     @Override
     protected ExecutorService createExecutor() {
         return Executors.newFixedThreadPool(seeds.size(), r -> {
-            Thread thread = Executors.defaultThreadFactory().newThread(r);
-            thread.setName("DNS seed lookups");
+            Thread thread = new Thread(Thread.currentThread().getThreadGroup(), r, "DNS seed lookups", 0);
             thread.setDaemon(true);
             return thread;
         });


### PR DESCRIPTION
This is a child of (the first commit in) PR #4031 