### PR TITLE
Transaction/TransactionOutput: move methods to TransactionBag

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerGroup.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerGroup.java
@@ -257,7 +257,7 @@ public class PeerGroup implements TransactionBroadcaster {
         for (TransactionOutput output : tx.getOutputs()) {
             Script scriptPubKey = output.getScriptPubKey();
             if (ScriptPattern.isP2PK(scriptPubKey) || ScriptPattern.isP2WPKH(scriptPubKey)) {
-                if (output.isMine(wallet)) {
+                if (wallet.isMine(output)) {
                     if (tx.getConfidence().getConfidenceType() == TransactionConfidence.ConfidenceType.BUILDING)
                         recalculateFastCatchupAndFilter(FilterRecalculateMode.SEND_IF_CHANGED);
                     else

--- a/core/src/main/java/org/bitcoinj/core/Transaction.java
+++ b/core/src/main/java/org/bitcoinj/core/Transaction.java
@@ -41,8 +41,6 @@ import org.bitcoinj.script.ScriptOpCodes;
 import org.bitcoinj.script.ScriptPattern;
 import org.bitcoinj.signers.TransactionSigner;
 import org.bitcoinj.utils.ExchangeRate;
-import org.bitcoinj.wallet.Wallet;
-import org.bitcoinj.wallet.WalletTransaction.Pool;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,7 +56,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -446,15 +443,11 @@ public class Transaction implements Message {
 
     /**
      * Calculates the sum of the outputs that are sending coins to a key in the wallet.
+     * @deprecated Use {@link TransactionBag#getValueSentToMe(Transaction)}
      */
+    @Deprecated
     public Coin getValueSentToMe(TransactionBag transactionBag) {
-        // This is tested in WalletTest.
-        Coin v = Coin.ZERO;
-        for (TransactionOutput o : outputs) {
-            if (!o.isMineOrWatched(transactionBag)) continue;
-            v = v.add(o.getValue());
-        }
-        return v;
+        return transactionBag.getValueSentToMe(this);
     }
 
     /**
@@ -518,27 +511,11 @@ public class Transaction implements Message {
      * blocks containing the input transactions if the key is in the wallet but the transactions are not.
      *
      * @return sum of the inputs that are spending coins with keys in the wallet
+     * @deprecated Use {@link TransactionBag#getValueSentToMe(Transaction)}
      */
-    public Coin getValueSentFromMe(TransactionBag wallet) throws ScriptException {
-        // This is tested in WalletTest.
-        Coin v = Coin.ZERO;
-        for (TransactionInput input : inputs) {
-            // This input is taking value from a transaction in our wallet. To discover the value,
-            // we must find the connected transaction.
-            TransactionOutput connected = input.getConnectedOutput(wallet.getTransactionPool(Pool.UNSPENT));
-            if (connected == null)
-                connected = input.getConnectedOutput(wallet.getTransactionPool(Pool.SPENT));
-            if (connected == null)
-                connected = input.getConnectedOutput(wallet.getTransactionPool(Pool.PENDING));
-            if (connected == null)
-                continue;
-            // The connected output may be the change to the sender of a previous input sent to this wallet. In this
-            // case we ignore it.
-            if (!connected.isMineOrWatched(wallet))
-                continue;
-            v = v.add(connected.getValue());
-        }
-        return v;
+    @Deprecated
+    public Coin getValueSentFromMe(TransactionBag transactionBag) throws ScriptException {
+        return transactionBag.getValueSentFromMe(this);
     }
 
     /**
@@ -552,10 +529,11 @@ public class Transaction implements Message {
     }
 
     /**
-     * Returns the difference of {@link Transaction#getValueSentToMe(TransactionBag)} and {@link Transaction#getValueSentFromMe(TransactionBag)}.
+     * @deprecated Use {@link TransactionBag#getValue}
      */
-    public Coin getValue(TransactionBag wallet) throws ScriptException {
-        return getValueSentToMe(wallet).subtract(getValueSentFromMe(wallet));
+    @Deprecated
+    public Coin getValue(TransactionBag transactionBag) throws ScriptException {
+        return transactionBag.getValue(this);
     }
 
     /**
@@ -593,13 +571,11 @@ public class Transaction implements Message {
     /**
      * Returns false if this transaction has at least one output that is owned by the given wallet and unspent, true
      * otherwise.
+     * @deprecated Use {@link TransactionBag#isEveryOwnedOutputSpent(Transaction)}
      */
+    @Deprecated
     public boolean isEveryOwnedOutputSpent(TransactionBag transactionBag) {
-        for (TransactionOutput output : outputs) {
-            if (output.isAvailableForSpending() && output.isMineOrWatched(transactionBag))
-                return false;
-        }
-        return true;
+        return transactionBag.isEveryOwnedOutputSpent(this);
     }
 
     /**
@@ -1193,7 +1169,7 @@ public class Transaction implements Message {
      * <p>Calculates a signature hash, that is, a hash of a simplified form of the transaction. How exactly the transaction
      * is simplified is specified by the type and anyoneCanPay parameters.</p>
      *
-     * <p>This is a low level API and when using the regular {@link Wallet} class you don't have to call this yourself.
+     * <p>This is a low level API and when using the regular {@link org.bitcoinj.wallet.Wallet} class you don't have to call this yourself.
      * When working with more complex transaction types and contracts, it can be necessary. When signing a P2SH output
      * the redeemScript should be the script encoded into the scriptSig field, for normal transactions, it's the
      * scriptPubKey of the output you're signing for.</p>
@@ -1213,7 +1189,7 @@ public class Transaction implements Message {
      * <p>Calculates a signature hash, that is, a hash of a simplified form of the transaction. How exactly the transaction
      * is simplified is specified by the type and anyoneCanPay parameters.</p>
      *
-     * <p>This is a low level API and when using the regular {@link Wallet} class you don't have to call this yourself.
+     * <p>This is a low level API and when using the regular {@link org.bitcoinj.wallet.Wallet} class you don't have to call this yourself.
      * When working with more complex transaction types and contracts, it can be necessary. When signing a P2SH output
      * the redeemScript should be the script encoded into the scriptSig field, for normal transactions, it's the
      * scriptPubKey of the output you're signing for.</p>
@@ -1376,7 +1352,7 @@ public class Transaction implements Message {
      * <p>Calculates a signature hash, that is, a hash of a simplified form of the transaction. How exactly the transaction
      * is simplified is specified by the type and anyoneCanPay parameters.</p>
      *
-     * <p>This is a low level API and when using the regular {@link Wallet} class you don't have to call this yourself.
+     * <p>This is a low level API and when using the regular {@link org.bitcoinj.wallet.Wallet} class you don't have to call this yourself.
      * When working with more complex transaction types and contracts, it can be necessary. When signing a Witness output
      * the scriptCode should be the script encoded into the scriptSig field, for normal transactions, it's the
      * scriptPubKey of the output you're signing for. (See BIP143: https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki)</p>
@@ -1587,15 +1563,11 @@ public class Transaction implements Message {
      *
      * @param transactionBag The wallet that controls addresses and watches scripts.
      * @return linked list of outputs relevant to the wallet in this transaction
+     * @deprecated Use {@link TransactionBag#getWalletOutputs(Transaction)}
      */
+    @Deprecated
     public List<TransactionOutput> getWalletOutputs(TransactionBag transactionBag){
-        List<TransactionOutput> walletOutputs = new LinkedList<>();
-        for (TransactionOutput o : outputs) {
-            if (!o.isMineOrWatched(transactionBag)) continue;
-            walletOutputs.add(o);
-        }
-
-        return walletOutputs;
+        return transactionBag.getWalletOutputs(this);
     }
 
     /** Randomly re-orders the transaction outputs: good for privacy */

--- a/core/src/main/java/org/bitcoinj/core/TransactionBag.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionBag.java
@@ -17,19 +17,28 @@
 
 package org.bitcoinj.core;
 
+import org.bitcoinj.base.Coin;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.script.Script;
-import org.bitcoinj.wallet.Wallet;
+import org.bitcoinj.script.ScriptException;
+import org.bitcoinj.script.ScriptPattern;
 import org.bitcoinj.wallet.WalletTransaction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.jspecify.annotations.Nullable;
+
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 /**
- * This interface is used to abstract the {@link Wallet} and the {@link Transaction}
+ * This interface is used to abstract the {@link org.bitcoinj.wallet.Wallet} and the {@link Transaction}
  */
 public interface TransactionBag {
+    Logger log = LoggerFactory.getLogger(TransactionBag.class);
+
     /**
      * Look for a public key which hashes to the given hash and (optionally) is used for a specific script type.
      * @param pubKeyHash hash of the public key to look for
@@ -49,4 +58,128 @@ public interface TransactionBag {
 
     /** Returns transactions from a specific pool. */
     Map<Sha256Hash, Transaction> getTransactionPool(WalletTransaction.Pool pool);
+
+    /**
+     * Returns false if this transaction has at least one output that is owned by the given wallet and unspent, true
+     * otherwise.
+     */
+    default boolean isEveryOwnedOutputSpent(Transaction tx) {
+        for (TransactionOutput output : tx.getOutputs()) {
+            if (output.isAvailableForSpending() && isMineOrWatched(output))
+                return false;
+        }
+        return true;
+    }
+
+    /**
+     * <p>Returns the list of transaction outputs, whether spent or unspent, that match a wallet by address or that are
+     * watched by a wallet, i.e., transaction outputs whose script's address is controlled by the wallet and transaction
+     * outputs whose script is watched by the wallet.</p>
+     *
+     * @param tx The transaction.
+     * @return linked list of outputs relevant to the wallet in this transaction
+     */
+    default List<TransactionOutput> getWalletOutputs(Transaction tx) {
+        List<TransactionOutput> walletOutputs = new LinkedList<>();
+        for (TransactionOutput o : tx.getOutputs()) {
+            if (!isMineOrWatched(o)) continue;
+            walletOutputs.add(o);
+        }
+
+        return walletOutputs;
+    }
+
+    /**
+     * Returns the difference of {@link #getValueSentToMe(Transaction)} and {@link #getValueSentFromMe(Transaction)}.
+     */
+    default Coin getValue(Transaction tx) throws ScriptException {
+        return getValueSentToMe(tx).subtract(getValueSentFromMe(tx));
+    }
+
+    /**
+     * Calculates the sum of the outputs that are sending coins to a key in the wallet.
+     */
+    default Coin getValueSentToMe(Transaction tx) {
+        // This is tested in WalletTest.
+        Coin v = Coin.ZERO;
+        for (TransactionOutput o : tx.getOutputs()) {
+            if (!isMineOrWatched(o)) continue;
+            v = v.add(o.getValue());
+        }
+        return v;
+    }
+
+    /**
+     * Calculates the sum of the inputs that are spending coins with keys in the wallet. This requires the
+     * transactions sending coins to those keys to be in the wallet. This method will not attempt to download the
+     * blocks containing the input transactions if the key is in the wallet but the transactions are not.
+     *
+     * @return sum of the inputs that are spending coins with keys in the wallet
+     */
+    default Coin getValueSentFromMe(Transaction tx) throws ScriptException {
+        // This is tested in WalletTest.
+        Coin v = Coin.ZERO;
+        for (TransactionInput input : tx.getInputs()) {
+            // This input is taking value from a transaction in our wallet. To discover the value,
+            // we must find the connected transaction.
+            TransactionOutput connected = input.getConnectedOutput(getTransactionPool(WalletTransaction.Pool.UNSPENT));
+            if (connected == null)
+                connected = input.getConnectedOutput(getTransactionPool(WalletTransaction.Pool.SPENT));
+            if (connected == null)
+                connected = input.getConnectedOutput(getTransactionPool(WalletTransaction.Pool.PENDING));
+            if (connected == null)
+                continue;
+            // The connected output may be the change to the sender of a previous input sent to this wallet. In this
+            // case we ignore it.
+            if (!isMineOrWatched(connected))
+                continue;
+            v = v.add(connected.getValue());
+        }
+        return v;
+    }
+
+
+    default boolean isMineOrWatched(TransactionOutput output) {
+        return isMine(output) || isWatched(output);
+    }
+
+    /**
+     * Returns true if this output is to a key, or an address we have the keys for, in the wallet.
+     */
+    default boolean isWatched(TransactionOutput output) {
+        try {
+            Script script = output.getScriptPubKey();
+            return isWatchedScript(script);
+        } catch (ScriptException e) {
+            // Just means we didn't understand the output of this transaction: ignore it.
+            log.debug("Could not parse tx output script: {}", e.toString());
+            return false;
+        }
+    }
+
+    /**
+     * Returns true if this output is to a key, or an address we have the keys for, in the wallet.
+     */
+    default boolean isMine(TransactionOutput output) {
+        try {
+            Script script = output.getScriptPubKey();
+            if (ScriptPattern.isP2PK(script))
+                return isPubKeyMine(ScriptPattern.extractKeyFromP2PK(script));
+            else if (ScriptPattern.isP2SH(script))
+                return isPayToScriptHashMine(ScriptPattern.extractHashFromP2SH(script));
+            else if (ScriptPattern.isP2PKH(script))
+                return isPubKeyHashMine(ScriptPattern.extractHashFromP2PKH(script),
+                        ScriptType.P2PKH);
+            else if (ScriptPattern.isP2WPKH(script))
+                return isPubKeyHashMine(ScriptPattern.extractHashFromP2WH(script),
+                        ScriptType.P2WPKH);
+            else
+                return false;
+        } catch (ScriptException e) {
+            // Just means we didn't understand the output of this transaction: ignore it.
+            log.debug("Could not parse tx {} output script: {}",
+                    output.getParentTransaction() != null ? output.getParentTransaction().getTxId() : "(no parent)", e.toString());
+            return false;
+        }
+    }
 }

--- a/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionOutput.java
@@ -30,7 +30,6 @@ import org.bitcoinj.script.Script;
 import org.bitcoinj.script.ScriptBuilder;
 import org.bitcoinj.script.ScriptException;
 import org.bitcoinj.script.ScriptPattern;
-import org.bitcoinj.wallet.Wallet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -273,7 +272,7 @@ public class TransactionOutput {
 
     /**
      * Returns whether {@link TransactionOutput#markAsSpent(TransactionInput)} has been called on this class. A
-     * {@link Wallet} will mark a transaction output as spent once it sees a transaction input that is connected to it.
+     * {@link org.bitcoinj.wallet.Wallet} will mark a transaction output as spent once it sees a transaction input that is connected to it.
      * Note that this flag can be false when an output has in fact been spent according to the rest of the network if
      * the spending transaction wasn't downloaded yet, and it can be marked as spent when in reality the rest of the
      * network believes it to be unspent if the signature or script connecting to it was not actually valid.
@@ -292,49 +291,29 @@ public class TransactionOutput {
 
     /**
      * Returns true if this output is to a key in the wallet or to an address/script we are watching.
+     * @deprecated Use {@link TransactionBag#isMineOrWatched(TransactionOutput)}
      */
+    @Deprecated
     public boolean isMineOrWatched(TransactionBag transactionBag) {
-        return isMine(transactionBag) || isWatched(transactionBag);
+        return transactionBag.isMineOrWatched(this);
     }
 
     /**
      * Returns true if this output is to a key, or an address we have the keys for, in the wallet.
+     * @deprecated Use {@link TransactionBag#isWatched(TransactionOutput)}
      */
+    @Deprecated
     public boolean isWatched(TransactionBag transactionBag) {
-        try {
-            Script script = getScriptPubKey();
-            return transactionBag.isWatchedScript(script);
-        } catch (ScriptException e) {
-            // Just means we didn't understand the output of this transaction: ignore it.
-            log.debug("Could not parse tx output script: {}", e.toString());
-            return false;
-        }
+        return transactionBag.isWatched(this);
     }
 
     /**
      * Returns true if this output is to a key, or an address we have the keys for, in the wallet.
+     * @deprecated Use {@link TransactionBag#isMine(TransactionOutput)}
      */
+    @Deprecated
     public boolean isMine(TransactionBag transactionBag) {
-        try {
-            Script script = getScriptPubKey();
-            if (ScriptPattern.isP2PK(script))
-                return transactionBag.isPubKeyMine(ScriptPattern.extractKeyFromP2PK(script));
-            else if (ScriptPattern.isP2SH(script))
-                return transactionBag.isPayToScriptHashMine(ScriptPattern.extractHashFromP2SH(script));
-            else if (ScriptPattern.isP2PKH(script))
-                return transactionBag.isPubKeyHashMine(ScriptPattern.extractHashFromP2PKH(script),
-                        ScriptType.P2PKH);
-            else if (ScriptPattern.isP2WPKH(script))
-                return transactionBag.isPubKeyHashMine(ScriptPattern.extractHashFromP2WH(script),
-                        ScriptType.P2WPKH);
-            else
-                return false;
-        } catch (ScriptException e) {
-            // Just means we didn't understand the output of this transaction: ignore it.
-            log.debug("Could not parse tx {} output script: {}",
-                    parent != null ? ((Transaction) parent).getTxId() : "(no parent)", e.toString());
-            return false;
-        }
+        return transactionBag.isMine(this);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/wallet/SendRequest.java
+++ b/core/src/main/java/org/bitcoinj/wallet/SendRequest.java
@@ -216,7 +216,7 @@ public class SendRequest {
     public static SendRequest childPaysForParent(Wallet wallet, Transaction parentTransaction, Coin feeRaise) {
         TransactionOutput outputToSpend = null;
         for (final TransactionOutput output : parentTransaction.getOutputs()) {
-            if (output.isMine(wallet) && output.isAvailableForSpending()
+            if (wallet.isMine(output) && output.isAvailableForSpending()
                     && output.getValue().isGreaterThan(feeRaise)) {
                 outputToSpend = output;
                 break;

--- a/core/src/main/java/org/bitcoinj/wallet/Wallet.java
+++ b/core/src/main/java/org/bitcoinj/wallet/Wallet.java
@@ -1849,7 +1849,7 @@ public class Wallet extends BaseTaggableObject
         boolean isActuallySpent = true;
         for (TransactionOutput o : tx.getOutputs()) {
             if (o.isAvailableForSpending()) {
-                if (o.isMineOrWatched(this)) isActuallySpent = false;
+                if (isMineOrWatched(o)) isActuallySpent = false;
                 if (o.getSpentBy() != null) {
                     log.error("isAvailableForSpending != spentBy");
                     return false;
@@ -1993,8 +1993,8 @@ public class Wallet extends BaseTaggableObject
                 log.warn("There are now {} risk dropped transactions being kept in memory", riskDropped.size());
                 return;
             }
-            Coin valueSentToMe = tx.getValueSentToMe(this);
-            Coin valueSentFromMe = tx.getValueSentFromMe(this);
+            Coin valueSentToMe = getValueSentToMe(tx);
+            Coin valueSentFromMe = getValueSentFromMe(tx);
             if (log.isInfoEnabled())
                 log.info("Received a pending transaction {} that spends {} from our own wallet, and sends us {}",
                         tx.getTxId(), valueSentFromMe.toFriendlyString(), valueSentToMe.toFriendlyString());
@@ -2103,8 +2103,8 @@ public class Wallet extends BaseTaggableObject
     public boolean isTransactionRelevant(Transaction tx) throws ScriptException {
         lock.lock();
         try {
-            return tx.getValueSentFromMe(this).signum() > 0 ||
-                   tx.getValueSentToMe(this).signum() > 0 ||
+            return getValueSentFromMe(tx).signum() > 0 ||
+                   getValueSentToMe(tx).signum() > 0 ||
                    !findDoubleSpendsAgainst(tx, transactions).isEmpty();
         } finally {
             lock.unlock();
@@ -2224,8 +2224,8 @@ public class Wallet extends BaseTaggableObject
         boolean bestChain = blockType == BlockChain.NewBlockType.BEST_CHAIN;
         boolean sideChain = blockType == BlockChain.NewBlockType.SIDE_CHAIN;
 
-        Coin valueSentFromMe = tx.getValueSentFromMe(this);
-        Coin valueSentToMe = tx.getValueSentToMe(this);
+        Coin valueSentFromMe = getValueSentFromMe(tx);
+        Coin valueSentToMe = getValueSentToMe(tx);
         Coin valueDifference = valueSentToMe.subtract(valueSentFromMe);
 
         log.info("Received tx{} for {}: {} [{}] in block {}", sideChain ? " on a side chain" : "",
@@ -2505,18 +2505,18 @@ public class Wallet extends BaseTaggableObject
         // Now make sure it ends up in the right pool. Also, handle the case where this TX is double-spending
         // against our pending transactions. Note that a tx may double spend our pending transactions and also send
         // us money/spend our money.
-        boolean hasOutputsToMe = tx.getValueSentToMe(this).signum() > 0;
+        boolean hasOutputsToMe = getValueSentToMe(tx).signum() > 0;
         boolean hasOutputsFromMe = false;
         if (hasOutputsToMe) {
             // Needs to go into either unspent or spent (if the outputs were already spent by a pending tx).
-            if (tx.isEveryOwnedOutputSpent(this)) {
+            if (isEveryOwnedOutputSpent(tx)) {
                 log.info("  tx {} ->spent (by pending)", tx.getTxId());
                 addWalletTransaction(Pool.SPENT, tx);
             } else {
                 log.info("  tx {} ->unspent", tx.getTxId());
                 addWalletTransaction(Pool.UNSPENT, tx);
             }
-        } else if (tx.getValueSentFromMe(this).signum() > 0) {
+        } else if (getValueSentFromMe(tx).signum() > 0) {
             hasOutputsFromMe = true;
             // Didn't send us any money, but did spend some. Keep it around for record keeping purposes.
             log.info("  tx {} ->spent", tx.getTxId());
@@ -2541,7 +2541,7 @@ public class Wallet extends BaseTaggableObject
             // disconnect irrelevant inputs (otherwise might cause protobuf serialization issue)
             for (TransactionInput input : tx.getInputs()) {
                 TransactionOutput output = input.getConnectedOutput();
-                if (output != null && !output.isMineOrWatched(this)) {
+                if (output != null && !isMineOrWatched(output)) {
                     input.disconnect();
                 }
             }
@@ -2612,7 +2612,7 @@ public class Wallet extends BaseTaggableObject
                 log.info("  marked {} as spent by {}", input.getOutpoint(), tx.getTxId());
                 maybeMovePool(connected, "prevtx");
                 // Just because it's connected doesn't mean it's actually ours: sometimes we have total visibility.
-                if (output.isMineOrWatched(this)) {
+                if (isMineOrWatched(output)) {
                     checkState(myUnspents.remove(output));
                 }
             }
@@ -2711,7 +2711,7 @@ public class Wallet extends BaseTaggableObject
      */
     private void maybeMovePool(Transaction tx, String context) {
         checkState(lock.isHeldByCurrentThread());
-        if (tx.isEveryOwnedOutputSpent(this)) {
+        if (isEveryOwnedOutputSpent(tx)) {
             // There's nothing left I can spend in this transaction.
             if (unspent.remove(tx.getTxId()) != null) {
                 if (log.isInfoEnabled()) {
@@ -2754,7 +2754,7 @@ public class Wallet extends BaseTaggableObject
             // Put any outputs that are sending money back to us into the unspents map, and calculate their total value.
             Coin valueSentToMe = Coin.ZERO;
             for (TransactionOutput o : tx.getOutputs()) {
-                if (!o.isMineOrWatched(this)) continue;
+                if (!isMineOrWatched(o)) continue;
                 valueSentToMe = valueSentToMe.add(o.getValue());
             }
             // Mark the outputs we're spending as spent so we won't try and use them in future creations. This will also
@@ -2803,7 +2803,7 @@ public class Wallet extends BaseTaggableObject
             // they are showing to the user in qr codes etc.
             markKeysAsUsed(tx);
             try {
-                Coin valueSentFromMe = tx.getValueSentFromMe(this);
+                Coin valueSentFromMe = getValueSentFromMe(tx);
                 Coin newBalance = balance.add(valueSentToMe).subtract(valueSentFromMe);
                 if (valueSentToMe.signum() > 0) {
                     checkBalanceFuturesLocked();
@@ -3188,7 +3188,7 @@ public class Wallet extends BaseTaggableObject
         }
         if (pool == Pool.UNSPENT || pool == Pool.PENDING) {
             for (TransactionOutput output : tx.getOutputs()) {
-                if (output.isAvailableForSpending() && output.isMineOrWatched(this))
+                if (output.isAvailableForSpending() && isMineOrWatched(output))
                     myUnspents.add(output);
             }
         }
@@ -3362,7 +3362,7 @@ public class Wallet extends BaseTaggableObject
                         for (TransactionInput input : tx.getInputs()) {
                             TransactionOutput output = input.getConnectedOutput();
                             if (output == null) continue;
-                            if (output.isMineOrWatched(this))
+                            if (isMineOrWatched(output))
                                 checkState(myUnspents.add(output));
                             input.disconnect();
                         }
@@ -3570,11 +3570,11 @@ public class Wallet extends BaseTaggableObject
 
         for (Transaction tx : txns) {
             try {
-                builder.append(tx.getValue(this).toFriendlyString());
+                builder.append(getValue(tx).toFriendlyString());
                 builder.append(" total value (sends ");
-                builder.append(tx.getValueSentFromMe(this).toFriendlyString());
+                builder.append(getValueSentFromMe(tx).toFriendlyString());
                 builder.append(" and receives ");
-                builder.append(tx.getValueSentToMe(this).toFriendlyString());
+                builder.append(getValueSentToMe(tx).toFriendlyString());
                 builder.append(")\n");
             } catch (ScriptException e) {
                 // Ignore and don't print this line.
@@ -3897,13 +3897,13 @@ public class Wallet extends BaseTaggableObject
         for (Transaction tx: transactions.values()) {
             Coin txTotal = Coin.ZERO;
             for (TransactionOutput output : tx.getOutputs()) {
-                if (output.isMine(this)) {
+                if (isMine(output)) {
                     txTotal = txTotal.add(output.getValue());
                 }
             }
             for (TransactionInput in : tx.getInputs()) {
                 TransactionOutput prevOut = in.getConnectedOutput();
-                if (prevOut != null && prevOut.isMine(this)) {
+                if (prevOut != null && isMine(prevOut)) {
                     txTotal = txTotal.subtract(prevOut.getValue());
                 }
             }
@@ -3929,7 +3929,7 @@ public class Wallet extends BaseTaggableObject
             // Count spent outputs to only if they were not to us. This means we don't count change outputs.
             Coin txOutputTotal = Coin.ZERO;
             for (TransactionOutput out : tx.getOutputs()) {
-                if (out.isMine(this) == false) {
+                if (isMine(out) == false) {
                     txOutputTotal = txOutputTotal.add(out.getValue());
                 }
             }
@@ -3938,7 +3938,7 @@ public class Wallet extends BaseTaggableObject
             Coin txOwnedInputsTotal = Coin.ZERO;
             for (TransactionInput in : tx.getInputs()) {
                 TransactionOutput prevOut = in.getConnectedOutput();
-                if (prevOut != null && prevOut.isMine(this)) {
+                if (prevOut != null && isMine(prevOut)) {
                     txOwnedInputsTotal = txOwnedInputsTotal.add(prevOut.getValue());
                 }
             }
@@ -4657,14 +4657,14 @@ public class Wallet extends BaseTaggableObject
         for (Transaction tx : pending.values()) {
             // Remove the spent outputs.
             for (TransactionInput input : tx.getInputs()) {
-                if (input.getConnectedOutput().isMine(this)) {
+                if (isMine(input.getConnectedOutput())) {
                     candidates.remove(input.getConnectedOutput());
                 }
             }
             // Add change outputs. Do not try and spend coinbases that were mined too recently, the protocol forbids it.
             if (!excludeImmatureCoinbases || isTransactionMature(tx)) {
                 for (TransactionOutput output : tx.getOutputs()) {
-                    if (output.isAvailableForSpending() && output.isMine(this)) {
+                    if (output.isAvailableForSpending() && isMine(output)) {
                         candidates.add(output);
                     }
                 }
@@ -4895,7 +4895,7 @@ public class Wallet extends BaseTaggableObject
                         for (TransactionOutput output : tx.getOutputs()) {
                             TransactionInput input = output.getSpentBy();
                             if (input != null) {
-                                if (output.isMineOrWatched(this))
+                                if (isMineOrWatched(output))
                                     checkState(myUnspents.add(output));
                                 input.disconnect();
                             }
@@ -5098,7 +5098,7 @@ public class Wallet extends BaseTaggableObject
         Script script = out.getScriptPubKey();
         boolean isScriptTypeSupported = ScriptPattern.isP2PK(script) || ScriptPattern.isP2SH(script)
                 || ScriptPattern.isP2WPKH(script) || ScriptPattern.isP2WSH(script);
-        return (isScriptTypeSupported && out.isMine(this)) || watchedScripts.contains(script);
+        return (isScriptTypeSupported && isMine(out)) || watchedScripts.contains(script);
     }
 
     /**

--- a/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/WalletTest.java
@@ -73,6 +73,8 @@ import org.bitcoinj.protobuf.wallet.Protos;
 import org.bitcoinj.wallet.Wallet.BalanceType;
 import org.bitcoinj.wallet.WalletTransaction.Pool;
 import org.easymock.EasyMock;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -638,14 +640,14 @@ public class WalletTest extends TestWithWallet {
     public void balances() throws Exception {
         Coin nanos = COIN;
         Transaction tx1 = sendMoneyToWallet(AbstractBlockChain.NewBlockType.BEST_CHAIN, nanos);
-        assertEquals(nanos, tx1.getValueSentToMe(wallet));
-        assertTrue(tx1.getWalletOutputs(wallet).size() >= 1);
+        assertEquals(nanos, wallet.getValueSentToMe(tx1));
+        assertTrue(wallet.getWalletOutputs(tx1).size() >= 1);
         // Send 0.10 to somebody else.
         Transaction send1 = wallet.createSend(OTHER_ADDRESS, valueOf(0, 10));
         // Reserialize.
         Transaction send2 = TESTNET_PARAMS.getDefaultSerializer().makeTransaction(ByteBuffer.wrap(send1.serialize()));
-        assertEquals(nanos, send2.getValueSentFromMe(wallet));
-        assertEquals(ZERO.subtract(valueOf(0, 10)), send2.getValue(wallet));
+        assertEquals(nanos, wallet.getValueSentFromMe(send2));
+        assertEquals(ZERO.subtract(valueOf(0, 10)), wallet.getValue(send2));
     }
 
     @Test
@@ -700,7 +702,7 @@ public class WalletTest extends TestWithWallet {
         Wallet wallet = Wallet.createDeterministic(TESTNET, ScriptType.P2PKH);
         TransactionOutput to = createMock(TransactionOutput.class);
         EasyMock.expect(to.isAvailableForSpending()).andReturn(true);
-        EasyMock.expect(to.isMineOrWatched(wallet)).andReturn(true);
+        EasyMock.expect(to.getScriptPubKey()).andReturn(ScriptBuilder.createOutputScript(wallet.currentReceiveAddress()));
         EasyMock.expect(to.getSpentBy()).andReturn(
                 new TransactionInput(null, new byte[0], TransactionOutPoint.UNCONNECTED));
 
@@ -743,7 +745,7 @@ public class WalletTest extends TestWithWallet {
         tx2.addInput(output);
         tx2.addOutput(new TransactionOutput(tx2, valueOf(0, 5), myAddress));
         // tx2 doesn't send any coins from us, even though the output is in the wallet.
-        assertEquals(ZERO, tx2.getValueSentFromMe(wallet));
+        assertEquals(ZERO, wallet.getValueSentFromMe(tx2));
     }
 
     @Test
@@ -763,11 +765,11 @@ public class WalletTest extends TestWithWallet {
         Transaction outbound1 = req.tx;
         wallet.commitTx(outbound1);
         sendMoneyToWallet(AbstractBlockChain.NewBlockType.BEST_CHAIN, outbound1);
-        assertTrue(outbound1.getWalletOutputs(wallet).size() <= 1); //the change address at most
+        assertTrue(wallet.getWalletOutputs(outbound1).size() <= 1); //the change address at most
         // That other guy gives us the coins right back.
         Transaction inbound2 = new Transaction();
         inbound2.addOutput(new TransactionOutput(inbound2, coinHalf, myAddress));
-        assertTrue(outbound1.getWalletOutputs(wallet).size() >= 1);
+        assertTrue(wallet.getWalletOutputs(outbound1).size() >= 1);
         inbound2.addInput(outbound1.getOutput(0));
         sendMoneyToWallet(AbstractBlockChain.NewBlockType.BEST_CHAIN, inbound2);
         assertEquals(coin1, wallet.getBalance());
@@ -1585,7 +1587,7 @@ public class WalletTest extends TestWithWallet {
         wallet.addWatchedAddress(watchedAddress);
         Coin value = valueOf(5, 0);
         Transaction t1 = createFakeTx(TESTNET, value, watchedAddress);
-        assertTrue(t1.getWalletOutputs(wallet).size() >= 1);
+        assertTrue(wallet.getWalletOutputs(t1).size() >= 1);
         assertTrue(wallet.isPendingTransactionRelevant(t1));
     }
 
@@ -1619,7 +1621,7 @@ public class WalletTest extends TestWithWallet {
         st2.addInput(t2.getOutput(0));
         sendMoneyToWallet(AbstractBlockChain.NewBlockType.BEST_CHAIN, st2);
         assertEquals(baseElements + 2, wallet.getBloomFilterElementCount());
-        assertEquals(CENT, st2.getValueSentFromMe(wallet));
+        assertEquals(CENT, wallet.getValueSentFromMe(st2));
     }
 
     @Test
@@ -2226,10 +2228,10 @@ public class WalletTest extends TestWithWallet {
         Transaction txCoin = sendMoneyToWallet(AbstractBlockChain.NewBlockType.BEST_CHAIN, COIN);
         assertEquals(COIN.add(CENT), wallet.getBalance());
 
-        assertTrue(txCent.getOutput(0).isMine(wallet));
+        assertTrue(wallet.isMine(txCent.getOutput(0)));
         assertTrue(txCent.getOutput(0).isAvailableForSpending());
         assertEquals(199, txCent.getConfidence().getDepthInBlocks());
-        assertTrue(txCoin.getOutput(0).isMine(wallet));
+        assertTrue(wallet.isMine(txCoin.getOutput(0)));
         assertTrue(txCoin.getOutput(0).isAvailableForSpending());
         assertEquals(1, txCoin.getConfidence().getDepthInBlocks());
         // txCent has higher coin*depth than txCoin...
@@ -2241,10 +2243,10 @@ public class WalletTest extends TestWithWallet {
         assertEquals(CENT, spend1.getInput(0).getValue());
 
         sendMoneyToWallet(AbstractBlockChain.NewBlockType.BEST_CHAIN);
-        assertTrue(txCent.getOutput(0).isMine(wallet));
+        assertTrue(wallet.isMine(txCent.getOutput(0)));
         assertTrue(txCent.getOutput(0).isAvailableForSpending());
         assertEquals(200, txCent.getConfidence().getDepthInBlocks());
-        assertTrue(txCoin.getOutput(0).isMine(wallet));
+        assertTrue(wallet.isMine(txCoin.getOutput(0)));
         assertTrue(txCoin.getOutput(0).isAvailableForSpending());
         assertEquals(2, txCoin.getConfidence().getDepthInBlocks());
         // Now txCent and txCoin have exactly the same coin*depth...
@@ -2256,10 +2258,10 @@ public class WalletTest extends TestWithWallet {
         assertEquals(COIN, spend2.getInput(0).getValue());
 
         sendMoneyToWallet(AbstractBlockChain.NewBlockType.BEST_CHAIN);
-        assertTrue(txCent.getOutput(0).isMine(wallet));
+        assertTrue(wallet.isMine(txCent.getOutput(0)));
         assertTrue(txCent.getOutput(0).isAvailableForSpending());
         assertEquals(201, txCent.getConfidence().getDepthInBlocks());
-        assertTrue(txCoin.getOutput(0).isMine(wallet));
+        assertTrue(wallet.isMine(txCoin.getOutput(0)));
         assertTrue(txCoin.getOutput(0).isAvailableForSpending());
         assertEquals(3, txCoin.getConfidence().getDepthInBlocks());
         // Now txCent has lower coin*depth than txCoin...
@@ -2888,8 +2890,8 @@ public class WalletTest extends TestWithWallet {
         Transaction tx = broadcaster.waitForTransactionAndSucceed();
         final Coin THREE_CENTS = CENT.add(CENT).add(CENT);
         assertEquals(Coin.valueOf(4910), tx.getFee());
-        assertEquals(THREE_CENTS, tx.getValueSentFromMe(wallet));
-        assertEquals(THREE_CENTS.subtract(tx.getFee()), tx.getValueSentToMe(wallet));
+        assertEquals(THREE_CENTS, wallet.getValueSentFromMe(tx));
+        assertEquals(THREE_CENTS.subtract(tx.getFee()), wallet.getValueSentToMe(tx));
         // TX sends to one of our addresses (for now we ignore married wallets).
         final Address toAddress = tx.getOutput(0).getScriptPubKey().getToAddress(TESTNET);
         final ECKey rotatingToKey = wallet.findKeyFromPubKeyHash(toAddress.getHash(), toAddress.getOutputScriptType());
@@ -2914,8 +2916,8 @@ public class WalletTest extends TestWithWallet {
         assertEquals(Coin.valueOf(1930), tx.getFee());
         assertEquals(1, tx.getInputs().size());
         assertEquals(1, tx.getOutputs().size());
-        assertEquals(CENT, tx.getValueSentFromMe(wallet));
-        assertEquals(CENT.subtract(tx.getFee()), tx.getValueSentToMe(wallet));
+        assertEquals(CENT, wallet.getValueSentFromMe(tx));
+        assertEquals(CENT.subtract(tx.getFee()), wallet.getValueSentToMe(tx));
 
         assertEquals(Transaction.Purpose.KEY_ROTATION, tx.getPurpose());
 
@@ -3010,8 +3012,8 @@ public class WalletTest extends TestWithWallet {
         wallet.doMaintenance(null, true);
 
         Transaction tx = broadcaster.waitForTransactionAndSucceed();
-        final Coin valueSentToMe = tx.getValueSentToMe(wallet);
-        Coin fee = tx.getValueSentFromMe(wallet).subtract(valueSentToMe);
+        final Coin valueSentToMe = wallet.getValueSentToMe(tx);
+        Coin fee = wallet.getValueSentFromMe(tx).subtract(valueSentToMe);
         assertEquals(Coin.valueOf(900000), fee);
         assertEquals(KeyTimeCoinSelector.MAX_SIMULTANEOUS_INPUTS, tx.getInputs().size());
         assertEquals(Coin.valueOf(599100000), valueSentToMe);

--- a/examples-kotlin/src/main/kotlin/org/bitcoinj/ForwardingService.kt
+++ b/examples-kotlin/src/main/kotlin/org/bitcoinj/ForwardingService.kt
@@ -95,7 +95,7 @@ class ForwardingService(val config: Config) : Closeable {
     private fun coinForwardingListener(wallet: Wallet, incomingTx: Transaction, prevBalance: Coin, newBalance: Coin) {
         // Incoming transaction received, now "compose" (i.e. chain) a call to wait for required confirmations
         // The transaction "incomingTx" can either be pending, or included into a block (we didn't see the broadcast).
-        val value = incomingTx.getValueSentToMe(wallet)
+        val value = wallet.getValueSentToMe(incomingTx)
         println("Received tx for ${value.toFriendlyString()} : $incomingTx \n")
         println("Transaction will be forwarded after it confirms.")
         println("Waiting for confirmation...")

--- a/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
@@ -136,7 +136,7 @@ public class ForwardingService implements Closeable {
     private void coinForwardingListener(Wallet wallet, Transaction incomingTx, Coin prevBalance, Coin newBalance) {
         // Incoming transaction received, now "compose" (i.e. chain) a call to wait for required confirmations
         // The transaction "incomingTx" can either be pending, or included into a block (we didn't see the broadcast).
-        Coin value = incomingTx.getValueSentToMe(wallet);
+        Coin value = wallet.getValueSentToMe(incomingTx);
         System.out.printf("Received tx for %s : %s\n", value.toFriendlyString(), incomingTx);
         System.out.println("Transaction will be forwarded after it confirms.");
         System.out.println("Waiting for confirmation...");

--- a/examples/src/main/java/org/bitcoinj/examples/Kit.java
+++ b/examples/src/main/java/org/bitcoinj/examples/Kit.java
@@ -56,7 +56,7 @@ public class Kit {
 
         kit.wallet().addCoinsReceivedEventListener((wallet, tx, prevBalance, newBalance) -> {
             System.out.println("-----> coins received: " + tx.getTxId());
-            System.out.println("received: " + tx.getValue(wallet));
+            System.out.println("received: " + wallet.getValue(tx));
         });
 
         kit.wallet().addCoinsSentEventListener((wallet, tx, prevBalance, newBalance) -> System.out.println("coins sent"));

--- a/integration-test/src/test/java/org/bitcoinj/core/FullPrunedBlockChainTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/FullPrunedBlockChainTest.java
@@ -366,7 +366,7 @@ public class FullPrunedBlockChainTest {
             assertEquals(1, wallet.getPoolSize(WalletTransaction.Pool.PENDING), "Wrong number of PENDING.4");
             Coin totalPendingTxAmount = Coin.ZERO;
             for (Transaction tx : wallet.getPendingTransactions()) {
-                totalPendingTxAmount = totalPendingTxAmount.add(tx.getValueSentToMe(wallet));
+                totalPendingTxAmount = totalPendingTxAmount.add(wallet.getValueSentToMe(tx));
             }
 
             // The available balance should be the 0 (as we spent the 1 BTC that's pending) and estimated should be 1/2 - fee BTC

--- a/integration-test/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
@@ -212,7 +212,7 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
         }
         assertNotNull(t1);
         // 49 BTC in change.
-        assertEquals(valueOf(49, 0), t1.getValueSentToMe(wallet));
+        assertEquals(valueOf(49, 0), wallet.getValueSentToMe(t1));
         // The future won't complete until it's heard back from the network on p2.
         InventoryMessage inv = InventoryMessage.ofTransactions(t1);
         inbound(p2, inv);


### PR DESCRIPTION
* Move methods from Transaction/TransactionOutput that take a wallet/TransactionBag parameter to TransactionBag
* Deprecated existing methods
* Update existing code to use new calls

This is a rebased and updated version of PR #2536.
