### PR TITLE
Transaction: lower the default minimum transaction fee rate

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -142,7 +142,7 @@ public class Transaction implements Message {
     /**
      * If feePerKb is lower than this, Bitcoin Core will treat it as if there were no fee.
      */
-    public static final Coin REFERENCE_DEFAULT_MIN_TX_FEE = Coin.valueOf(1_000); // 0.01 mBTC
+    public static final Coin REFERENCE_DEFAULT_MIN_TX_FEE = Coin.valueOf(100); // per vkB
 
     /**
      * Minimum feerate for defining dust, in sats per kB.

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -2658,8 +2658,8 @@ public class WalletTest extends TestWithWallet {
         emptyReq.ensureMinRequiredFee = true;
         emptyReq.emptyWallet = true;
         emptyReq.allowUnconfirmed();
-        wallet.completeTx(emptyReq);
-        assertEquals(Coin.valueOf(342), emptyReq.tx.getFee()); // converted to fee rate this is close to min rate
+        wallet.completeTx(emptyReq); // resulting vsize ~339
+        assertEquals(Coin.valueOf(171), emptyReq.tx.getFee());
         wallet.commitTx(emptyReq.tx);
     }
 


### PR DESCRIPTION
As of Bitcoin Core 29.1 (released Sep 4, 2025) transaction with fee rates as low as 100 sat per vKB are now relayed.

However, the dust limit hasn't been changed. So we uncouple the two values by introducing a separate constant for the dust limit.

This is a candidate for backporting along with the PRs this depends on, maybe with a slight delay.

For context, this chart shows that at the moment many txns in the 0.1-0.2 sat/vB range are mined: https://jochen-hoenicke.de/queue/#BTC,24h,weight,0