### PR TITLE
Transaction: introduce constant for defining dust

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -145,6 +145,11 @@ public class Transaction implements Message {
     public static final Coin REFERENCE_DEFAULT_MIN_TX_FEE = Coin.valueOf(1_000); // 0.01 mBTC
 
     /**
+     * Minimum feerate for defining dust, in sats per kB.
+     */
+    public static final Coin DUST_RELAY_TX_FEE_RATE = Coin.valueOf(3_000); // per kB
+
+    /**
      * If using this feePerKb, transactions will get confirmed within the next couple of blocks.
      * This should be adjusted from time to time. Last adjustment: February 2017.
      */

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -241,7 +241,7 @@ public class TransactionOutput {
      * and mined by default miners.
      */
     public Coin getMinNonDustValue() {
-        return getMinNonDustValue(Transaction.REFERENCE_DEFAULT_MIN_TX_FEE.multiply(3));
+        return getMinNonDustValue(Transaction.DUST_RELAY_TX_FEE_RATE);
     }
 
     /**


### PR DESCRIPTION
Dust is defined by a minimum feerate. Historically this has been based on the REFERENCE_DEFAULT_MIN_TX_FEE, however changing the dust limit changes which transactions are standard and should be done with care.

Hence, we decouple the two constants.