### PR TITLE
Wallet: don't pass private keys to `UTXOProvider` in `getStoredOutputsFromUTXOProviderInternal()`

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4686,8 +4686,12 @@ public class Wallet extends BaseTaggableObject
     private List<UTXO> getStoredOutputsFromUTXOProviderInternal() throws UTXOProviderException {
         UTXOProvider utxoProvider = Objects.requireNonNull(vUTXOProvider, "No UTXO provider has been set");
         List<UTXO> candidates = new ArrayList<>();
-        List<ECKey> keys = getImportedKeys();
-        keys.addAll(getActiveKeyChain().getLeafKeys());
+        List<ECKey> keys = new LinkedList<>();
+        // don't pass private keys to UTXO provider
+        for (ECKey key : getImportedKeys())
+            keys.add(ECKey.fromPublicOnly(key));
+        for (ECKey key : getActiveKeyChain().getLeafKeys())
+            keys.add(ECKey.fromPublicOnly(key));
         candidates.addAll(utxoProvider.getOpenTransactionOutputs(keys));
         return candidates;
     }

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -20,9 +20,12 @@ package org.bitcoinj.wallet;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.bitcoinj.base.BitcoinNetwork;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.core.TestBlocks;
+import org.bitcoinj.core.UTXO;
+import org.bitcoinj.core.UTXOProvider;
 import org.bitcoinj.crypto.AesKey;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.core.AbstractBlockChain;
@@ -3525,5 +3528,32 @@ public class WalletTest extends TestWithWallet {
 
         Wallet wallet10 = Wallet.fromWatchingKeyB58(TESTNET, watchingKeyb58, Instant.ofEpochSecond(1415282801));
         assertEquals(TESTNET, wallet10.network());
+    }
+
+    @Test
+    public void utxoProviderDoesNotReceivePrivateKeys() {
+        Wallet wallet = Wallet.createDeterministic(BitcoinNetwork.TESTNET, ScriptType.P2WPKH);
+        wallet.importKey(ECKey.random());
+        wallet.freshReceiveKey();
+        AtomicBoolean receivedPrivateKey = new AtomicBoolean(false);
+        wallet.setUTXOProviderInternal(new UTXOProvider() {
+            @Override
+            public Network network() {
+                return BitcoinNetwork.TESTNET;
+            }
+
+            @Override
+            public List<UTXO> getOpenTransactionOutputs(List<ECKey> keys) {
+                receivedPrivateKey.set(keys.stream().anyMatch(ECKey::hasPrivKey));
+                return Collections.emptyList();
+            }
+
+            @Override
+            public int getChainHeadHeight() {
+                return 0;
+            }
+        });
+        wallet.calculateAllSpendCandidates(false, false);
+        assertFalse("UTXO providers only need public keys", receivedPrivateKey.get());
     }
 }


### PR DESCRIPTION
Public keys are just as good for its purpose of collecting UTXOs. This also helps guarding keys against modification by a misbehaving provider.