### PR TITLE
build.gradle: update to Bouncy Castle 1.84 (release 0.17)

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -9,7 +9,7 @@ plugins {
 version = '0.17.2-SNAPSHOT'
 
 dependencies {
-    api 'org.bouncycastle:bcprov-jdk15to18:1.83'
+    api 'org.bouncycastle:bcprov-jdk15to18:1.84'
     api 'com.google.guava:guava:33.4.0-android'
     api 'com.google.protobuf:protobuf-javalite:4.33.4'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'


### PR DESCRIPTION
This is a backport of PR #4198 to 0.17.