### PR TITLE
integration-tests: narrow throws declarations in helper methods

### DIFF
--- a/integration-test/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/FilteredBlockAndPartialMerkleTreeTest.java
@@ -27,6 +27,7 @@ import org.bitcoinj.base.internal.Buffers;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.core.TransactionConfidence.ConfidenceType;
 import org.bitcoinj.crypto.ECKey;
+import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.testing.FakeTxBuilder;
 import org.bitcoinj.testing.InboundMessageQueuer;
@@ -38,6 +39,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
@@ -69,7 +71,7 @@ public class FilteredBlockAndPartialMerkleTreeTest extends TestWithPeerGroup {
     }
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() throws BlockStoreException, IOException {
         MemoryBlockStore store = new MemoryBlockStore(TESTNET.getGenesisBlock());
 
         // Cheat and place the previous block (block 100000) at the head of the block store without supporting blocks

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -30,6 +30,7 @@ import org.bitcoinj.core.listeners.PreMessageReceivedEventListener;
 import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.net.discovery.PeerDiscovery;
 import org.bitcoinj.net.discovery.PeerDiscoveryException;
+import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.testing.FakeTxBuilder;
 import org.bitcoinj.testing.InboundMessageQueuer;
 import org.bitcoinj.testing.TestWithPeerGroup;
@@ -113,7 +114,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
 
     @Override
     @Before
-    public void setUp() throws Exception {
+    public void setUp() throws BlockStoreException, IOException {
         super.setUp();
         peerToMessageCount = new HashMap<>();
         connectedPeers = new LinkedBlockingQueue<>();
@@ -776,7 +777,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         }
     }
 
-    private <T extends Message> T assertNextMessageIs(InboundMessageQueuer q, Class<T> klass) throws Exception {
+    private <T extends Message> T assertNextMessageIs(InboundMessageQueuer q, Class<T> klass) throws InterruptedException {
         Message outbound = waitForOutbound(q);
         assertEquals(klass, outbound.getClass());
         return (T) outbound;

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -25,6 +25,7 @@ import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.core.listeners.BlocksDownloadedEventListener;
 import org.bitcoinj.core.listeners.PreMessageReceivedEventListener;
 import org.bitcoinj.crypto.ECKey;
+import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.testing.FakeTxBuilder;
 import org.bitcoinj.testing.InboundMessageQueuer;
 import org.bitcoinj.testing.TestWithNetworkConnections;
@@ -91,7 +92,7 @@ public class PeerTest extends TestWithNetworkConnections {
 
     @Override
     @Before
-    public void setUp() throws Exception {
+    public void setUp() throws IOException, BlockStoreException {
         super.setUp();
         VersionMessage ver = new VersionMessage(TESTNET, 100);
         InetSocketAddress address = new InetSocketAddress(InetAddress.getLoopbackAddress(), 4000);
@@ -101,16 +102,16 @@ public class PeerTest extends TestWithNetworkConnections {
 
     @Override
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         super.tearDown();
         assertFalse(fail.get());
     }
 
-    private void connect() throws Exception {
+    private void connect() throws IOException, ExecutionException, InterruptedException {
         connectWithVersion(70001, Services.NODE_NETWORK);
     }
 
-    private void connectWithVersion(int version, int flags) throws Exception {
+    private void connectWithVersion(int version, int flags) throws IOException, ExecutionException, InterruptedException {
         VersionMessage peerVersion = new VersionMessage(TESTNET, OTHER_PEER_CHAIN_HEIGHT);
         peerVersion.clientVersion = version;
         peerVersion.localServices = Services.of(flags);
@@ -714,7 +715,7 @@ public class PeerTest extends TestWithNetworkConnections {
         checkTimeLockedDependency(true);
     }
 
-    private void checkTimeLockedDependency(boolean shouldAccept) throws Exception {
+    private void checkTimeLockedDependency(boolean shouldAccept) throws IOException, ExecutionException, InterruptedException {
         // Initial setup.
         connectWithVersion(70001, Services.NODE_NETWORK);
         Wallet wallet = Wallet.createDeterministic(BitcoinNetwork.TESTNET, ScriptType.P2PKH);

--- a/integration-test/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
@@ -22,6 +22,7 @@ import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.crypto.ECKey;
+import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.testing.FakeTxBuilder;
 import org.bitcoinj.testing.InboundMessageQueuer;
 import org.bitcoinj.testing.TestWithPeerGroup;
@@ -34,6 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Objects;
@@ -66,7 +68,7 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
 
     @Override
     @Before
-    public void setUp() throws Exception {
+    public void setUp() throws BlockStoreException, IOException {
         TimeUtils.setMockClock(); // Use mock clock
         super.setUp();
         // Fix the random permutation that TransactionBroadcast uses to shuffle the peers.


### PR DESCRIPTION
This ~~is a child of PR #4107 which narrows the throws clauses of classes in `core`~~ PR narrows throws declarations in integration test helper methods..