### PR TITLE
WIP: Use secp256k1-jdk/secp-bouncy for ECKey, ECKey.sign, ECKey.verify

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
     env:
       # Use env variable to specify the JDK version to use for the `testMinJdk` Gradle option
-      MIN_JDK: ${{ matrix.os == 'macOS-15' && '11' || '8' }}
+      MIN_JDK: ${{ matrix.os == 'macOS-15' && '11' || '11' }}
     name: ${{ matrix.os }} JDK ${{ matrix.java }}.${{ matrix.distribution }} Gradle ${{ matrix.gradle }}
     steps:
       - name: Git checkout

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 }
 
 tasks.withType(JavaCompile) {
-    options.compilerArgs.addAll(['--release', '8'])
+    options.compilerArgs.addAll(['--release', '9'])
     options.compilerArgs << '-Xlint:deprecation'
     options.encoding = 'UTF-8'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ plugins {
 allprojects {
     repositories {
         mavenCentral()
+        maven {
+            url 'https://gitlab.com/api/v4/projects/55956336/packages/maven'        // secp256k1-jdk
+        }
     }
 
     group = 'org.bitcoinj'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -45,7 +45,7 @@ if (GradleVersion.current() > gradleVersionTargetJVM) {
 }
 
 tasks.withType(JavaCompile) {
-    options.compilerArgs.addAll(['--release', '8'])
+    options.compilerArgs.addAll(['--release', '9'])
     options.compilerArgs << '-Xlint:deprecation'
     options.encoding = 'UTF-8'
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,6 +11,7 @@ version = '0.18-SNAPSHOT'
 dependencies {
     api project(':bitcoinj-base')
     api 'org.jspecify:jspecify:1.0.1'
+    api 'org.bitcoinj.secp:secp-api:0.3.1'
     api 'org.bouncycastle:bcprov-jdk15to18:1.85.2'
     api 'com.google.guava:guava:33.6.0-android'
     api 'com.google.protobuf:protobuf-javalite:4.35.1'
@@ -18,6 +19,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:2.0.18'
 
     testImplementation project(':bitcoinj-test-support')
+    testImplementation 'org.bitcoinj.secp:secp-bouncy:0.3.1'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.easymock:easymock:5.6.0'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.21.5'

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -26,6 +26,7 @@ import org.bitcoinj.base.Base58;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.crypto.internal.CryptoUtils;
+import org.bitcoinj.secp.SecpPrivKey;
 import org.bouncycastle.math.ec.ECPoint;
 
 import org.jspecify.annotations.Nullable;
@@ -84,7 +85,7 @@ public class DeterministicKey extends ECKey {
                             ECPoint publicAsPoint,
                             @Nullable BigInteger priv,
                             @Nullable DeterministicKey parent) {
-        this(priv, publicAsPoint, parent == null ? 0 : parent.depth + 1, parent,
+        this(priv != null ? SecpPrivKey.of(priv) : null, publicAsPoint, parent == null ? 0 : parent.depth + 1, parent,
                 parent != null ? parent.getFingerprint() : 0, chainCode, childNumberPath, null, null);
     }
 
@@ -107,7 +108,7 @@ public class DeterministicKey extends ECKey {
                             byte[] chainCode,
                             BigInteger priv,
                             @Nullable DeterministicKey parent) {
-        this(priv, ECKey.publicBCPointFromPrivate(priv), parent == null ? 0 : parent.depth + 1,
+        this(SecpPrivKey.of(priv), ECKey.publicBCPointFromPrivate(priv), parent == null ? 0 : parent.depth + 1,
                 parent, parent != null ? parent.getFingerprint() : 0, chainCode, hdPath, null, null);
     }
 
@@ -194,14 +195,14 @@ public class DeterministicKey extends ECKey {
                             @Nullable DeterministicKey parent,
                             int depth,
                             int parentFingerprint) {
-        this(priv, ECKey.publicBCPointFromPrivate(priv), depth, parent, parentFingerprint,
+        this(SecpPrivKey.of(priv), ECKey.publicBCPointFromPrivate(priv), depth, parent, parentFingerprint,
                 chainCode, childNumberPath, null, null);
     }
 
     /** @deprecated use {@link #withParent(DeterministicKey)} */
     @Deprecated
     public DeterministicKey(DeterministicKey keyToClone, DeterministicKey newParent) {
-        this(keyToClone.getNullableS(), keyToClone.getPubKeyPoint(), keyToClone.childNumberPath.size(), newParent,
+        this(keyToClone.getSecpPrivKey(), keyToClone.getPubKeyPoint(), keyToClone.childNumberPath.size(), newParent,
                 newParent.getFingerprint(), keyToClone.chainCode, keyToClone.childNumberPath, null, null);
     }
 
@@ -222,7 +223,7 @@ public class DeterministicKey extends ECKey {
      * @param encryptedPrivateKey private key in encrypted form
      * @param keyCrypter          crypter to use for decrypting the private key
      */
-    private DeterministicKey(@Nullable BigInteger priv, ECPoint pub, int depth, @Nullable DeterministicKey parent,
+    private DeterministicKey(@Nullable SecpPrivKey priv, ECPoint pub, int depth, @Nullable DeterministicKey parent,
                              int parentFingerprint, byte[] chainCode, HDPath hdPath,
                              @Nullable EncryptedData encryptedPrivateKey, @Nullable KeyCrypter keyCrypter) {
         super(priv, pub, encryptedPrivateKey, keyCrypter);
@@ -358,7 +359,7 @@ public class DeterministicKey extends ECKey {
      */
     public DeterministicKey withParent(DeterministicKey parent) {
         Objects.requireNonNull(parent);
-        return new DeterministicKey(this.getNullableS(), this.getPubKeyPoint(), parent.getDepth() + 1, parent, parent.getFingerprint(),
+        return new DeterministicKey(this.getSecpPrivKey(), this.getPubKeyPoint(), parent.getDepth() + 1, parent, parent.getFingerprint(),
                 this.chainCode, this.childNumberPath, this.encryptedPrivateKey, this.keyCrypter);
     }
 
@@ -373,7 +374,7 @@ public class DeterministicKey extends ECKey {
      * @return this key without parent pointer
      */
     public DeterministicKey withoutParent() {
-        return new DeterministicKey(getNullableS(), getPubKeyPoint(), depth, null, parentFingerprint, chainCode, childNumberPath,
+        return new DeterministicKey(getSecpPrivKey(), getPubKeyPoint(), depth, null, parentFingerprint, chainCode, childNumberPath,
                 encryptedPrivateKey, keyCrypter);
     }
 
@@ -524,7 +525,7 @@ public class DeterministicKey extends ECKey {
         if (parentalPrivateKeyBytes.length != 32)
             throw new KeyCrypterException.InvalidCipherText(
                     "Decrypted key must be 32 bytes long, but is " + parentalPrivateKeyBytes.length);
-        return derivePrivateKeyDownwards(cursor, ByteUtils.bytesToBigInteger(parentalPrivateKeyBytes));
+        return derivePrivateKeyDownwards(cursor, parentalPrivateKeyBytes);
     }
 
     @Nullable
@@ -540,14 +541,18 @@ public class DeterministicKey extends ECKey {
     @Nullable
     private BigInteger findOrDerivePrivateKey() {
         DeterministicKey cursor = findParentWithPrivKey();
-        if (cursor == null || cursor.getNullableS() == null)
+        if (cursor == null || !cursor.hasPrivKey())
             return null;
-        return derivePrivateKeyDownwards(cursor, cursor.getNullableS());
+        return derivePrivateKeyDownwards(cursor, Objects.requireNonNull(cursor.getSecpPrivKey()));
     }
 
-    private BigInteger derivePrivateKeyDownwards(DeterministicKey cursor, BigInteger parentalPrivateKey) {
+    private BigInteger derivePrivateKeyDownwards(DeterministicKey cursor, byte[] parentalPrivateKeyBytes) {
+        return derivePrivateKeyDownwards(cursor, SecpPrivKey.of(parentalPrivateKeyBytes));
+    }
+
+    private BigInteger derivePrivateKeyDownwards(DeterministicKey cursor, SecpPrivKey parentalPrivateKey) {
         DeterministicKey downCursor = new DeterministicKey(cursor.childNumberPath, cursor.chainCode,
-                cursor.getPubKeyPoint(), parentalPrivateKey, cursor.parent);
+                cursor.getPubKeyPoint(), parentalPrivateKey.getS(), cursor.parent);
         // Now we have to re-derive the keys along the path back to ourselves. That path can be found by just truncating
         // our path with the length of the parent's path.
         List<ChildNumber> path = childNumberPath.list().subList(cursor.getPath().size(), childNumberPath.size());

--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -234,7 +234,21 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * @param pub a serialized point
      */
     private ECKey(@Nullable BigInteger priv, byte[] pub) {
-        this(priv, decodeToBCPoint(pub), isPubKeyCompressed(pub));
+        this(priv != null ? SecpPrivKey.of(priv) : null, decodeToBCPoint(pub), isPubKeyCompressed(pub));
+    }
+
+    /**
+     * Construct a compressed ECKey. This constructor can be used for P2PWKH and HD keys that
+     * always have addresses generated using compressed serialization.
+     * @param priv optional private key
+     * @param pub a Bouncy Castle point
+     */
+    protected ECKey(@Nullable BigInteger priv, ECPoint pub) {
+        this(priv != null ? SecpPrivKey.of(priv) : null, Objects.requireNonNull(pub), true);
+    }
+
+    protected ECKey(@Nullable SecpPrivKey priv, ECPoint pub) {
+        this(priv, Objects.requireNonNull(pub), true);
     }
 
     /**
@@ -243,11 +257,8 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * @param pub a Bouncy Castle point
      * @param compressed whether to generate addresses using compressed serialization.
      */
-    private ECKey(@Nullable BigInteger priv, ECPoint pub, boolean compressed) {
-        if (priv != null) {
-            checkPrivateKey(priv);
-        }
-        this.privKey = priv != null ? SecpPrivKey.of(priv) : null;
+    private ECKey(@Nullable SecpPrivKey priv, ECPoint pub, boolean compressed) {
+        this.privKey = priv;
         this.pubKey = new SecpPubKeyImpl(ECKey.toJCPoint(Objects.requireNonNull(pub)));
         this.compressed = compressed;
         this.encryptedPrivateKey = null;
@@ -260,15 +271,12 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * @param encryptedPrivateKey encrypted private key
      * @param keyCrypter key crypter
      */
-    protected ECKey(@Nullable BigInteger priv, ECPoint pub, @Nullable EncryptedData encryptedPrivateKey, @Nullable KeyCrypter keyCrypter) {
+    protected ECKey(@Nullable SecpPrivKey priv, ECPoint pub, @Nullable EncryptedData encryptedPrivateKey, @Nullable KeyCrypter keyCrypter) {
         checkArgument(priv == null || encryptedPrivateKey == null, () ->
                 "priv and encryptedPrivateKey can't be set together");
         checkArgument((encryptedPrivateKey == null) == (keyCrypter == null), () ->
                 "encryptedPrivateKey and keyCrypter must be set together");
-        if (priv != null) {
-            checkPrivateKey(priv);
-        }
-        this.privKey = priv != null ? SecpPrivKey.of(priv) : null;
+        this.privKey = priv;
         this.pubKey = new SecpPubKeyImpl(ECKey.toJCPoint(Objects.requireNonNull(pub)));
         this.compressed = true;
         this.encryptedPrivateKey = encryptedPrivateKey;
@@ -288,16 +296,6 @@ public class ECKey implements EncryptableItem, ECPublicKey {
         this.compressed = compressed;
         this.encryptedPrivateKey = Objects.requireNonNull(encryptedPrivateKey);
         this.keyCrypter = Objects.requireNonNull(keyCrypter);
-    }
-
-    private static void checkPrivateKey(BigInteger priv) {
-        checkArgument(priv.bitLength() <= 32 * 8, () ->
-                "private key exceeds 32 bytes: " + priv.bitLength() + " bits");
-        // Try and catch buggy callers or bad key imports, etc. Zero and one are special because these are often
-        // used as sentinel values and because scripting languages have a habit of auto-casting true and false to
-        // 1 and 0 or vice-versa. Type confusion bugs could therefore result in private keys with these values.
-        checkArgument(!priv.equals(BigInteger.ZERO));
-        checkArgument(!priv.equals(BigInteger.ONE));
     }
 
     /**
@@ -322,7 +320,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      */
     public static ECKey fromPrivate(BigInteger privKey, boolean compressed) {
         ECPoint point = publicBCPointFromPrivate(privKey);
-        return new ECKey(privKey, point, compressed);
+        return new ECKey(SecpPrivKey.of(privKey), point, compressed);
     }
 
     /**
@@ -348,7 +346,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * @param compressed Determines whether the resulting ECKey will use a compressed encoding for the public key.
      */
     public static ECKey fromPrivateAndPrecalculatedPublic(BigInteger priv, ECPoint pub, boolean compressed) {
-        return new ECKey(priv, pub, compressed);
+        return new ECKey(SecpPrivKey.of(priv), pub, compressed);
     }
 
     /**
@@ -382,6 +380,11 @@ public class ECKey implements EncryptableItem, ECPublicKey {
         return fromPublicOnly(key.getPubKeyPoint(), key.isCompressed());
     }
 
+    @Nullable
+    protected SecpPrivKey getSecpPrivKey() {
+        return privKey;
+    }
+
     /**
      * Returns a copy of this key, but with the public point represented in uncompressed form. Normally you would
      * never need this: it's for specialized scenarios or when backwards compatibility in encoded form is necessary.
@@ -390,7 +393,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
         if (!this.isCompressed())
             return this;
         else
-            return new ECKey(getNullableS(), getPubKeyPoint(), false);
+            return new ECKey(privKey, getPubKeyPoint(), false);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -31,6 +31,15 @@ import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.base.VarInt;
 import org.bitcoinj.crypto.internal.CryptoUtils;
 import org.bitcoinj.base.internal.Secp256k1Constants;
+import org.bitcoinj.secp.EcdsaSignature;
+import org.bitcoinj.secp.Secp256k1;
+import org.bitcoinj.secp.SecpKeyPair;
+import org.bitcoinj.secp.SecpPrivKey;
+import org.bitcoinj.secp.SecpPubKey;
+import org.bitcoinj.secp.internal.EcdsaSignatureImpl;
+import org.bitcoinj.secp.internal.SecpPrivKeyImpl;
+import org.bitcoinj.secp.internal.SecpPubKeyImpl;
+import org.bitcoinj.secp.internal.SecpScalarImpl;
 import org.bitcoinj.wallet.Wallet;
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1Encoding;
@@ -47,16 +56,8 @@ import org.bouncycastle.asn1.DERTaggedObject;
 import org.bouncycastle.asn1.DLSequence;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.asn1.x9.X9IntegerConverter;
-import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
-import org.bouncycastle.crypto.digests.SHA256Digest;
 import org.bouncycastle.crypto.ec.CustomNamedCurves;
-import org.bouncycastle.crypto.generators.ECKeyPairGenerator;
 import org.bouncycastle.crypto.params.ECDomainParameters;
-import org.bouncycastle.crypto.params.ECKeyGenerationParameters;
-import org.bouncycastle.crypto.params.ECPrivateKeyParameters;
-import org.bouncycastle.crypto.params.ECPublicKeyParameters;
-import org.bouncycastle.crypto.signers.ECDSASigner;
-import org.bouncycastle.crypto.signers.HMacDSAKCalculator;
 import org.bouncycastle.math.ec.ECAlgorithms;
 import org.bouncycastle.math.ec.ECPoint;
 import org.bouncycastle.math.ec.FixedPointCombMultiplier;
@@ -132,6 +133,9 @@ public class ECKey implements EncryptableItem, ECPublicKey {
     /** The parameters of the secp256k1 curve that Bitcoin uses. */
     private static final ECDomainParameters CURVE;
 
+    /** The secp256k1-jdk provider to use (hard-coded for now) */
+    private static final Secp256k1.ProviderId SECP_PROVIDER_ID = Secp256k1.ProviderId.BOUNCY_CASTLE;
+
     /**
      * Return EC parameters for the SECP256K1 curve, in a Bouncy Castle type.
      * Note that we are migrating to using the built-in JDK types for EC parameters,
@@ -160,8 +164,8 @@ public class ECKey implements EncryptableItem, ECPublicKey {
     }
 
     // The two parts of the key. If "pub" is set but not "priv", we can only verify signatures, not make them.
-    @Nullable private final BigInteger priv;  // A field element.
-    private final ECPoint pub;
+    @Nullable private final SecpPrivKey privKey;
+    private final SecpPubKey pubKey;
     private final boolean compressed;
 
     // Creation time of the key, or null if the key was deserialized from a version that did
@@ -213,14 +217,11 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      */
     @Deprecated
     public ECKey(SecureRandom secureRandom) {
-        ECKeyPairGenerator generator = new ECKeyPairGenerator();
-        ECKeyGenerationParameters keygenParams = new ECKeyGenerationParameters(CURVE, secureRandom);
-        generator.init(keygenParams);
-        AsymmetricCipherKeyPair keypair = generator.generateKeyPair();
-        ECPrivateKeyParameters privParams = (ECPrivateKeyParameters) keypair.getPrivate();
-        ECPublicKeyParameters pubParams = (ECPublicKeyParameters) keypair.getPublic();
-        priv = privParams.getD();
-        pub = pubParams.getQ();
+        try (Secp256k1 secp = Secp256k1.getById(SECP_PROVIDER_ID)) {
+            SecpKeyPair keyPair = secp.ecKeyPairCreate();
+            privKey = keyPair.privateKey();
+            pubKey = keyPair.publicKey();
+        }
         compressed = true;
         creationTime = TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS);
         encryptedPrivateKey = null;
@@ -246,8 +247,8 @@ public class ECKey implements EncryptableItem, ECPublicKey {
         if (priv != null) {
             checkPrivateKey(priv);
         }
-        this.priv = priv;
-        this.pub = Objects.requireNonNull(pub);
+        this.privKey = priv != null ? SecpPrivKey.of(priv) : null;
+        this.pubKey = new SecpPubKeyImpl(ECKey.toJCPoint(Objects.requireNonNull(pub)));
         this.compressed = compressed;
         this.encryptedPrivateKey = null;
         this.keyCrypter = null;
@@ -267,8 +268,8 @@ public class ECKey implements EncryptableItem, ECPublicKey {
         if (priv != null) {
             checkPrivateKey(priv);
         }
-        this.priv = priv;
-        this.pub = Objects.requireNonNull(pub);
+        this.privKey = priv != null ? SecpPrivKey.of(priv) : null;
+        this.pubKey = new SecpPubKeyImpl(ECKey.toJCPoint(Objects.requireNonNull(pub)));
         this.compressed = true;
         this.encryptedPrivateKey = encryptedPrivateKey;
         this.keyCrypter = keyCrypter;
@@ -282,8 +283,8 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * @param keyCrypter key crypter
      */
     private ECKey(ECPoint pub, boolean compressed, EncryptedData encryptedPrivateKey, KeyCrypter keyCrypter) {
-        this.priv = null;
-        this.pub = Objects.requireNonNull(pub);
+        this.privKey = null;
+        this.pubKey = new SecpPubKeyImpl(ECKey.toJCPoint(Objects.requireNonNull(pub)));
         this.compressed = compressed;
         this.encryptedPrivateKey = Objects.requireNonNull(encryptedPrivateKey);
         this.keyCrypter = Objects.requireNonNull(keyCrypter);
@@ -389,7 +390,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
         if (!this.isCompressed())
             return this;
         else
-            return new ECKey(priv, pub, false);
+            return new ECKey(getNullableS(), getPubKeyPoint(), false);
     }
 
     /**
@@ -407,7 +408,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * @return private key or {@code null} if not available
      */
     protected @Nullable BigInteger getNullableS() {
-        return priv;
+        return (privKey != null) ? privKey.getS() : null;
     }
 
     /**
@@ -416,7 +417,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * {@link #isEncrypted()} to tell the cases apart.
      */
     public boolean isPubKeyOnly() {
-        return priv == null;
+        return privKey == null;
     }
 
     /**
@@ -424,7 +425,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * {@link #isPubKeyOnly()}.
      */
     public boolean hasPrivKey() {
-        return priv != null;
+        return privKey != null;
     }
 
     /** Returns true if this key is watch only, meaning it has a public key but no private key. */
@@ -540,7 +541,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
 
     /** Gets the public key in the form of an elliptic curve point object from Bouncy Castle. */
     public ECPoint getPubKeyPoint() {
-        return pub;
+        return ECKey.toBCPoint(pubKey.toECPoint());
     }
 
     /**
@@ -550,9 +551,9 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * @throws java.lang.IllegalStateException if the private key bytes are not available.
      */
     public BigInteger getPrivKey() {
-        if (priv == null)
+        if (privKey == null)
             throw new MissingPrivateKeyException();
-        return priv;
+        return privKey.getS();
     }
 
     /**
@@ -725,19 +726,22 @@ public class ECKey implements EncryptableItem, ECPublicKey {
             return decrypt(aesKey).sign(input);
         } else {
             // No decryption of private key required.
-            if (priv == null)
+            if (privKey == null)
                 throw new MissingPrivateKeyException();
         }
-        return doSign(input, priv);
+        return doSign(input, privKey);
     }
 
     protected ECDSASignature doSign(Sha256Hash input, BigInteger privateKeyForSigning) {
+        return doSign(input, new SecpPrivKeyImpl(privateKeyForSigning));
+    }
+
+    protected ECDSASignature doSign(Sha256Hash input, SecpPrivKey privateKeyForSigning) {
         Objects.requireNonNull(privateKeyForSigning);
-        ECDSASigner signer = new ECDSASigner(new HMacDSAKCalculator(new SHA256Digest()));
-        ECPrivateKeyParameters privKey = new ECPrivateKeyParameters(privateKeyForSigning, CURVE);
-        signer.init(true, privKey);
-        BigInteger[] components = signer.generateSignature(input.getBytes());
-        return new ECDSASignature(components[0], components[1]).toCanonicalised();
+        try (Secp256k1 secp = Secp256k1.getById(SECP_PROVIDER_ID)) {
+            EcdsaSignature secpSig = secp.ecdsaSign(input.getBytes(), privateKeyForSigning).get();
+            return new ECDSASignature(secpSig.r().toBigInteger(), secpSig.s().toBigInteger());
+        }
     }
 
     /**
@@ -748,17 +752,24 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * @param pub       The public key bytes to use.
      */
     public static boolean verify(byte[] data, ECDSASignature signature, byte[] pub) {
-        ECDSASigner signer = new ECDSASigner();
-        ECPublicKeyParameters params = new ECPublicKeyParameters(CURVE.getCurve().decodePoint(pub), CURVE);
-        signer.init(false, params);
-        try {
-            return signer.verifySignature(data, signature.r, signature.s);
-        } catch (NullPointerException e) {
-            // Bouncy Castle contains a bug that can cause NPEs given specially crafted signatures. Those signatures
-            // are inherently invalid/attack sigs so we just fail them here rather than crash the thread.
-            log.error("Caught NPE inside bouncy castle", e);
-            return false;
+        return verify(data, toSecpSignature(signature), pub);
+    }
+
+    public static boolean verify(byte[] data, EcdsaSignature signature, SecpPubKey pubKey) {
+        try (Secp256k1 secp = Secp256k1.getById(SECP_PROVIDER_ID)) {
+            return secp.ecdsaVerify(signature, data, pubKey).get();
         }
+    }
+
+    public static boolean verify(byte[] data, EcdsaSignature signature, byte[] pubKeyBytes) {
+        try (Secp256k1 secp = Secp256k1.getById(SECP_PROVIDER_ID)) {
+            SecpPubKey pubKey = secp.ecPubKeyParse(pubKeyBytes).get();
+            return secp.ecdsaVerify(signature, data, pubKey).get();
+        }
+    }
+
+    public static boolean verify(byte[] data, byte[] signature, SecpPubKey pubKey) throws SignatureDecodeException {
+        return verify(data, toSecpSignature(ECDSASignature.decodeFromDER(signature)), pubKey);
     }
 
     /**
@@ -770,7 +781,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * @throws SignatureDecodeException if the signature is unparseable in some way.
      */
     public static boolean verify(byte[] data, byte[] signature, byte[] pub) throws SignatureDecodeException {
-        return verify(data, ECDSASignature.decodeFromDER(signature), pub);
+        return verify(data, toSecpSignature(ECDSASignature.decodeFromDER(signature)), pub);
     }
 
     /**
@@ -781,7 +792,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * @throws SignatureDecodeException if the signature is unparseable in some way.
      */
     public boolean verify(byte[] hash, byte[] signature) throws SignatureDecodeException {
-        return ECKey.verify(hash, signature, getPubKey());
+        return ECKey.verify(hash, signature, this.pubKey);
     }
 
     /**
@@ -789,6 +800,12 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      */
     public boolean verify(Sha256Hash sigHash, ECDSASignature signature) {
         return ECKey.verify(sigHash.getBytes(), signature, getPubKey());
+    }
+
+    private static EcdsaSignature toSecpSignature(ECDSASignature signature) {
+        SecpScalarImpl r = new SecpScalarImpl(signature.r);
+        SecpScalarImpl s = new SecpScalarImpl(signature.s);
+        return new EcdsaSignatureImpl(r, s);
     }
 
     /**
@@ -1032,7 +1049,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
         byte recId = -1;
         for (byte i = 0; i < 4; i++) {
             ECKey k = ECKey.recoverFromSignature(i, sig, hash, isCompressed());
-            if (k != null && k.pub.equals(pub)) {
+            if (k != null && k.pubKey.getW().equals(pubKey.getW())) {
                 recId = i;
                 break;
             }
@@ -1393,8 +1410,8 @@ public class ECKey implements EncryptableItem, ECPublicKey {
         if (this == o) return true;
         if (o == null || !(o instanceof ECKey)) return false;
         ECKey other = (ECKey) o;
-        return Objects.equals(this.priv, other.priv)
-                && Objects.equals(this.pub, other.pub)
+        return Objects.equals(privKey != null ? privKey.getS() : null, (other.privKey != null) ? other.privKey.getS() : null)
+                && Objects.equals(this.pubKey.getW(), other.pubKey.getW())
                 && Objects.equals(this.creationTime, other.creationTime)
                 && Objects.equals(this.keyCrypter, other.keyCrypter)
                 && Objects.equals(this.encryptedPrivateKey, other.encryptedPrivateKey);
@@ -1402,7 +1419,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
 
     @Override
     public int hashCode() {
-        return pub.hashCode();
+        return pubKey.toECPoint().hashCode();
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -736,15 +736,22 @@ public class ECKey implements EncryptableItem, ECPublicKey {
     }
 
     protected ECDSASignature doSign(Sha256Hash input, BigInteger privateKeyForSigning) {
-        return doSign(input, new SecpPrivKeyImpl(privateKeyForSigning));
+        Objects.requireNonNull(privateKeyForSigning);
+        try (Secp256k1 secp = Secp256k1.getById(SECP_PROVIDER_ID)) {
+            return doSign(secp, input, new SecpPrivKeyImpl(privateKeyForSigning));
+        }
     }
 
     protected ECDSASignature doSign(Sha256Hash input, SecpPrivKey privateKeyForSigning) {
         Objects.requireNonNull(privateKeyForSigning);
         try (Secp256k1 secp = Secp256k1.getById(SECP_PROVIDER_ID)) {
-            EcdsaSignature secpSig = secp.ecdsaSign(input.getBytes(), privateKeyForSigning).get();
-            return new ECDSASignature(secpSig.r().toBigInteger(), secpSig.s().toBigInteger());
+            return doSign(secp, input, privateKeyForSigning);
         }
+    }
+
+    private ECDSASignature doSign(Secp256k1 secp, Sha256Hash input, SecpPrivKey privateKeyForSigning) {
+        EcdsaSignature secpSig = secp.ecdsaSign(input.getBytes(), privateKeyForSigning).get();
+        return new ECDSASignature(secpSig.r().toBigInteger(), secpSig.s().toBigInteger());
     }
 
     /**

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation project(':bitcoinj-examples')
     api 'org.jspecify:jspecify:1.0.1'
 
+    testImplementation 'org.bitcoinj.secp:secp-bouncy:0.3.1'
     testImplementation 'org.slf4j:slf4j-jdk14:2.0.18'
     testImplementation platform('org.junit:junit-bom:6.1.3')
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/test-support/build.gradle
+++ b/test-support/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 }
 
 tasks.withType(JavaCompile) {
-    options.compilerArgs.addAll(['--release', '8'])
+    options.compilerArgs.addAll(['--release', '9'])
     options.compilerArgs << '-Xlint:deprecation'
     options.encoding = 'UTF-8'
 }


### PR DESCRIPTION
This is a work-in-progress, proof-of-concept integration of secp256k1-jdk  using the 0.3.1 release (loaded from our GitLab Maven repo) that is passing all unit tests.

Three commits:

* Bump `test-support`,  `base`, and `core` modules to JDK 9 
* Convert `ECKey` to secp-jdk and the secp-bouncy provider
* Use SecpPrivKey in constructors to reduce round-trip conversions (SecpPrivKey -> BigInteger -> SecpPrivKey)

(One additional commit was added to bum the `MIN_JDK` used in the test matrix from `8` to `11` -- JDK 9 is not easily installable on GitHub Actions, so we test with a minimum of 11 even though we support a minimum of 9.)

Note that all unit and integration tests are passing.

I plan to update this PR once PR #4299 is merged and secp-jdk 0.3.2 is released.

**Reviewers:** I'm looking for "concept ack" and preliminary feedback.

Note that some `secp-api` internal classes are being used for type-conversion. This should not be necessary once the 0.3.2 release is finalized.

