### PR TITLE
Context: add setDefault() method

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Context.java
+++ b/core/src/main/java/org/bitcoinj/core/Context.java
@@ -141,13 +141,23 @@ public class Context {
     }
 
     /**
-     * Sets the given context as the current thread context. You should use this if you create your own threads that
-     * want to create core BitcoinJ objects. Generally, if a class can accept a Context in its constructor and might
-     * be used (even indirectly) by a thread, you will want to call this first. Your task may be simplified by using
-     * a {@link ContextPropagatingThreadFactory}.
+     * Sets the given {@code Context} as the current thread {@code Context}. This method is used by tests that create
+     * customized {@code Context} objects. <b>bitcoinj</b> applications should generally use {@link Context#setDefault()}.
+     * This method will likely be deprecated in the future, so if you are using a default context (that is {@code new Context()}),
+     * you should migrate to {@link Context#setDefault()}.
      */
     public static void propagate(Context context) {
         slot.set(Objects.requireNonNull(context));
+    }
+
+    /**
+     * Set the default <b>bitcoinj</b> context. This method is what nearly all <b>bitcoinj</b> applications should use to initialize
+     * the context. You should use this if you create your own threads that want to create core <b>bitcoinj</b> objects.
+     * Generally, if a class can accept a {@code Context} in its constructor and might be used (even indirectly) by a thread,
+     * you should call this first. Your task may be simplified by using a {@link ContextPropagatingThreadFactory}.
+     */
+    public static void setDefault() {
+        Context.propagate(new Context());
     }
 
     /**

--- a/core/src/test/java/org/bitcoinj/core/BlockTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockTest.java
@@ -64,7 +64,7 @@ public class BlockTest {
 
     @Before
     public void setUp() throws Exception {
-        Context.propagate(new Context());
+        Context.setDefault();
         // One with some of transactions in, so a good test of the merkle tree hashing.
         block700000Bytes = ByteStreams.toByteArray(BlockTest.class.getResourceAsStream("block_testnet700000.dat"));
         block700000 = TESTNET.getDefaultSerializer().makeBlock(ByteBuffer.wrap(block700000Bytes));

--- a/core/src/test/java/org/bitcoinj/core/BloomFilterTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BloomFilterTest.java
@@ -78,7 +78,7 @@ public class BloomFilterTest {
 
     @Test
     public void walletTest() {
-        Context.propagate(new Context());
+        Context.setDefault();
 
         DumpedPrivateKey privKey = DumpedPrivateKey.fromBase58(BitcoinNetwork.MAINNET, "5Kg1gnAjaLfKiwhhPpGS3QfRg2m6awQvaj98JCZBZQ5SuS2F15C");
 

--- a/core/src/test/java/org/bitcoinj/core/TransactionInputTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionInputTest.java
@@ -55,7 +55,7 @@ public class TransactionInputTest {
 
     @Before
     public void setUp() throws Exception {
-        Context.propagate(new Context());
+        Context.setDefault();
     }
 
     @Test

--- a/core/src/test/java/org/bitcoinj/core/TransactionTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TransactionTest.java
@@ -81,7 +81,7 @@ public class TransactionTest {
 
     @Before
     public void setUp() {
-        Context.propagate(new Context());
+        Context.setDefault();
     }
 
     @Test(expected = VerificationException.EmptyInputsOrOutputs.class)

--- a/core/src/test/java/org/bitcoinj/core/TxConfidenceTableTest.java
+++ b/core/src/test/java/org/bitcoinj/core/TxConfidenceTableTest.java
@@ -50,9 +50,8 @@ public class TxConfidenceTableTest {
     @Before
     public void setup() throws Exception {
         BriefLogFormatter.init();
-        Context context = new Context();
-        Context.propagate(context);
-        table = context.getConfidenceTable();
+        Context.setDefault();
+        table = Context.get().getConfidenceTable();
 
         Address to = ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);
         Address change = ECKey.random().toAddress(ScriptType.P2PKH, BitcoinNetwork.TESTNET);

--- a/core/src/test/java/org/bitcoinj/store/SPVBlockStoreTest.java
+++ b/core/src/test/java/org/bitcoinj/store/SPVBlockStoreTest.java
@@ -64,7 +64,7 @@ public class SPVBlockStoreTest {
 
     @Before
     public void setup() throws Exception {
-        Context.propagate(new Context());
+        Context.setDefault();
         blockStoreFile = File.createTempFile("spvblockstore", null);
         blockStoreFile.delete();
         blockStoreFile.deleteOnExit();

--- a/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
+++ b/core/src/test/java/org/bitcoinj/store/WalletProtobufSerializerTest.java
@@ -99,7 +99,7 @@ public class WalletProtobufSerializerTest {
     @BeforeClass
     public static void setUpClass() {
         TimeUtils.clearMockClock();
-        Context.propagate(new Context());
+        Context.setDefault();
     }
 
     @Before

--- a/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
+++ b/core/src/test/java/org/bitcoinj/wallet/DefaultRiskAnalysisTest.java
@@ -63,7 +63,7 @@ public class DefaultRiskAnalysisTest {
 
     @Before
     public void setup() {
-        Context.propagate(new Context());
+        Context.setDefault();
         wallet = Wallet.createDeterministic(BitcoinNetwork.MAINNET, ScriptType.P2PKH);
         wallet.setLastBlockSeenHeight(1000);
         wallet.setLastBlockSeenTime(Instant.ofEpochSecond(TIMESTAMP));

--- a/examples-kotlin/src/main/kotlin/org/bitcoinj/ForwardingService.kt
+++ b/examples-kotlin/src/main/kotlin/org/bitcoinj/ForwardingService.kt
@@ -39,7 +39,7 @@ val USAGE = "Usage: address-to-forward-to $NETS"
 fun main(args: Array<String>) { //pass the network and forwarding address in this order [address, network]
     // This line makes the log output more compact and easily read, especially when using the JDK log adapter.
     BriefLogFormatter.init()
-    Context.propagate(Context())
+    Context.setDefault()
 
     if (args.isEmpty() || args.size > 2) {
         System.err.println(USAGE)

--- a/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
@@ -58,7 +58,7 @@ public class ForwardingService implements Closeable {
     public static void main(String[] args) throws InterruptedException {
         // This line makes the log output more compact and easily read, especially when using the JDK log adapter.
         BriefLogFormatter.init();
-        Context.propagate(new Context());
+        Context.setDefault();
 
         if (args.length < 1 || args.length > 2) {
             System.err.println(USAGE);

--- a/examples/src/main/java/org/bitcoinj/examples/PrintPeers.java
+++ b/examples/src/main/java/org/bitcoinj/examples/PrintPeers.java
@@ -60,7 +60,7 @@ public class PrintPeers {
 
     public static void main(String[] args) throws Exception {
         BriefLogFormatter.init(Level.WARNING);
-        Context.propagate(new Context());
+        Context.setDefault();
         final Network network = BitcoinNetwork.MAINNET;
         final NetworkParameters params = NetworkParameters.of(network);
         System.out.println("=== DNS ===");

--- a/integration-test/src/test/java/org/bitcoinj/examples/ForwardingServiceTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/examples/ForwardingServiceTest.java
@@ -40,7 +40,7 @@ public class ForwardingServiceTest {
 
     @BeforeEach
     void setupTest() {
-        Context.propagate(new Context());
+        Context.setDefault();
     }
 
     @Test

--- a/integration-test/src/test/java/org/bitcoinj/kits/WalletAppKitTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/kits/WalletAppKitTest.java
@@ -40,7 +40,7 @@ public class WalletAppKitTest {
 
     @BeforeEach
     void setupTest(@TempDir File tempDir) {
-        Context.propagate(new Context());
+        Context.setDefault();
         kit = new WalletAppKit(network,
                 ScriptType.P2WPKH,
                 KeyChainGroupStructure.BIP43,

--- a/integration-test/src/test/java/org/bitcoinj/test/bitcoind/BlockFileLoaderBitcoindTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/test/bitcoind/BlockFileLoaderBitcoindTest.java
@@ -43,7 +43,7 @@ public class BlockFileLoaderBitcoindTest {
 
     @BeforeEach
     public void setUp() {
-        Context.propagate(new Context());
+        Context.setDefault();
     }
 
     @Test

--- a/integration-test/src/test/java/org/bitcoinj/test/integration/wallet/WalletAccountPathTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/test/integration/wallet/WalletAccountPathTest.java
@@ -87,7 +87,7 @@ public class WalletAccountPathTest {
 
     // Create a wallet, save it to a file, then reload from a file
     private static Wallet createWallet(File walletFile, Network network, KeyChainGroupStructure structure, ScriptType outputScriptType) throws IOException, UnreadableWalletException {
-        Context.propagate(new Context());
+        Context.setDefault();
         DeterministicSeed seed = DeterministicSeed.ofMnemonic(testWalletMnemonic, "", Instant.now());
         Wallet wallet = Wallet.fromSeed(network, seed, outputScriptType, structure);
         wallet.saveToFile(walletFile);

--- a/integration-test/src/test/java/org/bitcoinj/test/integration/wallet/WalletLoadTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/test/integration/wallet/WalletLoadTest.java
@@ -37,7 +37,7 @@ public class WalletLoadTest {
 
     @Test
     void basicWalletLoadTest() throws UnreadableWalletException {
-        Context.propagate(new Context());
+        Context.setDefault();
         Wallet wallet = Wallet.loadFromFile(walletFile);
 
         Instant creation = wallet.getKeyChainSeed().getCreationTime().get();

--- a/integration-test/src/test/java/org/bitcoinj/utils/BlockFileLoaderTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/utils/BlockFileLoaderTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class BlockFileLoaderTest {
     @BeforeEach
     public void setUp() throws Exception {
-        Context.propagate(new Context());
+        Context.setDefault();
     }
 
     @Test

--- a/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
@@ -93,7 +93,7 @@ public class BuildCheckpoints implements Callable<Integer> {
         final String suffix;
         params = NetworkParameters.of(net);
         Objects.requireNonNull(params);
-        Context.propagate(new Context());
+        Context.setDefault();
 
         switch (net) {
             case MAINNET:

--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/application/WalletApplication.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/application/WalletApplication.java
@@ -125,7 +125,7 @@ public abstract class WalletApplication implements AppDelegate {
     }
 
     protected void startWalletAppKit(Stage primaryStage) throws IOException {
-        Context.propagate(new Context());
+        Context.setDefault();
         // Tell bitcoinj to run event handlers on the JavaFX UI thread. This keeps things simple and means
         // we cannot forget to switch threads when adding event handlers. Unfortunately, the DownloadListener
         // we give to the app kit is currently an exception and runs on a library thread. It'll get fixed in

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -343,7 +343,7 @@ public class WalletTool implements Callable<Integer> {
         if (chainFile == null) {
             chainFile = new File(fileName);
         }
-        Context.propagate(new Context());
+        Context.setDefault();
 
         if (conditionStr != null) {
             condition = new Condition(conditionStr);


### PR DESCRIPTION
Since almost all applications and many tests are using the default context, we can simplify initialization by providing Context.setDefault().

This simplifies applications as they no longer need to decide which Context constructor to use or even call `new`. It also creates a migration path to when the Context thread local is removed. In the future Context.setDefault() can be made into a no-op, then deprecated, then  removed.

If PR #4344 is merged, the calls to `Context.setDefault()` in standalone apps can be removed, but they should be left in the tests because other tests may have set a non-default context and `setDefault()` may be needed to set the context back to the default for the current test.
