### PR TITLE
PeerGroupTest: fix call to PreMessageReceivedEventListener and verify it is called

### DIFF
--- a/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -157,6 +157,8 @@ public class PeerGroupTest extends TestWithPeerGroup {
         disconnectedPeers.take();
         assertEquals(0, disconnectedPeers.size());
 
+        assertTrue(peerToMessageCount.size() >= 2);     // Verify preMessageReceivedListener was called
+
         assertTrue(peerGroup.removeConnectedEventListener(connectedListener));
         assertFalse(peerGroup.removeConnectedEventListener(connectedListener));
         assertTrue(peerGroup.removeDisconnectedEventListener(disconnectedListener));


### PR DESCRIPTION
To make sure others don't make the same mistake as `PeerGroupTest`, see Issue #4052.