### PR TITLE
TestWithNetworkConnections subclasses: convert to JUnit 6 from JUnit 4

### DIFF
--- a/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerGroupTest.java
@@ -36,12 +36,12 @@ import org.bitcoinj.test.integration.peer.InboundMessageQueuer;
 import org.bitcoinj.test.integration.peer.TestWithPeerGroup;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.Wallet;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.net.BindException;
@@ -71,17 +71,18 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.bitcoinj.base.Coin.COIN;
 import static org.bitcoinj.base.Coin.valueOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 // TX announcement and broadcast is tested in TransactionBroadcastTest.
 
-@RunWith(value = Parameterized.class)
+@ParameterizedClass
+@MethodSource("parameters")
 public class PeerGroupTest extends TestWithPeerGroup {
     private static final int BLOCK_HEIGHT_GENESIS = 0;
 
@@ -102,7 +103,6 @@ public class PeerGroupTest extends TestWithPeerGroup {
     private PreMessageReceivedEventListener preMessageReceivedListener;
     private Map<Peer, AtomicInteger> peerToMessageCount;
 
-    @Parameterized.Parameters
     public static Collection<ClientType[]> parameters() {
         return List.of(new ClientType[] {ClientType.NIO_CLIENT_MANAGER},
                              new ClientType[] {ClientType.BLOCKING_CLIENT_MANAGER});
@@ -113,7 +113,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
     }
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() throws BlockStoreException, IOException {
         super.setUp();
         peerToMessageCount = new HashMap<>();
@@ -128,7 +128,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
     }
 
     @Override
-    @After
+    @AfterEach
     public void tearDown() {
         super.tearDown();
     }
@@ -362,7 +362,7 @@ public class PeerGroupTest extends TestWithPeerGroup {
         // Now we successfully connect to another peer. There should be no messages sent.
         InboundMessageQueuer p2 = connectPeer(2);
         Message message = outbound(p2);
-        assertNull(message == null ? "" : message.toString(), message);
+        assertNull(message, message == null ? "" : message.toString());
     }
 
     @Test
@@ -539,13 +539,13 @@ public class PeerGroupTest extends TestWithPeerGroup {
         // check things after disconnect
         assertFalse(peerConnectedFuture.isDone()); // should never have connected
         watch.stop();
-        assertTrue("Disconnect in " + watch + " for " + timeout.toMillis() + " ms timeout",
-                watch.elapsed().compareTo(timeout.minus(errorMargin)) >= 0); // should not disconnect before timeout
+        assertTrue(watch.elapsed().compareTo(timeout.minus(errorMargin)) >= 0,
+                "Disconnect in " + watch + " for " + timeout.toMillis() + " ms timeout"); // should not disconnect before timeout
         assertTrue(peerDisconnectedFuture.isDone()); // but should disconnect eventually
     }
 
     @Test
-    @Ignore("disabled for now as this test is too flaky")
+    @Disabled("disabled for now as this test is too flaky")
     public void peerPriority() throws Exception {
         final List<InetSocketAddress> addresses = new ArrayList<>(List.of(
                 new InetSocketAddress("localhost", 2000),
@@ -929,8 +929,8 @@ public class PeerGroupTest extends TestWithPeerGroup {
         Threading.waitForUserCode();
 
         // Assert the loose transaction was NOT silently dropped
-        assertNotNull("Loose transaction should be processed after FilteredBlock (issue #4116)",
-                broadcastTx[0]);
+        assertNotNull(broadcastTx[0],
+                "Loose transaction should be processed after FilteredBlock (issue #4116)");
         assertEquals(looseTx.getTxId(), broadcastTx[0].getTxId());
     }
 

--- a/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/PeerTest.java
@@ -31,11 +31,11 @@ import org.bitcoinj.test.integration.peer.InboundMessageQueuer;
 import org.bitcoinj.test.integration.peer.TestWithNetworkConnections;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.Wallet;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import org.jspecify.annotations.Nullable;
 import java.io.ByteArrayOutputStream;
@@ -63,22 +63,22 @@ import static org.bitcoinj.testing.FakeTxBuilder.createFakeBlock;
 import static org.bitcoinj.testing.FakeTxBuilder.createFakeTx;
 import static org.bitcoinj.testing.FakeTxBuilder.makeTestBlock;
 import static org.bitcoinj.testing.FakeTxBuilder.roundTripTransaction;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-@RunWith(value = Parameterized.class)
+@ParameterizedClass
+@MethodSource("parameters")
 public class PeerTest extends TestWithNetworkConnections {
     private Peer peer;
     private InboundMessageQueuer writeTarget;
     private static final int OTHER_PEER_CHAIN_HEIGHT = 110;
     private final AtomicBoolean fail = new AtomicBoolean(false);
 
-    @Parameterized.Parameters
     public static Collection<ClientType[]> parameters() {
         return Arrays.asList(new ClientType[] {ClientType.NIO_CLIENT_MANAGER},
                              new ClientType[] {ClientType.BLOCKING_CLIENT_MANAGER},
@@ -91,7 +91,7 @@ public class PeerTest extends TestWithNetworkConnections {
     }
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() throws IOException, BlockStoreException {
         super.setUp();
         VersionMessage ver = new VersionMessage(TESTNET, 100);
@@ -101,7 +101,7 @@ public class PeerTest extends TestWithNetworkConnections {
     }
 
     @Override
-    @After
+    @AfterEach
     public void tearDown() {
         super.tearDown();
         assertFalse(fail.get());
@@ -500,7 +500,7 @@ public class PeerTest extends TestWithNetworkConnections {
         pingAndWait(writeTarget);
         assertTrue(future.isDone());
         Duration elapsed = future.get();
-        assertTrue(elapsed.toMillis() + " ms", elapsed.toMillis() > 1000);
+        assertTrue(elapsed.toMillis() > 1000, elapsed.toMillis() + " ms");
         assertEquals(elapsed, peer.lastPingInterval().get());
         assertEquals(elapsed, peer.pingInterval().get());
         // Do it again and make sure it affects the average.

--- a/integration-test/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/TransactionBroadcastTest.java
@@ -29,11 +29,11 @@ import org.bitcoinj.test.integration.peer.TestWithPeerGroup;
 import org.bitcoinj.utils.Threading;
 import org.bitcoinj.wallet.SendRequest;
 import org.bitcoinj.wallet.Wallet;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -48,15 +48,15 @@ import static org.bitcoinj.base.Coin.CENT;
 import static org.bitcoinj.base.Coin.COIN;
 import static org.bitcoinj.base.Coin.FIFTY_COINS;
 import static org.bitcoinj.base.Coin.valueOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(value = Parameterized.class)
+@ParameterizedClass
+@MethodSource("parameters")
 public class TransactionBroadcastTest extends TestWithPeerGroup {
-    @Parameterized.Parameters
     public static Collection<ClientType[]> parameters() {
         return Arrays.asList(new ClientType[] {ClientType.NIO_CLIENT_MANAGER},
                              new ClientType[] {ClientType.BLOCKING_CLIENT_MANAGER});
@@ -67,7 +67,7 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
     }
 
     @Override
-    @Before
+    @BeforeEach
     public void setUp() throws BlockStoreException, IOException {
         TimeUtils.setMockClock(); // Use mock clock
         super.setUp();
@@ -78,7 +78,7 @@ public class TransactionBroadcastTest extends TestWithPeerGroup {
     }
 
     @Override
-    @After
+    @AfterEach
     public void tearDown() {
         super.tearDown();
         TimeUtils.clearMockClock();

--- a/integration-test/src/test/java/org/bitcoinj/test/integration/peer/FilteredBlockAndPartialMerkleTreeTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/test/integration/peer/FilteredBlockAndPartialMerkleTreeTest.java
@@ -45,11 +45,11 @@ import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.testing.FakeTxBuilder;
 import org.bitcoinj.wallet.Wallet;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -63,17 +63,18 @@ import java.util.List;
 import java.util.Set;
 
 import static org.bitcoinj.base.internal.ByteUtils.writeInt32LE;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-@RunWith(value = Parameterized.class)
+@ParameterizedClass
+@MethodSource("parameters")
 public class FilteredBlockAndPartialMerkleTreeTest extends TestWithPeerGroup {
     private static final BitcoinSerializer SERIALIZER = new BitcoinSerializer(BitcoinNetwork.TESTNET);
 
-    @Parameterized.Parameters
     public static Collection<ClientType[]> parameters() {
         return Arrays.asList(new ClientType[] {ClientType.NIO_CLIENT_MANAGER},
                              new ClientType[] {ClientType.BLOCKING_CLIENT_MANAGER});
@@ -83,7 +84,7 @@ public class FilteredBlockAndPartialMerkleTreeTest extends TestWithPeerGroup {
         super(clientType);
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws BlockStoreException, IOException {
         MemoryBlockStore store = new MemoryBlockStore(TESTNET.getGenesisBlock());
 
@@ -103,7 +104,7 @@ public class FilteredBlockAndPartialMerkleTreeTest extends TestWithPeerGroup {
         super.setUp(store);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         super.tearDown();
     }
@@ -152,7 +153,7 @@ public class FilteredBlockAndPartialMerkleTreeTest extends TestWithPeerGroup {
         return Sha256Hash.wrap(bits);
     }
 
-    @Test(expected = VerificationException.class)
+    @Test
     public void merkleTreeMalleability() {
         List<Sha256Hash> hashes = new ArrayList<>();
         for (byte i = 1; i <= 10; i++) hashes.add(numAsHash(i));
@@ -163,7 +164,9 @@ public class FilteredBlockAndPartialMerkleTreeTest extends TestWithPeerGroup {
         ByteUtils.setBitLE(includeBits, 10);
         PartialMerkleTree pmt = PartialMerkleTree.buildFromLeaves(includeBits, hashes);
         List<Sha256Hash> matchedHashes = new ArrayList<>();
-        pmt.getTxnHashAndMerkleRoot(matchedHashes);
+        assertThrows(VerificationException.class, () ->
+            pmt.getTxnHashAndMerkleRoot(matchedHashes)
+        );
     }
 
     @Test

--- a/integration-test/src/test/java/org/bitcoinj/test/integration/peer/TestWithPeerGroup.java
+++ b/integration-test/src/test/java/org/bitcoinj/test/integration/peer/TestWithPeerGroup.java
@@ -34,8 +34,7 @@ import org.bitcoinj.store.BlockStoreException;
 import org.bitcoinj.store.MemoryBlockStore;
 import org.bitcoinj.utils.ContextPropagatingThreadFactory;
 import org.jspecify.annotations.Nullable;
-import org.junit.Rule;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -57,6 +56,7 @@ import static org.bitcoinj.base.internal.Preconditions.checkState;
  * used with loopback peers created using connectPeer. This involves real TCP connections so is a pretty accurate
  * mock, but means unit tests cannot be run simultaneously.
  */
+@Timeout(15)
 public abstract class TestWithPeerGroup extends TestWithNetworkConnections {
     @Nullable protected PeerGroup peerGroup;
 
@@ -69,9 +69,6 @@ public abstract class TestWithPeerGroup extends TestWithNetworkConnections {
             throw new RuntimeException();
         this.clientType = clientType;
     }
-
-    @Rule
-    public Timeout globalTimeout = Timeout.seconds(15);
 
     @Override
     public void setUp() throws IOException, BlockStoreException {


### PR DESCRIPTION
All 5 of these tests are `TestWithNetworkConnections` subclasses. This PR does build with the JUnit 4/Junit Vintage dependencies removed from build.gradle, but we leave them there because they are needed as we continue to migrate JUnit 4 integration tests from bitcoinj-core.

This resolves:

* Issue #2436 

Which is part of:

* Issue #1984