### PR TITLE
build-gradle.yml: remove macOS-15-intel from build_graalvm matrix

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [ubuntu-24.04, macOS-15, macOS-15-intel]
+        os: [ubuntu-24.04, macOS-15]
         java: [ '25' ]
         distribution: [ 'graalvm-community' ]
         gradle: ['9.2.1']


### PR DESCRIPTION
As of Jan 20, 2026 GitHub Actions is failing for macOS-15-intel with:

```
Error: Failed to download graalvm-community-jdk-25.0.2_macos-x64_bin.tar.gz. Are you sure java-version: '25.0.2' is correct?
```

Since our GraalVM work is forward-looking and macOS Intel's days are numbered, we should probably remove this from the Matrix even if today's failure is only temporary.

**Update:** The [GraalVM Community Edition 25.0.1 release notes](https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-25.0.1) state :

> † Support for macOS x64 is deprecated. Version 25.0.1 is the last release that supports this hardware architecture. In future, GraalVM will only support macOS on AArch64 (Apple Silicon).

