### PR TITLE
Test: Add unit test for DeterministicKeyChain toString() safety

### DIFF
--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -796,4 +796,15 @@ public class DeterministicKeyChainTest {
             throw new RuntimeException(e);
         }
     }
+
+    @Test
+    public void testToString() {
+        DeterministicSeed seed = new DeterministicSeed("correct horse battery staple", null, "", Instant.ofEpochSecond(1000L));
+        DeterministicKeyChain chain = DeterministicKeyChain.builder().seed(seed).build();
+
+        String str = chain.toString();
+        assertTrue("Output should contain class name", str.contains("DeterministicKeyChain"));
+        assertFalse("Security Fail: toString() leaked the mnemonic!", str.contains("correct horse battery staple"));
+        assertFalse("Security Fail: toString() leaked the xprv (private key)!", str.contains("xprv"));
+    }
 }


### PR DESCRIPTION
Added a unit test to verify that `DeterministicKeyChain.toString()` correctly identifies the object but does not leak sensitive information (mnemonic or xprv) in its output.

Resolves #4068.

This test is a requested prerequisite for merging PR #4000. 
It establishes a safety baseline for the current master branch.