### PR TITLE
CheckpointManagerTest: only mock params.getId()

### DIFF
--- a/core/src/test/java/org/bitcoinj/core/CheckpointManagerTest.java
+++ b/core/src/test/java/org/bitcoinj/core/CheckpointManagerTest.java
@@ -16,21 +16,28 @@
 
 package org.bitcoinj.core;
 
-import org.easymock.EasyMockRunner;
-import org.easymock.Mock;
+import org.bitcoinj.params.MainNetParams;
+import org.easymock.EasyMock;
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.io.IOException;
 
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 
-@RunWith(EasyMockRunner.class)
 public class CheckpointManagerTest {
 
-    @Mock
     NetworkParameters params;
+
+    @Before
+    public void setUp() {
+        // Use MainNetParams and only mock the behavior of getId()
+        params = EasyMock.partialMockBuilder(MainNetParams.class)
+                .withConstructor()
+                .addMockedMethod("getId")
+                .createMock();
+    }
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerExceptionWhenCheckpointsNotFound() throws IOException {


### PR DESCRIPTION
The mock objects created for NetworkParams are overly sensitive to implementation changes. We just want to override getId() to force CheckPointManager to load checkpoints from different test files. We don't want to proscribe calls from CheckPointManager to other methods of `params`.

This change builds a "partial mock" which is a real object with only the `getId()` method overridden. The setUp() method builds the partial mock and assigns it to `params`.