### PR TITLE
fix: fixing integration test address collision

### DIFF
--- a/core/src/main/java/org/bitcoinj/net/NioServer.java
+++ b/core/src/main/java/org/bitcoinj/net/NioServer.java
@@ -134,4 +134,12 @@ public class NioServer extends AbstractExecutionThreadService {
         // Wake up the selector and let the selection thread break its loop as the ExecutionService !isRunning()
         selector.wakeup();
     }
+
+    /**
+     * Returns the port this server is bound to. Useful for testing when port 0 is used to let the OS allocate a port.
+     * @return the local port number
+     */
+    public int getPort() {
+        return sc.socket().getLocalPort();
+    }
 }

--- a/integration-test/src/test/java/org/bitcoinj/testing/TestWithPeerGroup.java
+++ b/integration-test/src/test/java/org/bitcoinj/testing/TestWithPeerGroup.java
@@ -133,7 +133,8 @@ public class TestWithPeerGroup extends TestWithNetworkConnections {
 
     protected InboundMessageQueuer connectPeerWithoutVersionExchange(int id) throws Exception {
         checkArgument(id < PEER_SERVERS);
-        InetSocketAddress remoteAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), TCP_PORT_BASE + id);
+        int port = getPeerServerPort(id);
+        InetSocketAddress remoteAddress = new InetSocketAddress(InetAddress.getLoopbackAddress(), port);
         Peer peer = peerGroup.connectTo(remoteAddress).getConnectionOpenFuture().get();
         InboundMessageQueuer writeTarget = newPeerWriteTargetQueue.take();
         writeTarget.peer = peer;


### PR DESCRIPTION
### Description 
So pipeline test is a bit flaky and keep getting socket address collisions that require restart test. I am replacing random addresses to 0 which basically let operating system to choose address

```
PeerGroupTest > [1] > transactionConfidence[1] FAILED
    java.net.BindException: Address already in use
        at java.base/sun.nio.ch.Net.bind0(Native Method)
        at java.base/sun.nio.ch.Net.bind(Net.java:577)
        at java.base/sun.nio.ch.ServerSocketChannelImpl.netBind(ServerSocketChannelImpl.java:344)
        at java.base/sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:301)
        at java.base/sun.nio.ch.ServerSocketAdaptor.bind(ServerSocketAdaptor.java:89)
        at java.base/sun.nio.ch.ServerSocketAdaptor.bind(ServerSocketAdaptor.java:81)
        at org.bitcoinj.net.NioServer.<init>(NioServer.java:78)
        at org.bitcoinj.testing.TestWithNetworkConnections.startPeerServer(TestWithNetworkConnections.java:153)
        at org.bitcoinj.testing.TestWithNetworkConnections.startPeerServers(TestWithNetworkConnections.java:133)
        at org.bitcoinj.testing.TestWithNetworkConnections.setUp(TestWithNetworkConnections.java:122)
        at org.bitcoinj.testing.TestWithPeerGroup.setUp(TestWithPeerGroup.java:78)
        at org.bitcoinj.testing.TestWithPeerGroup.setUp(TestWithPeerGroup.java:73)
        at org.bitcoinj.core.PeerGroupTest.setUp(PeerGroupTest.java:117)
```
@msgilligan I recall there was an item for this but just could not find which one 

### Testing 
Tested with remote. Test are still flaky but for other reasons, haven't see any address collisions after 3 runs 