### PR TITLE
ECKeyTest: use assertions in checkSomeBytesAreNonZero(), other code cleanup

### DIFF
--- a/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
@@ -508,7 +508,8 @@ public class ECKeyTest {
         assertNull(unencryptedKey.getEncryptedPrivateKey());
 
         assertNull(encryptedKey.getSecretBytes());
-        checkSomeBytesAreNonZero(Objects.requireNonNull(encryptedKey.getEncryptedPrivateKey()).encryptedBytes);
+        assertNotNull(encryptedKey.getEncryptedPrivateKey());
+        checkSomeBytesAreNonZero(encryptedKey.getEncryptedPrivateKey().encryptedBytes);
         checkSomeBytesAreNonZero(encryptedKey.getEncryptedPrivateKey().initialisationVector);
     }
 

--- a/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
@@ -223,7 +223,7 @@ public class ECKeyTest {
         Address address = key.toAddress(ScriptType.P2WPKH, TESTNET);
 
         assertTrue(address instanceof SegwitAddress);
-        assertEquals(((SegwitAddress) address).getWitnessVersion(), 0);
+        assertEquals(0, ((SegwitAddress) address).getWitnessVersion());
         assertEquals(addr, address.toString());
     }
 
@@ -240,7 +240,7 @@ public class ECKeyTest {
         Address address = key.toAddress(ScriptType.P2TR, TESTNET);
 
         assertTrue(address instanceof SegwitAddress);
-        assertEquals(((SegwitAddress) address).getWitnessVersion(), 1);
+        assertEquals(1, ((SegwitAddress) address).getWitnessVersion());
         assertEquals(addr, address.toString());
     }
 
@@ -351,7 +351,7 @@ public class ECKeyTest {
 
         byte recId = key.findRecoveryId(hash, sig);
         byte expectedRecId = 0;
-        assertEquals(recId, expectedRecId);
+        assertEquals(expectedRecId, recId);
 
         ECKey pubKey = ECKey.fromPublicOnly(key);
         ECKey recoveredKey = ECKey.recoverFromSignature(recId, sig, hash, true);

--- a/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
@@ -500,11 +500,11 @@ public class ECKeyTest {
     @Test
     public void clear() {
         ECKey unencryptedKey = ECKey.random();
-        ECKey encryptedKey = ECKey.random().encrypt(keyCrypter, keyCrypter.deriveKey(PASSWORD1));
 
         checkSomeBytesAreNonZero(unencryptedKey.getPrivKeyBytes());
-
         assertNull(unencryptedKey.getEncryptedPrivateKey());
+
+        ECKey encryptedKey = ECKey.random().encrypt(keyCrypter, keyCrypter.deriveKey(PASSWORD1));
 
         assertNull(encryptedKey.getSecretBytes());
         assertNotNull(encryptedKey.getEncryptedPrivateKey());

--- a/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
@@ -76,8 +76,8 @@ public class ECKeyTest {
     private KeyCrypter keyCrypter;
 
     private static final int SCRYPT_ITERATIONS = 256;
-    private static CharSequence PASSWORD1 = "my hovercraft has eels";
-    private static CharSequence WRONG_PASSWORD = "it is a snowy day today";
+    private static final CharSequence PASSWORD1 = "my hovercraft has eels";
+    private static final CharSequence WRONG_PASSWORD = "it is a snowy day today";
 
     @Before
     public void setUp() {

--- a/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
@@ -506,7 +506,7 @@ public class ECKeyTest {
         // The encryptedPrivateKey should be null in an unencrypted ECKey anyhow but check all the same.
         assertNull(unencryptedKey.getEncryptedPrivateKey());
 
-        checkSomeBytesAreNonZero(encryptedKey.getSecretBytes());
+        assertNull(encryptedKey.getSecretBytes());
         checkSomeBytesAreNonZero(Objects.requireNonNull(encryptedKey.getEncryptedPrivateKey()).encryptedBytes);
         checkSomeBytesAreNonZero(encryptedKey.getEncryptedPrivateKey().initialisationVector);
     }

--- a/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
@@ -60,6 +60,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -599,10 +600,10 @@ public class ECKeyTest {
         ECKey.isPubKeyCompressed(ByteUtils.parseHex("0438746c59d46d5408bf8b1d0af5740fe1a6e1703fcb56b2953f0b965c740d256f"));
     }
 
-    private static boolean checkSomeBytesAreNonZero(byte @Nullable[] bytes) {
-        if (bytes == null) return false;
-        for (byte b : bytes) if (b != 0) return true;
-        return false;
+    private static void checkSomeBytesAreNonZero(byte[] bytes) {
+        assertNotNull(bytes);
+        for (byte b : bytes) if (b != 0) return;
+        fail("Expected non-zero bytes");
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
@@ -17,6 +17,8 @@
 
 package org.bitcoinj.crypto;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.bitcoinj.base.Address;
 import org.bitcoinj.base.LegacyAddress;
 import org.bitcoinj.base.ScriptType;
@@ -517,19 +519,8 @@ public class ECKeyTest {
         // Tests the canonical sigs from Bitcoin Core unit tests
         InputStream in = getClass().getResourceAsStream("sig_canonical.json");
 
-        // Poor man's JSON parser (because pulling in a lib for this is overkill)
-        while (in.available() > 0) {
-            while (in.available() > 0 && in.read() != '"') ;
-            if (in.available() < 1)
-                break;
-
-            StringBuilder sig = new StringBuilder();
-            int c;
-            while (in.available() > 0 && (c = in.read()) != '"')
-                sig.append((char)c);
-
-            assertTrue(TransactionSignature.isEncodingCanonical(ByteUtils.parseHex(sig.toString())));
-        }
+        List<String> list = new ObjectMapper().readValue(in, new TypeReference<List<String>>() {});
+        list.forEach(sig -> assertTrue(TransactionSignature.isEncodingCanonical(ByteUtils.parseHex(sig))));
         in.close();
     }
 
@@ -538,24 +529,15 @@ public class ECKeyTest {
         // Tests the noncanonical sigs from Bitcoin Core unit tests
         InputStream in = getClass().getResourceAsStream("sig_noncanonical.json");
 
-        // Poor man's JSON parser (because pulling in a lib for this is overkill)
-        while (in.available() > 0) {
-            while (in.available() > 0 && in.read() != '"') ;
-            if (in.available() < 1)
-                break;
-
-            StringBuilder sig = new StringBuilder();
-            int c;
-            while (in.available() > 0 && (c = in.read()) != '"')
-                sig.append((char)c);
-
+        List<String> list = new ObjectMapper().readValue(in, new TypeReference<List<String>>() {});
+        list.forEach(sig -> {
             try {
-                final String sigStr = sig.toString();
-                assertFalse(TransactionSignature.isEncodingCanonical(ByteUtils.parseHex(sigStr)));
+                byte[] sigBytes = ByteUtils.parseHex(sig);
+                assertFalse(TransactionSignature.isEncodingCanonical(sigBytes));
             } catch (IllegalArgumentException e) {
-                // Expected for non-hex strings in the JSON that we should ignore
+                // Expected from `parseHex()` for non-hex strings in the JSON that we should ignore
             }
-        }
+        });
         in.close();
     }
 

--- a/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
@@ -504,7 +504,6 @@ public class ECKeyTest {
 
         checkSomeBytesAreNonZero(unencryptedKey.getPrivKeyBytes());
 
-        // The encryptedPrivateKey should be null in an unencrypted ECKey anyhow but check all the same.
         assertNull(unencryptedKey.getEncryptedPrivateKey());
 
         assertNull(encryptedKey.getSecretBytes());

--- a/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
@@ -517,28 +517,28 @@ public class ECKeyTest {
     @Test
     public void testCanonicalSigs() throws Exception {
         // Tests the canonical sigs from Bitcoin Core unit tests
-        InputStream in = getClass().getResourceAsStream("sig_canonical.json");
-
-        List<String> list = new ObjectMapper().readValue(in, new TypeReference<List<String>>() {});
-        list.forEach(sig -> assertTrue(TransactionSignature.isEncodingCanonical(ByteUtils.parseHex(sig))));
-        in.close();
+        try (InputStream in = getClass().getResourceAsStream("sig_canonical.json")) {
+            List<String> list = new ObjectMapper().readValue(in, new TypeReference<List<String>>() {
+            });
+            list.forEach(sig -> assertTrue(TransactionSignature.isEncodingCanonical(ByteUtils.parseHex(sig))));
+        }
     }
 
     @Test
     public void testNonCanonicalSigs() throws Exception {
         // Tests the noncanonical sigs from Bitcoin Core unit tests
-        InputStream in = getClass().getResourceAsStream("sig_noncanonical.json");
-
-        List<String> list = new ObjectMapper().readValue(in, new TypeReference<List<String>>() {});
-        list.forEach(sig -> {
-            try {
-                byte[] sigBytes = ByteUtils.parseHex(sig);
-                assertFalse(TransactionSignature.isEncodingCanonical(sigBytes));
-            } catch (IllegalArgumentException e) {
-                // Expected from `parseHex()` for non-hex strings in the JSON that we should ignore
-            }
-        });
-        in.close();
+        try (InputStream in = getClass().getResourceAsStream("sig_noncanonical.json")) {
+            List<String> list = new ObjectMapper().readValue(in, new TypeReference<List<String>>() {
+            });
+            list.forEach(sig -> {
+                try {
+                    byte[] sigBytes = ByteUtils.parseHex(sig);
+                    assertFalse(TransactionSignature.isEncodingCanonical(sigBytes));
+                } catch (IllegalArgumentException e) {
+                    // Expected from `parseHex()` for non-hex strings in the JSON that we should ignore
+                }
+            });
+        }
     }
 
     @Test


### PR DESCRIPTION
9 commits that fall into roughly 3 categories:

1. Fix `checkSomeBytesAreNonZero` so it fails tests when the check fails (its boolean result was being ignored)
2. Use Jackson instead of "Poor Man's JSON Parser" for reading some .json files
3. Miscellaneous test cleanup (mostly driven by IDE suggestions)

See the individual commits for details.
