### PR TITLE
core: add package-info.java to all remaining packages

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/internal/package-info.java
+++ b/core/src/main/java/org/bitcoinj/core/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package is for internal ({@code bitcoinj-core}) use only.
+ */
+package org.bitcoinj.core.internal;

--- a/core/src/main/java/org/bitcoinj/core/listeners/package-info.java
+++ b/core/src/main/java/org/bitcoinj/core/listeners/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Listeners for various bitcoinj events.
+ */
+package org.bitcoinj.core.listeners;

--- a/core/src/main/java/org/bitcoinj/crypto/internal/package-info.java
+++ b/core/src/main/java/org/bitcoinj/crypto/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package is for internal ({@code bitcoinj-core}) use only.
+ */
+package org.bitcoinj.crypto.internal;

--- a/core/src/main/java/org/bitcoinj/crypto/utils/package-info.java
+++ b/core/src/main/java/org/bitcoinj/crypto/utils/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utilities for verifying messages signed with Bitcoin private keys.
+ */
+package org.bitcoinj.crypto.utils;

--- a/core/src/main/java/org/bitcoinj/testing/package-info.java
+++ b/core/src/main/java/org/bitcoinj/testing/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Mock classes for unit testing.
+ */
+package org.bitcoinj.testing;

--- a/core/src/main/java/org/bitcoinj/wallet/listeners/package-info.java
+++ b/core/src/main/java/org/bitcoinj/wallet/listeners/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Listeners for various wallet events.
+ */
+package org.bitcoinj.wallet.listeners;


### PR DESCRIPTION
This is in preparation for making things `@NullMarked`, but is a good thing by itself.