### PR TITLE
modular-architecture.md: Split 0.18 release into two, add 0.20

### DIFF
--- a/designdocs/modular-architecture.md
+++ b/designdocs/modular-architecture.md
@@ -4,7 +4,7 @@ Note: Packages that are not significant or are not changing are not shown (and a
 
 Legend: Dashed lines represent Gradle "implementation" dependencies. Solid lines represent Gradle "api" dependencies (or internal package dependencies.)
 
-## bitcoinj 0.16.x (previous release)
+## bitcoinj 0.16 (November 2021)
 
 ````mermaid
 flowchart TD
@@ -29,9 +29,9 @@ classDef external fill:#999;
 class G,S,A,BC,P external;
 ````
            
-## bitcoinj 0.17
+## bitcoinj 0.17 (February 2025)
 
-In release 0.17 there has been a large amount of refactoring to prepare the `o.b.base` and `o.b.crypto` packages to become independent modules/JARs in the following release. Those packages will still contain some deprecated methods that depend on other internal packages and external modules. Those deprecated methods will be removed in release 0.18 when `o.b.base` and `o.b.crypto` are moved to their own modules.
+In release 0.17 there was significant refactoring to prepare the `o.b.base` package to become an independent module/JAR in 0.18. `base` still contains some deprecated methods that depend on `o.b.core`. In 0.18, `base` is moved to its own module and those deprecated methods are removed.
 
 
 ````mermaid
@@ -60,8 +60,10 @@ class G,S,A,BC,P external;
 ````
 
 ## bitcoinj 0.18 (current plan)
- 
-In this release the `bitcoinj-base` module will be a standalone module with minimal external dependencies. All use of Elliptic Curve Cryptography will be factored out to use the `secp-api` module from [secp256k1-jdk](https://github.com/bitcoinj/secp256k1-jdk) with API implementations provided for **Bouncy Castle** and the [secp256k1](https://github.com/bitcoin-core/secp256k1) native ('C') library.
+
+* The `bitcoinj-base` is now a standalone module with a single, small external dependency: **JSpecify** (for nullability annotations.)
+* All usage of jcip-annotations is replaced by **JSpecify**. All modules and packages will be `@NullMarked` (meaning all parameters and return types are non-nullable by default.)
+* All usage of Google's **Guava** library will be eliminated.
 
 ````mermaid
 flowchart TD
@@ -73,6 +75,39 @@ flowchart TD
     WT[wallettool] --> CORE
     subgraph CORE [bitcoinj-core]
         CO --> W
+        W[o.b.wallet] --> CO[o.b.core]
+        W --> CR[o.b.crypto]
+        CO --> CR
+    end
+    CORE --> BASE
+    subgraph BASE [bitcoinj-base]
+        B[o.b.base]
+    end
+    CORE --> BC[Bouncy Castle]
+    CORE --> P[ProtoBuf]
+    CORE .-> S[SLF4J]
+    BASE --> JS[JSpecify]
+
+classDef external fill:#999;
+class G,S,JS,BC,SECPC,P external;
+````
+
+## bitcoinj 0.19 (proposed)
+
+In this release all use of Elliptic Curve Cryptography will be refactored to use the `secp-api` module from [secp256k1-jdk](https://github.com/bitcoinj/secp256k1-jdk) with API implementations provided for **Bouncy Castle** and the [secp256k1](https://github.com/bitcoin-core/secp256k1) native ('C') library.
+
+We will also do some preliminary work to further decouple the `o.b.wallet` module from `o.b.core` in preparation for release 0.20.
+
+````mermaid
+flowchart TD
+    EJ[examples] --> CORE
+    EK[examples-kotlin] --> CORE
+    IT[integration-test] --> CORE
+    T[tools] --> CORE
+    FX[wallettemplate] --> CORE
+    WT[wallettool] --> CORE
+    subgraph CORE [bitcoinj-core]
+        CO .-> W
         W[o.b.wallet] --> CO[o.b.core]
         W --> CR[o.b.crypto]
         CO --> CR
@@ -94,12 +129,11 @@ classDef external fill:#999;
 class G,S,JS,BC,SECPC,P external;
 ````
 
-## bitcoinj 0.19 (proposed)
+## bitcoinj 0.20 (proposed)
 
-In a proposed 0.19 release, we hope to do the following:
+In a proposed 0.20 release, we hope to do the following:
 
 1. Separate the current ProtoBuf-based wallet implementation into its own module. This will require creating a `Wallet` interface in core.
-2. Eliminate dependencies on Guava for all modules.
 
 Stretch goal:
 


### PR DESCRIPTION
Split the secp-api refactoring out of 0.18 and into 0.19 and create an 0.20 release with what was previously release 0.19.

Also make some other minor updates and improvements.