### PR TITLE
Fiat: fix overflow in `negate()`

### DIFF
--- a/base/src/main/java/org/bitcoinj/base/utils/Fiat.java
+++ b/base/src/main/java/org/bitcoinj/base/utils/Fiat.java
@@ -179,7 +179,7 @@ public final class Fiat implements Monetary, Comparable<Fiat> {
     }
 
     public Fiat negate() {
-        return new Fiat(currencyCode, -this.value);
+        return new Fiat(currencyCode, Math.negateExact(this.value));
     }
 
     /**

--- a/base/src/test/java/org/bitcoinj/base/utils/FiatTest.java
+++ b/base/src/test/java/org/bitcoinj/base/utils/FiatTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import static org.bitcoinj.base.utils.Fiat.parseFiat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class FiatTest {
@@ -141,5 +142,16 @@ public class FiatTest {
         Fiat fiat2 = fiats[1];
         assertEquals(0, fiat2.getValue());
         assertEquals("USD", fiat2.getCurrencyCode());
+    }
+
+    @Test
+    public void testNegate() {
+        assertEquals(0, Fiat.valueOf("EUR", 0).negate().value);
+        assertEquals(1, Fiat.valueOf("EUR", -1).negate().value);
+        assertEquals(-1, Fiat.valueOf("EUR", 1).negate().value);
+        assertEquals(Long.MIN_VALUE + 1, Fiat.valueOf("EUR", Long.MAX_VALUE).negate().value);
+        assertEquals(Long.MAX_VALUE, Fiat.valueOf("EUR", Long.MIN_VALUE + 1).negate().value);
+
+        assertThrows(ArithmeticException.class, () -> Fiat.valueOf("EUR", Long.MIN_VALUE).negate());
     }
 }


### PR DESCRIPTION
Use `Math.negateExact()` rather than the native negate operator.

Add tests to confirm correct behavior.