### PR TITLE
TestWithWallet: suppress NullAway.Init warnings

### DIFF
--- a/core/src/test/java/org/bitcoinj/testing/TestWithWallet.java
+++ b/core/src/test/java/org/bitcoinj/testing/TestWithWallet.java
@@ -50,6 +50,7 @@ import static org.bitcoinj.testing.FakeTxBuilder.createFakeTx;
  * with money in whatever ways you wish. Note that for simplicity with amounts, this class sets the default
  * fee per kilobyte to zero in setUp.
  */
+@SuppressWarnings("NullAway.Init")      // Disable warnings/errors about members initialized in `setUp()`
 public class TestWithWallet {
     protected static final NetworkParameters TESTNET_PARAMS = TestNet3Params.get();
 


### PR DESCRIPTION
This fixes the following NullAway/ErrorProne failure:

```
error: [NullAway] @NonNull field myKey not initialized
```

Which occurs for 5 fields:

```
    protected ECKey myKey;
    protected Address myAddress;
    protected Wallet wallet;
    protected BlockChain chain;
    protected BlockStore blockStore;
```
