### PR TITLE
Block: add getGenesis(Network) static factor; Reduce use of NetworkParameters

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -19,6 +19,7 @@ package org.bitcoinj.core;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.bitcoinj.base.Difficulty;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.VarInt;
 import org.bitcoinj.base.internal.Buffers;
@@ -267,6 +268,15 @@ public class Block implements Message {
     public Block(long version, Sha256Hash prevHash, Sha256Hash merkleRoot, Instant time,
                  long difficultyTarget, long nonce, @Nullable List<Transaction> transactions) {
         this(version, prevHash, merkleRoot, time, Difficulty.ofCompact(difficultyTarget), nonce, transactions);
+    }
+
+    /**
+     * Get the standard full Genesis Block for a network
+     * @param network the network
+     * @return a complete block (should be treated as immutable)
+     */
+    public static Block getGenesis(Network network) {
+        return NetworkParameters.of(network).getGenesisBlock();
     }
 
     public static Block createGenesis(Instant time, Difficulty difficultyTarget) {

--- a/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
+++ b/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
@@ -17,6 +17,7 @@
 package org.bitcoinj.core;
 
 import com.google.common.io.BaseEncoding;
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.store.BlockStore;
@@ -83,7 +84,7 @@ public class CheckpointManager {
     // Map of block header time (in seconds) to data.
     protected final TreeMap<Instant, StoredBlock> checkpoints = new TreeMap<>();
 
-    protected final NetworkParameters params;
+    protected final Network network;
     protected final Sha256Hash dataHash;
 
     /**
@@ -99,7 +100,7 @@ public class CheckpointManager {
 
     /** Loads the checkpoints from the given stream */
     public CheckpointManager(NetworkParameters params, @Nullable InputStream inputStream) throws IOException {
-        this.params = Objects.requireNonNull(params);
+        network = Objects.requireNonNull(params).network();
         if (inputStream == null)
             inputStream = openStream(params);
         Objects.requireNonNull(inputStream);
@@ -161,11 +162,11 @@ public class CheckpointManager {
      */
     public StoredBlock getCheckpointBefore(Instant time) {
         try {
-            checkArgument(time.isAfter(params.getGenesisBlock().time()));
+            checkArgument(time.isAfter(Block.getGenesis(network).time()));
             // This is thread safe because the map never changes after creation.
             Map.Entry<Instant, StoredBlock> entry = checkpoints.floorEntry(time);
             if (entry != null) return entry.getValue();
-            Block genesis = params.getGenesisBlock().asHeader();
+            Block genesis = Block.getGenesis(network).asHeader();
             return new StoredBlock(genesis, genesis.getWork(), 0);
         } catch (VerificationException e) {
             throw new RuntimeException(e);  // Cannot happen.

--- a/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
+++ b/core/src/main/java/org/bitcoinj/store/SPVBlockStore.java
@@ -16,6 +16,7 @@
 
 package org.bitcoinj.store;
 
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.internal.ByteUtils;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.core.NetworkParameters;
@@ -65,7 +66,7 @@ public class SPVBlockStore implements BlockStore {
     static final byte[] HEADER_MAGIC_V2 = "SPV2".getBytes(StandardCharsets.US_ASCII);
 
     private volatile @Nullable MappedByteBuffer buffer;
-    protected final NetworkParameters params;
+    protected final Network network;
 
     // The entire ring-buffer is mmapped and accessing it should be as fast as accessing regular memory once it's
     // faulted in. Unfortunately, in theory practice and theory are the same. In practice they aren't.
@@ -119,7 +120,7 @@ public class SPVBlockStore implements BlockStore {
      */
     public SPVBlockStore(NetworkParameters params, File file, int capacity, boolean grow) throws BlockStoreException {
         Objects.requireNonNull(file);
-        this.params = Objects.requireNonNull(params);
+        network = Objects.requireNonNull(params).network();
         checkArgument(capacity > 0, () -> "capacity must be positive");
         checkArgument(capacity < 144 * 365 * 10, () -> "capacity must be sane"); // 10 years
 
@@ -157,7 +158,7 @@ public class SPVBlockStore implements BlockStore {
                 randomAccessFile.setLength(fileLength);
                 // Map it into memory read/write. See above comment.
                 buffer = channel.map(FileChannel.MapMode.READ_WRITE, 0, fileLength);
-                initNewStore(params.getGenesisBlock());
+                initNewStore(Block.getGenesis(network));
             }
 
             // Maybe migrate V1 to V2 format.
@@ -436,7 +437,7 @@ public class SPVBlockStore implements BlockStore {
                 buffer.put((byte)0);
             }
             // Initialize store again
-            initNewStore(params.getGenesisBlock());
+            initNewStore(Block.getGenesis(network));
         } finally { lock.unlock(); }
     }
 }

--- a/examples/src/main/java/org/bitcoinj/examples/FetchBlock.java
+++ b/examples/src/main/java/org/bitcoinj/examples/FetchBlock.java
@@ -22,7 +22,6 @@ import org.bitcoinj.base.Network;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.core.BlockChain;
-import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.Peer;
 import org.bitcoinj.core.PeerAddress;
 import org.bitcoinj.core.PeerGroup;
@@ -64,8 +63,7 @@ public class FetchBlock implements Callable<Integer> {
         Objects.requireNonNull(blockHashParam);
         System.out.println("Connecting to node");
         final Network network = BitcoinNetwork.TESTNET;
-        final NetworkParameters params = NetworkParameters.of(network);
-        BlockStore blockStore = new MemoryBlockStore(params.getGenesisBlock());
+        BlockStore blockStore = new MemoryBlockStore(Block.getGenesis(network));
         BlockChain chain = new BlockChain(network, blockStore);
         PeerGroup peerGroup = new PeerGroup(network, chain);
         if (localhost) {

--- a/examples/src/main/java/org/bitcoinj/examples/PrivateKeys.java
+++ b/examples/src/main/java/org/bitcoinj/examples/PrivateKeys.java
@@ -22,8 +22,8 @@ import org.bitcoinj.base.Base58;
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Network;
 import org.bitcoinj.base.ScriptType;
+import org.bitcoinj.core.Block;
 import org.bitcoinj.core.BlockChain;
-import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.PeerAddress;
 import org.bitcoinj.core.PeerGroup;
 import org.bitcoinj.crypto.DumpedPrivateKey;
@@ -46,7 +46,6 @@ public class PrivateKeys {
     public static void main(String[] args) throws Exception {
         // TODO: Assumes main network not testnet. Make it selectable.
         Network network = BitcoinNetwork.MAINNET;
-        NetworkParameters params = NetworkParameters.of(network);
         try {
             // Decode the private key from Satoshis Base58 variant. If 51 characters long then it's from Bitcoins
             // dumpprivkey command and includes a version byte and checksum, or if 52 characters long then it has 
@@ -69,7 +68,7 @@ public class PrivateKeys {
             Address destination = wallet.parseAddress(args[1]);
 
             // Find the transactions that involve those coins.
-            final MemoryBlockStore blockStore = new MemoryBlockStore(params.getGenesisBlock());
+            final MemoryBlockStore blockStore = new MemoryBlockStore(Block.getGenesis(network));
             BlockChain chain = new BlockChain(network, wallet, blockStore);
 
             final PeerGroup peerGroup = new PeerGroup(network, chain);

--- a/integration-test/src/test/java/org/bitcoinj/test/bitcoind/BlockFileLoaderBitcoindTest.java
+++ b/integration-test/src/test/java/org/bitcoinj/test/bitcoind/BlockFileLoaderBitcoindTest.java
@@ -22,7 +22,6 @@ import org.bitcoinj.core.AbstractBlockChain;
 import org.bitcoinj.core.Block;
 import org.bitcoinj.core.BlockChain;
 import org.bitcoinj.core.Context;
-import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.core.PrunedException;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.BlockStoreException;
@@ -66,9 +65,8 @@ public class BlockFileLoaderBitcoindTest {
     @Test
     public void iterateEntireBitcoindBlockchainIntoBlockStore() throws BlockStoreException, PrunedException {
         Network network = BitcoinNetwork.MAINNET;
-        NetworkParameters params = NetworkParameters.of(network);
         BlockFileLoader loader = new BlockFileLoader(network, BlockFileLoader.getReferenceClientBlockFileList());
-        BlockStore store = new MemoryBlockStore(params.getGenesisBlock());
+        BlockStore store = new MemoryBlockStore(Block.getGenesis(network));
         AbstractBlockChain chain = new BlockChain(network, store);
 
         long blockCount = 0;

--- a/tools/src/main/java/org/bitcoinj/tools/BlockImporter.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BlockImporter.java
@@ -56,7 +56,7 @@ public class BlockImporter {
                 break;
             case "Mem":
                 checkArgument(args.length == 2);
-                store = new MemoryBlockStore(params.getGenesisBlock());
+                store = new MemoryBlockStore(Block.getGenesis(network));
                 break;
             case "SPV":
                 checkArgument(args.length == 3);

--- a/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
+++ b/tools/src/main/java/org/bitcoinj/tools/BuildCheckpoints.java
@@ -19,6 +19,7 @@ package org.bitcoinj.tools;
 
 import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.internal.TimeUtils;
+import org.bitcoinj.core.Block;
 import org.bitcoinj.core.BlockChain;
 import org.bitcoinj.core.CheckpointManager;
 import org.bitcoinj.core.Context;
@@ -116,7 +117,7 @@ public class BuildCheckpoints implements Callable<Integer> {
         // node and to save block headers that are on interval boundaries, as long as they are <1 month old.
         final TreeMap<Integer, StoredBlock> checkpoints;
         final File textFile;
-        try (BlockStore store = new MemoryBlockStore(params.getGenesisBlock())) {
+        try (BlockStore store = new MemoryBlockStore(Block.getGenesis(net))) {
             final BlockChain chain = new BlockChain(net, store);
             final PeerGroup peerGroup = new PeerGroup(net, chain);
 


### PR DESCRIPTION
~~This is a child of~~:

*  PR #4353

~~which fixes a mocking issue in `CheckPointManagerTest` that makes it overly sensitive to changes unrelated to the test~~.

Two commits:

* Add `getGenesis(Network)`
* Reduce use of `NetworkParameters` in several apps and tests.

This is an important milestone in finishing the migration of our public API to `Network` from `NetworkParameters`.
