### PR TITLE
Context: auto-set default Context, remove strict mode enforcement.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Context.java
+++ b/core/src/main/java/org/bitcoinj/core/Context.java
@@ -80,7 +80,6 @@ public class Context {
     }
 
     private static volatile Context lastConstructed;
-    private static boolean isStrictMode;
     private static final ThreadLocal<Context> slot = new ThreadLocal<>();
 
     /**
@@ -96,11 +95,6 @@ public class Context {
     public static Context get() {
         Context tls = slot.get();
         if (tls == null) {
-            if (isStrictMode) {
-                log.error("Thread is missing a bitcoinj context.");
-                log.error("You should use Context.propagate() or a ContextPropagatingThreadFactory.");
-                throw new IllegalStateException("missing context");
-            }
             if (lastConstructed == null)
                 throw new IllegalStateException("You must construct a Context object before using bitcoinj!");
             slot.set(lastConstructed);
@@ -124,7 +118,6 @@ public class Context {
      */
     @Deprecated
     public static void enableStrictMode() {
-        isStrictMode = true;
     }
 
     // A temporary internal shim designed to help us migrate internally in a way that doesn't wreck source compatibility.

--- a/core/src/main/java/org/bitcoinj/core/Context.java
+++ b/core/src/main/java/org/bitcoinj/core/Context.java
@@ -83,28 +83,17 @@ public class Context {
     private static final ThreadLocal<Context> slot = new ThreadLocal<>();
 
     /**
-     * Returns the current context that is associated with the <b>calling thread</b>. BitcoinJ is an API that has thread
-     * affinity: much like OpenGL it expects each thread that accesses it to have been configured with a global Context
-     * object. This method returns that. Note that to help you develop, this method will <i>also</i> propagate whichever
-     * context was created last onto the current thread, if it's missing. However it will print an error when doing so
-     * because propagation of contexts is meant to be done manually: this is so two libraries or subsystems that
-     * independently use bitcoinj (or possibly alt coin forks of it) can operate correctly.
-     *
-     * @throws java.lang.IllegalStateException if no context exists at all or if we are in strict mode and there is no context.
+     * Returns the current context that is associated with the <b>calling thread</b>. <b>bitcoinj</b> uses the {@code Context}
+     * object for overriding certain behaviors in tests. Most applications should use the default context.
      */
     public static Context get() {
         Context tls = slot.get();
         if (tls == null) {
-            if (lastConstructed == null)
-                throw new IllegalStateException("You must construct a Context object before using bitcoinj!");
-            slot.set(lastConstructed);
-            log.error("Performing thread fixup: you are accessing bitcoinj via a thread that has not had any context set on it.");
-            log.error("This error has been corrected for, but doing this makes your app less robust.");
-            log.error("You should use Context.propagate() or a ContextPropagatingThreadFactory.");
-            log.error("Please refer to the user guide for more information about this.");
-            log.error("Thread name is {}.", Thread.currentThread().getName());
-            // TODO: Actually write the user guide section about this.
-            // TODO: If the above TODO makes it past the 0.13 release, kick Mike and tell him he sucks.
+            if (lastConstructed != null) {
+                slot.set(lastConstructed);
+            } else {
+                slot.set(new Context());    // No context previously set, use default context
+            }
             return lastConstructed;
         } else {
             return tls;

--- a/examples-kotlin/src/main/kotlin/org/bitcoinj/ForwardingService.kt
+++ b/examples-kotlin/src/main/kotlin/org/bitcoinj/ForwardingService.kt
@@ -18,7 +18,6 @@ import org.bitcoinj.base.Address
 import org.bitcoinj.base.AddressParser
 import org.bitcoinj.base.BitcoinNetwork
 import org.bitcoinj.base.Coin
-import org.bitcoinj.core.Context
 import org.bitcoinj.core.Transaction
 import org.bitcoinj.core.TransactionBroadcast
 import org.bitcoinj.core.TransactionConfidence
@@ -39,7 +38,6 @@ val USAGE = "Usage: address-to-forward-to $NETS"
 fun main(args: Array<String>) { //pass the network and forwarding address in this order [address, network]
     // This line makes the log output more compact and easily read, especially when using the JDK log adapter.
     BriefLogFormatter.init()
-    Context.propagate(Context())
 
     if (args.isEmpty() || args.size > 2) {
         System.err.println(USAGE)

--- a/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
+++ b/examples/src/main/java/org/bitcoinj/examples/ForwardingService.java
@@ -20,7 +20,6 @@ import org.bitcoinj.base.Address;
 import org.bitcoinj.base.AddressParser;
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Coin;
-import org.bitcoinj.core.Context;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.TransactionBroadcast;
 import org.bitcoinj.kits.WalletAppKit;
@@ -58,7 +57,6 @@ public class ForwardingService implements Closeable {
     public static void main(String[] args) throws InterruptedException {
         // This line makes the log output more compact and easily read, especially when using the JDK log adapter.
         BriefLogFormatter.init();
-        Context.propagate(new Context());
 
         if (args.length < 1 || args.length > 2) {
             System.err.println(USAGE);

--- a/examples/src/main/java/org/bitcoinj/examples/PrintPeers.java
+++ b/examples/src/main/java/org/bitcoinj/examples/PrintPeers.java
@@ -18,7 +18,6 @@ package org.bitcoinj.examples;
 
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Network;
-import org.bitcoinj.core.Context;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Peer;
 import org.bitcoinj.core.PeerAddress;
@@ -60,7 +59,6 @@ public class PrintPeers {
 
     public static void main(String[] args) throws Exception {
         BriefLogFormatter.init(Level.WARNING);
-        Context.propagate(new Context());
         final Network network = BitcoinNetwork.MAINNET;
         final NetworkParameters params = NetworkParameters.of(network);
         System.out.println("=== DNS ===");

--- a/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
@@ -21,7 +21,6 @@ import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.core.BlockChain;
 import org.bitcoinj.core.CheckpointManager;
-import org.bitcoinj.core.Context;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Peer;
 import org.bitcoinj.core.PeerAddress;
@@ -93,7 +92,6 @@ public class BuildCheckpoints implements Callable<Integer> {
         final String suffix;
         params = NetworkParameters.of(net);
         Objects.requireNonNull(params);
-        Context.propagate(new Context());
 
         switch (net) {
             case MAINNET:

--- a/wallettemplate/src/main/java/org/bitcoinj/walletfx/application/WalletApplication.java
+++ b/wallettemplate/src/main/java/org/bitcoinj/walletfx/application/WalletApplication.java
@@ -25,7 +25,6 @@ import javafx.stage.Stage;
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.ScriptType;
 import org.bitcoinj.base.internal.PlatformUtils;
-import org.bitcoinj.core.Context;
 import org.bitcoinj.kits.WalletAppKit;
 import org.bitcoinj.utils.AppDataDirectory;
 import org.bitcoinj.utils.BriefLogFormatter;
@@ -125,7 +124,6 @@ public abstract class WalletApplication implements AppDelegate {
     }
 
     protected void startWalletAppKit(Stage primaryStage) throws IOException {
-        Context.propagate(new Context());
         // Tell bitcoinj to run event handlers on the JavaFX UI thread. This keeps things simple and means
         // we cannot forget to switch threads when adding event handlers. Unfortunately, the DownloadListener
         // we give to the app kit is currently an exception and runs on a library thread. It'll get fixed in

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -32,7 +32,6 @@ import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.core.AbstractBlockChain;
 import org.bitcoinj.core.BlockChain;
 import org.bitcoinj.core.CheckpointManager;
-import org.bitcoinj.core.Context;
 import org.bitcoinj.core.InsufficientMoneyException;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Peer;
@@ -343,7 +342,6 @@ public class WalletTool implements Callable<Integer> {
         if (chainFile == null) {
             chainFile = new File(fileName);
         }
-        Context.propagate(new Context());
 
         if (conditionStr != null) {
             condition = new Condition(conditionStr);


### PR DESCRIPTION
Two commits:

1. `enableStrictMode()` is deprecated, but this commit removes enforcement even if `enableStrictMode()` is called.
2. Rather than fail if no `lastConstructed` context is available, creating a default context.

This implements step 2 in:

* Issue #4093
