### PR TITLE
LazyECPoint: remove JCA ECPoint constructor

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
+++ b/core/src/main/java/org/bitcoinj/crypto/LazyECPoint.java
@@ -63,15 +63,6 @@ public final class LazyECPoint {
     }
 
     /**
-     * Construct a LazyECPoint from a Java ECPoint.
-     *
-     * @param point the wrapped point
-     */
-    LazyECPoint(java.security.spec.ECPoint point) {
-        this(ECKey.toBCPoint(point), true);
-    }
-
-    /**
      * Returns a compressed version of this elliptic curve point. Returns the same point if it's already compressed.
      * See the {@link ECKey} class docs for a discussion of point compression.
      */


### PR DESCRIPTION
This is unused and was added since the last release, so we can remove it without deprecation.