### PR TITLE
.gitlab-ci.yml: add forky-jdk25 job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,6 +37,17 @@ trixie-jdk21:
     - gradle --version
     - sha256sum core/build/libs/*.jar wallettool/build/install/wallet-tool/bin/*  wallettool/build/install/wallet-tool/lib/*.jar
 
+forky-jdk25:
+  image: debian:forky-slim
+  before_script:
+    - apt-get update
+    - apt-get -y install openjdk-25-jdk-headless gradle
+  script:
+    - gradle --settings-file settings-debian.gradle build publishToMavenLocal installDist --init-script build-scan-agree.gradle --scan --stacktrace
+  after_script:
+    - gradle --version
+    - sha256sum core/build/libs/*.jar wallettool/build/install/wallet-tool/bin/*  wallettool/build/install/wallet-tool/lib/*.jar
+
 sast:
   stage: test
 


### PR DESCRIPTION
[Forky Gradle](https://packages.debian.org/forky/java/gradle) (4.4.1-23) now works with Java 25. [Trixie Gradle](https://packages.debian.org/trixie/java/gradle) is still at 4.4.1-22, which from the Debian Gradle release notes is missing a JDK 25 patch that is in 4.4.1-23.