### PR TITLE
ECKeyTest: canonicalize signature in testSignatures

### DIFF
--- a/core/src/main/java/org/bitcoinj/script/ScriptExecution.java
+++ b/core/src/main/java/org/bitcoinj/script/ScriptExecution.java
@@ -900,7 +900,7 @@ public class ScriptExecution {
 
             // TODO: Should check hash type is known
             Sha256Hash hash = txContainingThis.hashForSignature(index, connectedScript, (byte) sig.sighashFlags);
-            sigValid = ECKey.verify(hash.getBytes(), sig, pubKey);
+            sigValid = ECKey.verify(hash.getBytes(), sig.toCanonicalised(), pubKey);
         } catch (VerificationException.NoncanonicalSignature e) {
             throw new ScriptException(ScriptError.SCRIPT_ERR_SIG_DER, "Script contains non-canonical signature");
         } catch (SignatureDecodeException e) {
@@ -978,7 +978,7 @@ public class ScriptExecution {
             try {
                 TransactionSignature sig = TransactionSignature.decodeFromBitcoin(sigs.getFirst(), requireCanonical, false);
                 Sha256Hash hash = txContainingThis.hashForSignature(index, connectedScript, (byte) sig.sighashFlags);
-                if (ECKey.verify(hash.getBytes(), sig, pubKey))
+                if (ECKey.verify(hash.getBytes(), sig.toCanonicalised(), pubKey))
                     sigs.pollFirst();
             } catch (Exception e) {
                 // There is (at least) one exception that could be hit here (EOFException, if the sig is too short)
@@ -1078,7 +1078,7 @@ public class ScriptExecution {
             ECKey pubkey = ECKey.fromPublicOnly(ScriptPattern.extractKeyFromP2PK(scriptPubKey));
             Sha256Hash sigHash = txContainingThis.hashForSignature(scriptSigIndex, scriptPubKey,
                     signature.sigHashMode(), false);
-            boolean validSig = pubkey.verify(sigHash, signature);
+            boolean validSig = pubkey.verify(sigHash, signature.toCanonicalised());  // ???
             if (!validSig)
                 throw new ScriptException(ScriptError.SCRIPT_ERR_CHECKSIGVERIFY, "Invalid signature");
         } else {

--- a/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
@@ -121,10 +121,17 @@ public class ECKeyTest {
         byte[] output = key.sign(Sha256Hash.ZERO_HASH).encodeToDER();
         assertTrue(key.verify(Sha256Hash.ZERO_HASH.getBytes(), output));
 
-        // Test interop with a signature from elsewhere.
+        // Test interop with a (non-canonical) signature from elsewhere.
         byte[] sig = ByteUtils.parseHex(
                 "3046022100dffbc26774fc841bbe1c1362fd643609c6e42dcb274763476d87af2c0597e89e022100c59e3c13b96b316cae9fa0ab0260612c7a133a6fe2b3445b6bf80b3123bf274d");
-        assertTrue(key.verify(Sha256Hash.ZERO_HASH.getBytes(), sig));
+
+        ECDSASignature uncanonical = ECDSASignature.decodeFromDER(sig);
+        assertFalse(uncanonical.isCanonical());
+
+        ECDSASignature canonical = uncanonical.toCanonicalised();
+        assertTrue(canonical.isCanonical());
+
+        assertTrue(key.verify(Sha256Hash.ZERO_HASH.getBytes(), canonical.encodeToDER()));
     }
 
     @Test
@@ -147,9 +154,16 @@ public class ECKeyTest {
 
             output = ByteUtils.parseHex(
                     "304502206faa2ebc614bf4a0b31f0ce4ed9012eb193302ec2bcaccc7ae8bb40577f47549022100c73a1a1acc209f3f860bf9b9f5e13e9433db6f8b7bd527a088a0e0cd0a4c83e9");
-            assertTrue(key.verify(message, output));
+
+            ECDSASignature uncanonical = ECDSASignature.decodeFromDER(output);
+            assertFalse(uncanonical.isCanonical());
+
+            ECDSASignature canonical = uncanonical.toCanonicalised();
+            assertTrue(canonical.isCanonical());
+
+            assertTrue(key.verify(message, canonical.encodeToDER()));
         }
-        
+
         // Try to sign with one key and verify with the other.
         byte[] message = reverseBytes(ByteUtils.parseHex(
             "11da3761e86431e4a54c176789e41f1651b324d240d599a7067bee23d328ec2a"));
@@ -176,9 +190,17 @@ public class ECKeyTest {
 
             output = ByteUtils.parseHex(
                     "304502206faa2ebc614bf4a0b31f0ce4ed9012eb193302ec2bcaccc7ae8bb40577f47549022100c73a1a1acc209f3f860bf9b9f5e13e9433db6f8b7bd527a088a0e0cd0a4c83e9");
-            assertTrue(key.verify(message, output));
+
+            ECDSASignature uncanonical = ECDSASignature.decodeFromDER(output);
+            assertFalse(uncanonical.isCanonical());
+
+            ECDSASignature canonical = uncanonical.toCanonicalised();
+            assertTrue(canonical.isCanonical());
+
+
+            assertTrue(key.verify(message, canonical.encodeToDER()));
         }
-        
+
         // Try to sign with one key and verify with the other.
         byte[] message = reverseBytes(ByteUtils.parseHex(
             "11da3761e86431e4a54c176789e41f1651b324d240d599a7067bee23d328ec2a"));


### PR DESCRIPTION
The "signature from elsewhere" is non-canonical and will fail if using libsecp256k1 to verify.

There are 2 other tests in ECKeyTest that need a similar update...