### PR TITLE
GuiUtils: remove varargs and `String.format()` from `informationalAlert()`

### DIFF
--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/utils/GuiUtils.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/utils/GuiUtils.java
@@ -79,9 +79,8 @@ public class GuiUtils {
         Thread.currentThread().setUncaughtExceptionHandler((thread, exception) -> GuiUtils.crashAlert(findRootCause(exception)));
     }
 
-    public static void informationalAlert(String message, String details, Object... args) {
-        String formattedDetails = String.format(details, args);
-        Runnable r = () -> runAlert((stage, controller) -> controller.informational(stage, message, formattedDetails));
+    public static void informationalAlert(String message, String details) {
+        Runnable r = () -> runAlert((stage, controller) -> controller.informational(stage, message, details));
         if (Platform.isFxApplicationThread())
             r.run();
         else


### PR DESCRIPTION
The additional args are never used and the String.format() is effectively a no-op. It is also consider bad practice to use a potentially untrusted string as a format string.