### PR TITLE
CheckpointManager, BuildCheckpoints: JavaDoc changes around signatures, and bounds check

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
+++ b/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
@@ -126,6 +126,8 @@ public class CheckpointManager {
             if (!TEXTUAL_MAGIC.equals(magic))
                 throw new IOException("unexpected magic: " + magic);
             int numSigs = Integer.parseInt(reader.readLine());
+            if (numSigs < 0 || numSigs > MAX_SIGNATURES)
+                throw new IOException("invalid number of signatures: " + numSigs);
             for (int i = 0; i < numSigs; i++)
                 reader.readLine(); // Skip sigs for now.
             int numCheckpoints = Integer.parseInt(reader.readLine());

--- a/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
+++ b/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
@@ -65,10 +65,11 @@ import static org.bitcoinj.base.internal.Preconditions.checkState;
  * coinbase transactions). Those "checkpoints" can be found in NetworkParameters.</p>
  *
  * <p>Checkpoints are read from a text file, one value per line.
- * It consists of the magic string "TXT CHECKPOINTS 1", followed by the number of signatures
- * to read. The value may not be larger than 256.
- * If the number of signatures is larger than zero, each 65 byte ECDSA secp256k1 signature then follows. The signatures
- * sign the hash of all bytes that follow the last signature.</p>
+ * The first line contains the magic string "TXT CHECKPOINTS 1". The next line contains the number of signatures
+ * to read. Currently, this is always zero because the feature hasn't been implemented. In future, the value may be
+ * larger than zero, but not larger than {@link #MAX_SIGNATURES}.
+ * If the number of signatures is larger than zero, each 65 byte ECDSA secp256k1 signature then follows. Currently,
+ * these signatures are read but ignored. In future, they sign the hash of all bytes that follow the last signature.</p>
  *
  * <p>After the signatures come the number of checkpoints in the file. Then each checkpoint follows one per line in
  * compact format (as written by {@link StoredBlock#serializeCompactV2(ByteBuffer)}) as a base64-encoded blob.</p>

--- a/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
@@ -61,7 +61,7 @@ import static org.bitcoinj.base.internal.Preconditions.checkState;
 
 /**
  * Downloads and verifies a full chain from your local peer, emitting checkpoints at each difficulty transition period
- * to a file which is then signed with your key.
+ * to a file.
  */
 @CommandLine.Command(name = "build-checkpoints", usageHelpAutoWidth = true, sortOptions = false, description = "Create checkpoint files to use with CheckpointManager.")
 public class BuildCheckpoints implements Callable<Integer> {


### PR DESCRIPTION
Two commits.

1. CheckpointManager, BuildCheckpoints: make clear in the JavaDoc that checkpoint signatures are currently not implemented
2. CheckpointManager: check that number of signatures is within bounds