### PR TITLE
ContextPropagatingThreadFactory: move to o.b.core package

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Context.java
+++ b/core/src/main/java/org/bitcoinj/core/Context.java
@@ -17,7 +17,6 @@
 package org.bitcoinj.core;
 
 import org.bitcoinj.base.Coin;
-import org.bitcoinj.utils.ContextPropagatingThreadFactory;
 import org.bitcoinj.wallet.SendRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/core/src/main/java/org/bitcoinj/core/ContextPropagatingThreadFactory.java
+++ b/core/src/main/java/org/bitcoinj/core/ContextPropagatingThreadFactory.java
@@ -43,7 +43,17 @@ public class ContextPropagatingThreadFactory implements ThreadFactory {
     @Override
     public Thread newThread(final Runnable r) {
         final Context context = Context.get();
-        Thread thread = new Thread(() -> {
+        Thread thread = newThreadWithContext(context, r, name);
+        thread.setPriority(priority);
+        thread.setDaemon(true);
+        Thread.UncaughtExceptionHandler handler = Threading.uncaughtExceptionHandler;
+        if (handler != null)
+            thread.setUncaughtExceptionHandler(handler);
+        return thread;
+    }
+
+    public static Thread newThreadWithContext(Context context, Runnable r, String name) {
+        return new Thread(() -> {
             try {
                 Context.propagate(context);
                 r.run();
@@ -52,11 +62,5 @@ public class ContextPropagatingThreadFactory implements ThreadFactory {
                 throw e;
             }
         }, name);
-        thread.setPriority(priority);
-        thread.setDaemon(true);
-        Thread.UncaughtExceptionHandler handler = Threading.uncaughtExceptionHandler;
-        if (handler != null)
-            thread.setUncaughtExceptionHandler(handler);
-        return thread;
     }
 }

--- a/core/src/main/java/org/bitcoinj/core/ContextPropagatingThreadFactory.java
+++ b/core/src/main/java/org/bitcoinj/core/ContextPropagatingThreadFactory.java
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package org.bitcoinj.utils;
+package org.bitcoinj.core;
 
-import org.bitcoinj.core.Context;
+import org.bitcoinj.utils.Threading;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/FullPrunedBlockChain.java
@@ -28,7 +28,6 @@ import org.bitcoinj.script.ScriptExecution;
 import org.bitcoinj.script.ScriptPattern;
 import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.store.FullPrunedBlockStore;
-import org.bitcoinj.utils.ContextPropagatingThreadFactory;
 import org.bitcoinj.wallet.Wallet;
 import org.bitcoinj.wallet.WalletExtension;
 import org.slf4j.Logger;

--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -44,7 +44,6 @@ import org.bitcoinj.net.discovery.PeerDiscovery;
 import org.bitcoinj.net.discovery.PeerDiscoveryException;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptPattern;
-import org.bitcoinj.utils.ContextPropagatingThreadFactory;
 import org.bitcoinj.utils.ExponentialBackoff;
 import org.bitcoinj.utils.ListenerRegistration;
 import org.bitcoinj.utils.Threading;

--- a/core/src/main/java/org/bitcoinj/net/BlockingClient.java
+++ b/core/src/main/java/org/bitcoinj/net/BlockingClient.java
@@ -17,6 +17,7 @@
 package org.bitcoinj.net;
 
 import org.bitcoinj.core.Context;
+import org.bitcoinj.core.ContextPropagatingThreadFactory;
 import org.bitcoinj.core.Peer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,8 +74,7 @@ public class BlockingClient implements MessageWriteTarget {
         connection.setWriteTarget(this);
         socket = socketFactory.createSocket();
         final Context context = Context.get();
-        Thread t = new Thread(() -> {
-            Context.propagate(context);
+        Thread t = ContextPropagatingThreadFactory.newThreadWithContext(context, () -> {
             if (clientSet != null)
                 clientSet.add(BlockingClient.this);
             try {
@@ -98,8 +98,7 @@ public class BlockingClient implements MessageWriteTarget {
                     clientSet.remove(BlockingClient.this);
                 connection.connectionClosed();
             }
-        });
-        t.setName("BlockingClient network thread for " + serverAddress);
+        }, "BlockingClient network thread for " + serverAddress);
         t.setDaemon(true);
         t.start();
     }

--- a/core/src/main/java/org/bitcoinj/net/BlockingClient.java
+++ b/core/src/main/java/org/bitcoinj/net/BlockingClient.java
@@ -73,8 +73,7 @@ public class BlockingClient implements MessageWriteTarget {
         // sure it doesn't get too large or have to call read too often.
         connection.setWriteTarget(this);
         socket = socketFactory.createSocket();
-        final Context context = Context.get();
-        Thread t = ContextPropagatingThreadFactory.newThreadWithContext(context, () -> {
+        Thread t = ContextPropagatingThreadFactory.newThreadWithContext(Context.get(), () -> {
             if (clientSet != null)
                 clientSet.add(BlockingClient.this);
             try {

--- a/core/src/main/java/org/bitcoinj/net/NioClientManager.java
+++ b/core/src/main/java/org/bitcoinj/net/NioClientManager.java
@@ -19,7 +19,7 @@ package org.bitcoinj.net;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import org.bitcoinj.base.internal.FutureUtils;
-import org.bitcoinj.utils.ContextPropagatingThreadFactory;
+import org.bitcoinj.core.ContextPropagatingThreadFactory;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/core/src/main/java/org/bitcoinj/net/discovery/MultiplexingDiscovery.java
+++ b/core/src/main/java/org/bitcoinj/net/discovery/MultiplexingDiscovery.java
@@ -22,7 +22,7 @@ import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Services;
 import org.bitcoinj.core.VersionMessage;
 import org.bitcoinj.net.discovery.DnsDiscovery.DnsSeedDiscovery;
-import org.bitcoinj.utils.ContextPropagatingThreadFactory;
+import org.bitcoinj.core.ContextPropagatingThreadFactory;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/core/src/main/java/org/bitcoinj/wallet/WalletFiles.java
+++ b/core/src/main/java/org/bitcoinj/wallet/WalletFiles.java
@@ -19,7 +19,7 @@ package org.bitcoinj.wallet;
 
 import org.bitcoinj.base.internal.Stopwatch;
 import org.bitcoinj.base.internal.TimeUtils;
-import org.bitcoinj.utils.ContextPropagatingThreadFactory;
+import org.bitcoinj.core.ContextPropagatingThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/integration-test/src/test/java/org/bitcoinj/test/integration/peer/TestWithPeerGroup.java
+++ b/integration-test/src/test/java/org/bitcoinj/test/integration/peer/TestWithPeerGroup.java
@@ -32,7 +32,7 @@ import org.bitcoinj.net.NioClientManager;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.store.MemoryBlockStore;
-import org.bitcoinj.utils.ContextPropagatingThreadFactory;
+import org.bitcoinj.core.ContextPropagatingThreadFactory;
 import org.jspecify.annotations.Nullable;
 import org.junit.Rule;
 import org.junit.rules.Timeout;

--- a/integration-test/src/test/java/org/bitcoinj/test/integration/peer/TestWithPeerGroup.java
+++ b/integration-test/src/test/java/org/bitcoinj/test/integration/peer/TestWithPeerGroup.java
@@ -32,7 +32,7 @@ import org.bitcoinj.net.NioClientManager;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.store.MemoryBlockStore;
-import org.bitcoinj.utils.ContextPropagatingThreadFactory;
+import org.bitcoinj.core.ContextPropagatingThreadFactory;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Timeout;
 


### PR DESCRIPTION
This is a step towards deprecating `Context` entirely. The move will allow ContextPropagatingThreadFactory to use (soon-to-be) package private methods in `Context` and will also allow ContextPropagatingThreadFactory itself to be made package-private.