### PR TITLE
PeerNetwork: new class to store TxConfidenceTable

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Context.java
+++ b/core/src/main/java/org/bitcoinj/core/Context.java
@@ -47,15 +47,15 @@ public class Context {
 
     public static final int DEFAULT_EVENT_HORIZON = 100;
 
-    final private TxConfidenceTable confidenceTable;
     final private int eventHorizon;
     final private boolean ensureMinRequiredFee;
     final private Coin feePerKb;
     final private boolean relaxProofOfWork;
+    private final PeerNetwork peerNetwork;
 
     /**
-     * Creates a new context object. For now, this will be done for you by the framework. Eventually you will be
-     * expected to do this yourself.
+     * Creates a new context object. For now, this will be done for you (??) by the framework. Eventually, context objects
+     * will be deprecated and removed.
      */
     public Context() {
         this(DEFAULT_EVENT_HORIZON, Transaction.DEFAULT_TX_FEE_RATE, true, false);
@@ -71,7 +71,7 @@ public class Context {
      */
     public Context(int eventHorizon, Coin feePerKb, boolean ensureMinRequiredFee, boolean relaxProofOfWork) {
         log.info("Creating bitcoinj {} context.", VersionMessage.BITCOINJ_VERSION);
-        this.confidenceTable = new TxConfidenceTable();
+        this.peerNetwork = new PeerNetwork();
         this.eventHorizon = eventHorizon;
         this.ensureMinRequiredFee = ensureMinRequiredFee;
         this.feePerKb = feePerKb;
@@ -153,9 +153,22 @@ public class Context {
      * and downloaded transactions so their confidence can be measured as a proportion of how many peers announced it.
      * With an un-tampered with internet connection, the more peers announce a transaction the more confidence you can
      * have that it's really valid.
+     * @deprecated Use a {@link PeerNetwork}. You can use {@link #peerNetwork}, but eventually you should be getting
+     * it from somewhere else like a {@link org.bitcoinj.wallet.Wallet} or {@link PeerGroup}.
      */
+    @Deprecated
     public TxConfidenceTable getConfidenceTable() {
-        return confidenceTable;
+        return peerNetwork.txConfidenceTable();
+    }
+
+    /**
+     * Returns the {@link PeerNetwork} for this context. In the future {@link Context} will be deprecated and removed,
+     * so if you have an alternate mechanism for getting the {@link PeerNetwork}, you should use it (e.g. from a
+     * {@link org.bitcoinj.wallet.Wallet} or {@link PeerGroup} instance.)
+     * @return the {@link PeerNetwork} for this context
+     */
+    public PeerNetwork peerNetwork() {
+        return peerNetwork;
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -1738,10 +1738,10 @@ public class PeerGroup implements TransactionBroadcaster {
         }
     }
 
-    /** Use "Context.get().getConfidenceTable()" instead */
+    /** Use "Context.get().peerNetwork().txConfidenceTable()" instead */
     @Deprecated @Nullable
     public TxConfidenceTable getMemoryPool() {
-        return Context.get().getConfidenceTable();
+        return Context.get().peerNetwork().txConfidenceTable();
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/PeerNetwork.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerNetwork.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoinj.core;
+
+/**
+ * Represents the "live" state of a Bitcoin P2P Network. Typically, the network state tracked in this object
+ * comes from a {@link PeerGroup}, but this object is independent and there are posisble configurations where
+ * it may get its data from other sources.
+ * <p>
+ * Currently this only contains a {@link TxConfidenceTable} instance, but other "live" data from the P2P network
+ * may be migrated here in the future.
+ */
+public class PeerNetwork {
+    private final TxConfidenceTable txConfidenceTable;
+
+    /**
+     * Constructor.
+     */
+    public PeerNetwork() {
+        this.txConfidenceTable = new TxConfidenceTable();
+    }
+
+    /**
+     * Get the {@link TxConfidenceTable}
+     * @return The confidence table for this P2P network/chain
+     */
+    public TxConfidenceTable txConfidenceTable() {
+        return txConfidenceTable;
+    }
+}

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -1631,7 +1631,7 @@ public class Transaction implements Message {
      * referenced by the implicit {@link Context}.
      */
     public TransactionConfidence getConfidence() {
-        return getConfidence(Context.get());
+        return getConfidence(Context.get().peerNetwork().txConfidenceTable());
     }
 
     /**
@@ -1639,7 +1639,7 @@ public class Transaction implements Message {
      * referenced by the given {@link Context}.
      */
     TransactionConfidence getConfidence(Context context) {
-        return getConfidence(context.getConfidenceTable());
+        return getConfidence(context.peerNetwork().txConfidenceTable());
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4272,7 +4272,7 @@ public class Wallet extends BaseTaggableObject
     }
 
     TransactionConfidence getConfidence(Transaction tx) {
-        return Context.get().getConfidenceTable().getConfidence(tx);
+        return Context.get().peerNetwork().txConfidenceTable().getConfidence(tx);
     }
 
     /**

--- a/core/src/test/java/org/bitcoinj/core/TxConfidenceTableTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TxConfidenceTableTest.java
@@ -52,7 +52,7 @@ public class TxConfidenceTableTest {
         BriefLogFormatter.init();
         Context context = new Context();
         Context.propagate(context);
-        table = context.getConfidenceTable();
+        table = context.peerNetwork().txConfidenceTable();
 
         Address to = ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
         Address change = ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);


### PR DESCRIPTION
* Add PeerNetwork class
* (For now) construct it in the `Context` constructor
* Deprecate Context.getConfidenceTable()
* Update callers to use Context.peerNetwork().txConfidenceTable()

TODO: Make a default PeerNetwork singleton and update apps/samples to set it in the initial/propagated Context.