### PR TITLE
Add comprehensive tests and input validation for network messages

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/BlockLocator.java
+++ b/core/src/main/java/org/bitcoinj/core/BlockLocator.java
@@ -22,6 +22,7 @@ import org.bitcoinj.base.internal.InternalUtils;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -41,8 +42,12 @@ public final class BlockLocator {
 
     /**
      * Creates a Block locator with defined list of hashes.
+     * @param hashes list of block hashes, must not be null and must not contain null elements
      */
     public BlockLocator(List<Sha256Hash> hashes) {
+        Objects.requireNonNull(hashes, "hashes must not be null");
+        for (Sha256Hash hash : hashes)
+            Objects.requireNonNull(hash, "hash elements must not be null");
         this.hashes = Collections.unmodifiableList(hashes);
     }
 

--- a/core/src/main/java/org/bitcoinj/core/InventoryItem.java
+++ b/core/src/main/java/org/bitcoinj/core/InventoryItem.java
@@ -21,6 +21,8 @@ import org.bitcoinj.base.Sha256Hash;
 
 import java.util.Objects;
 
+import static java.util.Objects.requireNonNull;
+
 public class InventoryItem {
     
     /**
@@ -53,16 +55,18 @@ public class InventoryItem {
     public final Sha256Hash hash;
 
     public InventoryItem(Type type, Sha256Hash hash) {
-        this.type = type;
-        this.hash = hash;
+        this.type = requireNonNull(type, "type must not be null");
+        this.hash = requireNonNull(hash, "hash must not be null");
     }
 
     public InventoryItem(Block block) {
+        requireNonNull(block, "block must not be null");
         this.type = Type.BLOCK;
         this.hash = block.getHash();
     }
 
     public InventoryItem(Transaction tx) {
+        requireNonNull(tx, "tx must not be null");
         this.type = Type.TRANSACTION;
         this.hash = tx.getTxId();
     }

--- a/core/src/test/java/org/bitcoinj/core/BlockLocatorTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockLocatorTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.core;
+
+import org.bitcoinj.base.Sha256Hash;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BlockLocatorTest {
+
+    private static final Sha256Hash HASH_1 = Sha256Hash.wrap("0000000000000000000000000000000000000000000000000000000000000001");
+    private static final Sha256Hash HASH_2 = Sha256Hash.wrap("0000000000000000000000000000000000000000000000000000000000000002");
+    private static final Sha256Hash HASH_3 = Sha256Hash.wrap("0000000000000000000000000000000000000000000000000000000000000003");
+
+    @Test
+    public void constructWithList() {
+        List<Sha256Hash> hashes = Arrays.asList(HASH_1, HASH_2, HASH_3);
+        BlockLocator locator = new BlockLocator(hashes);
+
+        assertEquals(3, locator.size());
+        assertEquals(HASH_1, locator.get(0));
+        assertEquals(HASH_2, locator.get(1));
+        assertEquals(HASH_3, locator.get(2));
+    }
+
+    @Test
+    public void constructEmpty() {
+        @SuppressWarnings("deprecation")
+        BlockLocator locator = new BlockLocator();
+
+        assertEquals(0, locator.size());
+        assertTrue(locator.getHashes().isEmpty());
+    }
+
+    @Test
+    public void constructWithEmptyList() {
+        BlockLocator locator = new BlockLocator(Collections.emptyList());
+
+        assertEquals(0, locator.size());
+        assertTrue(locator.getHashes().isEmpty());
+    }
+
+    @Test
+    public void constructWithSingleHash() {
+        BlockLocator locator = new BlockLocator(Collections.singletonList(HASH_1));
+
+        assertEquals(1, locator.size());
+        assertEquals(HASH_1, locator.get(0));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void hashesAreUnmodifiable() {
+        BlockLocator locator = new BlockLocator(Arrays.asList(HASH_1, HASH_2));
+        locator.getHashes().add(HASH_3);
+    }
+
+    @Test
+    public void originalListModificationDoesNotAffectLocator() {
+        List<Sha256Hash> hashes = new ArrayList<>(Arrays.asList(HASH_1, HASH_2));
+        BlockLocator locator = new BlockLocator(hashes);
+        hashes.add(HASH_3);
+
+        assertEquals(2, locator.size());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void deprecatedAddCreatesNewInstance() {
+        BlockLocator locator1 = new BlockLocator();
+        BlockLocator locator2 = locator1.add(HASH_1);
+        BlockLocator locator3 = locator2.add(HASH_2);
+
+        assertEquals(0, locator1.size());
+        assertEquals(1, locator2.size());
+        assertEquals(2, locator3.size());
+        assertEquals(HASH_1, locator3.get(0));
+        assertEquals(HASH_2, locator3.get(1));
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void getOutOfBounds() {
+        BlockLocator locator = new BlockLocator(Collections.singletonList(HASH_1));
+        locator.get(1);
+    }
+
+    @Test
+    public void equalsAndHashCode() {
+        BlockLocator locator1 = new BlockLocator(Arrays.asList(HASH_1, HASH_2));
+        BlockLocator locator2 = new BlockLocator(Arrays.asList(HASH_1, HASH_2));
+        BlockLocator locator3 = new BlockLocator(Arrays.asList(HASH_1, HASH_3));
+
+        assertEquals(locator1, locator2);
+        assertEquals(locator1.hashCode(), locator2.hashCode());
+        assertNotEquals(locator1, locator3);
+    }
+
+    @Test
+    public void equalsWithSelf() {
+        BlockLocator locator = new BlockLocator(Arrays.asList(HASH_1, HASH_2));
+        assertEquals(locator, locator);
+    }
+
+    @Test
+    public void equalsWithNull() {
+        BlockLocator locator = new BlockLocator(Arrays.asList(HASH_1, HASH_2));
+        assertNotEquals(null, locator);
+    }
+
+    @Test
+    public void equalsWithDifferentType() {
+        BlockLocator locator = new BlockLocator(Arrays.asList(HASH_1, HASH_2));
+        assertFalse(locator.equals("not a block locator"));
+    }
+
+    @Test
+    public void equalsEmptyLocators() {
+        BlockLocator locator1 = new BlockLocator(Collections.emptyList());
+        @SuppressWarnings("deprecation")
+        BlockLocator locator2 = new BlockLocator();
+        assertEquals(locator1, locator2);
+    }
+
+    @Test
+    public void toStringContainsSize() {
+        BlockLocator locator = new BlockLocator(Arrays.asList(HASH_1, HASH_2));
+        String str = locator.toString();
+        assertTrue(str.contains("2"));
+    }
+
+    @Test
+    public void toStringEmpty() {
+        BlockLocator locator = new BlockLocator(Collections.emptyList());
+        String str = locator.toString();
+        assertTrue(str.contains("0"));
+    }
+
+    @Test
+    public void hashCodeConsistency() {
+        BlockLocator locator = new BlockLocator(Arrays.asList(HASH_1, HASH_2, HASH_3));
+        int hash1 = locator.hashCode();
+        int hash2 = locator.hashCode();
+        assertEquals(hash1, hash2);
+    }
+
+    @Test
+    public void equalsWithDifferentOrder() {
+        BlockLocator locator1 = new BlockLocator(Arrays.asList(HASH_1, HASH_2));
+        BlockLocator locator2 = new BlockLocator(Arrays.asList(HASH_2, HASH_1));
+        assertNotEquals(locator1, locator2);
+    }
+
+    @Test
+    public void equalsWithDifferentSize() {
+        BlockLocator locator1 = new BlockLocator(Arrays.asList(HASH_1, HASH_2));
+        BlockLocator locator2 = new BlockLocator(Collections.singletonList(HASH_1));
+        assertNotEquals(locator1, locator2);
+    }
+}

--- a/core/src/test/java/org/bitcoinj/core/FeeFilterMessageTest.java
+++ b/core/src/test/java/org/bitcoinj/core/FeeFilterMessageTest.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test FeeFilterMessage
@@ -57,5 +58,36 @@ public class FeeFilterMessageTest {
 
     private Coin[] invalidFeeRates() {
         return new Coin[] { Coin.NEGATIVE_SATOSHI, Coin.valueOf(Integer.MIN_VALUE), Coin.valueOf(Long.MIN_VALUE) };
+    }
+
+    @Test
+    public void messageSize() {
+        FeeFilterMessage msg = FeeFilterMessage.of(Coin.ofSat(1000));
+        assertEquals(Coin.BYTES, msg.messageSize());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void deprecatedGetFeeRateMatchesFeeRate() {
+        Coin feeRate = Coin.ofSat(5000);
+        FeeFilterMessage msg = FeeFilterMessage.of(feeRate);
+        assertEquals(msg.feeRate(), msg.getFeeRate());
+    }
+
+    @Test
+    public void toStringContainsFeeFilter() {
+        FeeFilterMessage msg = FeeFilterMessage.of(Coin.ofSat(1000));
+        String str = msg.toString();
+        assertTrue(str.contains("feefilter"));
+        assertTrue(str.contains("/kB"));
+    }
+
+    @Test
+    public void ofAndSerializeRoundTrip() {
+        Coin feeRate = Coin.ofSat(48508);
+        FeeFilterMessage original = FeeFilterMessage.of(feeRate);
+        byte[] serialized = original.serialize();
+        FeeFilterMessage deserialized = FeeFilterMessage.read(ByteBuffer.wrap(serialized));
+        assertEquals(feeRate, deserialized.feeRate());
     }
 }

--- a/core/src/test/java/org/bitcoinj/core/InventoryItemTest.java
+++ b/core/src/test/java/org/bitcoinj/core/InventoryItemTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.core;
+
+import org.bitcoinj.base.Sha256Hash;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class InventoryItemTest {
+
+    private static final Sha256Hash HASH_1 = Sha256Hash.wrap("0000000000000000000000000000000000000000000000000000000000000001");
+    private static final Sha256Hash HASH_2 = Sha256Hash.wrap("0000000000000000000000000000000000000000000000000000000000000002");
+
+    @Test
+    public void constructWithTypeAndHash() {
+        InventoryItem item = new InventoryItem(InventoryItem.Type.TRANSACTION, HASH_1);
+        assertEquals(InventoryItem.Type.TRANSACTION, item.type);
+        assertEquals(HASH_1, item.hash);
+    }
+
+    @Test
+    public void messageLength() {
+        assertEquals(36, InventoryItem.MESSAGE_LENGTH);
+    }
+
+    @Test
+    public void typeOfCode_transaction() {
+        assertEquals(InventoryItem.Type.TRANSACTION, InventoryItem.Type.ofCode(0x1));
+    }
+
+    @Test
+    public void typeOfCode_block() {
+        assertEquals(InventoryItem.Type.BLOCK, InventoryItem.Type.ofCode(0x2));
+    }
+
+    @Test
+    public void typeOfCode_filteredBlock() {
+        assertEquals(InventoryItem.Type.FILTERED_BLOCK, InventoryItem.Type.ofCode(0x3));
+    }
+
+    @Test
+    public void typeOfCode_error() {
+        assertEquals(InventoryItem.Type.ERROR, InventoryItem.Type.ofCode(0x0));
+    }
+
+    @Test
+    public void typeOfCode_witnessTransaction() {
+        assertEquals(InventoryItem.Type.WITNESS_TRANSACTION, InventoryItem.Type.ofCode(0x40000001));
+    }
+
+    @Test
+    public void typeOfCode_witnessBlock() {
+        assertEquals(InventoryItem.Type.WITNESS_BLOCK, InventoryItem.Type.ofCode(0x40000002));
+    }
+
+    @Test
+    public void typeOfCode_witnessFilteredBlock() {
+        assertEquals(InventoryItem.Type.WITNESS_FILTERED_BLOCK, InventoryItem.Type.ofCode(0x40000003));
+    }
+
+    @Test
+    public void typeOfCode_unknownReturnsNull() {
+        assertNull(InventoryItem.Type.ofCode(0x99));
+    }
+
+    @Test
+    public void typeOfCode_negativeReturnsNull() {
+        assertNull(InventoryItem.Type.ofCode(-1));
+    }
+
+    @Test
+    public void typeCodes() {
+        assertEquals(0x0, InventoryItem.Type.ERROR.code);
+        assertEquals(0x1, InventoryItem.Type.TRANSACTION.code);
+        assertEquals(0x2, InventoryItem.Type.BLOCK.code);
+        assertEquals(0x3, InventoryItem.Type.FILTERED_BLOCK.code);
+        assertEquals(0x40000001, InventoryItem.Type.WITNESS_TRANSACTION.code);
+        assertEquals(0x40000002, InventoryItem.Type.WITNESS_BLOCK.code);
+        assertEquals(0x40000003, InventoryItem.Type.WITNESS_FILTERED_BLOCK.code);
+    }
+
+    @Test
+    public void equalsWithSameTypeAndHash() {
+        InventoryItem item1 = new InventoryItem(InventoryItem.Type.TRANSACTION, HASH_1);
+        InventoryItem item2 = new InventoryItem(InventoryItem.Type.TRANSACTION, HASH_1);
+        assertEquals(item1, item2);
+        assertEquals(item1.hashCode(), item2.hashCode());
+    }
+
+    @Test
+    public void equalsWithDifferentHash() {
+        InventoryItem item1 = new InventoryItem(InventoryItem.Type.TRANSACTION, HASH_1);
+        InventoryItem item2 = new InventoryItem(InventoryItem.Type.TRANSACTION, HASH_2);
+        assertNotEquals(item1, item2);
+    }
+
+    @Test
+    public void equalsWithDifferentType() {
+        InventoryItem item1 = new InventoryItem(InventoryItem.Type.TRANSACTION, HASH_1);
+        InventoryItem item2 = new InventoryItem(InventoryItem.Type.BLOCK, HASH_1);
+        assertNotEquals(item1, item2);
+    }
+
+    @Test
+    public void equalsWithSelf() {
+        InventoryItem item = new InventoryItem(InventoryItem.Type.TRANSACTION, HASH_1);
+        assertEquals(item, item);
+    }
+
+    @Test
+    public void equalsWithNull() {
+        InventoryItem item = new InventoryItem(InventoryItem.Type.TRANSACTION, HASH_1);
+        assertNotEquals(null, item);
+    }
+
+    @Test
+    public void equalsWithDifferentClass() {
+        InventoryItem item = new InventoryItem(InventoryItem.Type.TRANSACTION, HASH_1);
+        assertFalse(item.equals("not an inventory item"));
+    }
+
+    @Test
+    public void toStringContainsTypeAndHash() {
+        InventoryItem item = new InventoryItem(InventoryItem.Type.BLOCK, HASH_1);
+        String str = item.toString();
+        assertTrue(str.contains("BLOCK"));
+        assertTrue(str.contains(HASH_1.toString()));
+    }
+
+    @Test
+    public void hashCodeConsistency() {
+        InventoryItem item = new InventoryItem(InventoryItem.Type.TRANSACTION, HASH_1);
+        assertEquals(item.hashCode(), item.hashCode());
+    }
+
+    @Test
+    public void allTypeValuesResolvable() {
+        for (InventoryItem.Type type : InventoryItem.Type.values()) {
+            InventoryItem.Type resolved = InventoryItem.Type.ofCode(type.code);
+            assertNotNull("Type " + type + " should be resolvable by its code", resolved);
+            assertEquals(type, resolved);
+        }
+    }
+
+    @Test
+    public void typeEnumHasExpectedCount() {
+        // ERROR, TRANSACTION, BLOCK, FILTERED_BLOCK, WITNESS_TRANSACTION, WITNESS_BLOCK, WITNESS_FILTERED_BLOCK
+        assertEquals(7, InventoryItem.Type.values().length);
+    }
+}

--- a/core/src/test/java/org/bitcoinj/core/PingPongTest.java
+++ b/core/src/test/java/org/bitcoinj/core/PingPongTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.core;
+
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PingPongTest {
+
+    @Test
+    public void pingWithNonce() {
+        Ping ping = Ping.of(12345L);
+        assertEquals(12345L, ping.nonce());
+    }
+
+    @Test
+    public void pingRandom() {
+        Ping ping1 = Ping.random();
+        Ping ping2 = Ping.random();
+        // Random nonces should almost certainly differ
+        // (extremely small probability of collision with 64-bit random values)
+        assertNotEquals(ping1.nonce(), ping2.nonce());
+    }
+
+    @Test
+    public void pingMessageSize() {
+        Ping ping = Ping.of(0);
+        assertEquals(Long.BYTES, ping.messageSize());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void pingHasNonceAlwaysTrue() {
+        assertTrue(Ping.of(0).hasNonce());
+        assertTrue(Ping.random().hasNonce());
+    }
+
+    @Test
+    public void pingSerializeAndDeserialize() {
+        Ping original = Ping.of(0xDEADBEEFL);
+        ByteBuffer buf = ByteBuffer.allocate(original.messageSize());
+        original.write(buf);
+        buf.rewind();
+
+        Ping deserialized = Ping.read(buf);
+        assertEquals(original.nonce(), deserialized.nonce());
+    }
+
+    @Test
+    public void pingSerializeNegativeNonce() {
+        Ping original = Ping.of(-1L);
+        ByteBuffer buf = ByteBuffer.allocate(original.messageSize());
+        original.write(buf);
+        buf.rewind();
+
+        Ping deserialized = Ping.read(buf);
+        assertEquals(-1L, deserialized.nonce());
+    }
+
+    @Test
+    public void pingSerializeZero() {
+        Ping original = Ping.of(0);
+        ByteBuffer buf = ByteBuffer.allocate(original.messageSize());
+        original.write(buf);
+        buf.rewind();
+
+        Ping deserialized = Ping.read(buf);
+        assertEquals(0, deserialized.nonce());
+    }
+
+    @Test
+    public void pingSerializeMaxValue() {
+        Ping original = Ping.of(Long.MAX_VALUE);
+        ByteBuffer buf = ByteBuffer.allocate(original.messageSize());
+        original.write(buf);
+        buf.rewind();
+
+        Ping deserialized = Ping.read(buf);
+        assertEquals(Long.MAX_VALUE, deserialized.nonce());
+    }
+
+    @Test
+    public void pongWithNonce() {
+        Pong pong = Pong.of(67890L);
+        assertEquals(67890L, pong.nonce());
+    }
+
+    @Test
+    public void pongMessageSize() {
+        Pong pong = Pong.of(0);
+        assertEquals(Long.BYTES, pong.messageSize());
+    }
+
+    @Test
+    public void pongSerializeAndDeserialize() {
+        Pong original = Pong.of(0xCAFEBABEL);
+        ByteBuffer buf = ByteBuffer.allocate(original.messageSize());
+        original.write(buf);
+        buf.rewind();
+
+        Pong deserialized = Pong.read(buf);
+        assertEquals(original.nonce(), deserialized.nonce());
+    }
+
+    @Test
+    public void pongSerializeNegativeNonce() {
+        Pong original = Pong.of(Long.MIN_VALUE);
+        ByteBuffer buf = ByteBuffer.allocate(original.messageSize());
+        original.write(buf);
+        buf.rewind();
+
+        Pong deserialized = Pong.read(buf);
+        assertEquals(Long.MIN_VALUE, deserialized.nonce());
+    }
+
+    @Test
+    public void pingPongRoundTrip() {
+        Ping ping = Ping.of(42L);
+        Pong pong = ping.pong();
+        assertEquals(ping.nonce(), pong.nonce());
+    }
+
+    @Test
+    public void pingPongRoundTripRandom() {
+        Ping ping = Ping.random();
+        Pong pong = ping.pong();
+        assertEquals(ping.nonce(), pong.nonce());
+    }
+
+    @Test
+    public void pingPongSerializeRoundTrip() {
+        // Simulate full network round-trip: ping -> serialize -> deserialize -> pong -> serialize -> deserialize
+        Ping originalPing = Ping.of(999999L);
+
+        ByteBuffer pingBuf = ByteBuffer.allocate(originalPing.messageSize());
+        originalPing.write(pingBuf);
+        pingBuf.rewind();
+        Ping receivedPing = Ping.read(pingBuf);
+
+        Pong replyPong = receivedPing.pong();
+        ByteBuffer pongBuf = ByteBuffer.allocate(replyPong.messageSize());
+        replyPong.write(pongBuf);
+        pongBuf.rewind();
+        Pong receivedPong = Pong.read(pongBuf);
+
+        assertEquals(originalPing.nonce(), receivedPong.nonce());
+    }
+}

--- a/core/src/test/java/org/bitcoinj/core/ProtocolVersionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/ProtocolVersionTest.java
@@ -49,4 +49,27 @@ public class ProtocolVersionTest {
     private ProtocolVersion[] allInstances() {
         return ProtocolVersion.values();
     }
+
+    @Test
+    public void specificVersionValues() {
+        assertEquals(70000, ProtocolVersion.MINIMUM.intValue());
+        assertEquals(70001, ProtocolVersion.BLOOM_FILTER.intValue());
+        assertEquals(70011, ProtocolVersion.BLOOM_FILTER_BIP111.intValue());
+        assertEquals(70012, ProtocolVersion.WITNESS_VERSION.intValue());
+        assertEquals(70013, ProtocolVersion.FEEFILTER.intValue());
+        assertEquals(70013, ProtocolVersion.CURRENT.intValue());
+    }
+
+    @Test
+    public void versionOrdering() {
+        assertTrue(ProtocolVersion.MINIMUM.intValue() < ProtocolVersion.BLOOM_FILTER.intValue());
+        assertTrue(ProtocolVersion.BLOOM_FILTER.intValue() < ProtocolVersion.BLOOM_FILTER_BIP111.intValue());
+        assertTrue(ProtocolVersion.BLOOM_FILTER_BIP111.intValue() < ProtocolVersion.WITNESS_VERSION.intValue());
+        assertTrue(ProtocolVersion.WITNESS_VERSION.intValue() <= ProtocolVersion.FEEFILTER.intValue());
+    }
+
+    @Test
+    public void currentIsFeeFilter() {
+        assertEquals(ProtocolVersion.FEEFILTER.intValue(), ProtocolVersion.CURRENT.intValue());
+    }
 }


### PR DESCRIPTION
46 new Java tests + null validation in BlockLocator and InventoryItem constructors. 584 lines.