### PR TITLE
TestWithPeerGroup, TestWithNetworkConnections: fix test teardown to prevent port leaks

### DIFF
--- a/integration-test/src/main/java/org/bitcoinj/test/integration/peer/TestWithNetworkConnections.java
+++ b/integration-test/src/main/java/org/bitcoinj/test/integration/peer/TestWithNetworkConnections.java
@@ -166,8 +166,13 @@ public class TestWithNetworkConnections {
     }
 
     protected void stopPeerServers() {
-        for (int i = 0 ; i < PEER_SERVERS ; i++)
-            stopPeerServer(i);
+        for (int i = 0 ; i < PEER_SERVERS ; i++) {
+            try {
+                stopPeerServer(i);
+            } catch (Exception e) {
+                // continue stopping remaining servers
+            }
+        }
     }
 
     protected void stopPeerServer(int i) {

--- a/integration-test/src/test/java/org/bitcoinj/test/integration/peer/TestWithNetworkConnectionsTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/test/integration/peer/TestWithNetworkConnectionsTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 the bitcoinj contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.test.integration.peer;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for the {@link TestWithNetworkConnections} test fixture itself.
+ */
+public class TestWithNetworkConnectionsTest {
+
+    // Reproducer for https://github.com/bitcoinj/bitcoinj/issues/1984
+    @Test
+    public void stopPeerServersContinuesAfterException() {
+        final int[] stopCount = {0};
+
+        TestWithNetworkConnections fixture = new TestWithNetworkConnections(
+                TestWithNetworkConnections.ClientType.NIO_CLIENT_MANAGER) {
+            @Override
+            protected void stopPeerServer(int i) {
+                stopCount[0]++;
+                if (i == 0) {
+                    throw new IllegalStateException("simulated: server entered FAILED state");
+                }
+            }
+        };
+
+        // Call stopPeerServers() directly without setUp() to avoid port conflicts.
+        // Without the fix, the loop aborts when server 0 throws and only 1 server
+        // is visited. With the fix, all PEER_SERVERS are visited.
+        fixture.stopPeerServers();
+
+        assertEquals(TestWithNetworkConnections.PEER_SERVERS, stopCount[0]);
+    }
+}

--- a/integration-test/src/test/java/org/bitcoinj/test/integration/peer/TestWithPeerGroup.java
+++ b/integration-test/src/test/java/org/bitcoinj/test/integration/peer/TestWithPeerGroup.java
@@ -94,12 +94,13 @@ public abstract class TestWithPeerGroup extends TestWithNetworkConnections {
     @Override
     public void tearDown() {
         try {
-            super.tearDown();
             blockJobs = false;
             if (peerGroup != null && peerGroup.isRunning())
                 peerGroup.stopAsync();
         } catch (Exception e) {
             throw new RuntimeException(e);
+        } finally {
+            super.tearDown();
         }
     }
 


### PR DESCRIPTION
Fixes #1984 (partially — addresses the teardown-related root causes of flaky integration tests).

2 commits:

`TestWithPeerGroup`: the `tearDown()` method was calling `super.tearDown()` (which stops the NioServers) before stopping the `peerGroup`. This left the PeerGroup with active connections to dead servers, causing `CancelledKeyException` and `RejectedExecutionException`. The fix reverses the order — stop the PeerGroup first, then the servers. `super.tearDown()` is also moved to a `finally` block so servers are always cleaned up even if stopping the PeerGroup throws.

`TestWithNetworkConnections`: if `stopPeerServer(i)` throws (e.g. `IllegalStateException` from `awaitTerminated()` on a FAILED NioServer), the `stopPeerServers()` loop would abort and the remaining servers would never be stopped, leaking bound ports and causing `BindException` in subsequent tests. Each iteration is now wrapped in try-catch so all servers get a chance to shut down.