### PR TITLE
Replace all use of LazyECPoint constructors outside of ECKey and LazyECPoint

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -95,7 +95,8 @@ public class DeterministicKey extends ECKey {
                             boolean compressed,
                             @Nullable BigInteger priv,
                             @Nullable DeterministicKey parent) {
-        this(childNumberPath, chainCode, new LazyECPoint(publicAsPoint, compressed), priv, parent);
+        this(childNumberPath, chainCode, publicAsPoint, priv, parent);
+        checkArgument(compressed, () -> "pub must be compressed");
     }
 
     /** Constructs a key from its components. This is not normally something you should use. */
@@ -103,7 +104,7 @@ public class DeterministicKey extends ECKey {
                             byte[] chainCode,
                             BigInteger priv,
                             @Nullable DeterministicKey parent) {
-        this(priv, new LazyECPoint(ECKey.publicBCPointFromPrivate(priv), true), parent == null ? 0 : parent.depth + 1,
+        this(priv, ECKey.publicBCPointFromPrivate(priv), parent == null ? 0 : parent.depth + 1,
                 parent, parent != null ? parent.getFingerprint() : 0, chainCode, hdPath, null, null);
     }
 
@@ -188,7 +189,7 @@ public class DeterministicKey extends ECKey {
                             @Nullable DeterministicKey parent,
                             int depth,
                             int parentFingerprint) {
-        this(priv, new LazyECPoint(ECKey.publicBCPointFromPrivate(priv), true), depth, parent, parentFingerprint,
+        this(priv, ECKey.publicBCPointFromPrivate(priv), depth, parent, parentFingerprint,
                 chainCode, childNumberPath, null, null);
     }
 

--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -481,7 +481,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * @param pubBytes serialized public key (compressed or uncompressed)
      * @return a Bouncy Castle ECPoint
      */
-    static ECPoint decodeToBCPoint(byte[] pubBytes) {
+    public static ECPoint decodeToBCPoint(byte[] pubBytes) {
         return CURVE.getCurve().decodePoint(pubBytes);
     }
 

--- a/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
+++ b/core/src/main/java/org/bitcoinj/crypto/HDKeyDerivation.java
@@ -93,7 +93,7 @@ public final class HDKeyDerivation {
     }
 
     public static DeterministicKey createMasterPubKeyFromBytes(byte[] pubKeyBytes, byte[] chainCode) {
-        return new DeterministicKey(HDPath.partial(), chainCode, new LazyECPoint(pubKeyBytes), null, null);
+        return new DeterministicKey(HDPath.partial(), chainCode, ECKey.decodeToBCPoint(pubKeyBytes), null, null);
     }
 
     /**
@@ -193,7 +193,7 @@ public final class HDKeyDerivation {
             PublicDeriveMode mode) throws HDDerivationException {
         RawKeyBytes rawKey = deriveChildKeyBytesFromPublic(parent, childNumber, PublicDeriveMode.NORMAL);
         return new DeterministicKey(parent.getPath().extend(childNumber), rawKey.chainCode,
-                new LazyECPoint(rawKey.keyBytes), null, parent);
+                ECKey.decodeToBCPoint(rawKey.keyBytes), null, parent);
     }
 
     public static RawKeyBytes deriveChildKeyBytesFromPublic(DeterministicKey parent, ChildNumber childNumber, PublicDeriveMode mode) throws HDDerivationException {

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -44,6 +44,7 @@ import org.bitcoinj.utils.ListenerRegistration;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.listeners.KeyChainEventListener;
 import org.bitcoinj.protobuf.wallet.Protos;
+import org.bouncycastle.math.ec.ECPoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -903,7 +904,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
                     throw new UnreadableWalletException("Deterministic key missing extra data: " + key);
                 byte[] chainCode = key.getDeterministicKey().getChainCode().toByteArray();
                 // Deserialize the public key and path.
-                LazyECPoint pubkey = new LazyECPoint(key.getPublicKey().toByteArray());
+                ECPoint pubkey = ECKey.decodeToBCPoint(key.getPublicKey().toByteArray());
                 // Deserialize the path through the tree.
                 final HDPath.HDPartialPath path = HDPath.deserialize(key.getDeterministicKey().getPathList());
                 if (key.hasOutputScriptType())
@@ -960,7 +961,7 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
                         EncryptedData data = new EncryptedData(proto.getInitialisationVector().toByteArray(),
                                 proto.getEncryptedPrivateKey().toByteArray());
                         Objects.requireNonNull(crypter, "Encountered an encrypted key but no key crypter provided");
-                        detkey = new DeterministicKey(path, chainCode, pubkey.get(), parent, data, crypter);
+                        detkey = new DeterministicKey(path, chainCode, pubkey, parent, data, crypter);
                     } else {
                         // No secret key bytes and key is not encrypted: either a watching key or private key bytes
                         // will be rederived on the fly from the parent.


### PR DESCRIPTION
Child of:

* PR #4293.

The first commit replaces all remaining use of the `pubKey byte[]` constructor.
The second commit replaces all us of the `ECPoint` constructs (except internal to `LazyECPoint` and `ECKey`)