### PR TITLE
DeterministicKeyChain: verify seed when decoding a key chain from protobuf

### DIFF
--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicKeyChain.java
@@ -881,7 +881,9 @@ public class DeterministicKeyChain implements EncryptableKeyChain {
                     if (key.hasDeterministicSeed()) {
                         seedBytes = key.getDeterministicSeed().toByteArray();
                     }
-                    seed = DeterministicSeed.fromProtobuf(key.getSecretBytes().toStringUtf8(), seedBytes, passphrase, seedCreationTime);
+                    seed = DeterministicSeed.fromProtobuf(key.getSecretBytes().toStringUtf8(), passphrase, seedCreationTime);
+                    if (seedBytes != null && !Arrays.equals(seedBytes, seed.getSeedBytes()))
+                        throw new UnreadableWalletException("Seed bytes do not match mnemonic");
                 } else if (key.hasEncryptedData()) {
                     if (key.hasDeterministicSeed())
                         throw new UnreadableWalletException("Malformed key proto: " + key);

--- a/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
+++ b/core/src/main/java/org/bitcoinj/wallet/DeterministicSeed.java
@@ -141,8 +141,8 @@ public class DeterministicSeed implements EncryptableItem {
     }
 
     // For use in DeteministicKeyChain.fromProtobuf() only
-    static DeterministicSeed fromProtobuf(String mnemonicString, byte @Nullable [] seed, String passphrase, @Nullable Instant creationTime) {
-        return new DeterministicSeed(optionalSeedFromMnemonic(splitMnemonicCode(mnemonicString), passphrase, seed), splitMnemonicCode(mnemonicString), creationTime);
+    static DeterministicSeed fromProtobuf(String mnemonicString, String passphrase, @Nullable Instant creationTime) {
+        return new DeterministicSeed(seedFromMnemonic(splitMnemonicCode(mnemonicString), passphrase), splitMnemonicCode(mnemonicString), creationTime);
     }
 
     // For use in DeteministicKeyChain.fromProtobuf() only
@@ -166,11 +166,6 @@ public class DeterministicSeed implements EncryptableItem {
         this.encryptedMnemonicCode = Objects.requireNonNull(encryptedMnemonic);
         this.encryptedSeed = encryptedSeed;
         this.creationTime = creationTime;
-    }
-
-    // If seed is null, generate seed from mnemonic and passphrase. Otherwise, return unmodified seed.
-    private static byte[] optionalSeedFromMnemonic(List<String> mnemonicCode, String passphrase, byte @Nullable [] seed) {
-        return seed != null ? seed : seedFromMnemonic(mnemonicCode, passphrase);
     }
 
     private static byte[] seedFromMnemonic(List<String> mnemonicCode, String passphrase) {
@@ -278,8 +273,7 @@ public class DeterministicSeed implements EncryptableItem {
         checkState(isEncrypted());
         Objects.requireNonNull(encryptedMnemonicCode);
         List<String> mnemonic = decodeMnemonicCode(crypter.decrypt(encryptedMnemonicCode, aesKey));
-        byte[] seed = encryptedSeed == null ? null : crypter.decrypt(encryptedSeed, aesKey);
-        return new DeterministicSeed(optionalSeedFromMnemonic(mnemonic, passphrase, seed), mnemonic, creationTime);
+        return new DeterministicSeed(seedFromMnemonic(mnemonic, passphrase), mnemonic, creationTime);
     }
 
     @Override

--- a/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DeterministicKeyChainTest.java
@@ -17,6 +17,7 @@
 
 package org.bitcoinj.wallet;
 
+import com.google.protobuf.ByteString;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.Address;
@@ -60,6 +61,7 @@ import static org.bitcoinj.base.BitcoinNetwork.TESTNET;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -808,5 +810,23 @@ public class DeterministicKeyChainTest {
         assertTrue("Output should contain class name", str.contains("DeterministicKeyChain"));
         assertFalse("Security Fail: toString() leaked the mnemonic!", str.contains("correct horse battery staple"));
         assertFalse("Security Fail: toString() leaked the xprv (private key)!", str.contains("xprv"));
+    }
+
+    @Test
+    public void fromProtobuf_rejectMnemonicThatDoesNotMatchSeedBytes() {
+        DeterministicKeyChain mismatchingChain = DeterministicKeyChain.builder()
+                .entropy(ENTROPY, Instant.EPOCH)
+                .accountPath(DeterministicKeyChain.ACCOUNT_ZERO_PATH)
+                .build();
+        List<Protos.Key> mismatchingProto = new ArrayList<>(mismatchingChain.serializeToProtobuf());
+        byte[] anotherSeed =
+                DeterministicSeed.ofEntropy(Sha256Hash.hash("another".getBytes()), "").getSeedBytes();
+        Protos.Key mismatchingMnemonic = mismatchingProto.get(0).toBuilder()
+                .setSecretBytes(ByteString.copyFrom(anotherSeed))
+                .build();
+        mismatchingProto.set(0, mismatchingMnemonic);
+
+        assertThrows("Mnemonic words must be verified against the serialized seed bytes",
+                UnreadableWalletException.class, () -> DeterministicKeyChain.fromProtobuf(mismatchingProto, null));
     }
 }


### PR DESCRIPTION
Addresses https://github.com/project-loupe/audit-bitcoinj/issues/331.

When decoding a key chain from protobuf format, always derive the seed from the mnemonic words and verify the stored seed against it.

Also remove helper method `DeterministicSeed.optionalSeedFromMnemonic()` and add a test.
