### PR TITLE
ScriptTest: fix scope of catch clause

### DIFF
--- a/core/src/test/java/org/bitcoinj/script/ScriptTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptTest.java
@@ -127,7 +127,7 @@ public class ScriptTest {
             // Fail if we ask for more signatures than keys.
             Script.createMultiSigOutputScript(4, keys);
             fail();
-        } catch (Throwable e) {
+        } catch (RuntimeException e) {
             // Expected.
         }
         try {


### PR DESCRIPTION
We should catch `RuntimeException`, but not catch `Throwable`. `fail()` throws `AssertionError` which is how we indicate `createMultiSigOutputScript()` has not thrown as expected and must not be swallowed so the test will fail.