### PR TITLE
PeerGroupTest: better failure message on timeout comparison assert

### DIFF
--- a/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -537,7 +537,8 @@ public class PeerGroupTest extends TestWithPeerGroup {
         // check things after disconnect
         assertFalse(peerConnectedFuture.isDone()); // should never have connected
         watch.stop();
-        assertTrue(watch.toString(), watch.elapsed().compareTo(timeout) >= 0); // should not disconnect before timeout
+        assertTrue("Disconnect in " + watch + " for " + timeout.toMillis() + " ms timeout",
+                watch.elapsed().compareTo(timeout) >= 0); // should not disconnect before timeout
         assertTrue(peerDisconnectedFuture.isDone()); // but should disconnect eventually
     }
 


### PR DESCRIPTION
This should change the message from:

```
99 ms
```

to

```
Disconnect in 99 ms for 100 ms timeout"
```

This is simply a change for better error messages. We separately may want to add 1 or 2 ms of error margin. See Issue #4105.