### PR TITLE
Sha256Hash: use Cloneable prototype in newDigest()

### DIFF
--- a/base/src/main/java/org/bitcoinj/base/Sha256Hash.java
+++ b/base/src/main/java/org/bitcoinj/base/Sha256Hash.java
@@ -39,6 +39,17 @@ import static org.bitcoinj.base.internal.Preconditions.checkArgument;
  * Given that {@code Sha256Hash} instances can be created using {@link #wrapReversed(byte[])} or {@link #twiceOf(byte[])} or by wrapping raw bytes, there is no guarantee that if two {@code Sha256Hash} instances are found equal (via {@link #equals(Object)}) that their preimages would be the same (even in the absence of a hash collision.)
  */
 public class Sha256Hash implements Comparable<Sha256Hash> {
+    // Keep a newly initialized SHA256 MessageDigest for cloning in newDigest()
+    private static final MessageDigest sha256Prototype;
+
+    static {
+        try {
+            sha256Prototype = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public static final int LENGTH = 32; // bytes
     public static final Sha256Hash ZERO_HASH = wrap(new byte[LENGTH]);
 
@@ -152,9 +163,9 @@ public class Sha256Hash implements Comparable<Sha256Hash> {
      */
     public static MessageDigest newDigest() {
         try {
-            return MessageDigest.getInstance("SHA-256");
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);  // Can't happen.
+            return (MessageDigest) sha256Prototype.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new RuntimeException(e);  // Built-in SHA256 implementation is Cloneable, this should never happen.
         }
     }
 


### PR DESCRIPTION
This is a performance optimization. ~~I have not benchmarked it.~~

I ran a quick test:
```
        byte[] r = new SecureRandom().generateSeed(Sha256Hash.LENGTH);
        long millis = System.currentTimeMillis();
        for (int i = 0; i < 1_000_000_000; i++) {
            r = Sha256Hash.hash(r);
        }
        System.out.println("Performance test time: " + (System.currentTimeMillis() - millis));
```

On an M1 Max, this test of 1 billion hashes is sped up from 61071 ms to 46701 ms. So about 30% faster.

We don't recommend using bitcoinj for mining, but we do solve blocks in unit tests, and SHA256 hashing is a fairly common operation, so this performance improvement seems worth the slight increase in complexity.
