### PR TITLE
NetworkParameters: add check for null block-version tally-count

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
+++ b/core/src/main/java/org/bitcoinj/core/NetworkParameters.java
@@ -397,8 +397,10 @@ public abstract class NetworkParameters {
 
         // Start enforcing CHECKLOCKTIMEVERIFY, (BIP65) for block.nVersion=4
         // blocks, when 75% of the network has upgraded:
+        Integer tallyCount = tally.getCountAtOrAbove(Block.BLOCK_VERSION_BIP65);
         if (block.version() >= Block.BLOCK_VERSION_BIP65 &&
-            tally.getCountAtOrAbove(Block.BLOCK_VERSION_BIP65) > this.getMajorityEnforceBlockUpgrade()) {
+                tallyCount != null &&
+                tallyCount > this.getMajorityEnforceBlockUpgrade()) {
             verifyFlags.add(ScriptExecution.VerifyFlag.CHECKLOCKTIMEVERIFY);
         }
 

--- a/core/src/main/java/org/bitcoinj/utils/VersionTally.java
+++ b/core/src/main/java/org/bitcoinj/utils/VersionTally.java
@@ -21,8 +21,8 @@ import org.bitcoinj.core.StoredBlock;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.BlockStoreException;
 import org.jspecify.annotations.Nullable;
-
 import java.util.Stack;
+import java.util.stream.LongStream;
 
 /**
  * Caching counter for the block versions within a moving window. This class
@@ -80,15 +80,11 @@ public class VersionTally {
     public Integer getCountAtOrAbove(final long version) {
         if (versionsStored < versionWindow.length) {
             return null;
+        } else {
+            return (int) LongStream.of(versionWindow)
+                    .filter(l -> l >= version)
+                    .count();
         }
-        int count = 0;
-        for (long l : versionWindow) {
-            if (l >= version) {
-                count++;
-            }
-        }
-
-        return count;
     }
 
     /**


### PR DESCRIPTION
A second commit makes VersionTally.getCountAtOrAbove() more "functional".