### PR TITLE
CryptoUtils: Use JCA to access RIPEMD160 and SHA3

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/internal/CryptoUtils.java
+++ b/core/src/main/java/org/bitcoinj/crypto/internal/CryptoUtils.java
@@ -16,20 +16,24 @@
 package org.bitcoinj.crypto.internal;
 
 import org.bitcoinj.base.Sha256Hash;
-import org.bouncycastle.crypto.digests.RIPEMD160Digest;
 import org.bouncycastle.jcajce.provider.digest.SHA3;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
 
 /**
  * Utilities for the crypto module (e.g. wrapping built-in primitives and/or Bouncy Castle)
  */
 public class CryptoUtils {
+    private static final Provider bcProvider = new BouncyCastleProvider();
+
     /**
      * Calculate RIPEMD160(SHA256(input)). This is used in Address calculations.
      * @param input bytes to hash
@@ -46,11 +50,11 @@ public class CryptoUtils {
      * @return RIPEMD160(input)
      */
     public static byte[] digestRipeMd160(byte[] input) {
-        RIPEMD160Digest digest = new RIPEMD160Digest();
-        digest.update(input, 0, input.length);
-        byte[] ripmemdHash = new byte[20];
-        digest.doFinal(ripmemdHash, 0);
-        return ripmemdHash;
+        try {
+            return MessageDigest.getInstance("RIPEMD160", bcProvider).digest(input);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("RIPEMD160 algorithm not found", e);
+        }
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/crypto/internal/CryptoUtils.java
+++ b/core/src/main/java/org/bitcoinj/crypto/internal/CryptoUtils.java
@@ -32,6 +32,21 @@ import java.security.Provider;
  */
 public class CryptoUtils {
     private static final Provider bcProvider = new BouncyCastleProvider();
+    private static final MessageDigest ripemd160Prototype;
+    private static final MessageDigest sha3Prototype;
+
+    static {
+        try {
+            ripemd160Prototype = MessageDigest.getInstance("RIPEMD160", bcProvider);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        try {
+            sha3Prototype = MessageDigest.getInstance("SHA3-256", bcProvider);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     /**
      * Calculate RIPEMD160(SHA256(input)). This is used in Address calculations.
@@ -50,9 +65,10 @@ public class CryptoUtils {
      */
     public static byte[] digestRipeMd160(byte[] input) {
         try {
-            return MessageDigest.getInstance("RIPEMD160", bcProvider).digest(input);
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("RIPEMD160 algorithm not found", e);
+            return ((MessageDigest) ripemd160Prototype.clone()).digest(input);
+        } catch (CloneNotSupportedException e) {
+            // These implementations are cloneable, this should never happen
+            throw new RuntimeException("RIPEMD160 MessageDigest not cloneable", e);
         }
     }
 
@@ -97,9 +113,10 @@ public class CryptoUtils {
         MessageDigest digest;
         {
             try {
-                digest = MessageDigest.getInstance("SHA3-256", bcProvider);
-            } catch (NoSuchAlgorithmException e) {
-                throw new RuntimeException("SHA3-256 algorithm not found", e);
+                digest = ((MessageDigest) sha3Prototype.clone());
+            } catch (CloneNotSupportedException e) {
+                // These implementations are cloneable, this should never happen
+                throw new RuntimeException("SHA3-256 MessageDigest not cloneable", e);
             }
         }
         for (byte[] input : inputs) {

--- a/core/src/main/java/org/bitcoinj/crypto/internal/CryptoUtils.java
+++ b/core/src/main/java/org/bitcoinj/crypto/internal/CryptoUtils.java
@@ -16,7 +16,6 @@
 package org.bitcoinj.crypto.internal;
 
 import org.bitcoinj.base.Sha256Hash;
-import org.bouncycastle.jcajce.provider.digest.SHA3;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import javax.crypto.Mac;
@@ -95,7 +94,14 @@ public class CryptoUtils {
      * @return A SHA3 256-bit hash
      */
     public static byte[] sha3Digest(byte[] ...inputs) {
-        SHA3.Digest256 digest = new SHA3.Digest256();
+        MessageDigest digest;
+        {
+            try {
+                digest = MessageDigest.getInstance("SHA3-256", bcProvider);
+            } catch (NoSuchAlgorithmException e) {
+                throw new RuntimeException("SHA3-256 algorithm not found", e);
+            }
+        }
         for (byte[] input : inputs) {
             digest.update(input);
         }


### PR DESCRIPTION
Three commits: one for RIPEMD160 and one for SHA3 and a third to `clone()` instances for improved performance.