### PR TITLE
Test: Add unit test for DeterministicKey toString() format

### DIFF
--- a/core/src/test/java/org/bitcoinj/crypto/DeterministicKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/DeterministicKeyTest.java
@@ -18,6 +18,7 @@ package org.bitcoinj.crypto;
 
 import org.bitcoinj.base.BitcoinNetwork;
 import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
 
@@ -40,5 +41,16 @@ public class DeterministicKeyTest {
         DeterministicKey ehkey = dh.get(path, false, true);
 
         ehkey.serialize(BitcoinNetwork.MAINNET, false);
+    }
+
+    @Test
+    public void testToString() {
+        // Create a key from a 32-byte seed
+        DeterministicKey key = HDKeyDerivation.createMasterPrivateKey(new byte[32]);
+        String str = key.toString();
+
+        // Verify it prints standard ECKey fields (inherited behavior in master)
+        assertTrue("Should contain public key", str.contains("pub"));
+        assertTrue("Should contain encryption status", str.contains("isEncrypted"));
     }
 }


### PR DESCRIPTION
Added a unit test to verify that `DeterministicKey.toString()` maintains standard ECKey output formatting (including public key presence and encryption status), ensuring no regression in debug output.

Resolves #4069.

This test is a requested prerequisite for merging PR #4000. 
It establishes a safety baseline for the current master branch.