### PR TITLE
EncodedPrivateKey: implement method `toString()`, redacting the private key

### DIFF
--- a/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/BIP38PrivateKey.java
@@ -193,9 +193,4 @@ public class BIP38PrivateKey extends EncodedPrivateKey {
             throw new RuntimeException(x);
         }
     }
-
-    @Override
-    public String toString() {
-        return toBase58();
-    }
 }

--- a/core/src/main/java/org/bitcoinj/crypto/DumpedPrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/DumpedPrivateKey.java
@@ -112,9 +112,4 @@ public class DumpedPrivateKey extends EncodedPrivateKey {
     public boolean isPubKeyCompressed() {
         return bytes.length == 33 && bytes[32] == 1;
     }
-
-    @Override
-    public String toString() {
-        return toBase58();
-    }
 }

--- a/core/src/main/java/org/bitcoinj/crypto/ECKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/ECKey.java
@@ -1428,7 +1428,7 @@ public class ECKey implements EncryptableItem, ECPublicKey {
 
 
     public String getPrivateKeyAsWiF(Network network) {
-        return getPrivateKeyEncoded(network).toString();
+        return getPrivateKeyEncoded(network).toBase58();
     }
 
     private String toString(boolean includePrivate, @Nullable AesKey aesKey, Network network) {

--- a/core/src/main/java/org/bitcoinj/crypto/EncodedPrivateKey.java
+++ b/core/src/main/java/org/bitcoinj/crypto/EncodedPrivateKey.java
@@ -54,4 +54,13 @@ public abstract class EncodedPrivateKey {
         EncodedPrivateKey other = (EncodedPrivateKey) o;
         return this.network.equals(other.network) && Arrays.equals(this.bytes, other.bytes);
     }
+
+    /**
+     * This implementation redacts the private key. If absolutely necessary, use specific accessors in subclasses,
+     * e.g. {@code toBase58()}.
+     */
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{network=" + network + ",bytes=redacted}";
+    }
 }

--- a/core/src/test/java/org/bitcoinj/crypto/BIP38PrivateKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/BIP38PrivateKeyTest.java
@@ -36,7 +36,7 @@ public class BIP38PrivateKeyTest {
                 "6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg");
         ECKey key = encryptedKey.decrypt("TestingOneTwoThree");
         assertEquals("5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR", key.getPrivateKeyEncoded(MAINNET)
-                .toString());
+                .toBase58());
     }
 
     @Test
@@ -45,7 +45,7 @@ public class BIP38PrivateKeyTest {
                 "6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTePPX1dWByq");
         ECKey key = encryptedKey.decrypt("Satoshi");
         assertEquals("5HtasZ6ofTHP6HCwTqTkLDuLQisYPah7aUnSKfC7h4hMUVw2gi5", key.getPrivateKeyEncoded(MAINNET)
-                .toString());
+                .toBase58());
     }
 
     @Test
@@ -60,7 +60,7 @@ public class BIP38PrivateKeyTest {
         passphrase.appendCodePoint(0x01f4a9); // PILE OF POO
         ECKey key = encryptedKey.decrypt(passphrase.toString());
         assertEquals("5Jajm8eQ22H3pGWLEVCXyvND8dQZhiQhoLJNKjYXk9roUFTMSZ4", key.getPrivateKeyEncoded(MAINNET)
-                .toString());
+                .toBase58());
     }
 
     @Test
@@ -69,7 +69,7 @@ public class BIP38PrivateKeyTest {
                 "6PYNKZ1EAgYgmQfmNVamxyXVWHzK5s6DGhwP4J5o44cvXdoY7sRzhtpUeo");
         ECKey key = encryptedKey.decrypt("TestingOneTwoThree");
         assertEquals("L44B5gGEpqEDRS9vVPz7QT35jcBG2r3CZwSwQ4fCewXAhAhqGVpP", key.getPrivateKeyEncoded(MAINNET)
-                .toString());
+                .toBase58());
     }
 
     @Test
@@ -78,7 +78,7 @@ public class BIP38PrivateKeyTest {
                 "6PYLtMnXvfG3oJde97zRyLYFZCYizPU5T3LwgdYJz1fRhh16bU7u6PPmY7");
         ECKey key = encryptedKey.decrypt("Satoshi");
         assertEquals("KwYgW8gcxj1JWJXhPSu4Fqwzfhp5Yfi42mdYmMa4XqK7NJxXUSK7", key.getPrivateKeyEncoded(MAINNET)
-                .toString());
+                .toBase58());
     }
 
     @Test
@@ -87,7 +87,7 @@ public class BIP38PrivateKeyTest {
                 "6PfQu77ygVyJLZjfvMLyhLMQbYnu5uguoJJ4kMCLqWwPEdfpwANVS76gTX");
         ECKey key = encryptedKey.decrypt("TestingOneTwoThree");
         assertEquals("5K4caxezwjGCGfnoPTZ8tMcJBLB7Jvyjv4xxeacadhq8nLisLR2", key.getPrivateKeyEncoded(MAINNET)
-                .toString());
+                .toBase58());
     }
 
     @Test
@@ -96,7 +96,7 @@ public class BIP38PrivateKeyTest {
                 "6PfLGnQs6VZnrNpmVKfjotbnQuaJK4KZoPFrAjx1JMJUa1Ft8gnf5WxfKd");
         ECKey key = encryptedKey.decrypt("Satoshi");
         assertEquals("5KJ51SgxWaAYR13zd9ReMhJpwrcX47xTJh2D3fGPG9CM8vkv5sH", key.getPrivateKeyEncoded(MAINNET)
-                .toString());
+                .toBase58());
     }
 
     @Test
@@ -105,7 +105,7 @@ public class BIP38PrivateKeyTest {
                 "6PgNBNNzDkKdhkT6uJntUXwwzQV8Rr2tZcbkDcuC9DZRsS6AtHts4Ypo1j");
         ECKey key = encryptedKey.decrypt("MOLON LABE");
         assertEquals("5JLdxTtcTHcfYcmJsNVy1v2PMDx432JPoYcBTVVRHpPaxUrdtf8", key.getPrivateKeyEncoded(MAINNET)
-                .toString());
+                .toBase58());
     }
 
     @Test
@@ -114,7 +114,7 @@ public class BIP38PrivateKeyTest {
                 "6PgGWtx25kUg8QWvwuJAgorN6k9FbE25rv5dMRwu5SKMnfpfVe5mar2ngH");
         ECKey key = encryptedKey.decrypt("ΜΟΛΩΝ ΛΑΒΕ");
         assertEquals("5KMKKuUmAkiNbA3DazMQiLfDq47qs8MAEThm4yL8R2PhV1ov33D", key.getPrivateKeyEncoded(MAINNET)
-                .toString());
+                .toBase58());
     }
 
     @Test
@@ -124,7 +124,7 @@ public class BIP38PrivateKeyTest {
                 "6PRPhQhmtw6dQu6jD8E1KS4VphwJxBS9Eh9C8FQELcrwN3vPvskv9NKvuL");
         ECKey key = encryptedKey.decrypt("password");
         assertEquals("93MLfjbY6ugAsLeQfFY6zodDa8izgm1XAwA9cpMbUTwLkDitopg", key.getPrivateKeyEncoded(TESTNET)
-                .toString());
+                .toBase58());
     }
 
     @Test
@@ -134,7 +134,7 @@ public class BIP38PrivateKeyTest {
                 "6PfMmVHn153N3x83Yiy4Nf76dHUkXufe2Adr9Fw5bewrunGNeaw2QCpifb");
         ECKey key = encryptedKey.decrypt("password");
         assertEquals("91tCpdaGr4Khv7UAuUxa6aMqeN5GcPVJxzLtNsnZHTCndxkRcz2", key.getPrivateKeyEncoded(TESTNET)
-                .toString());
+                .toBase58());
     }
 
     @Test(expected = BadPassphraseException.class)

--- a/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
+++ b/core/src/test/java/org/bitcoinj/crypto/ECKeyTest.java
@@ -196,7 +196,7 @@ public class ECKeyTest {
         String addr = "mqAJmaxMcG5pPHHc3H3NtyXzY7kGbJLuMF";
         String privkey = "92shANodC6Y4evT5kFzjNFQAdjqTtHAnDTLzqBBq4BbKUPyx6CD";
         ECKey key = DumpedPrivateKey.fromBase58(TESTNET, privkey).getKey();
-        assertEquals(privkey, key.getPrivateKeyEncoded(TESTNET).toString());
+        assertEquals(privkey, key.getPrivateKeyEncoded(TESTNET).toBase58());
         assertEquals(addr, key.toAddress(ScriptType.P2PKH, TESTNET).toString());
     }
 
@@ -248,7 +248,7 @@ public class ECKeyTest {
     public void base58Encoding_leadingZero() {
         String privkey = "91axuYLa8xK796DnBXXsMbjuc8pDYxYgJyQMvFzrZ6UfXaGYuqL";
         ECKey key = DumpedPrivateKey.fromBase58(TESTNET, privkey).getKey();
-        assertEquals(privkey, key.getPrivateKeyEncoded(TESTNET).toString());
+        assertEquals(privkey, key.getPrivateKeyEncoded(TESTNET).toBase58());
         assertEquals(0, key.getPrivKeyBytes()[0]);
     }
 
@@ -258,7 +258,7 @@ public class ECKeyTest {
         for (int i = 0 ; i < 20 ; i++) {
             ECKey key = ECKey.random();
             ECKey key1 = DumpedPrivateKey.fromBase58(TESTNET,
-                    key.getPrivateKeyEncoded(TESTNET).toString()).getKey();
+                    key.getPrivateKeyEncoded(TESTNET).toBase58()).getKey();
             assertEquals(ByteUtils.formatHex(key.getPrivKeyBytes()),
                     ByteUtils.formatHex(key1.getPrivKeyBytes()));
         }
@@ -492,7 +492,7 @@ public class ECKeyTest {
     public void roundTripDumpedPrivKey() {
         ECKey key = ECKey.random();
         assertTrue(key.isCompressed());
-        String base58 = key.getPrivateKeyEncoded(TESTNET).toString();
+        String base58 = key.getPrivateKeyEncoded(TESTNET).toBase58();
         ECKey key2 = DumpedPrivateKey.fromBase58(TESTNET, base58).getKey();
         assertTrue(key2.isCompressed());
         assertArrayEquals(key.getPrivKeyBytes(), key2.getPrivKeyBytes());


### PR DESCRIPTION
Remove implementations from subclasses that could leak private keys to logs and similar. This is a breaking change: legitimate uses will need to be changed to call `toBase58()` instead.

Also adapts various tests and one internal use in `ECKey`.

This is candidate for backporting to 0.17, TBD.