### PR TITLE
PeerGroupTest: add 1 ms error margin to peerTimeoutTest()

### DIFF
--- a/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -518,6 +518,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
     @Test
     public void peerTimeoutTest() throws Exception {
         final Duration timeout = Duration.ofMillis(100);
+        final Duration errorMargin = Duration.ofMillis(1);
         peerGroup.start();
         peerGroup.setConnectTimeout(timeout);
 
@@ -538,7 +539,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         assertFalse(peerConnectedFuture.isDone()); // should never have connected
         watch.stop();
         assertTrue("Disconnect in " + watch + " for " + timeout.toMillis() + " ms timeout",
-                watch.elapsed().compareTo(timeout) >= 0); // should not disconnect before timeout
+                watch.elapsed().compareTo(timeout.minus(errorMargin)) >= 0); // should not disconnect before timeout
         assertTrue(peerDisconnectedFuture.isDone()); // but should disconnect eventually
     }
 


### PR DESCRIPTION
Recent changes have made the disconnect in this test happen faster and the stopwatch now occasionally measure it happening in 99 ms.

See Issue #4105

This change gives us a 1 ms margin for error, so if the watch measure 99ms, the test will not fail.