### PR TITLE
Script: always use compressed key size for getNumberOfBytesRequiredToSpend()

### DIFF
--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -622,13 +622,13 @@ public class Script {
         } else if (ScriptPattern.isP2WPKH(this)) {
             // scriptSig is empty
             // witness: <sig> <pubKey>
+            // P2WPKH spends with uncompressed keys are non-standard, we should never generate or send them
             int compressedPubKeySize = 33;
-            int publicKeyLength = pubKey != null ? pubKey.getPubKey().length : compressedPubKeySize;
             return VarInt.sizeOf(2) // number of witness pushes
                     + VarInt.sizeOf(SIG_SIZE) // size of signature push
                     + SIG_SIZE // signature push
-                    + VarInt.sizeOf(publicKeyLength) // size of pubKey push
-                    + publicKeyLength; // pubKey push
+                    + VarInt.sizeOf(compressedPubKeySize) // size of pubKey push
+                    + compressedPubKeySize; // pubKey push
         } else {
             throw new IllegalStateException("Unsupported script type");
         }

--- a/core/src/main/java/org/bitcoinj/script/Script.java
+++ b/core/src/main/java/org/bitcoinj/script/Script.java
@@ -603,6 +603,9 @@ public class Script {
     /**
      * Returns number of bytes required to spend this script. It accepts optional ECKey and redeemScript that may
      * be required for certain types of script to estimate target size.
+     * @param pubKey length/isCompressed should match that of the Script's pub key hash (only and optionally used for P2PKH)
+     * @param redeemScript (only used/required for P2SH)
+     * @return number of bytes (unweighted)
      */
     public int getNumberOfBytesRequiredToSpend(@Nullable ECKey pubKey, @Nullable Script redeemScript) {
         if (ScriptPattern.isP2SH(this)) {

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -5367,7 +5367,7 @@ public class Wallet extends BaseTaggableObject
             } else if (ScriptPattern.isP2WPKH(script)) {
                 ECKey key = findKeyFromPubKeyHash(ScriptPattern.extractHashFromP2WH(script), ScriptType.P2WPKH);
                 Objects.requireNonNull(key, "Coin selection includes unspendable outputs");
-                return Transaction.calculateVirtualTransactionSize(script.getNumberOfBytesRequiredToSpend(key, null));
+                return Transaction.calculateVirtualTransactionSize(script.getNumberOfBytesRequiredToSpend(null, null));
             } else if (ScriptPattern.isP2SH(script)) {
                 Script redeemScript = findRedeemDataFromScriptHash(ScriptPattern.extractHashFromP2SH(script)).redeemScript;
                 Objects.requireNonNull(redeemScript, "Coin selection includes unspendable outputs");


### PR DESCRIPTION
`Script.getNumberOfBytesRequiredToSpend()` incorrectly uses 65 bytes for pubKey length in P2WPKH transactions when ECKey is uncompressed. This PR changes to always use 33 bytes, improves Javadoc, etc.

See the individual commits for details.