### PR TITLE
Block: add getGenesis(), SPVBlockStore: use Network in constructors

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -19,6 +19,7 @@ package org.bitcoinj.core;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.bitcoinj.base.Difficulty;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.VarInt;
 import org.bitcoinj.base.internal.Buffers;
@@ -267,6 +268,15 @@ public class Block implements Message {
     public Block(long version, Sha256Hash prevHash, Sha256Hash merkleRoot, Instant time,
                  long difficultyTarget, long nonce, @Nullable List<Transaction> transactions) {
         this(version, prevHash, merkleRoot, time, Difficulty.ofCompact(difficultyTarget), nonce, transactions);
+    }
+
+    /**
+     * Get the standard full Genesis Block for a network
+     * @param network the network
+     * @return a complete block (should be treated as immutable)
+     */
+    public static Block getGenesis(Network network) {
+        return NetworkParameters.of(network).getGenesisBlock();
     }
 
     public static Block createGenesis(Instant time, Difficulty difficultyTarget) {

--- a/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
+++ b/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
@@ -17,6 +17,7 @@
 package org.bitcoinj.core;
 
 import com.google.common.io.BaseEncoding;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.store.BlockStore;
@@ -83,7 +84,7 @@ public class CheckpointManager {
     // Map of block header time (in seconds) to data.
     protected final TreeMap<Instant, StoredBlock> checkpoints = new TreeMap<>();
 
-    protected final NetworkParameters params;
+    protected final Network network;
     protected final Sha256Hash dataHash;
 
     /**
@@ -99,7 +100,7 @@ public class CheckpointManager {
 
     /** Loads the checkpoints from the given stream */
     public CheckpointManager(NetworkParameters params, @Nullable InputStream inputStream) throws IOException {
-        this.params = Objects.requireNonNull(params);
+        network = Objects.requireNonNull(params).network();
         if (inputStream == null)
             inputStream = openStream(params);
         Objects.requireNonNull(inputStream);
@@ -161,11 +162,11 @@ public class CheckpointManager {
      */
     public StoredBlock getCheckpointBefore(Instant time) {
         try {
-            checkArgument(time.isAfter(params.getGenesisBlock().time()));
+            checkArgument(time.isAfter(Block.getGenesis(network).time()));
             // This is thread safe because the map never changes after creation.
             Map.Entry<Instant, StoredBlock> entry = checkpoints.floorEntry(time);
             if (entry != null) return entry.getValue();
-            Block genesis = params.getGenesisBlock().asHeader();
+            Block genesis = Block.getGenesis(network).asHeader();
             return new StoredBlock(genesis, genesis.getWork(), 0);
         } catch (VerificationException e) {
             throw new RuntimeException(e);  // Cannot happen.

--- a/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
+++ b/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
@@ -383,7 +383,7 @@ public class WalletAppKit extends AbstractIdleService implements Closeable {
         vWallet = createOrLoadWallet(shouldReplayWallet);
 
         // Initiate Bitcoin network objects (block store, blockchain and peer group)
-        vStore = new SPVBlockStore(params, chainFile);
+        vStore = new SPVBlockStore(network, chainFile);
         if (!chainFileExists || restoreFromSeed != null || restoreFromKey != null) {
             if (checkpoints == null && !PlatformUtils.isAndroidRuntime()) {
                 checkpoints = CheckpointManager.openStream(params);

--- a/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
@@ -103,24 +103,54 @@ public class SPVBlockStore implements BlockStore {
     /**
      * Creates and initializes an SPV block store that can hold {@link #DEFAULT_CAPACITY} block headers. Will create the
      * given file if it's missing. This operation will block on disk.
+     * @param network specifies the network
      * @param file file to use for the block store
      * @throws BlockStoreException if something goes wrong
      */
+    public SPVBlockStore(Network network, File file) throws BlockStoreException {
+        this(network, file, DEFAULT_CAPACITY, false);
+    }
+
+    /**
+     * Creates and initializes an SPV block store that can hold {@link #DEFAULT_CAPACITY} block headers. Will create the
+     * given file if it's missing. This operation will block on disk.
+     * @param params specifies the network
+     * @param file file to use for the block store
+     * @throws BlockStoreException if something goes wrong
+     * @deprecated Use {@link #SPVBlockStore(Network, File)}
+     */
+    @Deprecated
     public SPVBlockStore(NetworkParameters params, File file) throws BlockStoreException {
-        this(params, file, DEFAULT_CAPACITY, false);
+        this(params.network(), file);
     }
 
     /**
      * Creates and initializes an SPV block store that can hold a given amount of blocks. Will create the given file if
      * it's missing. This operation will block on disk.
+     * @param params specifies the network
      * @param file file to use for the block store
      * @param capacity custom capacity in number of block headers
      * @param grow whether or not to migrate an existing block store of different capacity
      * @throws BlockStoreException if something goes wrong
+     * @deprecated Use {@link #SPVBlockStore(Network, File, int, boolean)}
      */
+    @Deprecated
     public SPVBlockStore(NetworkParameters params, File file, int capacity, boolean grow) throws BlockStoreException {
+        this(params.network(), file, capacity, grow);
+    }
+
+    /**
+      * Creates and initializes an SPV block store that can hold a given amount of blocks. Will create the given file if
+      * it's missing. This operation will block on disk.
+      * @param network specifies the network
+      * @param file file to use for the block store
+      * @param capacity custom capacity in number of block headers
+      * @param grow whether or not to migrate an existing block store of different capacity
+      * @throws BlockStoreException if something goes wrong
+      */
+    public SPVBlockStore(Network network, File file, int capacity, boolean grow) throws BlockStoreException {
         Objects.requireNonNull(file);
-        network = Objects.requireNonNull(params).network();
+        this.network = Objects.requireNonNull(network);
         checkArgument(capacity > 0, () -> "capacity must be positive");
         checkArgument(capacity < 144 * 365 * 10, () -> "capacity must be sane"); // 10 years
 

--- a/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.store;
 
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.core.NetworkParameters;
@@ -65,7 +66,7 @@ public class SPVBlockStore implements BlockStore {
     static final byte[] HEADER_MAGIC_V2 = "SPV2".getBytes(StandardCharsets.US_ASCII);
 
     private volatile @Nullable MappedByteBuffer buffer;
-    protected final NetworkParameters params;
+    protected final Network network;
 
     // The entire ring-buffer is mmapped and accessing it should be as fast as accessing regular memory once it's
     // faulted in. Unfortunately, in theory practice and theory are the same. In practice they aren't.
@@ -102,24 +103,41 @@ public class SPVBlockStore implements BlockStore {
     /**
      * Creates and initializes an SPV block store that can hold {@link #DEFAULT_CAPACITY} block headers. Will create the
      * given file if it's missing. This operation will block on disk.
+     * @param network specifies the network
      * @param file file to use for the block store
      * @throws BlockStoreException if something goes wrong
      */
-    public SPVBlockStore(NetworkParameters params, File file) throws BlockStoreException {
-        this(params, file, DEFAULT_CAPACITY, false);
+    public SPVBlockStore(Network network, File file) throws BlockStoreException {
+        this(network, file, DEFAULT_CAPACITY, false);
     }
 
     /**
      * Creates and initializes an SPV block store that can hold a given amount of blocks. Will create the given file if
      * it's missing. This operation will block on disk.
+     * @param params specifies the network
      * @param file file to use for the block store
      * @param capacity custom capacity in number of block headers
      * @param grow whether or not to migrate an existing block store of different capacity
      * @throws BlockStoreException if something goes wrong
+     * @deprecated Use {@link #SPVBlockStore(Network, File, int, boolean)}
      */
+    @Deprecated
     public SPVBlockStore(NetworkParameters params, File file, int capacity, boolean grow) throws BlockStoreException {
+        this(params.network(), file, capacity, grow);
+    }
+
+    /**
+      * Creates and initializes an SPV block store that can hold a given amount of blocks. Will create the given file if
+      * it's missing. This operation will block on disk.
+      * @param network specifies the network
+      * @param file file to use for the block store
+      * @param capacity custom capacity in number of block headers
+      * @param grow whether or not to migrate an existing block store of different capacity
+      * @throws BlockStoreException if something goes wrong
+      */
+    public SPVBlockStore(Network network, File file, int capacity, boolean grow) throws BlockStoreException {
         Objects.requireNonNull(file);
-        this.params = Objects.requireNonNull(params);
+        this.network = Objects.requireNonNull(network);
         checkArgument(capacity > 0, () -> "capacity must be positive");
         checkArgument(capacity < 144 * 365 * 10, () -> "capacity must be sane"); // 10 years
 
@@ -157,7 +175,7 @@ public class SPVBlockStore implements BlockStore {
                 randomAccessFile.setLength(fileLength);
                 // Map it into memory read/write. See above comment.
                 buffer = channel.map(FileChannel.MapMode.READ_WRITE, 0, fileLength);
-                initNewStore(params.getGenesisBlock());
+                initNewStore(Block.getGenesis(network));
             }
 
             // Maybe migrate V1 to V2 format.
@@ -203,6 +221,19 @@ public class SPVBlockStore implements BlockStore {
             }
             throw new BlockStoreException(e);
         }
+    }
+
+    /**
+     * Creates and initializes an SPV block store that can hold {@link #DEFAULT_CAPACITY} block headers. Will create the
+     * given file if it's missing. This operation will block on disk.
+     * @param params specifies the network
+     * @param file file to use for the block store
+     * @throws BlockStoreException if something goes wrong
+     * @deprecated Use {@link #SPVBlockStore(Network, File)}
+     */
+    @Deprecated
+    public SPVBlockStore(NetworkParameters params, File file) throws BlockStoreException {
+        this(params.network(), file);
     }
 
     private void initNewStore(Block genesisBlock) throws Exception {
@@ -436,7 +467,7 @@ public class SPVBlockStore implements BlockStore {
                 buffer.put((byte)0);
             }
             // Initialize store again
-            initNewStore(params.getGenesisBlock());
+            initNewStore(Block.getGenesis(network));
         } finally { lock.unlock(); }
     }
 }

--- a/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.store;
 
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.core.NetworkParameters;
@@ -65,7 +66,7 @@ public class SPVBlockStore implements BlockStore {
     static final byte[] HEADER_MAGIC_V2 = "SPV2".getBytes(StandardCharsets.US_ASCII);
 
     private volatile @Nullable MappedByteBuffer buffer;
-    protected final NetworkParameters params;
+    protected final Network network;
 
     // The entire ring-buffer is mmapped and accessing it should be as fast as accessing regular memory once it's
     // faulted in. Unfortunately, in theory practice and theory are the same. In practice they aren't.
@@ -119,7 +120,7 @@ public class SPVBlockStore implements BlockStore {
      */
     public SPVBlockStore(NetworkParameters params, File file, int capacity, boolean grow) throws BlockStoreException {
         Objects.requireNonNull(file);
-        this.params = Objects.requireNonNull(params);
+        network = Objects.requireNonNull(params).network();
         checkArgument(capacity > 0, () -> "capacity must be positive");
         checkArgument(capacity < 144 * 365 * 10, () -> "capacity must be sane"); // 10 years
 
@@ -157,7 +158,7 @@ public class SPVBlockStore implements BlockStore {
                 randomAccessFile.setLength(fileLength);
                 // Map it into memory read/write. See above comment.
                 buffer = channel.map(FileChannel.MapMode.READ_WRITE, 0, fileLength);
-                initNewStore(params.getGenesisBlock());
+                initNewStore(Block.getGenesis(network));
             }
 
             // Maybe migrate V1 to V2 format.
@@ -436,7 +437,7 @@ public class SPVBlockStore implements BlockStore {
                 buffer.put((byte)0);
             }
             // Initialize store again
-            initNewStore(params.getGenesisBlock());
+            initNewStore(Block.getGenesis(network));
         } finally { lock.unlock(); }
     }
 }

--- a/core/src/test/java/org/bitcoinj/store/SPVBlockStoreTest.java
+++ b/core/src/test/java/org/bitcoinj/store/SPVBlockStoreTest.java
@@ -20,6 +20,7 @@ package org.bitcoinj.store;
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Difficulty;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.internal.PlatformUtils;
@@ -29,10 +30,8 @@ import org.bitcoinj.core.Block;
 import org.bitcoinj.core.TestBlocks;
 import org.bitcoinj.core.Context;
 import org.bitcoinj.crypto.ECKey;
-import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.core.StoredBlock;
-import org.bitcoinj.params.TestNet3Params;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -54,7 +53,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class SPVBlockStoreTest {
-    private static final NetworkParameters TESTNET = TestNet3Params.get();
+    private static final Network TESTNET = BitcoinNetwork.TESTNET;
     private File blockStoreFile;
 
     @BeforeClass
@@ -78,7 +77,7 @@ public class SPVBlockStoreTest {
         Address to = ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
         // Check the first block in a new store is the genesis block.
         StoredBlock genesis = store.getChainHead();
-        assertEquals(TESTNET.getGenesisBlock(), genesis.getHeader());
+        assertEquals(Block.getGenesis(TESTNET), genesis.getHeader());
         assertEquals(0, genesis.getHeight());
 
         // Build a new block.
@@ -192,7 +191,7 @@ public class SPVBlockStoreTest {
         assertEquals(b1.getHeader().getHash(), store.getChainHead().getHeader().getHash());
         store.clear();
         assertNull(store.get(b1.getHeader().getHash()));
-        assertEquals(TESTNET.getGenesisBlock().getHash(), store.getChainHead().getHeader().getHash());
+        assertEquals(Block.getGenesis(TESTNET).getHash(), store.getChainHead().getHeader().getHash());
         store.close();
     }
 
@@ -215,7 +214,7 @@ public class SPVBlockStoreTest {
         ByteBuffer buffer = channel.map(FileChannel.MapMode.READ_WRITE, 0,
                 SPVBlockStore.FILE_PROLOGUE_BYTES + SPVBlockStore.RECORD_SIZE_V1 * 3);
         buffer.put(SPVBlockStore.HEADER_MAGIC_V1); // header magic
-        Block genesisBlock = TESTNET.getGenesisBlock();
+        Block genesisBlock = Block.getGenesis(TESTNET);
         StoredBlock storedGenesisBlock = new StoredBlock(genesisBlock.asHeader(), genesisBlock.getWork(), 0);
         Sha256Hash genesisHash = storedGenesisBlock.getHeader().getHash();
         ((Buffer) buffer).position(SPVBlockStore.FILE_PROLOGUE_BYTES);

--- a/core/src/test/java/org/bitcoinj/store/SPVBlockStoreTest.java
+++ b/core/src/test/java/org/bitcoinj/store/SPVBlockStoreTest.java
@@ -20,6 +20,7 @@ package org.bitcoinj.store;
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.Difficulty;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.internal.PlatformUtils;
@@ -29,10 +30,8 @@ import org.bitcoinj.core.Block;
 import org.bitcoinj.core.TestBlocks;
 import org.bitcoinj.core.Context;
 import org.bitcoinj.crypto.ECKey;
-import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.core.StoredBlock;
-import org.bitcoinj.params.TestNet3Params;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -54,7 +53,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class SPVBlockStoreTest {
-    private static final NetworkParameters TESTNET = TestNet3Params.get();
+    private static final Network TESTNET = BitcoinNetwork.TESTNET;
     private File blockStoreFile;
 
     @BeforeClass
@@ -79,7 +78,7 @@ public class SPVBlockStoreTest {
             Address to = ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
             // Check the first block in a new store is the genesis block.
             StoredBlock genesis = store.getChainHead();
-            assertEquals(TESTNET.getGenesisBlock(), genesis.getHeader());
+            assertEquals(Block.getGenesis(TESTNET), genesis.getHeader());
             assertEquals(0, genesis.getHeight());
 
             // Build a new block.
@@ -193,7 +192,7 @@ public class SPVBlockStoreTest {
             assertEquals(b1.getHeader().getHash(), store.getChainHead().getHeader().getHash());
             store.clear();
             assertNull(store.get(b1.getHeader().getHash()));
-            assertEquals(TESTNET.getGenesisBlock().getHash(), store.getChainHead().getHeader().getHash());
+            assertEquals(Block.getGenesis(TESTNET).getHash(), store.getChainHead().getHeader().getHash());
         }
     }
 
@@ -215,7 +214,7 @@ public class SPVBlockStoreTest {
         ByteBuffer buffer = channel.map(FileChannel.MapMode.READ_WRITE, 0,
                 SPVBlockStore.FILE_PROLOGUE_BYTES + SPVBlockStore.RECORD_SIZE_V1 * 3);
         buffer.put(SPVBlockStore.HEADER_MAGIC_V1); // header magic
-        Block genesisBlock = TESTNET.getGenesisBlock();
+        Block genesisBlock = Block.getGenesis(TESTNET);
         StoredBlock storedGenesisBlock = new StoredBlock(genesisBlock.asHeader(), genesisBlock.getWork(), 0);
         Sha256Hash genesisHash = storedGenesisBlock.getHeader().getHash();
         ((Buffer) buffer).position(SPVBlockStore.FILE_PROLOGUE_BYTES);

--- a/examples/src/main/java/org/bitcoinj/examples/FetchBlock.java
+++ b/examples/src/main/java/org/bitcoinj/examples/FetchBlock.java
@@ -22,7 +22,6 @@ import org.bitcoinj.base.Network;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.core.BlockChain;
-import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Peer;
 import org.bitcoinj.core.PeerAddress;
 import org.bitcoinj.core.PeerGroup;
@@ -64,8 +63,7 @@ public class FetchBlock implements Callable<Integer> {
         Objects.requireNonNull(blockHashParam);
         System.out.println("Connecting to node");
         final Network network = BitcoinNetwork.TESTNET;
-        final NetworkParameters params = NetworkParameters.of(network);
-        BlockStore blockStore = new MemoryBlockStore(params.getGenesisBlock());
+        BlockStore blockStore = new MemoryBlockStore(Block.getGenesis(network));
         BlockChain chain = new BlockChain(network, blockStore);
         PeerGroup peerGroup = new PeerGroup(network, chain);
         if (localhost) {

--- a/examples/src/main/java/org/bitcoinj/examples/PrivateKeys.java
+++ b/examples/src/main/java/org/bitcoinj/examples/PrivateKeys.java
@@ -22,8 +22,8 @@ import org.bitcoinj.base.Base58;
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
+import org.bitcoinj.core.Block;
 import org.bitcoinj.core.BlockChain;
-import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.PeerAddress;
 import org.bitcoinj.core.PeerGroup;
 import org.bitcoinj.crypto.DumpedPrivateKey;
@@ -46,7 +46,6 @@ public class PrivateKeys {
     public static void main(String[] args) throws Exception {
         // TODO: Assumes main network not testnet. Make it selectable.
         Network network = BitcoinNetwork.MAINNET;
-        NetworkParameters params = NetworkParameters.of(network);
         try {
             // Decode the private key from Satoshis Base58 variant. If 51 characters long then it's from Bitcoins
             // dumpprivkey command and includes a version byte and checksum, or if 52 characters long then it has 
@@ -69,7 +68,7 @@ public class PrivateKeys {
             Address destination = wallet.parseAddress(args[1]);
 
             // Find the transactions that involve those coins.
-            final MemoryBlockStore blockStore = new MemoryBlockStore(params.getGenesisBlock());
+            final MemoryBlockStore blockStore = new MemoryBlockStore(Block.getGenesis(network));
             BlockChain chain = new BlockChain(network, wallet, blockStore);
 
             final PeerGroup peerGroup = new PeerGroup(network, chain);

--- a/examples/src/main/java/org/bitcoinj/examples/RestoreFromSeed.java
+++ b/examples/src/main/java/org/bitcoinj/examples/RestoreFromSeed.java
@@ -20,7 +20,6 @@ import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.BlockChain;
-import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.PeerGroup;
 import org.bitcoinj.core.listeners.DownloadProgressTracker;
 import org.bitcoinj.net.discovery.DnsDiscovery;
@@ -39,7 +38,6 @@ public class RestoreFromSeed {
 
     public static void main(String[] args) throws Exception {
         Network network = BitcoinNetwork.TESTNET;
-        NetworkParameters params = NetworkParameters.of(network);
 
         // Bitcoinj supports hierarchical deterministic wallets (or "HD Wallets"): https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
         // HD wallets allow you to restore your wallet simply from a root seed. This seed can be represented using a short mnemonic sentence as described in BIP 39: https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
@@ -65,7 +63,7 @@ public class RestoreFromSeed {
         }
 
         // Setting up the BlochChain, the BlocksStore and connecting to the network.
-        SPVBlockStore chainStore = new SPVBlockStore(params, chainFile);
+        SPVBlockStore chainStore = new SPVBlockStore(network, chainFile);
         BlockChain chain = new BlockChain(network, chainStore);
         PeerGroup peerGroup = new PeerGroup(network, chain);
         peerGroup.addPeerDiscovery(new DnsDiscovery(network));

--- a/integration-test/src/test/java/org/bitcoinj/test/bitcoind/BlockFileLoaderBitcoindTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/test/bitcoind/BlockFileLoaderBitcoindTest.java
@@ -22,7 +22,6 @@ import org.bitcoinj.core.AbstractBlockChain;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.core.BlockChain;
 import org.bitcoinj.core.Context;
-import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.PrunedException;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.BlockStoreException;
@@ -66,9 +65,8 @@ public class BlockFileLoaderBitcoindTest {
     @Test
     public void iterateEntireBitcoindBlockchainIntoBlockStore() throws BlockStoreException, PrunedException {
         Network network = BitcoinNetwork.MAINNET;
-        NetworkParameters params = NetworkParameters.of(network);
         BlockFileLoader loader = new BlockFileLoader(network, BlockFileLoader.getReferenceClientBlockFileList());
-        BlockStore store = new MemoryBlockStore(params.getGenesisBlock());
+        BlockStore store = new MemoryBlockStore(Block.getGenesis(network));
         AbstractBlockChain chain = new BlockChain(network, store);
 
         long blockCount = 0;

--- a/tools/src/main/java/org/bitcoinj/tools/BlockImporter.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BlockImporter.java
@@ -60,7 +60,7 @@ public class BlockImporter {
                 break;
             case "SPV":
                 checkArgument(args.length == 3);
-                store = new SPVBlockStore(params, new File(args[2]));
+                store = new SPVBlockStore(network, new File(args[2]));
                 break;
             default:
                 System.err.println("Unknown store " + args[1]);

--- a/tools/src/main/java/org/bitcoinj/tools/BlockImporter.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BlockImporter.java
@@ -56,7 +56,7 @@ public class BlockImporter {
                 break;
             case "Mem":
                 checkArgument(args.length == 2);
-                store = new MemoryBlockStore(params.getGenesisBlock());
+                store = new MemoryBlockStore(Block.getGenesis(network));
                 break;
             case "SPV":
                 checkArgument(args.length == 3);

--- a/tools/src/main/java/org/bitcoinj/tools/BlockImporter.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BlockImporter.java
@@ -56,11 +56,11 @@ public class BlockImporter {
                 break;
             case "Mem":
                 checkArgument(args.length == 2);
-                store = new MemoryBlockStore(params.getGenesisBlock());
+                store = new MemoryBlockStore(Block.getGenesis(network));
                 break;
             case "SPV":
                 checkArgument(args.length == 3);
-                store = new SPVBlockStore(params, new File(args[2]));
+                store = new SPVBlockStore(network, new File(args[2]));
                 break;
             default:
                 System.err.println("Unknown store " + args[1]);

--- a/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
@@ -19,6 +19,7 @@ package org.bitcoinj.tools;
 
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.internal.TimeUtils;
+import org.bitcoinj.core.Block;
 import org.bitcoinj.core.BlockChain;
 import org.bitcoinj.core.CheckpointManager;
 import org.bitcoinj.core.Context;
@@ -116,7 +117,7 @@ public class BuildCheckpoints implements Callable<Integer> {
         // node and to save block headers that are on interval boundaries, as long as they are <1 month old.
         final TreeMap<Integer, StoredBlock> checkpoints;
         final File textFile;
-        try (BlockStore store = new MemoryBlockStore(params.getGenesisBlock())) {
+        try (BlockStore store = new MemoryBlockStore(Block.getGenesis(net))) {
             final BlockChain chain = new BlockChain(net, store);
             final PeerGroup peerGroup = new PeerGroup(net, chain);
 

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -817,7 +817,7 @@ public class WalletTool implements Callable<Integer> {
             System.out.println("Chain file is missing so resetting the wallet.");
             reset();
         }
-        store = new SPVBlockStore(params, chainFile);
+        store = new SPVBlockStore(net, chainFile);
         if (reset) {
             try {
                 CheckpointManager.checkpoint(params, CheckpointManager.openStream(params), store,


### PR DESCRIPTION
Existing SPVBlockStore constructors that take NetworkParameters are deprecated.

Note that the RestoreFromSeed example is now able to completely remove imports of NetworkParameters and subclasses.

BlockImporter can drop NetworkParameters once the MemoryFullPrunedBlockStore constructors are updated to take Network.

This is a step towards our goal of (typical) applications using only (Bitcoin)Network in API calls.

This also opens the possibility of migrating genesis block parameters out of network parameters.