### PR TITLE
PeerAddress: add localhost(Network) and use it where appropriate

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/PeerAddress.java
+++ b/core/src/main/java/org/bitcoinj/core/PeerAddress.java
@@ -17,6 +17,7 @@
 
 package org.bitcoinj.core;
 
+import org.bitcoinj.base.Network;
 import org.bitcoinj.base.VarInt;
 import org.bitcoinj.base.internal.Buffers;
 import org.bitcoinj.base.internal.TimeUtils;
@@ -231,6 +232,17 @@ public class PeerAddress {
         this.port = port;
         this.services = services;
         this.time = time;
+    }
+
+    /**
+     * Get the address for a localhost peer for a specified {@link Network}.
+     * <p>
+     * The {@code Network} determines the port the peer should be running on.
+     * @param network the network the peer is running on.
+     * @return peer address
+     */
+    public static PeerAddress localhost(Network network) {
+        return localhost(NetworkParameters.of(network));
     }
 
     public static PeerAddress localhost(NetworkParameters params) {

--- a/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
+++ b/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
@@ -213,7 +213,7 @@ public class WalletAppKit extends AbstractIdleService implements Closeable {
 
     /** Will only connect to localhost. Cannot be called after startup. */
     public WalletAppKit connectToLocalHost() {
-        return setPeerNodes(PeerAddress.localhost(params));
+        return setPeerNodes(PeerAddress.localhost(network));
     }
 
     /** If true, the wallet will save itself to disk automatically whenever it changes. */

--- a/examples/src/main/java/org/bitcoinj/examples/FetchBlock.java
+++ b/examples/src/main/java/org/bitcoinj/examples/FetchBlock.java
@@ -71,7 +71,7 @@ public class FetchBlock implements Callable<Integer> {
         if (localhost) {
             peerGroup.addPeerDiscovery(new DnsDiscovery(network));
         } else {
-            PeerAddress addr = PeerAddress.localhost(params);
+            PeerAddress addr = PeerAddress.localhost(network);
             peerGroup.addAddress(addr);
         }
         peerGroup.start();

--- a/examples/src/main/java/org/bitcoinj/examples/FetchTransactions.java
+++ b/examples/src/main/java/org/bitcoinj/examples/FetchTransactions.java
@@ -47,7 +47,7 @@ public class FetchTransactions {
         BlockChain chain = new BlockChain(network, blockStore);
         PeerGroup peerGroup = new PeerGroup(network, chain);
         peerGroup.start();
-        peerGroup.addAddress(PeerAddress.localhost(params));
+        peerGroup.addAddress(PeerAddress.localhost(network));
         peerGroup.waitForPeers(1).get();
         Peer peer = peerGroup.getConnectedPeers().get(0);
 

--- a/examples/src/main/java/org/bitcoinj/examples/PrivateKeys.java
+++ b/examples/src/main/java/org/bitcoinj/examples/PrivateKeys.java
@@ -73,7 +73,7 @@ public class PrivateKeys {
             BlockChain chain = new BlockChain(network, wallet, blockStore);
 
             final PeerGroup peerGroup = new PeerGroup(network, chain);
-            peerGroup.addAddress(PeerAddress.localhost(params));
+            peerGroup.addAddress(PeerAddress.localhost(network));
             peerGroup.startAsync();
             peerGroup.downloadBlockChain();
 

--- a/integration-test/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
+++ b/integration-test/src/test/java/org/bitcoinj/core/BitcoindComparisonTool.java
@@ -93,7 +93,7 @@ public class BitcoindComparisonTool {
         VersionMessage ver = new VersionMessage(PARAMS, 42);
         ver.appendToSubVer("BlockAcceptanceComparisonTool", "1.1", null);
         ver.localServices = Services.of(Services.NODE_NETWORK);
-        final Peer bitcoind = new Peer(PARAMS, ver, PeerAddress.localhost(PARAMS),
+        final Peer bitcoind = new Peer(PARAMS, ver, PeerAddress.localhost(PARAMS.network()),
                 new BlockChain(PARAMS.network(), new MemoryBlockStore(PARAMS.getGenesisBlock())));
         checkState(bitcoind.getVersionMessage().services().has(Services.NODE_NETWORK));
 

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -837,7 +837,7 @@ public class WalletTool implements Callable<Integer> {
         }
         peerGroup.setUserAgent("WalletTool", "1.0");
         if (net == BitcoinNetwork.REGTEST) {
-            peerGroup.addAddress(PeerAddress.localhost(params));
+            peerGroup.addAddress(PeerAddress.localhost(net));
             peerGroup.setMinBroadcastConnections(1);
             peerGroup.setMaxConnections(1);
         }


### PR DESCRIPTION
Use it in all apps (and WalletAppKit) that were previously using `localhost(`NetworkParameters`).

For now, we continue to use the `NetworkParameters` version in `PeerGroup` and `PeerGroupTest` as they both use params extensively.