### PR TITLE
ECKey: make `pub` LazyECPoint member private

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -577,7 +577,7 @@ public class DeterministicKey extends ECKey {
         // downCursor is now the same key as us, but with private key bytes.
         // If it's not, it means we tried decrypting with an invalid password and earlier checks e.g. for padding didn't
         // catch it.
-        if (!downCursor.pub.equals(pub))
+        if (!downCursor.getPubKeyPoint().equals(getPubKeyPoint()))
             throw new KeyCrypterException.PublicPrivateMismatch("Could not decrypt bytes");
         return Objects.requireNonNull(downCursor.priv);
     }

--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -159,7 +159,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
 
     // The two parts of the key. If "pub" is set but not "priv", we can only verify signatures, not make them.
     @Nullable protected final BigInteger priv;  // A field element.
-    protected final LazyECPoint pub;
+    private final LazyECPoint pub;
 
     // Creation time of the key, or null if the key was deserialized from a version that did
     // not have this field.

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -960,7 +960,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
                         EncryptedData data = new EncryptedData(proto.getInitialisationVector().toByteArray(),
                                 proto.getEncryptedPrivateKey().toByteArray());
                         Objects.requireNonNull(crypter, "Encountered an encrypted key but no key crypter provided");
-                        detkey = new DeterministicKey(path, chainCode, crypter, pubkey, data, parent);
+                        detkey = new DeterministicKey(path, chainCode, pubkey.get(), parent, data, crypter);
                     } else {
                         // No secret key bytes and key is not encrypted: either a watching key or private key bytes
                         // will be rederived on the fly from the parent.


### PR DESCRIPTION
This is a child of PR #4291.

The first two (additional) commits remove the last two non-private uses of `pub`. The third commit makes `pub` `private`.
