### PR TITLE
Base58: protect alphabet from mutation

### DIFF
--- a/base/src/main/java/org/bitcoinj/base/Base58.java
+++ b/base/src/main/java/org/bitcoinj/base/Base58.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2011 Google Inc.
- * Copyright 2018 Andreas Schildbach
+ * Copyright by the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +20,10 @@ import org.bitcoinj.base.exceptions.AddressFormatException;
 import org.bitcoinj.base.internal.ByteUtils;
 
 import java.math.BigInteger;
+import java.nio.CharBuffer;
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Base58 is a way to encode Bitcoin addresses (or arbitrary data) as alphanumeric strings.
@@ -48,7 +50,7 @@ import java.util.Arrays;
  * numbers), and finally represent the resulting base-58 digits as alphanumeric ASCII characters.
  */
 public class Base58 {
-    public static final char[] ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz".toCharArray();
+    private static final char[] ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz".toCharArray();
     private static final char ENCODED_ZERO = ALPHABET[0];
     private static final int[] INDEXES = new int[128];
     static {
@@ -56,6 +58,18 @@ public class Base58 {
         for (int i = 0; i < ALPHABET.length; i++) {
             INDEXES[ALPHABET[i]] = i;
         }
+    }
+
+    /**
+     * Get the Base58 alphabet.
+     *
+     * @return alphabet as a list of characters
+     */
+    public static List<Character> alphabet() {
+        return CharBuffer.wrap(ALPHABET)
+                .chars()
+                .mapToObj(c -> (char) c)
+                .collect(Collectors.toList());
     }
 
     /**

--- a/base/src/test/java/Base58Test.java
+++ b/base/src/test/java/Base58Test.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.bitcoinj.base.Base58;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class Base58Test {
+    @Test
+    public void alphabetHas58Chars() {
+        assertEquals(58, Base58.alphabet().size());
+    }
+
+    @Test
+    public void alphabetIsImmutable() {
+        List<Character> alphabet1 = Base58.alphabet();
+        char previousChar = alphabet1.remove(0);
+        alphabet1.add(0, '₿');
+        List<Character> alphabet2 = Base58.alphabet();
+        assertEquals(previousChar, alphabet2.get(0).charValue());
+    }
+}


### PR DESCRIPTION
Make the constant `ALPHABET` private and provide an accessor `alphabet()` to use instead.

Add tests to verify the alphabet cannot be mutated any more.