### PR TITLE
TestWithNetworkConnections: Don't randomize TCP_PORT_BASE

### DIFF
--- a/integration-test/src/main/java/org/bitcoinj/test/integration/peer/TestWithNetworkConnections.java
+++ b/integration-test/src/main/java/org/bitcoinj/test/integration/peer/TestWithNetworkConnections.java
@@ -72,7 +72,7 @@ import static org.bitcoinj.base.internal.Preconditions.checkState;
  * Utility class that makes it easy to work with mock NetworkConnections.
  */
 public class TestWithNetworkConnections {
-    protected static final int TCP_PORT_BASE = 10000 + new Random().nextInt(40000);
+    protected static final int TCP_PORT_BASE = 10000;
     public static final int PEER_SERVERS = 5;
 
     protected static final NetworkParameters UNITTEST = UnitTestParams.get();


### PR DESCRIPTION
This randomization does not prevent the 'address already in use' errors we have been seeing. It only randomizes the value upon class loading, so it is not randomized between tests. Since it is not necessary or helpful we should remove it.