### PR TITLE
MemoryFullPrunedBlockStore, TestBlocks: stop using deprecated TransactionOutPoint constructor

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TestBlocks.java
+++ b/core/src/main/java/org/bitcoinj/core/TestBlocks.java
@@ -90,7 +90,7 @@ public class TestBlocks {
             // The input does not really need to be a valid signature, as long as it has the right general form.
             TransactionInput input;
             if (prevOut == null) {
-                prevOut = new TransactionOutPoint(0, nextTestOutPointHash());
+                prevOut = TransactionOutPoint.of(nextTestOutPointHash(), 0);
             }
             input = new TransactionInput(t, Script.createInputScript(EMPTY_BYTES, EMPTY_BYTES), prevOut);
             t.addInput(input);

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -83,6 +83,9 @@ public class TransactionOutPoint {
         this(fromTx.getTxId(), index, fromTx, null);
     }
 
+    /**
+     * @deprecated use {@link TransactionOutPoint#of(Sha256Hash, long)}
+     */
     @Deprecated
     public TransactionOutPoint(long index, Sha256Hash hash) {
         this(hash, index, null, null);

--- a/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/MemoryFullPrunedBlockStore.java
@@ -309,19 +309,19 @@ public class MemoryFullPrunedBlockStore implements FullPrunedBlockStore {
     @Nullable
     public synchronized UTXO getTransactionOutput(Sha256Hash hash, long index) throws BlockStoreException {
         Objects.requireNonNull(transactionOutputMap, "MemoryFullPrunedBlockStore is closed");
-        return transactionOutputMap.get(new TransactionOutPoint(index, hash));
+        return transactionOutputMap.get(TransactionOutPoint.of(hash, index));
     }
 
     @Override
     public synchronized void addUnspentTransactionOutput(UTXO out) throws BlockStoreException {
         Objects.requireNonNull(transactionOutputMap, "MemoryFullPrunedBlockStore is closed");
-        transactionOutputMap.put(new TransactionOutPoint(out.getIndex(), out.getHash()), out);
+        transactionOutputMap.put(TransactionOutPoint.of(out.getHash(), out.getIndex()), out);
     }
 
     @Override
     public synchronized void removeUnspentTransactionOutput(UTXO out) throws BlockStoreException {
         Objects.requireNonNull(transactionOutputMap, "MemoryFullPrunedBlockStore is closed");
-        if (transactionOutputMap.remove(new TransactionOutPoint(out.getIndex(), out.getHash())) == null)
+        if (transactionOutputMap.remove(TransactionOutPoint.of(out.getHash(), out.getIndex())) == null)
             throw new BlockStoreException("Tried to remove a UTXO from MemoryFullPrunedBlockStore that it didn't have!");
     }
 


### PR DESCRIPTION
A first commit add a "use" comment to the deprecated constructor.