### PR TITLE
PeerGroup: better handle shutdown in triggerConnectionsJob

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -564,6 +564,10 @@ public class PeerGroup implements TransactionBroadcaster {
                 discoverySuccess = discoverPeers() > 0;
             }
 
+            // Check if PeerGroup is shutting down before doing further work
+            if (executor.isShutdown())
+                return;
+
             lock.lock();
             try {
                 if (doDiscovery) {
@@ -606,6 +610,11 @@ public class PeerGroup implements TransactionBroadcaster {
                     triggerConnectionsAfterDelay(delay.toMillis());
                     return;
                 }
+
+                // Check if PeerGroup has shut down before making a connection attempt
+                if (executor.isShutdown())
+                    return;
+
                 connectTo(addrToTry, false, vConnectTimeout);
             } finally {
                 lock.unlock();


### PR DESCRIPTION
This is a child of PR #4103, but could potentially be applied separately.

This contains two commits:

1. Checks for shutdown before trying to schedule jobs with `executor`
2. Avoid doing unnecessary work and I/O when `executor` is shutdown