### PR TITLE
AbstractFullPrunedBlockChainTest: use assertThrows() over ExpectedException

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -368,43 +368,43 @@ public abstract class AbstractFullPrunedBlockChainTest {
     public void missingHeightFromCoinbase() throws Exception {
         final int UNDOABLE_BLOCKS_STORED = PARAMS.getMajorityEnforceBlockUpgrade() + 1;
         try (FullPrunedBlockStore store = createStore(PARAMS, UNDOABLE_BLOCKS_STORED)) {
-            try {
-                FullPrunedBlockChain chain = new FullPrunedBlockChain(PARAMS, store);
-                ECKey outKey = ECKey.random();
-                int height = 1;
-                Block chainHead = PARAMS.getGenesisBlock();
+            FullPrunedBlockChain chain = new FullPrunedBlockChain(PARAMS, store);
+            ECKey outKey = ECKey.random();
+            int height = 1;
+            Block chainHead = PARAMS.getGenesisBlock();
 
-                // Build some blocks on genesis block to create a spendable output.
+            // Build some blocks on genesis block to create a spendable output.
 
-                // Put in just enough v1 blocks to stop the v2 blocks from forming a majority
-                for (height = 1; height <= (PARAMS.getMajorityWindow() - PARAMS.getMajorityEnforceBlockUpgrade()); height++) {
-                    chainHead = TestBlocks.createNextBlockWithCoinbase(chainHead, Block.BLOCK_VERSION_GENESIS,
-                            outKey.getPubKey(), height);
-                    TestBlocks.solve(chainHead);
-                    chain.add(chainHead);
-                }
-
-                // Fill the rest of the window in with v2 blocks
-                for (; height < PARAMS.getMajorityWindow(); height++) {
-                    chainHead = TestBlocks.createNextBlockWithCoinbase(chainHead, Block.BLOCK_VERSION_BIP34,
-                            outKey.getPubKey(), height);
-                    TestBlocks.solve(chainHead);
-                    chain.add(chainHead);
-                }
-                // Throw a broken v2 block in before we have a supermajority to enable
-                // enforcement, which should validate as-is
-                chainHead = TestBlocks.createNextBlockWithCoinbase(chainHead, Block.BLOCK_VERSION_BIP34,
-                        outKey.getPubKey(), height * 2);
+            // Put in just enough v1 blocks to stop the v2 blocks from forming a majority
+            for (height = 1; height <= (PARAMS.getMajorityWindow() - PARAMS.getMajorityEnforceBlockUpgrade()); height++) {
+                chainHead = TestBlocks.createNextBlockWithCoinbase(chainHead, Block.BLOCK_VERSION_GENESIS,
+                        outKey.getPubKey(), height);
                 TestBlocks.solve(chainHead);
                 chain.add(chainHead);
-                height++;
+            }
 
-                // Trying to add a broken v2 block should now result in rejection as
-                // we have a v2 supermajority
-                thrown.expect(VerificationException.CoinbaseHeightMismatch.class);
+            // Fill the rest of the window in with v2 blocks
+            for (; height < PARAMS.getMajorityWindow(); height++) {
                 chainHead = TestBlocks.createNextBlockWithCoinbase(chainHead, Block.BLOCK_VERSION_BIP34,
-                        outKey.getPubKey(), height * 2);
+                        outKey.getPubKey(), height);
                 TestBlocks.solve(chainHead);
+                chain.add(chainHead);
+            }
+            // Throw a broken v2 block in before we have a supermajority to enable
+            // enforcement, which should validate as-is
+            chainHead = TestBlocks.createNextBlockWithCoinbase(chainHead, Block.BLOCK_VERSION_BIP34,
+                    outKey.getPubKey(), height * 2);
+            TestBlocks.solve(chainHead);
+            chain.add(chainHead);
+            height++;
+
+            // Trying to add a broken v2 block should now result in rejection as
+            // we have a v2 supermajority
+            thrown.expect(VerificationException.CoinbaseHeightMismatch.class);
+            chainHead = TestBlocks.createNextBlockWithCoinbase(chainHead, Block.BLOCK_VERSION_BIP34,
+                    outKey.getPubKey(), height * 2);
+            TestBlocks.solve(chainHead);
+            try {
                 chain.add(chainHead);
             } catch (final VerificationException ex) {
                 throw (Exception) ex.getCause();

--- a/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/AbstractFullPrunedBlockChainTest.java
@@ -38,7 +38,6 @@ import org.bitcoinj.wallet.WalletTransaction;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,6 +50,7 @@ import static org.bitcoinj.base.Coin.FIFTY_COINS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 /**
@@ -58,9 +58,6 @@ import static org.junit.Assert.fail;
  */
 
 public abstract class AbstractFullPrunedBlockChainTest {
-    @org.junit.Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     private static final Logger log = LoggerFactory.getLogger(AbstractFullPrunedBlockChainTest.class);
 
     protected static UnitTestParams PARAMS;
@@ -400,15 +397,13 @@ public abstract class AbstractFullPrunedBlockChainTest {
 
             // Trying to add a broken v2 block should now result in rejection as
             // we have a v2 supermajority
-            thrown.expect(VerificationException.CoinbaseHeightMismatch.class);
-            chainHead = TestBlocks.createNextBlockWithCoinbase(chainHead, Block.BLOCK_VERSION_BIP34,
+            Block brokenBlock = TestBlocks.createNextBlockWithCoinbase(chainHead, Block.BLOCK_VERSION_BIP34,
                     outKey.getPubKey(), height * 2);
-            TestBlocks.solve(chainHead);
-            try {
-                chain.add(chainHead);
-            } catch (final VerificationException ex) {
-                throw (Exception) ex.getCause();
-            }
+            TestBlocks.solve(brokenBlock);
+            VerificationException ex = assertThrows(VerificationException.class, () ->
+                chain.add(brokenBlock)
+            );
+            assertEquals(VerificationException.CoinbaseHeightMismatch.class, ex.getCause().getClass());
         }
     }
 }


### PR DESCRIPTION
The first commit reduces the number of lines inside the try/catch block so that the second change is easier to read.

The second commit uses `assertThrows()` instead of `ExpectedException`.