### PR TITLE
ECKey: remove deprecated message signing/verification methods

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -30,7 +30,6 @@ import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.base.VarInt;
 import org.bitcoinj.crypto.internal.CryptoUtils;
-import org.bitcoinj.crypto.utils.MessageVerifyUtils;
 import org.bitcoinj.wallet.Wallet;
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1Integer;
@@ -804,35 +803,9 @@ public class ECKey implements EncryptableItem {
      *
      * @throws IllegalStateException if this ECKey does not have the private part.
      * @throws KeyCrypterException if this ECKey is encrypted and no AESKey is provided or it does not decrypt the ECKey.
-     * @deprecated use {@link #signMessage(String, ScriptType)} instead and specify the correct script type
-     */
-    @Deprecated
-    public String signMessage(String message) throws KeyCrypterException {
-        return signMessage(message, null, ScriptType.P2PKH);
-    }
-
-    /**
-     * Signs a text message using the standard Bitcoin messaging signing format and returns the signature as a base64
-     * encoded string.
-     *
-     * @throws IllegalStateException if this ECKey does not have the private part.
-     * @throws KeyCrypterException if this ECKey is encrypted and no AESKey is provided or it does not decrypt the ECKey.
      */
     public String signMessage(String message, ScriptType scriptType) throws KeyCrypterException {
         return signMessage(message, null, scriptType);
-    }
-
-    /**
-     * Signs a text message using the standard Bitcoin messaging signing format and returns the signature as a base64
-     * encoded string.
-     *
-     * @throws IllegalStateException if this ECKey does not have the private part.
-     * @throws KeyCrypterException if this ECKey is encrypted and no AESKey is provided or it does not decrypt the ECKey.
-     * @deprecated use {@link #signMessage(String, AesKey, ScriptType)} instead and specify the correct script type
-     */
-    @Deprecated
-    public String signMessage(String message, @Nullable AesKey aesKey) throws KeyCrypterException {
-        return signMessage(message, aesKey, ScriptType.P2PKH);
     }
 
     /**
@@ -950,20 +923,6 @@ public class ECKey implements EncryptableItem {
         if (key == null)
             throw new SignatureException("Could not recover public key from signature");
         return key;
-    }
-
-    /**
-     * Convenience wrapper around {@link ECKey#signedMessageToKey(String, String)}. If the key derived from the
-     * signature is not the same as this one, throws a SignatureException.
-     * @deprecated Use {@link MessageVerifyUtils#verifyMessage(Address, String, String)} instead,
-     * which works with different address types, which works also with legacy segwit (P2SH-P2WPKH, 3…)
-     * and native segwit addresses (P2WPKH, bc1…).
-     */
-    @Deprecated
-    public void verifyMessage(String message, String signatureBase64) throws SignatureException {
-        ECKey key = ECKey.signedMessageToKey(message, signatureBase64);
-        if (!key.pub.equals(pub))
-            throw new SignatureException("Signature did not match for message");
     }
 
     /**

--- a/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
@@ -29,6 +29,7 @@ import org.bitcoinj.crypto.ECKey.ECDSASignature;
 import org.bitcoinj.crypto.internal.CryptoUtils;
 import org.bitcoinj.base.internal.FutureUtils;
 import org.bitcoinj.crypto.secp.Secp256k1Constants;
+import org.bitcoinj.crypto.utils.MessageVerifyUtils;
 import org.jspecify.annotations.Nullable;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -259,13 +260,14 @@ public class ECKeyTest {
     @Test
     public void signTextMessage() throws Exception {
         ECKey key = ECKey.random();
+        Address address = key.toAddress(ScriptType.P2PKH, MAINNET);
         String message = "聡中本";
-        String signatureBase64 = key.signMessage(message);
-        log.info("Message signed with " + key.toAddress(ScriptType.P2PKH, MAINNET) + ": " + signatureBase64);
+        String signatureBase64 = key.signMessage(message, address.getOutputScriptType());
+        log.info("Message signed with " + address + ": " + signatureBase64);
         // Should verify correctly.
-        key.verifyMessage(message, signatureBase64);
+        MessageVerifyUtils.verifyMessage(address, message, signatureBase64);
         try {
-            key.verifyMessage("Evil attacker says hello!", signatureBase64);
+            MessageVerifyUtils.verifyMessage(address, "Evil attacker says hello!", signatureBase64);
             fail();
         } catch (SignatureException e) {
             // OK.

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -31,6 +31,7 @@ import org.bitcoinj.crypto.ChildNumber;
 import org.bitcoinj.crypto.DeterministicKey;
 import org.bitcoinj.crypto.HDKeyDerivation;
 import org.bitcoinj.crypto.HDPath;
+import org.bitcoinj.crypto.utils.MessageVerifyUtils;
 import org.bitcoinj.utils.BriefLogFormatter;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.listeners.AbstractKeyChainEventListener;
@@ -176,7 +177,8 @@ public class DeterministicKeyChainTest {
     @Test
     public void signMessage() throws Exception {
         ECKey key = chain.getKey(KeyChain.KeyPurpose.RECEIVE_FUNDS);
-        key.verifyMessage("test", key.signMessage("test"));
+        Address address = key.toAddress(chain.getOutputScriptType(), TESTNET);
+        MessageVerifyUtils.verifyMessage(address, "test", key.signMessage("test", address.getOutputScriptType()));
     }
 
     @Test


### PR DESCRIPTION
The changes to the unit tests make them a little more flexible (e.g. they could be modified to us a parameterized output ScriptType.)

cc: @johnzweng (who deprecated the methods a few years back)