### PR TITLE
ECKey: implement ECPublicKey, drop implementation from LazyECPoint 

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -751,7 +751,7 @@ public class DeterministicKey extends ECKey {
     @Override
     public String toString() {
         final MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this).omitNullValues();
-        helper.add("pub", ByteUtils.formatHex(pub.getEncoded()));
+        helper.add("pub", ByteUtils.formatHex(getEncoded()));
         helper.add("chainCode", ByteUtils.formatHex(chainCode));
         helper.add("path", getPathAsString());
         helper.add("depth", depth);

--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -425,6 +425,30 @@ public class ECKey implements EncryptableItem {
         return new FixedPointCombMultiplier().multiply(CURVE.getG(), privKey);
     }
 
+    /**
+     * Convert a Bouncy Castle ECPoint to a Java Cryptography ECPoint. For internal use only.
+     * @param bcPoint A Bouncy Castle ECPoint
+     * @return a Java Cryptography ECPoint
+     */
+    static java.security.spec.ECPoint toJCPoint(ECPoint bcPoint) {
+        return bcPoint.isInfinity()
+                ? java.security.spec.ECPoint.POINT_INFINITY
+                : new java.security.spec.ECPoint(
+                    bcPoint.normalize().getAffineXCoord().toBigInteger(),
+                    bcPoint.normalize().getAffineYCoord().toBigInteger());
+    }
+
+    /**
+     * Convert a Java Cryptography ECPoint to a Bouncy Castle ECPoint. For internal use only.
+     * @param jcPoint a Java Cryptography ECPoint
+     * @return a Bouncy Castle ECPoint
+     */
+    static ECPoint toBCPoint(java.security.spec.ECPoint jcPoint) {
+        return jcPoint == java.security.spec.ECPoint.POINT_INFINITY
+                ? CURVE.getCurve().getInfinity()
+                : CURVE.getCurve().createPoint(jcPoint.getAffineX(), jcPoint.getAffineY());
+    }
+
     /** Gets the hash160 form of the public key (as seen in addresses). */
     public byte[] getPubKeyHash() {
         if (pubKeyHash == null)

--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -30,6 +30,7 @@ import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.base.VarInt;
 import org.bitcoinj.crypto.internal.CryptoUtils;
+import org.bitcoinj.crypto.secp.Secp256k1Constants;
 import org.bitcoinj.wallet.Wallet;
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1Integer;
@@ -71,6 +72,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.security.SignatureException;
+import java.security.interfaces.ECPublicKey;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -111,7 +113,7 @@ import static org.bitcoinj.base.internal.Preconditions.checkState;
  * this class so round-tripping preserves state. Unless you're working with old software or doing unusual things, you
  * can usually ignore the compressed/uncompressed distinction.
  */
-public class ECKey implements EncryptableItem {
+public class ECKey implements EncryptableItem, ECPublicKey {
     private static final Logger log = LoggerFactory.getLogger(ECKey.class);
     // Note: this can be replaced with Arrays.compareUnsigned(a, b) once we require Java 9
     private static final Comparator<byte[]> LEXICOGRAPHICAL_COMPARATOR = ByteUtils.arrayUnsignedComparator();
@@ -1283,6 +1285,45 @@ public class ECKey implements EncryptableItem {
     }
 
     public static class KeyIsEncryptedException extends MissingPrivateKeyException {
+    }
+
+    /**
+     * @return string representing the algorithm used with this key
+     */
+    @Override
+    public String getAlgorithm() {
+        return "Secp256k1";
+    }
+
+    /**
+     * @return string representing encoded format of this key
+     */
+    @Override
+    public String getFormat() {
+        return "SEC";
+    }
+
+    /**
+     * Convert from internal Bouncy Castle {@link ECPoint} to return
+     * a {@code java.security.spec.ECPoint}.
+     * @return Java Cryptography ECPoint instance
+     */
+    @Override
+    public java.security.spec.ECPoint getW() {
+        return ECKey.toJCPoint(getPubKeyPoint());
+    }
+
+    /**
+     * @return Java Cryptography type with Elliptic Curve parameters
+     */
+    @Override
+    public java.security.spec.ECParameterSpec getParams() {
+        return Secp256k1Constants.EC_PARAMS;
+    }
+
+    @Override
+    public byte[] getEncoded() {
+        return getPubKeyPoint().getEncoded(isCompressed());
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -449,6 +449,15 @@ public class ECKey implements EncryptableItem {
                 : CURVE.getCurve().createPoint(jcPoint.getAffineX(), jcPoint.getAffineY());
     }
 
+    /**
+     * Decode (parse) a serialized public key. For internal use only.
+     * @param pubBytes serialized public key (compressed or uncompressed)
+     * @return a Bouncy Castle ECPoint
+     */
+    static ECPoint decodeToBCPoint(byte[] pubBytes) {
+        return CURVE.getCurve().decodePoint(pubBytes);
+    }
+
     /** Gets the hash160 form of the public key (as seen in addresses). */
     public byte[] getPubKeyHash() {
         if (pubKeyHash == null)

--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -463,7 +463,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
     /** Gets the hash160 form of the public key (as seen in addresses). */
     public byte[] getPubKeyHash() {
         if (pubKeyHash == null)
-            pubKeyHash = CryptoUtils.sha256hash160(this.pub.getEncoded());
+            pubKeyHash = CryptoUtils.sha256hash160(getEncoded());
         return pubKeyHash;
     }
 
@@ -472,7 +472,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * as the pubKeyHash/address.
      */
     public byte[] getPubKey() {
-        return pub.getEncoded();
+        return getEncoded();
     }
 
     /** Gets the public key in the form of an elliptic curve point object from Bouncy Castle. */
@@ -1361,7 +1361,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
     }
 
     public String getPublicKeyAsHex() {
-        return ByteUtils.formatHex(pub.getEncoded());
+        return ByteUtils.formatHex(getEncoded());
     }
 
 

--- a/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
+++ b/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
@@ -17,7 +17,6 @@
 package org.bitcoinj.crypto;
 
 import org.bitcoinj.crypto.secp.Secp256k1Constants;
-import org.bouncycastle.math.ec.ECCurve;
 import org.bouncycastle.math.ec.ECPoint;
 
 import org.jspecify.annotations.Nullable;
@@ -33,9 +32,8 @@ import java.util.Objects;
  * Apart from the lazy field {@link #point}, instances of this class are immutable.
  */
 public final class LazyECPoint implements ECPublicKey {
-    private static final ECCurve curve = ECKey.ecDomainParameters().getCurve();
-
-    // bits will be null if LazyECPoint is constructed from an (already decoded) point
+    // `bits` will be `null` if `LazyECPoint` is constructed from an (already decoded) point
+    // `bits` cannot be `null` if `point` is also `null`
     private final byte @Nullable [] bits;
     private final boolean compressed;
 
@@ -93,7 +91,7 @@ public final class LazyECPoint implements ECPublicKey {
 
     public ECPoint get() {
         if (point == null)
-            point = curve.decodePoint(bits);
+            point = ECKey.decodeToBCPoint(Objects.requireNonNull(bits));
         return point;
     }
 

--- a/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
+++ b/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
@@ -93,7 +93,10 @@ public final class LazyECPoint {
         return point;
     }
 
-
+    /**
+     * @deprecated Use {@link ECKey#getEncoded()}
+     */
+    @Deprecated
     public byte[] getEncoded() {
         if (bits != null)
             return Arrays.copyOf(bits, bits.length);

--- a/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
+++ b/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
@@ -72,13 +72,7 @@ public final class LazyECPoint implements ECPublicKey {
      * @param point the wrapped point
      */
     LazyECPoint(java.security.spec.ECPoint point) {
-        this(toBouncy(point), true);
-    }
-
-    private static org.bouncycastle.math.ec.ECPoint toBouncy(java.security.spec.ECPoint point) {
-        return point == java.security.spec.ECPoint.POINT_INFINITY
-                ? curve.getInfinity()
-                : curve.createPoint(point.getAffineX(), point.getAffineY());
+        this(ECKey.toBCPoint(point), true);
     }
 
     /**
@@ -127,11 +121,7 @@ public final class LazyECPoint implements ECPublicKey {
     @Override
     public java.security.spec.ECPoint getW() {
         ECPoint bcPoint = get();
-        return bcPoint.isInfinity()
-                ? java.security.spec.ECPoint.POINT_INFINITY
-                : new java.security.spec.ECPoint(
-                    bcPoint.normalize().getAffineXCoord().toBigInteger(),
-                    bcPoint.normalize().getAffineYCoord().toBigInteger());
+        return ECKey.toJCPoint(bcPoint);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
+++ b/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
@@ -16,11 +16,9 @@
 
 package org.bitcoinj.crypto;
 
-import org.bitcoinj.crypto.secp.Secp256k1Constants;
 import org.bouncycastle.math.ec.ECPoint;
 
 import org.jspecify.annotations.Nullable;
-import java.security.interfaces.ECPublicKey;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -31,7 +29,7 @@ import java.util.Objects;
  * <p>
  * Apart from the lazy field {@link #point}, instances of this class are immutable.
  */
-public final class LazyECPoint implements ECPublicKey {
+public final class LazyECPoint {
     // `bits` will be `null` if `LazyECPoint` is constructed from an (already decoded) point
     // `bits` cannot be `null` if `point` is also `null`
     private final byte @Nullable [] bits;
@@ -95,40 +93,6 @@ public final class LazyECPoint implements ECPublicKey {
         return point;
     }
 
-    /**
-     * @return string representing the algorithm used with this key
-     */
-    @Override
-    public String getAlgorithm() {
-        return "Secp256k1";
-    }
-
-    /**
-     * @return string representing encoded format of this key
-     */
-    @Override
-    public String getFormat() {
-        return "SEC";
-    }
-
-    /**
-     * Convert from internal Bouncy Castle {@link ECPoint} to return
-     * a {@code java.security.spec.ECPoint}.
-     * @return Java Cryptography ECPoint instance
-     */
-    @Override
-    public java.security.spec.ECPoint getW() {
-        ECPoint bcPoint = get();
-        return ECKey.toJCPoint(bcPoint);
-    }
-
-    /**
-     * @return Java Cryptography type with Elliptic Curve parameters
-     */
-    @Override
-    public java.security.spec.ECParameterSpec getParams() {
-        return Secp256k1Constants.EC_PARAMS;
-    }
 
     public byte[] getEncoded() {
         if (bits != null)

--- a/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
@@ -40,6 +40,9 @@ import org.slf4j.LoggerFactory;
 import java.io.InputStream;
 import java.math.BigInteger;
 import java.security.SignatureException;
+import java.security.spec.ECField;
+import java.security.spec.ECFieldFp;
+import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPoint;
 import java.time.Instant;
 import java.util.Arrays;
@@ -623,6 +626,26 @@ public class ECKeyTest {
     static final ECPoint JC_INFINITY = ECPoint.POINT_INFINITY;
 
     @Test
+    public void testGetWRandomPoint() {
+        ECKey key = ECKey.random();
+        ECPoint jcPoint = key.getW();
+        org.bouncycastle.math.ec.ECPoint bcPoint = ECKey.toBCPoint(jcPoint);
+        assertEquals(key.getPubKeyPoint(), bcPoint);
+    }
+
+    @Test
+    public void testGetEncoded() {
+        // Java Cryptography encoding should be the same as Bouncy Castle
+        ECKey compressedKey = ECKey.random();
+        byte[] compressedEncoding = compressedKey.getEncoded();
+        assertArrayEquals(compressedKey.getPubKey(), compressedEncoding);
+
+        ECKey uncompressedKey = compressedKey.decompress();
+        byte[] uncompressedEncoding = uncompressedKey.getEncoded();
+        assertArrayEquals(uncompressedKey.getPubKey(), uncompressedEncoding);
+    }
+
+    @Test
     public void convertRandomPoint() {
         org.bouncycastle.math.ec.ECPoint bcPoint = ECKey.random().getPubKeyPoint();
         ECPoint jcPoint = ECKey.toJCPoint(bcPoint);
@@ -633,5 +656,18 @@ public class ECKeyTest {
     public void infinityConversionTest() {
         assertEquals(JC_INFINITY, ECKey.toJCPoint(BC_INFINITY));
         assertEquals(BC_INFINITY, ECKey.toBCPoint(JC_INFINITY));
+    }
+
+    @Test
+    public void testECPublicKeyInterface() {
+        ECKey key = ECKey.random();
+        assertEquals("Secp256k1", key.getAlgorithm());
+        assertEquals("SEC", key.getFormat());
+
+        ECParameterSpec spec = key.getParams();
+        ECField field = spec.getCurve().getField();
+        assertTrue(field instanceof ECFieldFp);
+        ECFieldFp fieldFp = (ECFieldFp) field;
+        assertEquals(Secp256k1Constants.P, fieldFp.getP());
     }
 }

--- a/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import java.io.InputStream;
 import java.math.BigInteger;
 import java.security.SignatureException;
+import java.security.spec.ECPoint;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
@@ -616,5 +617,21 @@ public class ECKeyTest {
         final byte[] bytes = new byte[33];
         bytes[0] = 42;
         ECKey.fromPrivate(bytes);
+    }
+
+    static final org.bouncycastle.math.ec.ECPoint BC_INFINITY = ECKey.ecDomainParameters().getCurve().getInfinity();
+    static final ECPoint JC_INFINITY = ECPoint.POINT_INFINITY;
+
+    @Test
+    public void convertRandomPoint() {
+        org.bouncycastle.math.ec.ECPoint bcPoint = ECKey.random().getPubKeyPoint();
+        ECPoint jcPoint = ECKey.toJCPoint(bcPoint);
+        assertEquals(bcPoint, ECKey.toBCPoint(jcPoint));
+    }
+
+    @Test
+    public void infinityConversionTest() {
+        assertEquals(JC_INFINITY, ECKey.toJCPoint(BC_INFINITY));
+        assertEquals(BC_INFINITY, ECKey.toBCPoint(JC_INFINITY));
     }
 }

--- a/core/src/test/java/org/bitcoinj/crypto/LazyECPointTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/LazyECPointTest.java
@@ -1,31 +1,7 @@
 package org.bitcoinj.crypto;
 
-import org.junit.Ignore;
-import org.junit.Test;
-
-import java.security.spec.ECPoint;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 /**
  * Tests for LazyECPoint
  */
 public class LazyECPointTest {
-    org.bouncycastle.math.ec.ECPoint BOUNCY_INFINITY = ECKey.ecDomainParameters().getCurve().getInfinity();
-    ECPoint JAVA_INFINITY = ECPoint.POINT_INFINITY;
-
-    @Test
-    public void convertRandomPoint() {
-        LazyECPoint p1 = ECKey.random().pub;
-        LazyECPoint p2 = new LazyECPoint(p1.getW());  // Round-trip conversion Bouncy -> JCA -> Bouncy
-        assertNotNull(p2);
-        assertEquals(p1, p2);
-    }
-
-    @Test
-    public void infinityConversionTest() {
-        LazyECPoint infinity = new LazyECPoint(BOUNCY_INFINITY, true);
-        assertEquals(JAVA_INFINITY, infinity.getW());
-    }
 }


### PR DESCRIPTION
Note that there is no deprecation needed for removing ECPublicKey from `LazyECPoint` because there has been no release since `ECPublicKey` was added to `LazyECPoint`.

I originally thought it would be best to have `LazyECPoint` become our wrapper for the new secp256k1-jdk types, but now I am certain that `ECKey` itself should be the wrapper.
