### PR TITLE
PeerTest: clear uncaughtExceptionHandler after setting

### DIFF
--- a/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -843,6 +843,7 @@ public class PeerTest extends TestWithNetworkConnections {
         } catch (ExecutionException e) {
             assertTrue(e.getCause() instanceof ProtocolException);
         }
+        Threading.uncaughtExceptionHandler = null;
         peerDisconnected.get();
         try {
             peer.writeTarget.writeBytes(new byte[1]);


### PR DESCRIPTION
`badMessage()` sets Threading.uncaughtExceptionHandler to complete a local `CompletableFuture` at the start of the test, but does not set it back to `null` when finished, like the `exceptionListener()` test does.