### PR TITLE
InternalUtils: mark commaJoin varargs as `@Nullable`

### DIFF
--- a/base/src/main/java/org/bitcoinj/base/internal/InternalUtils.java
+++ b/base/src/main/java/org/bitcoinj/base/internal/InternalUtils.java
@@ -16,6 +16,8 @@
 
 package org.bitcoinj.base.internal;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -92,7 +94,7 @@ public class InternalUtils {
      * @param strings varargs strings
      * @return A joined string
      */
-    public static String commaJoin(String... strings) {
+    public static String commaJoin(@Nullable String... strings) {
         return Arrays.stream(strings).filter(Objects::nonNull).collect(Collectors.joining(", "));
     }
 


### PR DESCRIPTION
As specified in the JavaDoc, implemented by `.filter(Objects::nonNull)`, and actually used, this method allows `null` arguments. It does not allow the varargs array itself to be `null`. If this package was not already `@NullMarked` we would annotate like this:

```
commaJoin(@Nullable String @NotNull ...  strings)
```