### PR TITLE
PeerSocketHandler: Don't store PeerAddress

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -84,7 +84,7 @@ public class Peer extends PeerSocketHandler {
     private static final Logger log = LoggerFactory.getLogger(Peer.class);
     protected final ReentrantLock lock = Threading.lock(Peer.class);
 
-    protected final @NonNull PeerAddress peerAddress;
+    private final @NonNull PeerAddress peerAddress;
 
     private final NetworkParameters params;
     private final AbstractBlockChain blockChain;

--- a/core/src/main/java/org/bitcoinj/core/Peer.java
+++ b/core/src/main/java/org/bitcoinj/core/Peer.java
@@ -38,6 +38,7 @@ import org.bitcoinj.base.internal.FutureUtils;
 import org.bitcoinj.utils.ListenerRegistration;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.Wallet;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,6 +83,8 @@ import static org.bitcoinj.base.internal.Preconditions.checkState;
 public class Peer extends PeerSocketHandler {
     private static final Logger log = LoggerFactory.getLogger(Peer.class);
     protected final ReentrantLock lock = Threading.lock(Peer.class);
+
+    protected final @NonNull PeerAddress peerAddress;
 
     private final NetworkParameters params;
     private final AbstractBlockChain blockChain;
@@ -247,7 +250,8 @@ public class Peer extends PeerSocketHandler {
      */
     public Peer(NetworkParameters params, VersionMessage ver, PeerAddress remoteAddress,
                 @Nullable AbstractBlockChain chain, long requiredServices, int downloadTxDependencyDepth) {
-        super(remoteAddress, params.getDefaultSerializer());
+        super(params.getDefaultSerializer());
+        this.peerAddress = remoteAddress;
         this.params = Objects.requireNonNull(params);
         this.versionMessage = Objects.requireNonNull(ver);
         this.vDownloadTxDependencyDepth = chain != null ? downloadTxDependencyDepth : 0;
@@ -282,6 +286,12 @@ public class Peer extends PeerSocketHandler {
     public Peer(NetworkParameters params, AbstractBlockChain blockChain, PeerAddress peerAddress, String thisSoftwareName, String thisSoftwareVersion) {
         this(params, new VersionMessage(params, blockChain.getBestChainHeight()), peerAddress, blockChain);
         this.versionMessage.appendToSubVer(thisSoftwareName, thisSoftwareVersion, null);
+    }
+
+    @Override
+    @NonNull
+    public PeerAddress getAddress() {
+        return peerAddress;
     }
 
     /** Registers a listener that is invoked when new blocks are downloaded. */

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -2382,7 +2382,7 @@ public class PeerGroup implements TransactionBroadcaster {
             if (peerHeight < mostCommonChainHeight || peerHeight > mostCommonChainHeight + 1)
                 continue;
             candidates.add(peer);
-            highestPriority = Math.max(highestPriority, getPriority(peer.peerAddress));
+            highestPriority = Math.max(highestPriority, getPriority(peer.getAddress()));
         }
         if (candidates.isEmpty())
             return null;
@@ -2390,7 +2390,7 @@ public class PeerGroup implements TransactionBroadcaster {
         // If there is a difference in priority, consider only the highest.
         for (Iterator<Peer> i = candidates.iterator(); i.hasNext(); ) {
             Peer peer = i.next();
-            if (getPriority(peer.peerAddress) < highestPriority)
+            if (getPriority(peer.getAddress()) < highestPriority)
                 i.remove();
         }
 

--- a/core/src/main/java/org/bitcoinj/core/PeerSocketHandler.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerSocketHandler.java
@@ -25,6 +25,7 @@ import org.bitcoinj.net.SocketTimeoutTask;
 import org.bitcoinj.net.StreamConnection;
 import org.bitcoinj.net.TimeoutHandler;
 import org.bitcoinj.utils.Threading;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +53,6 @@ public abstract class PeerSocketHandler implements TimeoutHandler, StreamConnect
     private final SocketTimeoutTask timeoutTask;
 
     private final MessageSerializer serializer;
-    protected final PeerAddress peerAddress;
     // If we close() before we know our writeTarget, set this to true to call writeTarget.closeConnection() right away.
     private boolean closePending = false;
     // writeTarget will be thread-safe, and may call into PeerGroup, which calls us, so we should call it unlocked
@@ -65,8 +65,7 @@ public abstract class PeerSocketHandler implements TimeoutHandler, StreamConnect
     private int largeReadBufferPos;
     private BitcoinSerializer.BitcoinPacketHeader header;
 
-    protected PeerSocketHandler(PeerAddress peerAddress, MessageSerializer messageSerializer) {
-        this.peerAddress = Objects.requireNonNull(peerAddress);
+    protected PeerSocketHandler(MessageSerializer messageSerializer) {
         this.serializer = Objects.requireNonNull(messageSerializer);
         this.timeoutTask = new SocketTimeoutTask(this::timeoutOccurred);
     }
@@ -220,12 +219,12 @@ public abstract class PeerSocketHandler implements TimeoutHandler, StreamConnect
         return Message.MAX_SIZE;
     }
 
+    // getAddress() is only used for logging and exception messages in PeerSocketHandler
     /**
      * @return the IP address and port of peer.
      */
-    public PeerAddress getAddress() {
-        return peerAddress;
-    }
+    @NonNull
+    public abstract PeerAddress getAddress();
 
     /** Catch any exceptions, logging them and then closing the channel. */
     private void exceptionCaught(Exception e) {

--- a/integration-test/src/test/java/org/bitcoinj/testing/InboundMessageQueuer.java
+++ b/integration-test/src/test/java/org/bitcoinj/testing/InboundMessageQueuer.java
@@ -43,9 +43,16 @@ public abstract class InboundMessageQueuer extends PeerSocketHandler {
 
     @Nullable public Peer peer;
     @Nullable public BloomFilter lastReceivedFilter;
+    private final PeerAddress peerAddress;
 
     protected InboundMessageQueuer(BitcoinSerializer serializer) {
-        super(PeerAddress.simple(new InetSocketAddress(InetAddress.getLoopbackAddress(), 2000)), serializer);
+        super(serializer);
+        peerAddress = PeerAddress.simple(new InetSocketAddress(InetAddress.getLoopbackAddress(), 2000));
+    }
+
+    @Override
+    public PeerAddress getAddress() {
+        return peerAddress;
     }
 
     public Message nextMessage() {


### PR DESCRIPTION
PeerSocketHandler does not use the PeerAddress for anything other than log and exception messages. For those purposes it can get the PeerAddress from implementing subclasses.

This makes it more clear that PeerSocketHandler doesn't use a socket address for networking purposes. It also opens the door to further refactoring that emphasizes PeerSocketHandler's true role of serializing and deserializing messages.