### PR TITLE
CheckpointManager: constructors/methods that take BitcoinNetwork rather than NetworkParameters

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
+++ b/core/src/main/java/org/bitcoinj/core/CheckpointManager.java
@@ -17,6 +17,7 @@
 package org.bitcoinj.core;
 
 import com.google.common.io.BaseEncoding;
+import org.bitcoinj.base.BitcoinNetwork;
 import org.bitcoinj.base.Sha256Hash;
 import org.bitcoinj.base.internal.TimeUtils;
 import org.bitcoinj.store.BlockStore;
@@ -113,6 +114,15 @@ public class CheckpointManager {
             throw new IOException("Unsupported format.");
     }
 
+    /**
+     * Open a checkpoints stream for the given {@link BitcoinNetwork} pointing to inside the bitcoinj JAR.
+     * @param network the network
+     * @return input stream
+     */
+    public static InputStream openStream(BitcoinNetwork network) {
+        return openStream(NetworkParameters.of(network));
+    }
+
     /** Returns a checkpoints stream pointing to inside the bitcoinj JAR */
     public static InputStream openStream(NetworkParameters params) {
         return CheckpointManager.class.getResourceAsStream("/" + params.getId() + ".checkpoints.txt");
@@ -180,6 +190,17 @@ public class CheckpointManager {
     /** Returns a hash of the concatenated checkpoint data. */
     public Sha256Hash getDataHash() {
         return dataHash;
+    }
+
+    /**
+     * Convenience method that creates a CheckpointManager, loads the given data, gets the checkpoint for the given
+     * time, then inserts it into the store and sets that to be the chain head. Useful when you have just created
+     * a new store from scratch and want to use configure it all in one go.
+     * <p>
+     * Note that time is adjusted backwards by a week to account for possible clock drift in the block headers.
+     */
+    public static void checkpoint(BitcoinNetwork network, InputStream checkpoints, BlockStore store, Instant time) throws BlockStoreException, IOException {
+        checkpoint(NetworkParameters.of(network), checkpoints, store, time);
     }
 
     /**

--- a/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
+++ b/core/src/main/java/org/bitcoinj/kits/WalletAppKit.java
@@ -410,7 +410,7 @@ public class WalletAppKit extends AbstractIdleService implements Closeable {
                     time = vWallet.earliestKeyCreationTime();
                 }
                 if (time.isAfter(Instant.EPOCH))
-                    CheckpointManager.checkpoint(params, checkpoints, vStore, time);
+                    CheckpointManager.checkpoint(network, checkpoints, vStore, time);
                 else
                     log.warn("Creating a new uncheckpointed block store due to a wallet with a creation time of zero: this will result in a very slow chain sync");
             } else if (chainFileExists) {

--- a/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
+++ b/wallettool/src/main/java/org/bitcoinj/wallettool/WalletTool.java
@@ -820,7 +820,7 @@ public class WalletTool implements Callable<Integer> {
         store = new SPVBlockStore(params, chainFile);
         if (reset) {
             try {
-                CheckpointManager.checkpoint(params, CheckpointManager.openStream(params), store,
+                CheckpointManager.checkpoint(net, CheckpointManager.openStream(net), store,
                         wallet.earliestKeyCreationTime());
                 StoredBlock head = store.getChainHead();
                 System.out.println("Skipped to checkpoint " + head.getHeight() + " at "


### PR DESCRIPTION
This will need a rebase and finishing after several other recent PRs have been merged.

After this is merged, we should be able to update `WalletTool` to remove all dependencies on `NetworkParameters`!
