### PR TITLE
ECKey, DeterministicKey: use BC ECPoint internally, prepare to deprecate `LazyECPoint`

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -71,7 +71,16 @@ public class DeterministicKey extends ECKey {
                             LazyECPoint publicAsPoint,
                             @Nullable BigInteger priv,
                             @Nullable DeterministicKey parent) {
-        this(priv, publicAsPoint.compress(), parent == null ? 0 : parent.depth + 1, parent,
+        this(childNumberPath, chainCode, publicAsPoint.get(), priv, parent);
+    }
+
+    /** Constructs a key from its components. This is not normally something you should use. */
+    public DeterministicKey(HDPath.HDPartialPath childNumberPath,
+                            byte[] chainCode,
+                            ECPoint publicAsPoint,
+                            @Nullable BigInteger priv,
+                            @Nullable DeterministicKey parent) {
+        this(priv, publicAsPoint, parent == null ? 0 : parent.depth + 1, parent,
                 parent != null ? parent.getFingerprint() : 0, chainCode, childNumberPath, null, null);
     }
 
@@ -85,7 +94,8 @@ public class DeterministicKey extends ECKey {
                             boolean compressed,
                             @Nullable BigInteger priv,
                             @Nullable DeterministicKey parent) {
-        this(childNumberPath, chainCode, new LazyECPoint(publicAsPoint, compressed), priv, parent);
+        this(priv, publicAsPoint, parent == null ? 0 : parent.depth + 1, parent,
+                parent != null ? parent.getFingerprint() : 0, chainCode, childNumberPath, null, null);
     }
 
     /** Constructs a key from its components. This is not normally something you should use. */
@@ -93,7 +103,7 @@ public class DeterministicKey extends ECKey {
                             byte[] chainCode,
                             BigInteger priv,
                             @Nullable DeterministicKey parent) {
-        this(priv, new LazyECPoint(ECKey.publicBCPointFromPrivate(priv), true), parent == null ? 0 : parent.depth + 1,
+        this(priv, ECKey.publicBCPointFromPrivate(priv), parent == null ? 0 : parent.depth + 1,
                 parent, parent != null ? parent.getFingerprint() : 0, chainCode, hdPath, null, null);
     }
 
@@ -104,7 +114,17 @@ public class DeterministicKey extends ECKey {
                             LazyECPoint pub,
                             EncryptedData encryptedPrivateKey,
                             @Nullable DeterministicKey parent) {
-        this(null, pub.compress(), parent == null ? 0 : parent.depth + 1, parent,
+        this(childNumberPath, chainCode, crypter, pub.get(), encryptedPrivateKey, parent);
+    }
+
+    /** Constructs a key from its components. This is not normally something you should use. */
+    public DeterministicKey(HDPath.HDPartialPath childNumberPath,
+                            byte[] chainCode,
+                            KeyCrypter crypter,
+                            ECPoint pub,
+                            EncryptedData encryptedPrivateKey,
+                            @Nullable DeterministicKey parent) {
+        this(null, pub, parent == null ? 0 : parent.depth + 1, parent,
                 parent != null ? parent.getFingerprint() : 0, chainCode, childNumberPath,
                 Objects.requireNonNull(encryptedPrivateKey), Objects.requireNonNull(crypter));
     }
@@ -134,7 +154,22 @@ public class DeterministicKey extends ECKey {
                             @Nullable DeterministicKey parent,
                             int depth,
                             int parentFingerprint) {
-        this(null, publicAsPoint.compress(), depth, parent, parentFingerprint, chainCode, childNumberPath,
+        this(null, publicAsPoint.get(), depth, parent, parentFingerprint, chainCode, childNumberPath,
+                null, null);
+    }
+
+    /**
+     * Constructs a key from its components, including its public key data and possibly-redundant
+     * information about its parent key.  Invoked when deserializing, but otherwise not something that
+     * you normally should use.
+     */
+    public DeterministicKey(HDPath childNumberPath,
+                            byte[] chainCode,
+                            ECPoint publicAsPoint,
+                            @Nullable DeterministicKey parent,
+                            int depth,
+                            int parentFingerprint) {
+        this(null, publicAsPoint, depth, parent, parentFingerprint, chainCode, childNumberPath,
                 null, null);
     }
 
@@ -149,14 +184,14 @@ public class DeterministicKey extends ECKey {
                             @Nullable DeterministicKey parent,
                             int depth,
                             int parentFingerprint) {
-        this(priv, new LazyECPoint(ECKey.publicBCPointFromPrivate(priv), true), depth, parent, parentFingerprint,
+        this(priv, ECKey.publicBCPointFromPrivate(priv), depth, parent, parentFingerprint,
                 chainCode, childNumberPath, null, null);
     }
 
     /** @deprecated use {@link #withParent(DeterministicKey)} */
     @Deprecated
     public DeterministicKey(DeterministicKey keyToClone, DeterministicKey newParent) {
-        this(keyToClone.priv, keyToClone.pub, keyToClone.childNumberPath.size(), newParent,
+        this(keyToClone.priv, keyToClone.getPubKeyPoint(), keyToClone.childNumberPath.size(), newParent,
                 newParent.getFingerprint(), keyToClone.chainCode, keyToClone.childNumberPath, null, null);
     }
 
@@ -177,11 +212,10 @@ public class DeterministicKey extends ECKey {
      * @param encryptedPrivateKey private key in encrypted form
      * @param keyCrypter          crypter to use for decrypting the private key
      */
-    private DeterministicKey(@Nullable BigInteger priv, LazyECPoint pub, int depth, @Nullable DeterministicKey parent,
+    private DeterministicKey(@Nullable BigInteger priv, ECPoint pub, int depth, @Nullable DeterministicKey parent,
                              int parentFingerprint, byte[] chainCode, HDPath hdPath,
                              @Nullable EncryptedData encryptedPrivateKey, @Nullable KeyCrypter keyCrypter) {
         super(priv, pub);
-        checkArgument(pub.isCompressedInternal(), () -> "pub must be compressed");
         checkArgument(chainCode.length == 32);
         checkArgument(priv == null || encryptedPrivateKey == null, () ->
                 "priv and encryptedPrivateKey can't be set together");
@@ -301,7 +335,7 @@ public class DeterministicKey extends ECKey {
     public DeterministicKey withoutPrivateKey() {
         return priv == null && encryptedPrivateKey == null && keyCrypter == null ?
                 this :
-                new DeterministicKey(null, pub, depth, parent, parentFingerprint, chainCode, childNumberPath,
+                new DeterministicKey(null, getPubKeyPoint(), depth, parent, parentFingerprint, chainCode, childNumberPath,
                         null, null);
     }
 
@@ -320,7 +354,7 @@ public class DeterministicKey extends ECKey {
      */
     public DeterministicKey withParent(DeterministicKey parent) {
         Objects.requireNonNull(parent);
-        return new DeterministicKey(this.priv, this.pub, parent.getDepth() + 1, parent, parent.getFingerprint(),
+        return new DeterministicKey(this.priv, getPubKeyPoint(), parent.getDepth() + 1, parent, parent.getFingerprint(),
                 this.chainCode, this.childNumberPath, this.encryptedPrivateKey, this.keyCrypter);
     }
 
@@ -335,7 +369,7 @@ public class DeterministicKey extends ECKey {
      * @return this key without parent pointer
      */
     public DeterministicKey withoutParent() {
-        return new DeterministicKey(priv, pub, depth, null, parentFingerprint, chainCode, childNumberPath,
+        return new DeterministicKey(priv, getPubKeyPoint(), depth, null, parentFingerprint, chainCode, childNumberPath,
                 encryptedPrivateKey, keyCrypter);
     }
 
@@ -367,7 +401,7 @@ public class DeterministicKey extends ECKey {
         final byte[] privKeyBytes = getPrivKeyBytes();
         checkState(privKeyBytes != null, () -> "Private key is not available");
         EncryptedData encryptedPrivateKey = keyCrypter.encrypt(privKeyBytes, aesKey);
-        DeterministicKey key = new DeterministicKey(childNumberPath, chainCode, keyCrypter, pub, encryptedPrivateKey, newParent);
+        DeterministicKey key = new DeterministicKey(childNumberPath, chainCode, keyCrypter, getPubKeyPoint(), encryptedPrivateKey, newParent);
         if (newParent == null) {
             Optional<Instant> creationTime = this.getCreationTime();
             if (creationTime.isPresent())
@@ -509,7 +543,7 @@ public class DeterministicKey extends ECKey {
 
     private BigInteger derivePrivateKeyDownwards(DeterministicKey cursor, byte[] parentalPrivateKeyBytes) {
         DeterministicKey downCursor = new DeterministicKey(cursor.childNumberPath, cursor.chainCode,
-                cursor.pub, ByteUtils.bytesToBigInteger(parentalPrivateKeyBytes), cursor.parent);
+                cursor.getPubKeyPoint(), ByteUtils.bytesToBigInteger(parentalPrivateKeyBytes), cursor.parent);
         // Now we have to re-derive the keys along the path back to ourselves. That path can be found by just truncating
         // our path with the length of the parent's path.
         List<ChildNumber> path = childNumberPath.list().subList(cursor.getPath().size(), childNumberPath.size());
@@ -519,7 +553,7 @@ public class DeterministicKey extends ECKey {
         // downCursor is now the same key as us, but with private key bytes.
         // If it's not, it means we tried decrypting with an invalid password and earlier checks e.g. for padding didn't
         // catch it.
-        if (!downCursor.pub.equals(pub))
+        if (!downCursor.getPubKeyPoint().equals(getPubKeyPoint()))
             throw new KeyCrypterException.PublicPrivateMismatch("Could not decrypt bytes");
         return Objects.requireNonNull(downCursor.priv);
     }
@@ -685,7 +719,7 @@ public class DeterministicKey extends ECKey {
         checkArgument(!buffer.hasRemaining(), () ->
                 "found unexpected data in key");
         if (pub) {
-            return new DeterministicKey(path, chainCode, new LazyECPoint(data), parent, depth, parentFingerprint);
+            return new DeterministicKey(path, chainCode, ECKey.parseToBCPoint(data), parent, depth, parentFingerprint);
         } else {
             return new DeterministicKey(path, chainCode, ByteUtils.bytesToBigInteger(data), parent, depth, parentFingerprint);
         }
@@ -751,7 +785,7 @@ public class DeterministicKey extends ECKey {
     @Override
     public String toString() {
         final MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this).omitNullValues();
-        helper.add("pub", ByteUtils.formatHex(pub.getEncoded()));
+        helper.add("pub", ByteUtils.formatHex(getPubKeyPoint().getEncoded(true)));
         helper.add("chainCode", ByteUtils.formatHex(chainCode));
         helper.add("path", getPathAsString());
         helper.add("depth", depth);

--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -158,7 +158,8 @@ public class ECKey implements EncryptableItem {
 
     // The two parts of the key. If "pub" is set but not "priv", we can only verify signatures, not make them.
     @Nullable protected final BigInteger priv;  // A field element.
-    protected final LazyECPoint pub;
+    private final ECPoint bcPoint;
+    private final boolean compressed;
 
     // Creation time of the key, or null if the key was deserialized from a version that did
     // not have this field.
@@ -216,15 +217,18 @@ public class ECKey implements EncryptableItem {
         ECPrivateKeyParameters privParams = (ECPrivateKeyParameters) keypair.getPrivate();
         ECPublicKeyParameters pubParams = (ECPublicKeyParameters) keypair.getPublic();
         priv = privParams.getD();
-        pub = new LazyECPoint(pubParams.getQ(), true);
+        bcPoint = pubParams.getQ();
+        compressed = true;
         creationTime = TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS);
     }
 
+    /**
+     * Canonical ECKey constructor
+     * @param priv optional private key
+     * @param pub public key point
+     * @param compressed compression state
+     */
     private ECKey(@Nullable BigInteger priv, ECPoint pub, boolean compressed) {
-        this(priv, new LazyECPoint(Objects.requireNonNull(pub), compressed));
-    }
-
-    protected ECKey(@Nullable BigInteger priv, LazyECPoint pub) {
         if (priv != null) {
             checkArgument(priv.bitLength() <= 32 * 8, () ->
                     "private key exceeds 32 bytes: " + priv.bitLength() + " bits");
@@ -235,7 +239,12 @@ public class ECKey implements EncryptableItem {
             checkArgument(!priv.equals(BigInteger.ONE));
         }
         this.priv = priv;
-        this.pub = Objects.requireNonNull(pub);
+        this.bcPoint = pub;
+        this.compressed = compressed;
+    }
+
+    protected ECKey(@Nullable BigInteger priv, ECPoint pub) {
+        this(priv, Objects.requireNonNull(pub), true);
     }
 
     /**
@@ -260,7 +269,7 @@ public class ECKey implements EncryptableItem {
      */
     public static ECKey fromPrivate(BigInteger privKey, boolean compressed) {
         ECPoint point = publicBCPointFromPrivate(privKey);
-        return new ECKey(privKey, new LazyECPoint(point, compressed));
+        return new ECKey(privKey, point, compressed);
     }
 
     /**
@@ -297,7 +306,7 @@ public class ECKey implements EncryptableItem {
     public static ECKey fromPrivateAndPrecalculatedPublic(byte[] priv, byte[] pub) {
         Objects.requireNonNull(priv);
         Objects.requireNonNull(pub);
-        return new ECKey(ByteUtils.bytesToBigInteger(priv), new LazyECPoint(pub));
+        return new ECKey(ByteUtils.bytesToBigInteger(priv), parseToBCPoint(pub), isPubKeyCompressed(pub));
     }
 
     /**
@@ -313,7 +322,7 @@ public class ECKey implements EncryptableItem {
      * The compression state of pub will be preserved.
      */
     public static ECKey fromPublicOnly(byte[] pub) {
-        return new ECKey(null, new LazyECPoint(pub));
+        return new ECKey(null, parseToBCPoint(pub), isPubKeyCompressed(pub));
     }
 
     public static ECKey fromPublicOnly(ECKey key) {
@@ -325,10 +334,10 @@ public class ECKey implements EncryptableItem {
      * never need this: it's for specialized scenarios or when backwards compatibility in encoded form is necessary.
      */
     public ECKey decompress() {
-        if (!pub.isCompressedInternal())
+        if (!compressed)
             return this;
         else
-            return new ECKey(priv, new LazyECPoint(pub.get(), false));
+            return new ECKey(priv, bcPoint, false);
     }
 
     /**
@@ -341,6 +350,15 @@ public class ECKey implements EncryptableItem {
         key.encryptedPrivateKey = Objects.requireNonNull(encryptedPrivateKey);
         key.keyCrypter = Objects.requireNonNull(crypter);
         return key;
+    }
+
+    /**
+     * Parse a serialized public key. For internal use only.
+     * @param pub serialized public key bytes
+     * @return A Bouncy Castle ECPoint
+     */
+    public static ECPoint parseToBCPoint(byte[] pub) {
+        return CURVE.getCurve().decodePoint(pub);
     }
 
     /**
@@ -429,7 +447,7 @@ public class ECKey implements EncryptableItem {
     /** Gets the hash160 form of the public key (as seen in addresses). */
     public byte[] getPubKeyHash() {
         if (pubKeyHash == null)
-            pubKeyHash = CryptoUtils.sha256hash160(this.pub.getEncoded());
+            pubKeyHash = CryptoUtils.sha256hash160(this.bcPoint.getEncoded(compressed));
         return pubKeyHash;
     }
 
@@ -438,12 +456,12 @@ public class ECKey implements EncryptableItem {
      * as the pubKeyHash/address.
      */
     public byte[] getPubKey() {
-        return pub.getEncoded();
+        return bcPoint.getEncoded(compressed);
     }
 
     /** Gets the public key in the form of an elliptic curve point object from Bouncy Castle. */
     public ECPoint getPubKeyPoint() {
-        return pub.get();
+        return bcPoint;
     }
 
     /**
@@ -462,7 +480,7 @@ public class ECKey implements EncryptableItem {
      * Returns whether this key is using the compressed form or not. Compressed pubkeys are only 33 bytes, not 64.
      */
     public boolean isCompressed() {
-        return pub.isCompressedInternal();
+        return compressed;
     }
 
     /**
@@ -962,7 +980,7 @@ public class ECKey implements EncryptableItem {
     @Deprecated
     public void verifyMessage(String message, String signatureBase64) throws SignatureException {
         ECKey key = ECKey.signedMessageToKey(message, signatureBase64);
-        if (!key.pub.equals(pub))
+        if (!(key.bcPoint.equals(bcPoint) && key.compressed == compressed))
             throw new SignatureException("Signature did not match for message");
     }
 
@@ -976,7 +994,7 @@ public class ECKey implements EncryptableItem {
         byte recId = -1;
         for (byte i = 0; i < 4; i++) {
             ECKey k = ECKey.recoverFromSignature(i, sig, hash, isCompressed());
-            if (k != null && k.pub.equals(pub)) {
+            if (k != null && k.bcPoint.equals(bcPoint) && k.compressed == compressed) {
                 recId = i;
                 break;
             }
@@ -1299,7 +1317,7 @@ public class ECKey implements EncryptableItem {
         if (o == null || !(o instanceof ECKey)) return false;
         ECKey other = (ECKey) o;
         return Objects.equals(this.priv, other.priv)
-                && Objects.equals(this.pub, other.pub)
+                && Objects.equals(this.bcPoint, other.bcPoint)
                 && Objects.equals(this.creationTime, other.creationTime)
                 && Objects.equals(this.keyCrypter, other.keyCrypter)
                 && Objects.equals(this.encryptedPrivateKey, other.encryptedPrivateKey);
@@ -1307,7 +1325,7 @@ public class ECKey implements EncryptableItem {
 
     @Override
     public int hashCode() {
-        return pub.hashCode();
+        return Arrays.hashCode(bcPoint.getEncoded(true));   // hashcode of "canonical encoding"
     }
 
     @Override
@@ -1328,7 +1346,7 @@ public class ECKey implements EncryptableItem {
     }
 
     public String getPublicKeyAsHex() {
-        return ByteUtils.formatHex(pub.getEncoded());
+        return ByteUtils.formatHex(bcPoint.getEncoded(compressed));
     }
 
 

--- a/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
@@ -93,7 +93,7 @@ public final class HDKeyDerivation {
     }
 
     public static DeterministicKey createMasterPubKeyFromBytes(byte[] pubKeyBytes, byte[] chainCode) {
-        return new DeterministicKey(HDPath.partial(), chainCode, new LazyECPoint(pubKeyBytes), null, null);
+        return new DeterministicKey(HDPath.partial(), chainCode, ECKey.parseToBCPoint(pubKeyBytes), null, null);
     }
 
     /**
@@ -193,7 +193,7 @@ public final class HDKeyDerivation {
             PublicDeriveMode mode) throws HDDerivationException {
         RawKeyBytes rawKey = deriveChildKeyBytesFromPublic(parent, childNumber, PublicDeriveMode.NORMAL);
         return new DeterministicKey(parent.getPath().extend(childNumber), rawKey.chainCode,
-                new LazyECPoint(rawKey.keyBytes), null, parent);
+                ECKey.parseToBCPoint(rawKey.keyBytes), null, parent);
     }
 
     public static RawKeyBytes deriveChildKeyBytesFromPublic(DeterministicKey parent, ChildNumber childNumber, PublicDeriveMode mode) throws HDDerivationException {

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -37,13 +37,13 @@ import org.bitcoinj.crypto.HDPath;
 import org.bitcoinj.crypto.KeyCrypter;
 import org.bitcoinj.crypto.KeyCrypterException;
 import org.bitcoinj.crypto.KeyCrypterScrypt;
-import org.bitcoinj.crypto.LazyECPoint;
 import org.bitcoinj.crypto.MnemonicCode;
 import org.bitcoinj.script.Script;
 import org.bitcoinj.utils.ListenerRegistration;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.listeners.KeyChainEventListener;
 import org.bitcoinj.protobuf.wallet.Protos;
+import org.bouncycastle.math.ec.ECPoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -903,7 +903,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
                     throw new UnreadableWalletException("Deterministic key missing extra data: " + key);
                 byte[] chainCode = key.getDeterministicKey().getChainCode().toByteArray();
                 // Deserialize the public key and path.
-                LazyECPoint pubkey = new LazyECPoint(key.getPublicKey().toByteArray());
+                ECPoint pubkey = ECKey.parseToBCPoint(key.getPublicKey().toByteArray());
                 // Deserialize the path through the tree.
                 final HDPath.HDPartialPath path = HDPath.deserialize(key.getDeterministicKey().getPathList());
                 if (key.hasOutputScriptType())

--- a/core/src/test/java/org/bitcoinj/crypto/LazyECPointTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/LazyECPointTest.java
@@ -17,7 +17,7 @@ public class LazyECPointTest {
 
     @Test
     public void convertRandomPoint() {
-        LazyECPoint p1 = ECKey.random().pub;
+        LazyECPoint p1 = new LazyECPoint(ECKey.random().getPubKeyPoint(), true);
         LazyECPoint p2 = new LazyECPoint(p1.getW());  // Round-trip conversion Bouncy -> JCA -> Bouncy
         assertNotNull(p2);
         assertEquals(p1, p2);


### PR DESCRIPTION
This is a draft/proof-of-concept, but I think it is pretty close to being ready. So preliminary reviews are welcome.

All use of `LazyECPoint` can now be deprecated. We should also remove the `ECPublicKey` superclass we added to `LazyECPoint` since that was never released and add it to ECKey.

This (when finalized) will supersede:

* PR #4278 
* PR #3756
