### PR TITLE
WalletTest: replace vague fee range by an exact fee amount in an assert

### DIFF
--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -127,7 +127,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -2660,8 +2659,7 @@ public class WalletTest extends TestWithWallet {
         emptyReq.emptyWallet = true;
         emptyReq.allowUnconfirmed();
         wallet.completeTx(emptyReq);
-        final Coin feePerKb = emptyReq.tx.getFee().multiply(1000).divide(emptyReq.tx.getVsize());
-        assertThat((double) feePerKb.toSat(), closeTo(Transaction.REFERENCE_DEFAULT_MIN_TX_FEE.toSat(),20));
+        assertEquals(Coin.valueOf(342), emptyReq.tx.getFee()); // converted to fee rate this is close to min rate
         wallet.commitTx(emptyReq.tx);
     }
 


### PR DESCRIPTION
This makes the assert independant of the transaction size which varies depending on the length of the signature.
    
Also, it decouples the assert from a constant which will change in future.
