### PR TITLE
Transaction: remove getConfidence(Context context)

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -1631,13 +1631,15 @@ public class Transaction implements Message {
      * referenced by the implicit {@link Context}.
      */
     public TransactionConfidence getConfidence() {
-        return getConfidence(Context.get());
+        return getConfidence(Context.get().getConfidenceTable());
     }
 
     /**
      * Returns the confidence object for this transaction from the {@link TxConfidenceTable}
      * referenced by the given {@link Context}.
+     * @deprecated Use {@link #getConfidence()}
      */
+    @Deprecated
     TransactionConfidence getConfidence(Context context) {
         return getConfidence(context.getConfidenceTable());
     }

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -1603,15 +1603,7 @@ public class Transaction implements Message {
      * referenced by the implicit {@link Context}.
      */
     public TransactionConfidence getConfidence() {
-        return getConfidence(Context.get());
-    }
-
-    /**
-     * Returns the confidence object for this transaction from the {@link TxConfidenceTable}
-     * referenced by the given {@link Context}.
-     */
-    TransactionConfidence getConfidence(Context context) {
-        return getConfidence(context.getConfidenceTable());
+        return getConfidence(Context.get().getConfidenceTable());
     }
 
     /**


### PR DESCRIPTION
`getConfidence()` is the preferred method for getting `TransactionConfidence`. This commit changes its implementation to directly call `getConfidence(TxConfidenceTable)` rather than using the removed method as an intermediary.
