### PR TITLE
Dev maven phase 2

### DIFF
--- a/.github/workflows/build-maven.yml
+++ b/.github/workflows/build-maven.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           maven-version: ${{ matrix.maven }}
       - name: Run Maven
-        run: mvn clean validate compile
+        run: mvn clean validate compile test-compile -X
       - name: Upload Build Results
         uses: actions/upload-artifact@v4
         if: always()
@@ -67,7 +67,7 @@ jobs:
         with:
           maven-version: ${{ matrix.maven }}
       - name: Run Maven
-        run: mvn clean validate compile -X
+        run: mvn clean validate compile test-compile -X
       - name: Upload Build Results
         uses: actions/upload-artifact@v4
         with:

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <groupId>org.bitcoinj</groupId>
+        <artifactId>bitcoinj-parent</artifactId>
+        <version>0.18-SNAPSHOT</version>
+    </parent>
+    
+    <artifactId>bitcoinj-base</artifactId>
+    <packaging>jar</packaging>
+    
+    <name>BitcoinJ Base</name>
+    <description>A Java Bitcoin library - Base module</description>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.bitcoinj</groupId>
+            <artifactId>bitcoinj-test-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>pl.pragmatists</groupId>
+            <artifactId>JUnitParams</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.bitcoinj.base</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/base/src/test/java/org/bitcoinj/base/SegwitAddressTest.java
+++ b/base/src/test/java/org/bitcoinj/base/SegwitAddressTest.java
@@ -132,7 +132,7 @@ public class SegwitAddressTest {
         for (AddressData valid : AddressData.VALID_ADDRESSES) {
             SegwitAddress address = (SegwitAddress) addressParser.parseAddress(valid.address);
 
-            assertEquals(valid.expectedNetwork, address.network());
+            assertEquals(valid.expectedNetwork, address.network().id());
             assertEquals(valid.address.toLowerCase(Locale.ROOT), address.toBech32());
             assertEquals(valid.expectedWitnessVersion, address.getWitnessVersion());
         }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <groupId>org.bitcoinj</groupId>
+        <artifactId>bitcoinj-parent</artifactId>
+        <version>0.18-SNAPSHOT</version>
+    </parent>
+    
+    <artifactId>bitcoinj-core</artifactId>
+    <packaging>jar</packaging>
+    
+    <name>BitcoinJ Core</name>
+    <description>A Java Bitcoin library - Core module</description>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.bitcoinj</groupId>
+            <artifactId>bitcoinj-base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15to18</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-javalite</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.bitcoinj</groupId>
+            <artifactId>bitcoinj-test-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>pl.pragmatists</groupId>
+            <artifactId>JUnitParams</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.1</version>
+            </extension>
+        </extensions>
+        
+        <plugins>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+                            <pluginId>javalite</pluginId>
+                            <pluginArtifact>com.google.protobuf:protoc-gen-javalite:${protobuf.version}:exe:${os.detected.classifier}</pluginArtifact>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.bitcoinj.core</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/core/src/test/java/org/bitcoinj/script/ScriptBuilderTest.java
+++ b/core/src/test/java/org/bitcoinj/script/ScriptBuilderTest.java
@@ -18,6 +18,7 @@ package org.bitcoinj.script;
 
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.AddressParser;
+import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.LegacyAddress;
 import org.bitcoinj.base.SegwitAddress;
 import org.bitcoinj.base.internal.ByteUtils;
@@ -228,13 +229,15 @@ public class ScriptBuilderTest {
         AddressParser addressParser = AddressParser.getDefault();
 
         for (AddressData valid : AddressData.VALID_ADDRESSES) {
+            BitcoinNetwork network = BitcoinNetwork.fromIdString(valid.expectedNetwork)
+                    .orElseThrow(() -> new IllegalArgumentException("Invalid network id: " + valid.expectedNetwork));
             SegwitAddress address = (SegwitAddress) addressParser.parseAddress(valid.address);
 
             assertEquals(valid.expectedScriptPubKey,
                     ByteUtils.formatHex(ScriptBuilder.createOutputScript(address).program()));
             if (valid.expectedWitnessVersion == 0) {
                 Script expectedScriptPubKey = Script.parse(ByteUtils.parseHex(valid.expectedScriptPubKey));
-                assertEquals(address, SegwitAddress.fromHash(valid.expectedNetwork,
+                assertEquals(address, SegwitAddress.fromHash(network,
                         ScriptPattern.extractHashFromP2WH(expectedScriptPubKey)));
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         
-        <!-- Minimum Maven version requirement -->
-        <maven.version>3.9.0</maven.version>
-        
         <slf4j.version>2.0.16</slf4j.version>
         <jspecify.version>1.0.0</jspecify.version>
         <junit.version>4.13.2</junit.version>
@@ -61,21 +58,21 @@
         <native.maven.plugin.version>0.9.28</native.maven.plugin.version>
         <asciidoctor.maven.plugin.version>2.2.6</asciidoctor.maven.plugin.version>
     </properties>
-    
-    <!-- Since we doing this in several steps, we will not use modules for now and will add them later one by one -->
-    <!--
+
+    <!-- Order matters when we're building -->
     <modules>
-        <module>bitcoinj-base</module>
-        <module>bitcoinj-test-support</module>
-        <module>bitcoinj-core</module>
-        <module>bitcoinj-examples</module>
-        <module>bitcoinj-tools</module>
-        <module>bitcoinj-wallettool</module>
-        <module>bitcoinj-wallettemplate</module>
-        <module>bitcoinj-examples-kotlin</module>
-        <module>bitcoinj-integration-test</module>
+        <module>base</module>
+        <module>test-support</module>
+        <!--Before enabling core module we may need to do some refactoring need to check this first -->
+        <!-- <module>core</module>
+        <module>examples</module>
+        <module>tools</module>
+        <module>wallettool</module>
+        <module>wallettemplate</module>
+        <module>examples-kotlin</module>
+        <module>integration-test</module>
+        -->
     </modules>
-    -->
     
     <dependencyManagement>
         <dependencies>
@@ -151,6 +148,11 @@
                 <groupId>nl.jqno.equalsverifier</groupId>
                 <artifactId>equalsverifier</artifactId>
                 <version>${equalsverifier.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>${hamcrest.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
@@ -322,6 +324,15 @@
                             </configuration>
                         </execution>
                     </executions>
+                </plugin>
+                
+                <plugin>
+                    <groupId>org.xolstice.maven.plugins</groupId>
+                    <artifactId>protobuf-maven-plugin</artifactId>
+                    <version>${protobuf.maven.plugin.version}</version>
+                    <configuration>
+                        <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/test-support/build.gradle
+++ b/test-support/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    api project(':bitcoinj-base')
+    api 'org.jspecify:jspecify:1.0.0'
 }
 
 tasks.withType(JavaCompile) {

--- a/test-support/pom.xml
+++ b/test-support/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <groupId>org.bitcoinj</groupId>
+        <artifactId>bitcoinj-parent</artifactId>
+        <version>0.18-SNAPSHOT</version>
+    </parent>
+    
+    <artifactId>bitcoinj-test-support</artifactId>
+    <packaging>jar</packaging>
+    
+    <name>BitcoinJ Test Support</name>
+    <description>A Java Bitcoin library - Test support module</description>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+    </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.bitcoinj.test.support</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/test-support/src/main/java/org/bitcoinj/test/support/AddressData.java
+++ b/test-support/src/main/java/org/bitcoinj/test/support/AddressData.java
@@ -16,34 +16,32 @@
 
 package org.bitcoinj.test.support;
 
-import org.bitcoinj.base.BitcoinNetwork;
-
-import static org.bitcoinj.base.BitcoinNetwork.MAINNET;
-import static org.bitcoinj.base.BitcoinNetwork.TESTNET;
-import static org.bitcoinj.base.BitcoinNetwork.REGTEST;
-
 /**
  * AddressData wrapper class with valid and invalid address test vectors.
  */
 public class AddressData {
+    public static String MAINNET_ID = "org.bitcoin.production";
+    public static String TESTNET_ID = "org.bitcoin.test";
+    public static String REGTEST_ID = "org.bitcoin.regtest";
+    
     public static AddressData[] VALID_ADDRESSES = {
             // from BIP350 (includes the corrected BIP173 vectors):
-            new AddressData("BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4", MAINNET,
+            new AddressData("BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4", MAINNET_ID,
                     "0014751e76e8199196d454941c45d1b3a323f1433bd6", 0),
-            new AddressData("tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7", TESTNET,
+            new AddressData("tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7", TESTNET_ID,
                     "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262", 0),
-            new AddressData("BC1SW50QGDZ25J", MAINNET, "6002751e", 16),
-            new AddressData("bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs", MAINNET, "5210751e76e8199196d454941c45d1b3a323", 2),
-            new AddressData("tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy", TESTNET,
+            new AddressData("BC1SW50QGDZ25J", MAINNET_ID, "6002751e", 16),
+            new AddressData("bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs", MAINNET_ID, "5210751e76e8199196d454941c45d1b3a323", 2),
+            new AddressData("tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy", TESTNET_ID,
                     "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433", 0),
-            new AddressData("tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c", TESTNET,
+            new AddressData("tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c", TESTNET_ID,
                     "5120000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433", 1),
-            new AddressData("bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0", MAINNET,
+            new AddressData("bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0", MAINNET_ID,
                     "512079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798", 1),
             // P2A (pay-to-anchor) output script address representations (see https://delvingbitcoin.org/t/segwit-ephemeral-anchors/160/2)
-            new AddressData("bc1pfeessrawgf", MAINNET, "51024e73", 1), // pay-2-anchor (P2A) mainnet address
-            new AddressData("tb1pfees9rn5nz", TESTNET, "51024e73", 1), // pay-2-anchor (P2A) testnet address
-            new AddressData("bcrt1pfeesnyr2tx", REGTEST, "51024e73", 1), // pay-2-anchor (P2A) regtest address
+            new AddressData("bc1pfeessrawgf", MAINNET_ID, "51024e73", 1), // pay-2-anchor (P2A) MAINNET_ID address
+            new AddressData("tb1pfees9rn5nz", TESTNET_ID, "51024e73", 1), // pay-2-anchor (P2A) TESTNET_ID address
+            new AddressData("bcrt1pfeesnyr2tx", REGTEST_ID, "51024e73", 1), // pay-2-anchor (P2A) REGTEST_ID address
     };
     public static String[] INVALID_ADDRESSES = {
             // from BIP173:
@@ -71,11 +69,11 @@ public class AddressData {
             "bc1gmk9yu", // Empty data section
     };
     public final String address;
-    public final BitcoinNetwork expectedNetwork;
+    public final String expectedNetwork;
     public final String expectedScriptPubKey;
     public final int expectedWitnessVersion;
 
-    public AddressData(String address, BitcoinNetwork expectedNetwork, String expectedScriptPubKey,
+    public AddressData(String address, String expectedNetwork, String expectedScriptPubKey,
                        int expectedWitnessVersion) {
         this.address = address;
         this.expectedNetwork = expectedNetwork;
@@ -87,7 +85,7 @@ public class AddressData {
     public String toString() {
         StringBuilder s = new StringBuilder(this.getClass().getSimpleName()).append('{');
         s.append("address=").append(address).append(',');
-        s.append("expected=").append(expectedNetwork.id()).append(',').append(expectedScriptPubKey).append(',').append(expectedWitnessVersion);
+        s.append("expected=").append(expectedNetwork).append(',').append(expectedScriptPubKey).append(',').append(expectedWitnessVersion);
         return s.append('}').toString();
     }
 }

--- a/test-support/src/main/java/org/bitcoinj/test/support/package-info.java
+++ b/test-support/src/main/java/org/bitcoinj/test/support/package-info.java
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 /**
- * Test support classes that depend upon {@code bitcoinj-base} and can be used in both
- * {@code bitcoinj-base} and {@code bitcoinj-core} tests.
+ * Test support classes that can be used in both {@code bitcoinj-base} and {@code bitcoinj-core} tests.
  */
 @NullMarked
 package org.bitcoinj.test.support;


### PR DESCRIPTION
# Description 

So this is Phase two of migrating to Maven build system #3840. This PR focuses on creating sub pom files and wiring them together. `base`, `test-support` and `core`. Note that `code` is not included in wiring just pom file, I faced some issue `protobuf-maven-plugin` that might need to have some code touches to get this working. So I need some time to investigate what needs to be done and what is path forward.

Also since we had a circular dependency that Maven cannot automatically resolve I cherry picked this PR #4089. 

# Testing 
Added `mvn clean validate compile test-compile -X` for test compile and run it manually 
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for BitcoinJ Parent 0.18-SNAPSHOT:
[INFO] 
[INFO] BitcoinJ Parent .................................... SUCCESS [  0.262 s]
[INFO] BitcoinJ Test Support .............................. SUCCESS [  0.532 s]
[INFO] BitcoinJ Base ...................................... SUCCESS [  0.998 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.842 s
[INFO] Finished at: 2026-01-30T15:59:13+04:00
[INFO] ------------------------------------------------------------------------
[DEBUG] Shutting down adapter factory; available factories [file-lock, rwlock-local, semaphore-local, noop]; available name mappers [discriminating, file-gav, file-hgav, file-static, gav, static]
[DEBUG] Shutting down 'file-lock' factory
[DEBUG] Shutting down 'rwlock-local' factory
[DEBUG] Shutting down 'semaphore-local' factory
[DEBUG] Shutting down 'noop' factory
```