### PR TITLE
PeerSocketHandler: simplify constructor

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -253,7 +253,7 @@ public class Peer extends PeerSocketHandler {
      */
     public Peer(NetworkParameters params, VersionMessage ver, PeerAddress remoteAddress,
                 @Nullable AbstractBlockChain chain, long requiredServices, int downloadTxDependencyDepth) {
-        super(params, remoteAddress);
+        super(remoteAddress, params.getDefaultSerializer());
         this.params = Objects.requireNonNull(params);
         this.versionMessage = Objects.requireNonNull(ver);
         this.vDownloadTxDependencyDepth = chain != null ? downloadTxDependencyDepth : 0;

--- a/core/src/main/java/org/bitcoinj/core/PeerSocketHandler.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerSocketHandler.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.nio.Buffer;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
@@ -66,14 +65,9 @@ public abstract class PeerSocketHandler implements TimeoutHandler, StreamConnect
     private int largeReadBufferPos;
     private BitcoinSerializer.BitcoinPacketHeader header;
 
-    public PeerSocketHandler(NetworkParameters params, InetSocketAddress remoteIp) {
-        this(params, PeerAddress.simple(remoteIp));
-    }
-
-    public PeerSocketHandler(NetworkParameters params, PeerAddress peerAddress) {
-        Objects.requireNonNull(params);
-        serializer = params.getDefaultSerializer();
+    protected PeerSocketHandler(PeerAddress peerAddress, MessageSerializer messageSerializer) {
         this.peerAddress = Objects.requireNonNull(peerAddress);
+        this.serializer = Objects.requireNonNull(messageSerializer);
         this.timeoutTask = new SocketTimeoutTask(this::timeoutOccurred);
     }
 

--- a/integration-test/src/test/java/org/bitcoinj/testing/InboundMessageQueuer.java
+++ b/integration-test/src/test/java/org/bitcoinj/testing/InboundMessageQueuer.java
@@ -20,6 +20,7 @@ import org.bitcoinj.core.BloomFilter;
 import org.bitcoinj.core.Message;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Peer;
+import org.bitcoinj.core.PeerAddress;
 import org.bitcoinj.core.PeerSocketHandler;
 import org.bitcoinj.core.Ping;
 
@@ -43,7 +44,7 @@ public abstract class InboundMessageQueuer extends PeerSocketHandler {
     public BloomFilter lastReceivedFilter;
 
     protected InboundMessageQueuer(NetworkParameters params) {
-        super(params, new InetSocketAddress(InetAddress.getLoopbackAddress(), 2000));
+        super(PeerAddress.simple(new InetSocketAddress(InetAddress.getLoopbackAddress(), 2000)), params.getDefaultSerializer());
     }
 
     public Message nextMessage() {


### PR DESCRIPTION
* Create new, protected constructor that takes peerAddress, messageSerializer
* Remove 2 constructors that take NetworkParameters
* Update Peer, MessageQueuer to use new constructor