### PR TITLE
PeerGroup: skip scheduling task in setupPinging() if executor is shutdown

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -1673,6 +1673,9 @@ public class PeerGroup implements TransactionBroadcaster {
         if (getPingIntervalMsec() <= 0)
             return;  // Disabled.
 
+        if (executor.isShutdown())
+            return;
+
         vPingTask = executor.scheduleAtFixedRate(() -> {
             try {
                 if (getPingIntervalMsec() <= 0) {


### PR DESCRIPTION
It is possible that the executor can be told to shutdown before setupPinging() is called. This prevents a `RejectedExecutionException` from being thrown. In some cases (if the PeerGroup is stopped before setupPinging() is called during PeerGroup startup) the `RejectedExecutionException` is ignored (but is logged) and in other cases it is not.

You can see the logged-and-ignored case in the bitcoinj-core `WalletAppKitTest` `launchAndClose()` and `launchAndCloseTwice()` tests. This commit should cause `RejectedExecutionException` to no longer show in the log for those tests.