### PR TITLE
AbstractBlockChain, BlockChainTest: use getters to access NetworkParameters

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
+++ b/core/src/main/java/org/bitcoinj/core/AbstractBlockChain.java
@@ -497,7 +497,7 @@ public abstract class AbstractBlockChain {
             }
 
             Difficulty target = block.difficultyTarget();
-            if (target.compareTo(params.maxTarget) > 0)
+            if (target.compareTo(params.maxTarget()) > 0)
                 throw new VerificationException("Difficulty target is out of range: " + target);
 
             // If we want to verify transactions (ie we are running with full blocks), verify that block has transactions

--- a/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
+++ b/core/src/test/java/org/bitcoinj/core/BlockChainTest.java
@@ -142,7 +142,7 @@ public class BlockChainTest {
 
     // adds 2015 (interval-1) intermediate blocks between the transition points
     private static void addIntermediteBlocks(BlockChain chain, int epoch, Duration spacing) throws PrunedException {
-        int interval = chain.params.interval;
+        int interval = chain.params.getInterval();
         Block prev = chain.getChainHead().getHeader();
         // there is an additional spacing here, to account for the fact that for the difficulty adjustment only
         // interval minus 1 blocks are taken into account
@@ -156,7 +156,7 @@ public class BlockChainTest {
     }
 
     private static void addTransitionBlock(BlockChain chain, int epoch, Duration spacing) throws PrunedException {
-        int interval = chain.params.interval;
+        int interval = chain.params.getInterval();
         Block prev = chain.getChainHead().getHeader();
         Instant newTime = prev.time().plus(spacing);
         Block newBlock = TestBlocks.createNextBlock(prev, null, 1, newTime, epoch * interval);


### PR DESCRIPTION
These classes should not be directly accessing protected fields of the abstract class `NetworkParameters`, so use the getters instead.