### PR TITLE
Transaction: require `amount` for `addSignedInput()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -957,9 +957,9 @@ public class Transaction implements Message {
         // Verify the API user didn't try to do operations out of order.
         checkState(!outputs.isEmpty(), () ->
                 "attempting to sign tx without outputs");
-        if (amount == null || amount.value <= 0) {
-            log.warn("Illegal amount value. Amount is required for SegWit transactions.");
-        }
+        Objects.requireNonNull(amount);
+        checkState(amount.value > 0, () ->
+                "Illegal amount value. Amount is required for SegWit transactions.");
         TransactionInput input = new TransactionInput(this, new byte[] {}, prevOut, amount);
         addInput(input);
         int inputIndex = inputs.size() - 1;


### PR DESCRIPTION
This is  a child of PR #4120 and is a breaking change that we should consider very carefully. I do not recommend merging this for 0.18. Although we might want to consider the `@NonNull` annotations without the `IllegalArgumentException`
