### PR TITLE
dependabot.yml: ignore major updates for equalsverifier

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "nl.jqno.equalsverifier:equalsverifier"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
This should allow an update from 3.18.x to 3.19.y, but not to 4.z.