### PR TITLE
KeyBag: move "backwards" methods from TransactionInput, TransactionOutPoint. Related changes.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -402,12 +402,12 @@ public class TransactionInput {
     }
 
     /**
-     * Alias for getOutpoint().getConnectedRedeemData(keyBag)
-     * @see TransactionOutPoint#getConnectedRedeemData(KeyBag)
+     * @deprecated Use {@link KeyBag#getConnectedRedeemData(TransactionInput)}
      */
+    @Deprecated
     @Nullable
     public RedeemData getConnectedRedeemData(KeyBag keyBag) throws ScriptException {
-        return getOutpoint().getConnectedRedeemData(keyBag);
+        return keyBag.getConnectedRedeemData(this);
     }
 
 

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -202,7 +202,7 @@ public class TransactionOutPoint {
 
     /**
      * Returns the ECKey identified in the connected output, for either P2PKH, P2WPKH or P2PK scripts.
-     * For P2SH scripts you can use {@link #getConnectedRedeemData(KeyBag)} and then get the
+     * For P2SH scripts you can use {@link KeyBag#getConnectedRedeemData(TransactionOutPoint)} and then get the
      * key from RedeemData.
      * If the script form cannot be understood, throws ScriptException.
      *
@@ -233,27 +233,12 @@ public class TransactionOutPoint {
      * If the script forms cannot be understood, throws ScriptException.
      *
      * @return a RedeemData or null if the connected data cannot be found in the wallet.
+     * @deprecated Use {@link KeyBag#getConnectedRedeemData(TransactionOutPoint)}
      */
+    @Deprecated
     @Nullable
     public RedeemData getConnectedRedeemData(KeyBag keyBag) throws ScriptException {
-        TransactionOutput connectedOutput = getConnectedOutput();
-        Objects.requireNonNull(connectedOutput, "Input is not connected so cannot retrieve key");
-        Script connectedScript = connectedOutput.getScriptPubKey();
-        if (ScriptPattern.isP2PKH(connectedScript)) {
-            byte[] addressBytes = ScriptPattern.extractHashFromP2PKH(connectedScript);
-            return RedeemData.of(keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2PKH), connectedScript);
-        } else if (ScriptPattern.isP2WPKH(connectedScript)) {
-            byte[] addressBytes = ScriptPattern.extractHashFromP2WH(connectedScript);
-            return RedeemData.of(keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2WPKH), connectedScript);
-        } else if (ScriptPattern.isP2PK(connectedScript)) {
-            byte[] pubkeyBytes = ScriptPattern.extractKeyFromP2PK(connectedScript);
-            return RedeemData.of(keyBag.findKeyFromPubKey(pubkeyBytes), connectedScript);
-        } else if (ScriptPattern.isP2SH(connectedScript)) {
-            byte[] scriptHash = ScriptPattern.extractHashFromP2SH(connectedScript);
-            return keyBag.findRedeemDataFromScriptHash(scriptHash);
-        } else {
-            throw new ScriptException(ScriptError.SCRIPT_ERR_UNKNOWN_ERROR, "Could not understand form of connected output script: " + connectedScript);
-        }
+        return keyBag.getConnectedRedeemData(this);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -17,14 +17,10 @@
 
 package org.bitcoinj.core;
 
-import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.crypto.ECKey;
-import org.bitcoinj.script.Script;
-import org.bitcoinj.script.ScriptError;
 import org.bitcoinj.script.ScriptException;
-import org.bitcoinj.script.ScriptPattern;
 import org.bitcoinj.wallet.KeyBag;
 import org.bitcoinj.wallet.RedeemData;
 
@@ -207,24 +203,12 @@ public class TransactionOutPoint {
      * If the script form cannot be understood, throws ScriptException.
      *
      * @return an ECKey or null if the connected key cannot be found in the wallet.
+     * @deprecated Use {@link KeyBag#getConnectedKey(TransactionOutPoint)}
      */
+    @Deprecated
     @Nullable
     public ECKey getConnectedKey(KeyBag keyBag) throws ScriptException {
-        TransactionOutput connectedOutput = getConnectedOutput();
-        Objects.requireNonNull(connectedOutput, "Input is not connected so cannot retrieve key");
-        Script connectedScript = connectedOutput.getScriptPubKey();
-        if (ScriptPattern.isP2PKH(connectedScript)) {
-            byte[] addressBytes = ScriptPattern.extractHashFromP2PKH(connectedScript);
-            return keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2PKH);
-        } else if (ScriptPattern.isP2WPKH(connectedScript)) {
-            byte[] addressBytes = ScriptPattern.extractHashFromP2WH(connectedScript);
-            return keyBag.findKeyFromPubKeyHash(addressBytes, ScriptType.P2WPKH);
-        } else if (ScriptPattern.isP2PK(connectedScript)) {
-            byte[] pubkeyBytes = ScriptPattern.extractKeyFromP2PK(connectedScript);
-            return keyBag.findKeyFromPubKey(pubkeyBytes);
-        } else {
-            throw new ScriptException(ScriptError.SCRIPT_ERR_UNKNOWN_ERROR, "Could not understand form of connected output script: " + connectedScript);
-        }
+        return keyBag.getConnectedKey(this);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutPoint.java
@@ -189,7 +189,9 @@ public class TransactionOutPoint {
     /**
      * Returns the pubkey script from the connected output.
      * @throws java.lang.NullPointerException if there is no connected output.
+     * @deprecated Use {@link #getConnectedOutput()}
      */
+    @Deprecated
     public byte[] getConnectedPubKeyScript() {
         byte[] result = Objects.requireNonNull(getConnectedOutput()).getScriptBytes();
         checkState(result.length > 0);

--- a/core/src/main/java/org/bitcoinj/signers/CustomTransactionSigner.java
+++ b/core/src/main/java/org/bitcoinj/signers/CustomTransactionSigner.java
@@ -82,7 +82,7 @@ public abstract class CustomTransactionSigner implements TransactionSigner {
                 // Expected.
             }
 
-            RedeemData redeemData = txIn.getConnectedRedeemData(keyBag);
+            RedeemData redeemData = keyBag.getConnectedRedeemData(txIn);
             if (redeemData == null) {
                 log.warn("No redeem data found for input {}", i);
                 continue;

--- a/core/src/main/java/org/bitcoinj/signers/LocalTransactionSigner.java
+++ b/core/src/main/java/org/bitcoinj/signers/LocalTransactionSigner.java
@@ -89,7 +89,7 @@ public class LocalTransactionSigner implements TransactionSigner {
                 // Expected.
             }
 
-            RedeemData redeemData = txIn.getConnectedRedeemData(keyBag);
+            RedeemData redeemData = keyBag.getConnectedRedeemData(txIn);
 
             // For P2SH inputs we need to share derivation path of the signing key with other signers, so that they
             // use correct key to calculate their signatures.

--- a/core/src/main/java/org/bitcoinj/wallet/KeyBag.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyBag.java
@@ -107,4 +107,32 @@ public interface KeyBag {
             throw new ScriptException(ScriptError.SCRIPT_ERR_UNKNOWN_ERROR, "Could not understand form of connected output script: " + connectedScript);
         }
     }
+
+    /**
+     * Returns the ECKey identified in the connected output, for either P2PKH, P2WPKH or P2PK scripts.
+     * For P2SH scripts you can use {@link KeyBag#getConnectedRedeemData(TransactionOutPoint)} and then get the
+     * key from RedeemData.
+     * If the script form cannot be understood, throws ScriptException.
+     *
+     * @param transactionOutPoint
+     * @return an ECKey or null if the connected key cannot be found in the wallet.
+     */
+    @Nullable
+    default ECKey getConnectedKey(TransactionOutPoint transactionOutPoint) throws ScriptException {
+        TransactionOutput connectedOutput = transactionOutPoint.getConnectedOutput();
+        Objects.requireNonNull(connectedOutput, "Input is not connected so cannot retrieve key");
+        Script connectedScript = connectedOutput.getScriptPubKey();
+        if (ScriptPattern.isP2PKH(connectedScript)) {
+            byte[] addressBytes = ScriptPattern.extractHashFromP2PKH(connectedScript);
+            return findKeyFromPubKeyHash(addressBytes, ScriptType.P2PKH);
+        } else if (ScriptPattern.isP2WPKH(connectedScript)) {
+            byte[] addressBytes = ScriptPattern.extractHashFromP2WH(connectedScript);
+            return findKeyFromPubKeyHash(addressBytes, ScriptType.P2WPKH);
+        } else if (ScriptPattern.isP2PK(connectedScript)) {
+            byte[] pubkeyBytes = ScriptPattern.extractKeyFromP2PK(connectedScript);
+            return findKeyFromPubKey(pubkeyBytes);
+        } else {
+            throw new ScriptException(ScriptError.SCRIPT_ERR_UNKNOWN_ERROR, "Could not understand form of connected output script: " + connectedScript);
+        }
+    }
 }

--- a/core/src/main/java/org/bitcoinj/wallet/KeyBag.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyBag.java
@@ -19,10 +19,16 @@ package org.bitcoinj.wallet;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.core.TransactionInput;
 import org.bitcoinj.core.TransactionOutPoint;
+import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.crypto.ECKey;
 
+import org.bitcoinj.script.Script;
+import org.bitcoinj.script.ScriptError;
 import org.bitcoinj.script.ScriptException;
+import org.bitcoinj.script.ScriptPattern;
 import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
 
 /**
  * A KeyBag is simply an object that can map public keys, their 160-bit hashes and script hashes to ECKey
@@ -65,10 +71,40 @@ public interface KeyBag {
      * Alias for getOutpoint().getConnectedRedeemData(keyBag)
      *
      * @param transactionInput
-     * @see TransactionOutPoint#getConnectedRedeemData(KeyBag)
+     * @see KeyBag#getConnectedRedeemData(TransactionOutPoint)
      */
     @Nullable
     default RedeemData getConnectedRedeemData(TransactionInput transactionInput) throws ScriptException {
-        return transactionInput.getOutpoint().getConnectedRedeemData(this);
+        return getConnectedRedeemData(transactionInput.getOutpoint());
+    }
+
+    /**
+     * Returns the RedeemData identified in the connected output, for either P2PKH, P2WPKH, P2PK
+     * or P2SH scripts.
+     * If the script forms cannot be understood, throws ScriptException.
+     *
+     * @param transactionOutPoint
+     * @return a RedeemData or null if the connected data cannot be found in the wallet.
+     */
+    @Nullable
+    default RedeemData getConnectedRedeemData(TransactionOutPoint transactionOutPoint) throws ScriptException {
+        TransactionOutput connectedOutput = transactionOutPoint.getConnectedOutput();
+        Objects.requireNonNull(connectedOutput, "Input is not connected so cannot retrieve key");
+        Script connectedScript = connectedOutput.getScriptPubKey();
+        if (ScriptPattern.isP2PKH(connectedScript)) {
+            byte[] addressBytes = ScriptPattern.extractHashFromP2PKH(connectedScript);
+            return RedeemData.of(findKeyFromPubKeyHash(addressBytes, ScriptType.P2PKH), connectedScript);
+        } else if (ScriptPattern.isP2WPKH(connectedScript)) {
+            byte[] addressBytes = ScriptPattern.extractHashFromP2WH(connectedScript);
+            return RedeemData.of(findKeyFromPubKeyHash(addressBytes, ScriptType.P2WPKH), connectedScript);
+        } else if (ScriptPattern.isP2PK(connectedScript)) {
+            byte[] pubkeyBytes = ScriptPattern.extractKeyFromP2PK(connectedScript);
+            return RedeemData.of(findKeyFromPubKey(pubkeyBytes), connectedScript);
+        } else if (ScriptPattern.isP2SH(connectedScript)) {
+            byte[] scriptHash = ScriptPattern.extractHashFromP2SH(connectedScript);
+            return findRedeemDataFromScriptHash(scriptHash);
+        } else {
+            throw new ScriptException(ScriptError.SCRIPT_ERR_UNKNOWN_ERROR, "Could not understand form of connected output script: " + connectedScript);
+        }
     }
 }

--- a/core/src/main/java/org/bitcoinj/wallet/KeyBag.java
+++ b/core/src/main/java/org/bitcoinj/wallet/KeyBag.java
@@ -17,8 +17,11 @@
 package org.bitcoinj.wallet;
 
 import org.bitcoinj.base.ScriptType;
+import org.bitcoinj.core.TransactionInput;
+import org.bitcoinj.core.TransactionOutPoint;
 import org.bitcoinj.crypto.ECKey;
 
+import org.bitcoinj.script.ScriptException;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -58,4 +61,14 @@ public interface KeyBag {
     @Nullable
     RedeemData findRedeemDataFromScriptHash(byte[] scriptHash);
 
+    /**
+     * Alias for getOutpoint().getConnectedRedeemData(keyBag)
+     *
+     * @param transactionInput
+     * @see TransactionOutPoint#getConnectedRedeemData(KeyBag)
+     */
+    @Nullable
+    default RedeemData getConnectedRedeemData(TransactionInput transactionInput) throws ScriptException {
+        return transactionInput.getOutpoint().getConnectedRedeemData(this);
+    }
 }

--- a/core/src/main/java/org/bitcoinj/wallet/RedeemData.java
+++ b/core/src/main/java/org/bitcoinj/wallet/RedeemData.java
@@ -21,6 +21,7 @@ import com.google.common.base.MoreObjects;
 import org.bitcoinj.crypto.ECKey;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptPattern;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -52,10 +53,13 @@ public class RedeemData {
     }
 
     /**
-     * Creates RedeemData for P2PKH, P2WPKH or P2PK input. Provided key is a single private key needed
-     * to spend such inputs.
+     * Create RedeemData for P2PKH, P2WPKH or P2PK input.
+     * @param key single private key needed to spend
+     * @param redeemScript script to spend
+     * @return RedeemData or {@code null} if {@code key} was {@code null}
      */
-    public static RedeemData of(ECKey key, Script redeemScript) {
+    @Nullable
+    public static RedeemData of(@Nullable ECKey key, Script redeemScript) {
         checkArgument(ScriptPattern.isP2PKH(redeemScript)
                 || ScriptPattern.isP2WPKH(redeemScript) || ScriptPattern.isP2PK(redeemScript));
         return key != null ? new RedeemData(Collections.singletonList(key), redeemScript) : null;

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -4526,7 +4526,7 @@ public class Wallet extends BaseTaggableObject
                     // Expected.
                 }
 
-                RedeemData redeemData = txIn.getConnectedRedeemData(maybeDecryptingKeyBag);
+                RedeemData redeemData = maybeDecryptingKeyBag.getConnectedRedeemData(txIn);
                 Objects.requireNonNull(redeemData, () ->
                         "Transaction exists in wallet that we cannot redeem: " + txIn.getOutpoint().hash());
                 tx.replaceInput(i, txIn.withScriptSig(scriptPubKey.createEmptyInputScript(redeemData.keys.get(0),

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -47,13 +47,11 @@ import org.bitcoinj.core.TransactionOutPoint;
 import org.bitcoinj.core.TransactionOutput;
 import org.bitcoinj.core.TransactionWitness;
 import org.bitcoinj.core.VerificationException;
-import org.bitcoinj.crypto.ChildNumber;
 import org.bitcoinj.crypto.DeterministicKey;
 import org.bitcoinj.crypto.HDPath;
 import org.bitcoinj.crypto.KeyCrypter;
 import org.bitcoinj.crypto.KeyCrypterException;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
-import org.bitcoinj.crypto.MnemonicCode;
 import org.bitcoinj.crypto.MnemonicException;
 import org.bitcoinj.crypto.TransactionSignature;
 import org.bitcoinj.crypto.internal.CryptoUtils;
@@ -62,11 +60,8 @@ import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptChunk;
 import org.bitcoinj.script.ScriptExecution;
 import org.bitcoinj.script.ScriptPattern;
-import org.bitcoinj.signers.TransactionSigner;
 import org.bitcoinj.store.BlockStoreException;
-import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.testing.FakeTxBuilder;
-import org.bitcoinj.testing.KeyChainTransactionSigner;
 import org.bitcoinj.testing.MockTransactionBroadcaster;
 import org.bitcoinj.testing.NopTransactionSigner;
 import org.bitcoinj.testing.TestWithWallet;
@@ -3451,7 +3446,7 @@ public class WalletTest extends TestWithWallet {
 
         // Wallet1 sign input 0
         TransactionInput inputW1 = sendReq.tx.getInput(0);
-        ECKey sigKey1 = inputW1.getOutpoint().getConnectedKey(wallet1);
+        ECKey sigKey1 = wallet1.getConnectedKey(inputW1.getOutpoint());
         Script scriptCode1 = ScriptBuilder.createP2PKHOutputScript(sigKey1);
         TransactionSignature txSig1 = sendReq.tx.calculateWitnessSignature(0, sigKey1, scriptCode1,
                 inputW1.getValue(), Transaction.SigHash.ALL, false);
@@ -3461,7 +3456,7 @@ public class WalletTest extends TestWithWallet {
 
         // Wallet2 sign input 1
         TransactionInput inputW2 = sendReq.tx.getInput(1);
-        ECKey sigKey2 = inputW2.getOutpoint().getConnectedKey(wallet2);
+        ECKey sigKey2 = wallet2.getConnectedKey(inputW2.getOutpoint());
         Script scriptCode2 = ScriptBuilder.createP2PKHOutputScript(sigKey2);
         TransactionSignature txSig2 = sendReq.tx.calculateWitnessSignature(0, sigKey2, scriptCode2,
                 inputW2.getValue(), Transaction.SigHash.ALL, false);

--- a/examples/src/main/java/org/bitcoinj/examples/GenerateLowSTests.java
+++ b/examples/src/main/java/org/bitcoinj/examples/GenerateLowSTests.java
@@ -147,7 +147,7 @@ public class GenerateLowSTests {
         for (int i = 0; i < numInputs; i++) {
             TransactionInput txIn = outputTransaction.getInput(i);
             Script scriptPubKey = txIn.getConnectedOutput().getScriptPubKey();
-            RedeemData redeemData = txIn.getConnectedRedeemData(bag);
+            RedeemData redeemData = bag.getConnectedRedeemData(txIn);
             Objects.requireNonNull(redeemData, () ->
                     "Transaction exists in wallet that we cannot redeem: " + txIn.getOutpoint().hash());
             outputTransaction.replaceInput(i, txIn.withScriptSig(scriptPubKey.createEmptyInputScript(redeemData.keys.get(0), redeemData.redeemScript)));


### PR DESCRIPTION
See the individual commits for details.