### PR TITLE
Address: add static constructor that takes ECPublicKey

### DIFF
--- a/base/src/main/java/org/bitcoinj/base/Address.java
+++ b/base/src/main/java/org/bitcoinj/base/Address.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.base;
 
+import java.security.interfaces.ECPublicKey;
 import java.util.Comparator;
 
 /**
@@ -66,6 +67,25 @@ public interface Address extends Comparable<Address> {
      * @return the Network.
      */
     Network network();
+
+    /**
+     * Create a Bitcoin Address from a JCA secp256k1 public key.
+     * <p>
+     * This is WIP. Once https://github.com/bitcoinj/bitcoinj/pull/4187 (or equivalent) is merged
+     * we can move RIPEMD160 to `o.b.base` and then move the CryptoUtils.sha256hash160() method to `base`, too.
+     */
+    static Address fromKey(ECPublicKey publicKey, ScriptType scriptType, BitcoinNetwork network) {
+        // TODO: make sure publicKey is a secp256k1 key
+        byte[] pubKeySerialized = publicKey.getEncoded();   // TODO: implement/verify correct serialization
+        byte[] pubKeyHash = new byte[20];                   // TODO: CryptoUtils.sha256hash160()
+        if (scriptType == ScriptType.P2PKH) {
+            return LegacyAddress.fromPubKeyHash(network, pubKeyHash);
+        } else if (scriptType == ScriptType.P2WPKH) {
+            return SegwitAddress.fromHash(network, pubKeyHash);
+        } else {
+            throw new UnsupportedOperationException("Script type not supported: " + scriptType);
+        }
+    }
 
     /**
      * Comparator for the first two comparison fields in {@code Address} comparisons, see {@link Address#compareTo(Address)}.

--- a/base/src/main/java/org/bitcoinj/base/Address.java
+++ b/base/src/main/java/org/bitcoinj/base/Address.java
@@ -16,7 +16,15 @@
 
 package org.bitcoinj.base;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.ECPublicKey;
 import java.util.Comparator;
+
+import static org.bitcoinj.base.internal.Preconditions.checkArgument;
+import static org.bitcoinj.base.internal.Secp256k1Constants.ALGORITHM_NAME;
+import static org.bitcoinj.base.internal.Secp256k1Constants.COMPRESSED_FORMAT_NAME;
+import static org.bitcoinj.base.internal.Secp256k1Constants.UNCOMPRESSED_FORMAT_NAME;
 
 /**
  * Interface for addresses, e.g. native segwit addresses ({@link SegwitAddress}) or legacy addresses ({@link LegacyAddress}).
@@ -66,6 +74,53 @@ public interface Address extends Comparable<Address> {
      * @return the Network.
      */
     Network network();
+
+    /**
+     * Create a Bitcoin Address from a Secp256k1 {@link ECPublicKey} (Java Cryptography public key.)
+     * <p>
+     * Requires that a {@link java.security.Provider} providing {@code "RIPEMD160"} {@link MessageDigest} be installed.
+     * For example, to install the Bouncy Castle Provider use:
+     * <p>
+     * {@code Security.addProvider(new BouncyCastleProvider());}
+     * <p>
+     * Since {@link org.bitcoinj.base} has minimal dependencies, it is the responsibility of the calling application
+     * to make sure a {@code "RIPEMD160"} provider is on the class path and installed. See the {@code AddressFromKeyTest}
+     * integration test for an example of how to do this.
+     * @param publicKey a Secp256k1 public key
+     * @param scriptType output script type
+     * @param network network address will be used on
+     * @return an address
+     */
+    static Address fromKey(ECPublicKey publicKey, ScriptType scriptType, BitcoinNetwork network) {
+        checkArgument(publicKey.getAlgorithm().equals(ALGORITHM_NAME) &&
+                (publicKey.getFormat().equals(COMPRESSED_FORMAT_NAME) || publicKey.getFormat().equals(UNCOMPRESSED_FORMAT_NAME)),
+                () -> "publicKey algorithm must be 'Secp256k1' and format must be 'Compressed SEC' or 'Uncompressed SEC'" );
+        byte [] pubKeyHash = sha256hash160(publicKey.getEncoded());
+        if (scriptType == ScriptType.P2PKH) {
+            return LegacyAddress.fromPubKeyHash(network, pubKeyHash);
+        } else if (scriptType == ScriptType.P2WPKH) {
+            return SegwitAddress.fromHash(network, pubKeyHash);
+        } else {
+            throw new UnsupportedOperationException("Script type not supported: " + scriptType);
+        }
+    }
+
+    // Temporary until we can move (part of) CryptoUtils to `base`
+    static byte[] sha256hash160(byte[] input) {
+        byte[] sha256 = Sha256Hash.hash(input);
+        return digestRipeMd160(sha256);
+    }
+
+    // Temporary until we can move (part of) CryptoUtils to `base`
+    static byte[] digestRipeMd160(byte[] input) {
+        byte[] pubKeyHash;
+        try {
+            pubKeyHash = MessageDigest.getInstance("RIPEMD160").digest(input);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        return pubKeyHash;
+    }
 
     /**
      * Comparator for the first two comparison fields in {@code Address} comparisons, see {@link Address#compareTo(Address)}.

--- a/integration-test/src/test/java/org/bitcoinj/base/AddressFromKeyTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/base/AddressFromKeyTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bitcoinj.base;
+
+import org.bitcoinj.base.internal.ByteUtils;
+import org.bitcoinj.base.internal.Secp256k1Constants;
+import org.bitcoinj.crypto.ECKey;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.security.Provider;
+import java.security.Security;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+
+import static org.bitcoinj.base.BitcoinNetwork.TESTNET;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * WIP test that demonstrates getting a Bitcoin address using {@link Address#fromKey(ECPublicKey, ScriptType, BitcoinNetwork)},
+ * which will (once finished) allow constructing address without {@code bitcoinj-core} or <b>secp256k1-jdk</b> or <b>Bouncy Castle</b>.
+ * For now, we are passing {@link BouncyCastleProvider}, but when finished there will be a built-in provider in {@code bitcoinj-base}.
+ */
+public class AddressFromKeyTest {
+    private static final Logger log = LoggerFactory.getLogger(AddressFromKeyTest.class);
+    static final String ADDRESS_STRING = "tb1q0yy3juscd3zfavw76g4h3eqdqzda7qyf7pcpwg";
+    static final Address ADDRESS = AddressParser.getDefault().parseAddress(ADDRESS_STRING);
+    static final byte[] PUBKEY =  ByteUtils.parseHex("03ad1d8e89212f0b92c74d23bb710c00662ad1470198ac48c43f7d6f93a2a26873");
+
+    public AddressFromKeyTest() {
+        // Install [BouncyCastleProvider] for `RIPEMD160`.
+        int preferencePosition = Security.addProvider(new BouncyCastleProvider());
+        // `preferencePosition` will be -1 if already installed.
+        log.info("Installed BouncyCastleProvider with preference position: {}", preferencePosition);
+    }
+
+    /**
+     * Test with bitcoinj-core's ECKey implementation
+     */
+    @Test
+    public void testAddressFromECKey() {
+        ECKey key = ECKey.fromPrivate(
+                ByteUtils.parseHex("eb696a065ef48a2192da5b28b694f87544b30fae8327c4510137a922f32c6dcf"));
+
+        Address address = Address.fromKey(key, ScriptType.P2WPKH, TESTNET);
+
+        assertArrayEquals(PUBKEY, key.getEncoded());
+        assertTrue(address instanceof SegwitAddress);
+        assertEquals(0, ((SegwitAddress) address).getWitnessVersion());
+        assertEquals(ADDRESS, address);
+    }
+
+    /**
+     * Test with an arbitrary (Secp256k1) implementation of ECPublicKey
+     */
+    @Test
+    public void testAddressFromGenericKey() {
+        TestSecpPubKey key = new TestSecpPubKey(PUBKEY);
+
+        Address address = Address.fromKey(key, ScriptType.P2WPKH, TESTNET);
+
+        assertTrue(address instanceof SegwitAddress);
+        assertEquals(0, ((SegwitAddress) address).getWitnessVersion());
+        assertEquals(ADDRESS, address);
+    }
+
+    /**
+     * A basic implementation of  ECPublicKey that conforms to Secp256k1Constants
+     */
+    public static class TestSecpPubKey implements ECPublicKey {
+        private final byte[] encodedPubKey;
+
+        public TestSecpPubKey(byte[] encodedPubKey) {
+            this.encodedPubKey = encodedPubKey;
+        }
+
+        @Override
+        public ECPoint getW() {
+            return ECKey.fromPrivate(encodedPubKey).getW();
+        }
+
+        @Override
+        public ECParameterSpec getParams() {
+            return Secp256k1Constants.EC_PARAMS;
+        }
+
+        @Override
+        public String getAlgorithm() {
+            return Secp256k1Constants.ALGORITHM_NAME;
+        }
+
+        @Override
+        public String getFormat() {
+            return Secp256k1Constants.COMPRESSED_FORMAT_NAME;
+        }
+
+        @Override
+        public byte[] getEncoded() {
+            return encodedPubKey;
+        }
+    }
+}


### PR DESCRIPTION
Allows the `base` module -- without `bitcoinj-core` and eventually without Bouncy Castle on the classpath to create addresses (using Sha256 and RIPEMD160).

See also:

* Issue #3964  
* PR #4187 