### PR TITLE
ECKey: Read ASN1 with fromByteArray() rather than ASN1InputStream

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -38,6 +38,7 @@ import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.ASN1Primitive;
+import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.ASN1TaggedObject;
 import org.bouncycastle.asn1.BERTags;
 import org.bouncycastle.asn1.DERBitString;
@@ -824,12 +825,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
         // } ASN1_SEQUENCE_END(EC_PRIVATEKEY)
         //
         try {
-            final DLSequence seq;
-            try (ASN1InputStream decoder = new ASN1InputStream(asn1privkey)) {
-                seq = (DLSequence) decoder.readObject();
-                checkArgument(decoder.readObject() == null, () ->
-                        "input contains extra bytes");
-            }
+            DLSequence seq = (DLSequence) ASN1Sequence.fromByteArray(asn1privkey);
 
             checkArgument(seq.size() == 4, () ->
                     "input does not appear to be an ASN.1 OpenSSL EC private key");


### PR DESCRIPTION
Child of PR #4305 

Note that making this same change to replace the other `ASN1InputStream` breaks tests due to `fromByteArray()` being strict about extra bytes in the stream.
