### PR TITLE
WIP: Use secp256k1-jdk/secp-ffm for ECKey, ECKey.sign, ECKey.verify

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -31,6 +31,17 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: ${{ matrix.gradle }}
+      - name: Install secp256k1 with APT
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt install -y libsecp256k1-dev
+          echo "LIBSECP_DIR=/usr/lib/$(uname -m)-linux-gnu" >> $GITHUB_ENV
+      - name: Install secp256k1 with Homebrew
+        if: runner.os == 'macOS'
+        run: |
+          brew install secp256k1
+          echo "DYLD_LIBRARY_PATH=$(brew --prefix secp256k1)/lib" >> $GITHUB_ENV
+          echo "LIBSECP_DIR=$(brew --prefix secp256k1)/lib" >> $GITHUB_ENV
       - name: Run Gradle
         run: gradle -PtestMinJdk=${{ env.MIN_JDK }} build installDist jlink --init-script build-scan-agree.gradle --scan --info --stacktrace
       - name: Upload Test Results and Reports
@@ -71,6 +82,17 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: ${{ matrix.gradle }}
+      - name: Install secp256k1 with APT
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt install -y libsecp256k1-dev
+          echo "LIBSECP_DIR=/usr/lib/$(uname -m)-linux-gnu" >> $GITHUB_ENV
+      - name: Install secp256k1 with Homebrew
+        if: runner.os == 'macOS'
+        run: |
+          brew install secp256k1
+          echo "DYLD_LIBRARY_PATH=$(brew --prefix secp256k1)/lib" >> $GITHUB_ENV
+          echo "LIBSECP_DIR=$(brew --prefix secp256k1)/lib" >> $GITHUB_ENV
       - name: Run Gradle
         run: gradle test nativeCompile --init-script build-scan-agree.gradle --scan --info --stacktrace
       - name: Upload wallet-tool as artifact

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -8,21 +8,10 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macOS-15, macOS-15-intel, windows-2022]
-        java: ['17', '21', '25']
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macOS-15, macOS-15-intel]
+        java: ['25']
         distribution: ['temurin']
-        gradle: ['8.14.4', '9.2.1']
-        exclude:
-          # Java 25+ requires Gradle 9.1+
-          - java: '25'
-            gradle: '8.14.4'
-          # Exclude older versions of Gradle on macOS and Windows
-          - os: macOS-15
-            gradle: '8.14.4'
-          - os: macOS-15-intel
-            gradle: '8.14.4'
-          - os: windows-2022
-            gradle: '8.14.4'
+        gradle: ['9.2.1']
       fail-fast: false
     env:
       # Use env variable to specify the JDK version to use for the `testMinJdk` Gradle option

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
     env:
       # Use env variable to specify the JDK version to use for the `testMinJdk` Gradle option
-      MIN_JDK: ${{ matrix.os == 'macOS-15' && '11' || '8' }}
+      MIN_JDK: ${{ matrix.os == 'macOS-15' && '11' || '11' }}
     name: ${{ matrix.os }} JDK ${{ matrix.java }}.${{ matrix.distribution }} Gradle ${{ matrix.gradle }}
     steps:
       - name: Git checkout

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 }
 
 tasks.withType(JavaCompile) {
-    options.compilerArgs.addAll(['--release', '8'])
+    options.compilerArgs.addAll(['--release', '9'])
     options.compilerArgs << '-Xlint:deprecation'
     options.encoding = 'UTF-8'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,11 @@ allprojects {
         }
     }
 
+    test {
+        jvmArgs += '--enable-native-access=ALL-UNNAMED'
+        systemProperty "java.library.path", findProperty("javaPath") ?: System.getenv("LIBSECP_DIR")
+    }
+
     // Ensure standard artifacts in all projects are built reproducibly
 
     tasks.withType(AbstractArchiveTask) {

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ plugins {
 allprojects {
     repositories {
         mavenCentral()
+        maven {
+            url 'https://gitlab.com/api/v4/projects/55956336/packages/maven'        // secp256k1-jdk
+        }
     }
 
     group = 'org.bitcoinj'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -45,7 +45,7 @@ if (GradleVersion.current() > gradleVersionTargetJVM) {
 }
 
 tasks.withType(JavaCompile) {
-    options.compilerArgs.addAll(['--release', '8'])
+    options.compilerArgs.addAll(['--release', '9'])
     options.compilerArgs << '-Xlint:deprecation'
     options.encoding = 'UTF-8'
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,6 +11,7 @@ version = '0.18-SNAPSHOT'
 dependencies {
     api project(':bitcoinj-base')
     api 'org.jspecify:jspecify:1.0.1'
+    api 'org.bitcoinj.secp:secp-api:0.3.1'
     api 'org.bouncycastle:bcprov-jdk15to18:1.85.2'
     api 'com.google.guava:guava:33.6.0-android'
     api 'com.google.protobuf:protobuf-javalite:4.35.1'
@@ -18,6 +19,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:2.0.18'
 
     testImplementation project(':bitcoinj-test-support')
+    testImplementation 'org.bitcoinj.secp:secp-bouncy:0.3.1'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.easymock:easymock:5.6.0'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.21.5'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 
     testImplementation project(':bitcoinj-test-support')
     testImplementation 'org.bitcoinj.secp:secp-bouncy:0.3.1'
+    testImplementation 'org.bitcoinj.secp:secp-ffm:0.3.1'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.easymock:easymock:5.6.0'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.21.5'

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -26,6 +26,7 @@ import org.bitcoinj.base.Base58;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.crypto.internal.CryptoUtils;
+import org.bitcoinj.secp.SecpPrivKey;
 import org.bouncycastle.math.ec.ECPoint;
 
 import org.jspecify.annotations.Nullable;
@@ -84,7 +85,7 @@ public class DeterministicKey extends ECKey {
                             ECPoint publicAsPoint,
                             @Nullable BigInteger priv,
                             @Nullable DeterministicKey parent) {
-        this(priv, publicAsPoint, parent == null ? 0 : parent.depth + 1, parent,
+        this(priv != null ? SecpPrivKey.of(priv) : null, publicAsPoint, parent == null ? 0 : parent.depth + 1, parent,
                 parent != null ? parent.getFingerprint() : 0, chainCode, childNumberPath, null, null);
     }
 
@@ -107,7 +108,7 @@ public class DeterministicKey extends ECKey {
                             byte[] chainCode,
                             BigInteger priv,
                             @Nullable DeterministicKey parent) {
-        this(priv, ECKey.publicBCPointFromPrivate(priv), parent == null ? 0 : parent.depth + 1,
+        this(SecpPrivKey.of(priv), ECKey.publicBCPointFromPrivate(priv), parent == null ? 0 : parent.depth + 1,
                 parent, parent != null ? parent.getFingerprint() : 0, chainCode, hdPath, null, null);
     }
 
@@ -194,14 +195,14 @@ public class DeterministicKey extends ECKey {
                             @Nullable DeterministicKey parent,
                             int depth,
                             int parentFingerprint) {
-        this(priv, ECKey.publicBCPointFromPrivate(priv), depth, parent, parentFingerprint,
+        this(SecpPrivKey.of(priv), ECKey.publicBCPointFromPrivate(priv), depth, parent, parentFingerprint,
                 chainCode, childNumberPath, null, null);
     }
 
     /** @deprecated use {@link #withParent(DeterministicKey)} */
     @Deprecated
     public DeterministicKey(DeterministicKey keyToClone, DeterministicKey newParent) {
-        this(keyToClone.getNullableS(), keyToClone.getPubKeyPoint(), keyToClone.childNumberPath.size(), newParent,
+        this(keyToClone.getSecpPrivKey(), keyToClone.getPubKeyPoint(), keyToClone.childNumberPath.size(), newParent,
                 newParent.getFingerprint(), keyToClone.chainCode, keyToClone.childNumberPath, null, null);
     }
 
@@ -222,7 +223,7 @@ public class DeterministicKey extends ECKey {
      * @param encryptedPrivateKey private key in encrypted form
      * @param keyCrypter          crypter to use for decrypting the private key
      */
-    private DeterministicKey(@Nullable BigInteger priv, ECPoint pub, int depth, @Nullable DeterministicKey parent,
+    private DeterministicKey(@Nullable SecpPrivKey priv, ECPoint pub, int depth, @Nullable DeterministicKey parent,
                              int parentFingerprint, byte[] chainCode, HDPath hdPath,
                              @Nullable EncryptedData encryptedPrivateKey, @Nullable KeyCrypter keyCrypter) {
         super(priv, pub);
@@ -364,7 +365,7 @@ public class DeterministicKey extends ECKey {
      */
     public DeterministicKey withParent(DeterministicKey parent) {
         Objects.requireNonNull(parent);
-        return new DeterministicKey(this.getNullableS(), this.getPubKeyPoint(), parent.getDepth() + 1, parent, parent.getFingerprint(),
+        return new DeterministicKey(this.getSecpPrivKey(), this.getPubKeyPoint(), parent.getDepth() + 1, parent, parent.getFingerprint(),
                 this.chainCode, this.childNumberPath, this.encryptedPrivateKey, this.keyCrypter);
     }
 
@@ -379,7 +380,7 @@ public class DeterministicKey extends ECKey {
      * @return this key without parent pointer
      */
     public DeterministicKey withoutParent() {
-        return new DeterministicKey(getNullableS(), getPubKeyPoint(), depth, null, parentFingerprint, chainCode, childNumberPath,
+        return new DeterministicKey(getSecpPrivKey(), getPubKeyPoint(), depth, null, parentFingerprint, chainCode, childNumberPath,
                 encryptedPrivateKey, keyCrypter);
     }
 
@@ -530,7 +531,7 @@ public class DeterministicKey extends ECKey {
         if (parentalPrivateKeyBytes.length != 32)
             throw new KeyCrypterException.InvalidCipherText(
                     "Decrypted key must be 32 bytes long, but is " + parentalPrivateKeyBytes.length);
-        return derivePrivateKeyDownwards(cursor, ByteUtils.bytesToBigInteger(parentalPrivateKeyBytes));
+        return derivePrivateKeyDownwards(cursor, parentalPrivateKeyBytes);
     }
 
     @Nullable
@@ -546,14 +547,18 @@ public class DeterministicKey extends ECKey {
     @Nullable
     private BigInteger findOrDerivePrivateKey() {
         DeterministicKey cursor = findParentWithPrivKey();
-        if (cursor == null || cursor.getNullableS() == null)
+        if (cursor == null || !cursor.hasPrivKey())
             return null;
-        return derivePrivateKeyDownwards(cursor, cursor.getNullableS());
+        return derivePrivateKeyDownwards(cursor, Objects.requireNonNull(cursor.getSecpPrivKey()));
     }
 
-    private BigInteger derivePrivateKeyDownwards(DeterministicKey cursor, BigInteger parentalPrivateKey) {
+    private BigInteger derivePrivateKeyDownwards(DeterministicKey cursor, byte[] parentalPrivateKeyBytes) {
+        return derivePrivateKeyDownwards(cursor, SecpPrivKey.of(parentalPrivateKeyBytes));
+    }
+
+    private BigInteger derivePrivateKeyDownwards(DeterministicKey cursor, SecpPrivKey parentalPrivateKey) {
         DeterministicKey downCursor = new DeterministicKey(cursor.childNumberPath, cursor.chainCode,
-                cursor.getPubKeyPoint(), parentalPrivateKey, cursor.parent);
+                cursor.getPubKeyPoint(), parentalPrivateKey.getS(), cursor.parent);
         // Now we have to re-derive the keys along the path back to ourselves. That path can be found by just truncating
         // our path with the length of the parent's path.
         List<ChildNumber> path = childNumberPath.list().subList(cursor.getPath().size(), childNumberPath.size());

--- a/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DeterministicKey.java
@@ -201,7 +201,7 @@ public class DeterministicKey extends ECKey {
     /** @deprecated use {@link #withParent(DeterministicKey)} */
     @Deprecated
     public DeterministicKey(DeterministicKey keyToClone, DeterministicKey newParent) {
-        this(keyToClone.priv, keyToClone.getPubKeyPoint(), keyToClone.childNumberPath.size(), newParent,
+        this(keyToClone.getNullableS(), keyToClone.getPubKeyPoint(), keyToClone.childNumberPath.size(), newParent,
                 newParent.getFingerprint(), keyToClone.chainCode, keyToClone.childNumberPath, null, null);
     }
 
@@ -343,7 +343,7 @@ public class DeterministicKey extends ECKey {
      * @return this key without private key
      */
     public DeterministicKey withoutPrivateKey() {
-        return priv == null && encryptedPrivateKey == null && keyCrypter == null ?
+        return getNullableS() == null && encryptedPrivateKey == null && keyCrypter == null ?
                 this :
                 new DeterministicKey(null, getPubKeyPoint(), depth, parent, parentFingerprint, chainCode, childNumberPath,
                         null, null);
@@ -364,7 +364,7 @@ public class DeterministicKey extends ECKey {
      */
     public DeterministicKey withParent(DeterministicKey parent) {
         Objects.requireNonNull(parent);
-        return new DeterministicKey(this.priv, this.getPubKeyPoint(), parent.getDepth() + 1, parent, parent.getFingerprint(),
+        return new DeterministicKey(this.getNullableS(), this.getPubKeyPoint(), parent.getDepth() + 1, parent, parent.getFingerprint(),
                 this.chainCode, this.childNumberPath, this.encryptedPrivateKey, this.keyCrypter);
     }
 
@@ -379,7 +379,7 @@ public class DeterministicKey extends ECKey {
      * @return this key without parent pointer
      */
     public DeterministicKey withoutParent() {
-        return new DeterministicKey(priv, getPubKeyPoint(), depth, null, parentFingerprint, chainCode, childNumberPath,
+        return new DeterministicKey(getNullableS(), getPubKeyPoint(), depth, null, parentFingerprint, chainCode, childNumberPath,
                 encryptedPrivateKey, keyCrypter);
     }
 
@@ -438,7 +438,7 @@ public class DeterministicKey extends ECKey {
 
     @Override
     public byte @Nullable [] getSecretBytes() {
-        return priv != null ? getPrivKeyBytes() : null;
+        return getNullableS() != null ? getPrivKeyBytes() : null;
     }
 
     /**
@@ -448,7 +448,7 @@ public class DeterministicKey extends ECKey {
      */
     @Override
     public boolean isEncrypted() {
-        return priv == null && (super.isEncrypted() || (parent != null && parent.isEncrypted()));
+        return getNullableS() == null && (super.isEncrypted() || (parent != null && parent.isEncrypted()));
     }
 
     /**
@@ -537,7 +537,7 @@ public class DeterministicKey extends ECKey {
     private DeterministicKey findParentWithPrivKey() {
         DeterministicKey cursor = this;
         while (cursor != null) {
-            if (cursor.priv != null) break;
+            if (cursor.getNullableS() != null) break;
             cursor = cursor.parent;
         }
         return cursor;
@@ -546,9 +546,9 @@ public class DeterministicKey extends ECKey {
     @Nullable
     private BigInteger findOrDerivePrivateKey() {
         DeterministicKey cursor = findParentWithPrivKey();
-        if (cursor == null || cursor.priv == null)
+        if (cursor == null || cursor.getNullableS() == null)
             return null;
-        return derivePrivateKeyDownwards(cursor, cursor.priv);
+        return derivePrivateKeyDownwards(cursor, cursor.getNullableS());
     }
 
     private BigInteger derivePrivateKeyDownwards(DeterministicKey cursor, BigInteger parentalPrivateKey) {
@@ -565,7 +565,7 @@ public class DeterministicKey extends ECKey {
         // catch it.
         if (!downCursor.getPubKeyPoint().equals(getPubKeyPoint()))
             throw new KeyCrypterException.PublicPrivateMismatch("Could not decrypt bytes");
-        return Objects.requireNonNull(downCursor.priv);
+        return Objects.requireNonNull(downCursor.getNullableS());
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -239,7 +239,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * @param pub a serialized point
      */
     private ECKey(@Nullable BigInteger priv, byte[] pub) {
-        this(priv, decodeToBCPoint(pub), isPubKeyCompressed(pub));
+        this(priv != null ? SecpPrivKey.of(priv) : null, decodeToBCPoint(pub), isPubKeyCompressed(pub));
     }
 
     /**
@@ -249,6 +249,10 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * @param pub a Bouncy Castle point
      */
     protected ECKey(@Nullable BigInteger priv, ECPoint pub) {
+        this(priv != null ? SecpPrivKey.of(priv) : null, Objects.requireNonNull(pub), true);
+    }
+
+    protected ECKey(@Nullable SecpPrivKey priv, ECPoint pub) {
         this(priv, Objects.requireNonNull(pub), true);
     }
 
@@ -258,17 +262,12 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * @param pub a Bouncy Castle point
      * @param compressed whether to generate addresses using compressed serialization.
      */
-    private ECKey(@Nullable BigInteger priv, ECPoint pub, boolean compressed) {
+    private ECKey(@Nullable SecpPrivKey priv, ECPoint pub, boolean compressed) {
         if (priv != null) {
-            checkArgument(priv.bitLength() <= 32 * 8, () ->
-                    "private key exceeds 32 bytes: " + priv.bitLength() + " bits");
-            // Try and catch buggy callers or bad key imports, etc. Zero and one are special because these are often
-            // used as sentinel values and because scripting languages have a habit of auto-casting true and false to
-            // 1 and 0 or vice-versa. Type confusion bugs could therefore result in private keys with these values.
-            checkArgument(!priv.equals(BigInteger.ZERO));
-            checkArgument(!priv.equals(BigInteger.ONE));
+            // checkArgument(!priv.equals(BigInteger.ZERO));
+            // checkArgument(!priv.equals(BigInteger.ONE));
         }
-        this.privKey = priv != null ? SecpPrivKey.of(priv) : null;
+        this.privKey = priv;
         this.pubKey = new SecpPubKeyImpl(ECKey.toJCPoint(Objects.requireNonNull(pub)));
         this.compressed = compressed;
     }
@@ -295,7 +294,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      */
     public static ECKey fromPrivate(BigInteger privKey, boolean compressed) {
         ECPoint point = publicBCPointFromPrivate(privKey);
-        return new ECKey(privKey, point, compressed);
+        return new ECKey(SecpPrivKey.of(privKey), point, compressed);
     }
 
     /**
@@ -321,7 +320,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * @param compressed Determines whether the resulting ECKey will use a compressed encoding for the public key.
      */
     public static ECKey fromPrivateAndPrecalculatedPublic(BigInteger priv, ECPoint pub, boolean compressed) {
-        return new ECKey(priv, pub, compressed);
+        return new ECKey(SecpPrivKey.of(priv), pub, compressed);
     }
 
     /**
@@ -355,6 +354,11 @@ public class ECKey implements EncryptableItem, ECPublicKey {
         return fromPublicOnly(key.getPubKeyPoint(), key.isCompressed());
     }
 
+    @Nullable
+    protected SecpPrivKey getSecpPrivKey() {
+        return privKey;
+    }
+
     // Nullable access (non-throwing) to private key as BigInteger
     @Nullable protected BigInteger getNullableS() {
         return (privKey != null) ? privKey.getS() : null;
@@ -368,7 +372,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
         if (!this.isCompressed())
             return this;
         else
-            return new ECKey(getNullableS(), getPubKeyPoint(), false);
+            return new ECKey(getSecpPrivKey(), getPubKeyPoint(), false);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -31,6 +31,14 @@ import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.base.VarInt;
 import org.bitcoinj.crypto.internal.CryptoUtils;
 import org.bitcoinj.base.internal.Secp256k1Constants;
+import org.bitcoinj.secp.EcdsaSignature;
+import org.bitcoinj.secp.Secp256k1;
+import org.bitcoinj.secp.SecpPrivKey;
+import org.bitcoinj.secp.SecpPubKey;
+import org.bitcoinj.secp.internal.EcdsaSignatureImpl;
+import org.bitcoinj.secp.internal.SecpPrivKeyImpl;
+import org.bitcoinj.secp.internal.SecpPubKeyImpl;
+import org.bitcoinj.secp.internal.SecpScalarImpl;
 import org.bitcoinj.wallet.Wallet;
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1Encoding;
@@ -48,15 +56,12 @@ import org.bouncycastle.asn1.DLSequence;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.asn1.x9.X9IntegerConverter;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
-import org.bouncycastle.crypto.digests.SHA256Digest;
 import org.bouncycastle.crypto.ec.CustomNamedCurves;
 import org.bouncycastle.crypto.generators.ECKeyPairGenerator;
 import org.bouncycastle.crypto.params.ECDomainParameters;
 import org.bouncycastle.crypto.params.ECKeyGenerationParameters;
 import org.bouncycastle.crypto.params.ECPrivateKeyParameters;
 import org.bouncycastle.crypto.params.ECPublicKeyParameters;
-import org.bouncycastle.crypto.signers.ECDSASigner;
-import org.bouncycastle.crypto.signers.HMacDSAKCalculator;
 import org.bouncycastle.math.ec.ECAlgorithms;
 import org.bouncycastle.math.ec.ECPoint;
 import org.bouncycastle.math.ec.FixedPointCombMultiplier;
@@ -132,6 +137,9 @@ public class ECKey implements EncryptableItem, ECPublicKey {
     /** The parameters of the secp256k1 curve that Bitcoin uses. */
     private static final ECDomainParameters CURVE;
 
+    /** The secp256k1-jdk provider to use (hard-coded for now) */
+    private static final Secp256k1.ProviderId SECP_PROVIDER_ID = Secp256k1.ProviderId.BOUNCY_CASTLE;
+
     /**
      * Return EC parameters for the SECP256K1 curve, in a Bouncy Castle type.
      * Note that we are migrating to using the built-in JDK types for EC parameters,
@@ -160,8 +168,8 @@ public class ECKey implements EncryptableItem, ECPublicKey {
     }
 
     // The two parts of the key. If "pub" is set but not "priv", we can only verify signatures, not make them.
-    @Nullable protected final BigInteger priv;  // A field element.
-    private final ECPoint pub;
+    @Nullable private final SecpPrivKey privKey;
+    private final SecpPubKey pubKey;
     private final boolean compressed;
 
     // Creation time of the key, or null if the key was deserialized from a version that did
@@ -219,8 +227,8 @@ public class ECKey implements EncryptableItem, ECPublicKey {
         AsymmetricCipherKeyPair keypair = generator.generateKeyPair();
         ECPrivateKeyParameters privParams = (ECPrivateKeyParameters) keypair.getPrivate();
         ECPublicKeyParameters pubParams = (ECPublicKeyParameters) keypair.getPublic();
-        priv = privParams.getD();
-        pub = pubParams.getQ();
+        privKey = SecpPrivKey.of(privParams.getD());
+        pubKey = new SecpPubKeyImpl(ECKey.toJCPoint(pubParams.getQ()));
         compressed = true;
         creationTime = TimeUtils.currentTime().truncatedTo(ChronoUnit.SECONDS);
     }
@@ -260,8 +268,8 @@ public class ECKey implements EncryptableItem, ECPublicKey {
             checkArgument(!priv.equals(BigInteger.ZERO));
             checkArgument(!priv.equals(BigInteger.ONE));
         }
-        this.priv = priv;
-        this.pub = Objects.requireNonNull(pub);
+        this.privKey = priv != null ? SecpPrivKey.of(priv) : null;
+        this.pubKey = new SecpPubKeyImpl(ECKey.toJCPoint(Objects.requireNonNull(pub)));
         this.compressed = compressed;
     }
 
@@ -347,6 +355,11 @@ public class ECKey implements EncryptableItem, ECPublicKey {
         return fromPublicOnly(key.getPubKeyPoint(), key.isCompressed());
     }
 
+    // Nullable access (non-throwing) to private key as BigInteger
+    @Nullable protected BigInteger getNullableS() {
+        return (privKey != null) ? privKey.getS() : null;
+    }
+
     /**
      * Returns a copy of this key, but with the public point represented in uncompressed form. Normally you would
      * never need this: it's for specialized scenarios or when backwards compatibility in encoded form is necessary.
@@ -355,7 +368,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
         if (!this.isCompressed())
             return this;
         else
-            return new ECKey(priv, pub, false);
+            return new ECKey(getNullableS(), getPubKeyPoint(), false);
     }
 
     /**
@@ -376,7 +389,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * {@link #isEncrypted()} to tell the cases apart.
      */
     public boolean isPubKeyOnly() {
-        return priv == null;
+        return privKey == null;
     }
 
     /**
@@ -384,7 +397,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * {@link #isPubKeyOnly()}.
      */
     public boolean hasPrivKey() {
-        return priv != null;
+        return privKey != null;
     }
 
     /** Returns true if this key is watch only, meaning it has a public key but no private key. */
@@ -500,7 +513,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
 
     /** Gets the public key in the form of an elliptic curve point object from Bouncy Castle. */
     public ECPoint getPubKeyPoint() {
-        return pub;
+        return ECKey.toBCPoint(pubKey.toECPoint());
     }
 
     /**
@@ -510,9 +523,9 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * @throws java.lang.IllegalStateException if the private key bytes are not available.
      */
     public BigInteger getPrivKey() {
-        if (priv == null)
+        if (privKey == null)
             throw new MissingPrivateKeyException();
-        return priv;
+        return Objects.requireNonNull(getNullableS());
     }
 
     /**
@@ -685,19 +698,22 @@ public class ECKey implements EncryptableItem, ECPublicKey {
             return decrypt(aesKey).sign(input);
         } else {
             // No decryption of private key required.
-            if (priv == null)
+            if (privKey == null)
                 throw new MissingPrivateKeyException();
         }
-        return doSign(input, priv);
+        return doSign(input, privKey);
     }
 
     protected ECDSASignature doSign(Sha256Hash input, BigInteger privateKeyForSigning) {
+        return doSign(input, new SecpPrivKeyImpl(privateKeyForSigning));
+    }
+
+    protected ECDSASignature doSign(Sha256Hash input, SecpPrivKey privateKeyForSigning) {
         Objects.requireNonNull(privateKeyForSigning);
-        ECDSASigner signer = new ECDSASigner(new HMacDSAKCalculator(new SHA256Digest()));
-        ECPrivateKeyParameters privKey = new ECPrivateKeyParameters(privateKeyForSigning, CURVE);
-        signer.init(true, privKey);
-        BigInteger[] components = signer.generateSignature(input.getBytes());
-        return new ECDSASignature(components[0], components[1]).toCanonicalised();
+        try (Secp256k1 secp = Secp256k1.getById(SECP_PROVIDER_ID)) {
+            EcdsaSignature secpSig = secp.ecdsaSign(input.getBytes(), privateKeyForSigning).get();
+            return new ECDSASignature(secpSig.r().toBigInteger(), secpSig.s().toBigInteger());
+        }
     }
 
     /**
@@ -708,17 +724,20 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * @param pub       The public key bytes to use.
      */
     public static boolean verify(byte[] data, ECDSASignature signature, byte[] pub) {
-        ECDSASigner signer = new ECDSASigner();
-        ECPublicKeyParameters params = new ECPublicKeyParameters(CURVE.getCurve().decodePoint(pub), CURVE);
-        signer.init(false, params);
-        try {
-            return signer.verifySignature(data, signature.r, signature.s);
-        } catch (NullPointerException e) {
-            // Bouncy Castle contains a bug that can cause NPEs given specially crafted signatures. Those signatures
-            // are inherently invalid/attack sigs so we just fail them here rather than crash the thread.
-            log.error("Caught NPE inside bouncy castle", e);
-            return false;
+        SecpScalarImpl r = new SecpScalarImpl(signature.r);
+        SecpScalarImpl s = new SecpScalarImpl(signature.s);
+        EcdsaSignature sig = new EcdsaSignatureImpl(r, s);
+        return verify(data, sig, toSecpPubKey(pub));
+    }
+
+    public static boolean verify(byte[] data, EcdsaSignature signature, SecpPubKey pubKey) {
+        try (Secp256k1 secp = Secp256k1.getById(SECP_PROVIDER_ID)) {
+            return secp.ecdsaVerify(signature, data, pubKey).get();
         }
+    }
+
+    public static boolean verify(byte[] data, byte[] signature, SecpPubKey pubKey) throws SignatureDecodeException {
+        return verify(data, toSecpSignature(ECDSASignature.decodeFromDER(signature)), pubKey);
     }
 
     /**
@@ -730,7 +749,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * @throws SignatureDecodeException if the signature is unparseable in some way.
      */
     public static boolean verify(byte[] data, byte[] signature, byte[] pub) throws SignatureDecodeException {
-        return verify(data, ECDSASignature.decodeFromDER(signature), pub);
+        return verify(data, toSecpSignature(ECDSASignature.decodeFromDER(signature)), toSecpPubKey(pub));
     }
 
     /**
@@ -741,7 +760,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      * @throws SignatureDecodeException if the signature is unparseable in some way.
      */
     public boolean verify(byte[] hash, byte[] signature) throws SignatureDecodeException {
-        return ECKey.verify(hash, signature, getPubKey());
+        return ECKey.verify(hash, signature, this.pubKey);
     }
 
     /**
@@ -749,6 +768,20 @@ public class ECKey implements EncryptableItem, ECPublicKey {
      */
     public boolean verify(Sha256Hash sigHash, ECDSASignature signature) {
         return ECKey.verify(sigHash.getBytes(), signature, getPubKey());
+    }
+
+    private static SecpPubKey toSecpPubKey(ECPoint bcPoint) {
+        return new SecpPubKeyImpl(toJCPoint(bcPoint));
+    }
+
+    private static SecpPubKey toSecpPubKey(byte[] pub) {
+        return toSecpPubKey(ECKey.decodeToBCPoint(pub));
+    }
+
+    private static EcdsaSignature toSecpSignature(ECDSASignature signature) {
+        SecpScalarImpl r = new SecpScalarImpl(signature.r);
+        SecpScalarImpl s = new SecpScalarImpl(signature.s);
+        return new EcdsaSignatureImpl(r, s);
     }
 
     /**
@@ -992,7 +1025,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
         byte recId = -1;
         for (byte i = 0; i < 4; i++) {
             ECKey k = ECKey.recoverFromSignature(i, sig, hash, isCompressed());
-            if (k != null && k.pub.equals(pub)) {
+            if (k != null && k.pubKey.getW().equals(pubKey.getW())) {
                 recId = i;
                 break;
             }
@@ -1353,8 +1386,8 @@ public class ECKey implements EncryptableItem, ECPublicKey {
         if (this == o) return true;
         if (o == null || !(o instanceof ECKey)) return false;
         ECKey other = (ECKey) o;
-        return Objects.equals(this.priv, other.priv)
-                && Objects.equals(this.pub, other.pub)
+        return Objects.equals(privKey != null ? privKey.getS() : null, (other.privKey != null) ? other.privKey.getS() : null)
+                && Objects.equals(this.pubKey.getW(), other.pubKey.getW())
                 && Objects.equals(this.creationTime, other.creationTime)
                 && Objects.equals(this.keyCrypter, other.keyCrypter)
                 && Objects.equals(this.encryptedPrivateKey, other.encryptedPrivateKey);
@@ -1362,7 +1395,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
 
     @Override
     public int hashCode() {
-        return pub.hashCode();
+        return pubKey.toECPoint().hashCode();
     }
 
     @Override

--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -138,7 +138,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
     private static final ECDomainParameters CURVE;
 
     /** The secp256k1-jdk provider to use (hard-coded for now) */
-    private static final Secp256k1.ProviderId SECP_PROVIDER_ID = Secp256k1.ProviderId.BOUNCY_CASTLE;
+    private static final Secp256k1.ProviderId SECP_PROVIDER_ID = Secp256k1.ProviderId.LIBSECP256K1_FFM;
 
     /**
      * Return EC parameters for the SECP256K1 curve, in a Bouncy Castle type.

--- a/core/src/main/java/org/bitcoinj/script/ScriptExecution.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptExecution.java
@@ -900,7 +900,7 @@ public class ScriptExecution {
 
             // TODO: Should check hash type is known
             Sha256Hash hash = txContainingThis.hashForSignature(index, connectedScript, (byte) sig.sighashFlags);
-            sigValid = ECKey.verify(hash.getBytes(), sig, pubKey);
+            sigValid = ECKey.verify(hash.getBytes(), sig.toCanonicalised(), pubKey);
         } catch (VerificationException.NoncanonicalSignature e) {
             throw new ScriptException(ScriptError.SCRIPT_ERR_SIG_DER, "Script contains non-canonical signature");
         } catch (SignatureDecodeException e) {
@@ -978,7 +978,7 @@ public class ScriptExecution {
             try {
                 TransactionSignature sig = TransactionSignature.decodeFromBitcoin(sigs.getFirst(), requireCanonical, false);
                 Sha256Hash hash = txContainingThis.hashForSignature(index, connectedScript, (byte) sig.sighashFlags);
-                if (ECKey.verify(hash.getBytes(), sig, pubKey))
+                if (ECKey.verify(hash.getBytes(), sig.toCanonicalised(), pubKey))
                     sigs.pollFirst();
             } catch (Exception e) {
                 // There is (at least) one exception that could be hit here (EOFException, if the sig is too short)
@@ -1078,7 +1078,7 @@ public class ScriptExecution {
             ECKey pubkey = ECKey.fromPublicOnly(ScriptPattern.extractKeyFromP2PK(scriptPubKey));
             Sha256Hash sigHash = txContainingThis.hashForSignature(scriptSigIndex, scriptPubKey,
                     signature.sigHashMode(), false);
-            boolean validSig = pubkey.verify(sigHash, signature);
+            boolean validSig = pubkey.verify(sigHash, signature.toCanonicalised());  // ???
             if (!validSig)
                 throw new ScriptException(ScriptError.SCRIPT_ERR_CHECKSIGVERIFY, "Invalid signature");
         } else {

--- a/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
@@ -121,10 +121,17 @@ public class ECKeyTest {
         byte[] output = key.sign(Sha256Hash.ZERO_HASH).encodeToDER();
         assertTrue(key.verify(Sha256Hash.ZERO_HASH.getBytes(), output));
 
-        // Test interop with a signature from elsewhere.
+        // Test interop with a (non-canonical) signature from elsewhere.
         byte[] sig = ByteUtils.parseHex(
                 "3046022100dffbc26774fc841bbe1c1362fd643609c6e42dcb274763476d87af2c0597e89e022100c59e3c13b96b316cae9fa0ab0260612c7a133a6fe2b3445b6bf80b3123bf274d");
-        assertTrue(key.verify(Sha256Hash.ZERO_HASH.getBytes(), sig));
+
+        ECDSASignature uncanonical = ECDSASignature.decodeFromDER(sig);
+        assertFalse(uncanonical.isCanonical());
+
+        ECDSASignature canonical = uncanonical.toCanonicalised();
+        assertTrue(canonical.isCanonical());
+
+        assertTrue(key.verify(Sha256Hash.ZERO_HASH.getBytes(), canonical.encodeToDER()));
     }
 
     @Test
@@ -147,9 +154,16 @@ public class ECKeyTest {
 
             output = ByteUtils.parseHex(
                     "304502206faa2ebc614bf4a0b31f0ce4ed9012eb193302ec2bcaccc7ae8bb40577f47549022100c73a1a1acc209f3f860bf9b9f5e13e9433db6f8b7bd527a088a0e0cd0a4c83e9");
-            assertTrue(key.verify(message, output));
+
+            ECDSASignature uncanonical = ECDSASignature.decodeFromDER(output);
+            assertFalse(uncanonical.isCanonical());
+
+            ECDSASignature canonical = uncanonical.toCanonicalised();
+            assertTrue(canonical.isCanonical());
+
+            assertTrue(key.verify(message, canonical.encodeToDER()));
         }
-        
+
         // Try to sign with one key and verify with the other.
         byte[] message = reverseBytes(ByteUtils.parseHex(
             "11da3761e86431e4a54c176789e41f1651b324d240d599a7067bee23d328ec2a"));
@@ -176,9 +190,17 @@ public class ECKeyTest {
 
             output = ByteUtils.parseHex(
                     "304502206faa2ebc614bf4a0b31f0ce4ed9012eb193302ec2bcaccc7ae8bb40577f47549022100c73a1a1acc209f3f860bf9b9f5e13e9433db6f8b7bd527a088a0e0cd0a4c83e9");
-            assertTrue(key.verify(message, output));
+
+            ECDSASignature uncanonical = ECDSASignature.decodeFromDER(output);
+            assertFalse(uncanonical.isCanonical());
+
+            ECDSASignature canonical = uncanonical.toCanonicalised();
+            assertTrue(canonical.isCanonical());
+
+
+            assertTrue(key.verify(message, canonical.encodeToDER()));
         }
-        
+
         // Try to sign with one key and verify with the other.
         byte[] message = reverseBytes(ByteUtils.parseHex(
             "11da3761e86431e4a54c176789e41f1651b324d240d599a7067bee23d328ec2a"));

--- a/test-support/build.gradle
+++ b/test-support/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 }
 
 tasks.withType(JavaCompile) {
-    options.compilerArgs.addAll(['--release', '8'])
+    options.compilerArgs.addAll(['--release', '9'])
     options.compilerArgs << '-Xlint:deprecation'
     options.encoding = 'UTF-8'
 }


### PR DESCRIPTION
This is a work-in-progress, proof-of-concept integration of secp256k1-jdk  using the 0.3.1 release (loaded from our GitLab Maven repo) that is passing all but 5 unit tests.

This is a child of:

* PR #4308 

One additional commit:

* Add `secp-ffm` to the classpath, configure GitHub Actions and the Maven pom.xml to find/local libsecp256k1 from the library path and change the providerId to `LIBSECP256K1_FFM`.

Since `secp-ffm` requires JDK 25, the test matrix jobs on earlier JDKs are going to fail.

I plan to update this PR once PR #4299 is merged and secp-jdk 0.3.2 is released.

**Reviewers:** I'm looking for "concept ack" and preliminary feedback.

Note that some `secp-api` internal classes are being used for type-conversion. This should not be necessary once the 0.3.2 release is finalized.

I suspect the 5 unit tests that are failing are because our Bouncy Castle implementation and unit tests are not fully compatible with the way libsecp256k1 signs transactions.
