### PR TITLE
SPVBlockStore: reject overflowing capacity in constructor

### DIFF
--- a/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
@@ -122,7 +122,8 @@ public class SPVBlockStore implements BlockStore {
     public SPVBlockStore(NetworkParameters params, File file, int capacity, boolean grow) throws BlockStoreException {
         Objects.requireNonNull(file);
         this.params = Objects.requireNonNull(params);
-        checkArgument(capacity > 0);
+        checkArgument(capacity > 0, () -> "capacity must be positive");
+        checkArgument(capacity < 144 * 365 * 10, () -> "capacity must be sane"); // 10 years
 
         boolean exists = file.exists();
 

--- a/core/src/test/java/org/bitcoinj/store/SPVBlockStoreTest.java
+++ b/core/src/test/java/org/bitcoinj/store/SPVBlockStoreTest.java
@@ -48,8 +48,10 @@ import java.time.Instant;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class SPVBlockStoreTest {
     private static final NetworkParameters TESTNET = TestNet3Params.get();
@@ -233,5 +235,17 @@ public class SPVBlockStoreTest {
         assertEquals(SPVBlockStore.FILE_PROLOGUE_BYTES + SPVBlockStore.RECORD_SIZE_V2 * 1,
                 store.getRingCursor());
         store.close();
+    }
+
+    @Test
+    public void constructor_rejectOverflowingCapacity() throws Exception {
+        try {
+            new SPVBlockStore(TESTNET, blockStoreFile, Integer.MAX_VALUE, false);
+        } catch (BlockStoreException | RuntimeException expected) {
+            assertFalse("overflowing capacity should be rejected before creating the file",
+                    blockStoreFile.exists());
+            return;
+        }
+        fail("overflowing capacity was accepted");
     }
 }


### PR DESCRIPTION
For now, we simply consider capacities larger than 10 years worth of block headers insane.