### PR TITLE
ChildNumber/HDPath: accept H, h, apostrophe for hardened derivation; add toString(char)

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/ChildNumber.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ChildNumber.java
@@ -68,13 +68,14 @@ public class ChildNumber implements Comparable<ChildNumber> {
 
     /**
      * Parse a single child number.
+     * Accepts {@code H}, {@code h}, or {@code '} as the hardened suffix.
      *
-     * @param str string of the form "1" or "1H"
+     * @param str string of the form "1", "1H", "1h", or "1'"
      * @return child number instance
      * @throws NumberFormatException when parsing fails
      */
     public static ChildNumber parse(String str) {
-        boolean isHard = str.endsWith("H") || str.endsWith("'");
+        boolean isHard = str.endsWith("H") || str.endsWith("h") || str.endsWith("'");
         String nodeNumber = isHard ?
                 str.substring(0, str.length() - 1) :
                 str;
@@ -105,6 +106,16 @@ public class ChildNumber implements Comparable<ChildNumber> {
     @Override
     public String toString() {
         return String.format(Locale.US, "%d%s", num(), isHardened() ? "H" : "");
+    }
+
+    /**
+     * Serialize this child number using the given character as the hardened suffix.
+     *
+     * @param hardeningSymbol character to use for hardened derivation (e.g. {@code 'H'}, {@code 'h'}, or {@code '\''})
+     * @return string representation with the specified hardening symbol
+     */
+    public String toString(char hardeningSymbol) {
+        return String.format(Locale.US, "%d%s", num(), isHardened() ? String.valueOf(hardeningSymbol) : "");
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/crypto/ChildNumber.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ChildNumber.java
@@ -74,7 +74,7 @@ public class ChildNumber implements Comparable<ChildNumber> {
      * @throws NumberFormatException when parsing fails
      */
     public static ChildNumber parse(String str) {
-        boolean isHard = str.endsWith("H");
+        boolean isHard = str.endsWith("H") || str.endsWith("'");
         String nodeNumber = isHard ?
                 str.substring(0, str.length() - 1) :
                 str;

--- a/core/src/main/java/org/bitcoinj/crypto/HDPath.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDPath.java
@@ -595,4 +595,22 @@ public abstract class HDPath {
         }
         return b.toString();
     }
+
+    /**
+     * Serialize this path using the given character as the hardened suffix.
+     *
+     * @param hardeningSymbol character to use for hardened derivation (e.g. {@code 'H'}, {@code 'h'}, or {@code '\''})
+     * @return string representation with the specified hardening symbol
+     */
+    public String toString(char hardeningSymbol) {
+        StringBuilder b = new StringBuilder();
+        if (this instanceof HDFullPath) {
+            b.append(((HDFullPath) this).prefix());
+        }
+        for (int child : children) {
+            b.append(SEPARATOR);
+            b.append(new ChildNumber(child).toString(hardeningSymbol));
+        }
+        return b.toString();
+    }
 }

--- a/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
@@ -235,6 +235,18 @@ public class HDPathTest {
             new PathVector (
                 "1 / 2 / 3 /",
                 HDPath.partial(new ChildNumber(1, false), new ChildNumber(2, false), new ChildNumber(3, false))
+            ),
+
+            // BIP-32 standard apostrophe notation
+            new PathVector (
+                "m/44'/0'/0'",
+                HDPath.m(new ChildNumber(44, true), new ChildNumber(0, true), new ChildNumber(0, true))
+            ),
+
+            new PathVector (
+                "M/44'/0'/0'/1/1",
+                HDPath.M(new ChildNumber(44, true), new ChildNumber(0, true), new ChildNumber(0, true),
+                    new ChildNumber(1, false), new ChildNumber(1, false))
             )
         };
     }

--- a/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/HDPathTest.java
@@ -237,7 +237,7 @@ public class HDPathTest {
                 HDPath.partial(new ChildNumber(1, false), new ChildNumber(2, false), new ChildNumber(3, false))
             ),
 
-            // BIP-32 standard apostrophe notation
+            // apostrophe notation
             new PathVector (
                 "m/44'/0'/0'",
                 HDPath.m(new ChildNumber(44, true), new ChildNumber(0, true), new ChildNumber(0, true))
@@ -247,6 +247,12 @@ public class HDPathTest {
                 "M/44'/0'/0'/1/1",
                 HDPath.M(new ChildNumber(44, true), new ChildNumber(0, true), new ChildNumber(0, true),
                     new ChildNumber(1, false), new ChildNumber(1, false))
+            ),
+
+            // lowercase h notation
+            new PathVector (
+                "m/44h/0h/0h",
+                HDPath.m(new ChildNumber(44, true), new ChildNumber(0, true), new ChildNumber(0, true))
             )
         };
     }
@@ -292,6 +298,102 @@ public class HDPathTest {
     @Test
     public void equals_not_M_m() {
         assertNotEquals(HDPath.M(), HDPath.m());
+    }
+
+    // ── ChildNumber.toString(char) ──────────────────────────────────────
+
+    @Test
+    public void childNumber_toString_defaultUsesH() {
+        assertEquals("44H", new ChildNumber(44, true).toString());
+        assertEquals("0", new ChildNumber(0, false).toString());
+    }
+
+    @Test
+    public void childNumber_toString_apostrophe() {
+        assertEquals("44'", new ChildNumber(44, true).toString('\''));
+        assertEquals("0", new ChildNumber(0, false).toString('\''));
+    }
+
+    @Test
+    public void childNumber_toString_lowercaseH() {
+        assertEquals("44h", new ChildNumber(44, true).toString('h'));
+        assertEquals("0", new ChildNumber(0, false).toString('h'));
+    }
+
+    @Test
+    public void childNumber_toString_uppercaseH() {
+        assertEquals("44H", new ChildNumber(44, true).toString('H'));
+    }
+
+    // ── ChildNumber.parse ───────────────────────────────────────────────
+
+    @Test
+    public void childNumber_parse_uppercaseH() {
+        ChildNumber cn = ChildNumber.parse("44H");
+        assertEquals(44, cn.num());
+        assertTrue(cn.isHardened());
+    }
+
+    @Test
+    public void childNumber_parse_lowercaseH() {
+        ChildNumber cn = ChildNumber.parse("44h");
+        assertEquals(44, cn.num());
+        assertTrue(cn.isHardened());
+    }
+
+    @Test
+    public void childNumber_parse_apostrophe() {
+        ChildNumber cn = ChildNumber.parse("44'");
+        assertEquals(44, cn.num());
+        assertTrue(cn.isHardened());
+    }
+
+    @Test
+    public void childNumber_parse_allFormatsEquivalent() {
+        assertEquals(ChildNumber.parse("44H"), ChildNumber.parse("44h"));
+        assertEquals(ChildNumber.parse("44H"), ChildNumber.parse("44'"));
+    }
+
+    // ── HDPath.toString(char) ───────────────────────────────────────────
+
+    @Test
+    public void hdPath_toString_apostrophe() {
+        HDPath path = HDPath.m(new ChildNumber(44, true), new ChildNumber(0, true), new ChildNumber(0, true));
+        assertEquals("m/44'/0'/0'", path.toString('\''));
+    }
+
+    @Test
+    public void hdPath_toString_lowercaseH() {
+        HDPath path = HDPath.m(new ChildNumber(44, true), new ChildNumber(0, true), new ChildNumber(0, true));
+        assertEquals("m/44h/0h/0h", path.toString('h'));
+    }
+
+    @Test
+    public void hdPath_toString_uppercaseH_matchesDefault() {
+        HDPath path = HDPath.M(new ChildNumber(44, true), new ChildNumber(0, true), new ChildNumber(0, true),
+                new ChildNumber(1, false), new ChildNumber(1, false));
+        assertEquals(path.toString(), path.toString('H'));
+    }
+
+    @Test
+    public void hdPath_toString_partialPath_apostrophe() {
+        HDPath path = HDPath.partial(new ChildNumber(44, true), new ChildNumber(0, true));
+        assertEquals("/44'/0'", path.toString('\''));
+    }
+
+    @Test
+    public void hdPath_toString_mixedHardenedAndNot() {
+        HDPath path = HDPath.m(new ChildNumber(44, true), new ChildNumber(0, true), new ChildNumber(0, true),
+                new ChildNumber(1, false), new ChildNumber(0, false));
+        assertEquals("m/44'/0'/0'/1/0", path.toString('\''));
+    }
+
+    @Test
+    public void hdPath_parse_then_toString_roundtrip() {
+        HDPath path = HDPath.parsePath("m/44'/0'/0'/1/1");
+        assertEquals("m/44'/0'/0'/1/1", path.toString('\''));
+        assertEquals("m/44H/0H/0H/1/1", path.toString('H'));
+        assertEquals("m/44h/0h/0h/1/1", path.toString('h'));
     }
 
     // This should be a record


### PR DESCRIPTION
## Summary

- `ChildNumber.parse()` now accepts `H`, `h`, and `'` (apostrophe) as hardened derivation suffixes
- Add `ChildNumber.toString(char)` to serialize with a chosen hardening symbol (e.g. `'H'`, `'h'`, or `'\''`)
- Add `HDPath.toString(char)` to serialize an entire path with a chosen hardening symbol
- Default `toString()` behavior unchanged (uses `H`)

## Test plan

- [x] Existing `HDPathTest` vectors pass unchanged
- [x] New parse test vectors verify `m/44'/0'/0'` and `m/44h/0h/0h` parse correctly
- [x] `ChildNumber.parse()` tests for `H`, `h`, and `'` — all equivalent
- [x] `ChildNumber.toString(char)` tests for apostrophe, lowercase h, uppercase H
- [x] `HDPath.toString(char)` tests for full paths, partial paths, mixed hardened/non-hardened
- [x] Roundtrip test: parse apostrophe path, serialize with all three symbols